### PR TITLE
Mejora: Config. Programas - Visualización campos

### DIFF
--- a/Configuraciones/templates/Configuraciones/programas_list.html
+++ b/Configuraciones/templates/Configuraciones/programas_list.html
@@ -46,8 +46,7 @@
             <th >Subsecretaría</th>
             <th >Secretaría</th>
             <th >Estado</th>
-              <th style="width: 15%" class="notexport">
-              </th>
+            <th style="width: 15%" class="notexport">Acciones</th>
             </tr>
           </thead>
           <tbody>

--- a/static/custom/js/custom.js
+++ b/static/custom/js/custom.js
@@ -98,7 +98,9 @@ $(function () {
 				exportOptions: {
 					columns: ":not(:last-child)"
 				}
-			}, { exportOptions: { columns: ':not(.notexport)' }, }],
+			},
+			
+			{ exportOptions: { columns: ':not(.notexport)' }, }],
 			"oTableTools": {
 				"sSwfPath": "/swf/copy_csv_xls_pdf.swf",
 				"aButtons": [
@@ -110,6 +112,14 @@ $(function () {
 			}
 
 		})
+		.on('column-visibility.dt', function (e, settings, column, state) {
+            var api = new $.fn.dataTable.Api(settings);
+            var visibleColumns = api.columns(':visible').count();
+            if (visibleColumns === 0) {
+                api.column(column).visible(true);
+                alert('Debe haber al menos una columna visible.');
+            }
+        })
 		.buttons()
 		.container()
 		.appendTo(".dataTables_wrapper .col-md-6:eq(0)");


### PR DESCRIPTION
# Información de la Tarea

- **Tarea:Mejora: Config. Programas - Visualización campos ** [Enlace a Notion](https://www.notion.so/Mejora-Config-Programas-Visualizaci-n-campos-b70c4374cb99465d9eb5eaf3923ff733)
- **Resumen de la Solución:** 
  - Se agrego un  callback para evitar que se filtren todas las columnas en cualquier tabla de clase .tabladt
  - Se agrego un  label de Acciones faltante en header de tabla y en dropdown en programas_list


- **Información Adicional:**
  - 
# Descripción de los Cambios

- **Cambios Principales:**
  - Se añade un evento column-visibility al custom.js que se dispara cada vez que se cambia la visibilidad de una columna. Si todas las columnas están ocultas, se vuelve a mostrar la columna que se intentó ocultar y se muestra un mensaje de alerta.


# Cómo Testear los Cambios

- **Pruebas Automáticas:**
  -

- **Pruebas Manuales:**
  - Ir a Configuraciones/programas
  - Pararnos en "Columnas" e ir desactivando cada una hasta que salga el alert avisando que tenemos que tener al menos una columna activa.


# Capturas de Pantalla
- Cualquier captura de pantalla que ayude a la review.
![image](https://github.com/user-attachments/assets/6570b6d9-b7b2-4858-8ff8-cbc822275f03)
