### PR TITLE
#123 bug educacion

### DIFF
--- a/static/custom/js/legajosdimensionesform.js
+++ b/static/custom/js/legajosdimensionesform.js
@@ -47,14 +47,14 @@ document.addEventListener("DOMContentLoaded", function() {
 
   // Estados de formulario
   let asisteEscuelaFormEstados = [
-    { valor: "a", mostrar: [ID_MAX_NIVEL, ID_ESTADO_NIVEL, ID_DATOS_INSTITUCION], ocultar: [ID_INCOMPLETO_FORM, ID_SIN_EDU_FORMAL] },
-    { valor: "b", mostrar: [ID_MAX_NIVEL, ID_ESTADO_NIVEL, ID_INCOMPLETO_FORM, ID_DATOS_INSTITUCION], ocultar: [ID_SIN_EDU_FORMAL] },
-    { valor: "c", mostrar: [ID_SIN_EDU_FORMAL], ocultar: [ID_MAX_NIVEL, ID_ESTADO_NIVEL, ID_INCOMPLETO_FORM, ID_DATOS_INSTITUCION] }
+    { valor: "a", mostrar: [ID_MAX_NIVEL, ID_DATOS_INSTITUCION], ocultar: [ID_ESTADO_NIVEL, ID_INCOMPLETO_FORM, ID_SIN_EDU_FORMAL] },
+    { valor: "b", mostrar: [ID_MAX_NIVEL, ID_ESTADO_NIVEL, ID_DATOS_INSTITUCION], ocultar: [ID_SIN_EDU_FORMAL] },
+    { valor: "c", mostrar: [ID_SIN_EDU_FORMAL], ocultar: [ID_MAX_NIVEL, ID_ESTADO_NIVEL, ID_DATOS_INSTITUCION] }
   ];
 
   let estadoNivelFormEstados = [
-    { valor: INCOMPLETO_OPTION, mostrar: [ID_INCOMPLETO_FORM, ID_SIN_EDU_FORMAL], ocultar: [] },
-    { valor: null, mostrar: [], ocultar: [ID_INCOMPLETO_FORM, ID_SIN_EDU_FORMAL] }
+    { valor: INCOMPLETO_OPTION, mostrar: [], ocultar: [] },
+    { valor: null, mostrar: [], ocultar: [] }
   ];
 
   let realizandoCursoFormEstados = [
@@ -99,7 +99,61 @@ document.addEventListener("DOMContentLoaded", function() {
   FormUtils.mostrarOcultar(hayBanioForm.value, hayBanioFormEstados);
   FormUtils.mostrarOcultar(tieneTrabajoForm.value, tieneTrabajoFormEstados);
   FormUtils.mostrarOcultar(busquedaLaboralForm.value, busquedaLaboralFormEstados);
-  FormUtils.mostrarOcultar(planSocialForm.value, planSocialFormEstados)
+  FormUtils.mostrarOcultar(planSocialForm.value, planSocialFormEstados);
+
+  // Manejo de pregunta id_nivelIncompleto, se maneja aparte
+  let preguntasVinculadas = document.querySelectorAll(
+    "#id_asiste_escuela, #id_max_nivel, #id_estado_nivel"
+  );
+
+  function mostrarOcultarPreguntaEducacionIncompleta() {
+    // Calculamos un puntaje acorde al progreso educativo hecho por el encuestado.
+    // Obtenemos los valores de los campos y la multiplicación de esos valores nos da un puntaje
+    // que de pasar cierto límite nos mostrará o no la pregunta.
+    const PUNTAJE_MINIMO = 12;
+    let maxNivelValue = document.querySelector("#id_max_nivel").selectedIndex;
+    let estadoNivelValue =
+      document.querySelector("#id_estado_nivel").selectedIndex;
+    let puntaje = maxNivelValue * estadoNivelValue;
+    console.log(maxNivelValue, estadoNivelValue, puntaje);
+    if (asisteEscuelaForm.value != "a" && puntaje < PUNTAJE_MINIMO) {
+      console.log("Mostrar pregunta incompleto");
+      FormUtils.mostrar(ID_INCOMPLETO_FORM, true);
+    } else {
+      FormUtils.mostrar(ID_INCOMPLETO_FORM, false);
+    }
+  }
+
+  preguntasVinculadas.forEach((elemento) => {
+    elemento.addEventListener("change", () => {
+      mostrarOcultarPreguntaEducacionIncompleta();
+    });
+  });
+
+  // Llamamos al inicio para dejar correcta su visualización
+  mostrarOcultarPreguntaEducacionIncompleta();
+  // Fin manejo de pregunta id_nivelIncompleto
+
+  // Si asisteEscuelaForm es "a", estadoNivel se oculta y por default queda su valor en "En curso"
+
+  function setEstadoNivelEnCurso() {
+    if (asisteEscuelaForm.value === "a") {
+      estadoNivelForm.selectedIndex = 1;
+    } else {
+      for (let i = 0; i < estadoNivelForm.options.length; i++) {
+        if (estadoNivelForm.options[i].text === "En curso") {
+          estadoNivelForm.remove(i);
+          break;
+        }
+      }
+    }
+  }
+
+  asisteEscuelaForm.addEventListener("change", () => {
+    setEstadoNivelEnCurso();
+  });
+
+  setEstadoNivelEnCurso();
 
   document.getElementById('id_provinciaInstitucion').addEventListener('change', function () {
     var url = ajaxLoadMunicipiosUrl;  // Obtén la URL de la vista

--- a/static/custom/js/legajosdimensionesform.js
+++ b/static/custom/js/legajosdimensionesform.js
@@ -115,9 +115,7 @@ document.addEventListener("DOMContentLoaded", function() {
     let estadoNivelValue =
       document.querySelector("#id_estado_nivel").selectedIndex;
     let puntaje = maxNivelValue * estadoNivelValue;
-    console.log(maxNivelValue, estadoNivelValue, puntaje);
     if (asisteEscuelaForm.value != "a" && puntaje < PUNTAJE_MINIMO) {
-      console.log("Mostrar pregunta incompleto");
       FormUtils.mostrar(ID_INCOMPLETO_FORM, true);
     } else {
       FormUtils.mostrar(ID_INCOMPLETO_FORM, false);


### PR DESCRIPTION
# Información de la Tarea #123 


### **Resumen de la Solución:** 
  - Modificadas algunas relaciones en los estados de las preguntas de asisteEscuelaFormEstados, estadoNivelFormEstados.
  - Implementado sistema de puntajes para calcular el progreso educativo realizado por el encuestado para determinar si se muestra o no la pregunta de nivelIncompleto.
  - Si la elección en asisteEscuelaFormEstados es "Si, asisto actualmente" se oculta estadoNivelFormEstados visualmente, y su valor se setea a "En curso", asumiendo que si actualmente asiste es porque ese es el valor que debe guardarse en la base de datos.

### **Información Adicional:**
  - To do post-merge, cambios en archivos fuera del repo, etc.

# Descripción de los Cambios
- Se toman los valores elegidos en id_asiste_escuela, id_max_nivel e id_estado_nivel.
- Si id_asiste_escuela es DISTINTO a "asisto actualmente", entonces:
- Tomamos el valor de id_max_nivel e id_estado_nivel, al estar en orden convertimos (para los fines de este cálculo) sus valores a números enteros. 
- Si la multiplicación de los mismos da 12 (lo que significa que llegó a tener el secundario completo), entonces no mostramos la pregunta.
- Si el valor es inferior, entonces si mostramos la pregunta (por ejemplo, si pone Secundario incompleto, o EGB completo)
- Si el encuestado responde en asisteEscuelaFormEstados es "Si, asistí en algún momento" o "No, nunca asistí", entonces se elimina la opción de "En curso" para evitar irregularidades o errores humanos en la encuesta.

### **Cambios:**
  - Cambios hechos en el codigo

# Cómo Testear los Cambios

### **Pruebas Automáticas:**
  - No

### **Prubeas Manuales:**
  - Se recomienda probar todas las combinaciones posibles en las tres preguntas involucradas.

# Capturas de Pantalla
![image](https://github.com/user-attachments/assets/ac96310d-ff25-4618-9a81-40f8724a8e9a)
![image](https://github.com/user-attachments/assets/c1c6e3dc-3584-4b24-ae39-d278ed1782b5)
![image](https://github.com/user-attachments/assets/a0b3e80a-8ba2-42d7-83f4-d4a4e7b5baec)
![image](https://github.com/user-attachments/assets/97ed96b5-2f9f-470a-ae32-f6b9819b4531)

