### PR TITLE
Fix buscar_ciudadano template path

### DIFF
--- a/centrodefamilia/tests/test_buscar_ciudadano.py
+++ b/centrodefamilia/tests/test_buscar_ciudadano.py
@@ -1,0 +1,19 @@
+import pytest
+from django.urls import reverse
+from ciudadanos.models import Ciudadano
+
+
+@pytest.mark.django_db
+def test_buscar_ciudadano_html(client):
+    ciudadano = Ciudadano.objects.create(
+        apellido="Perez",
+        nombre="Juan",
+        fecha_nacimiento="1990-01-01",
+        documento=12345678,
+    )
+    url = reverse("buscar_ciudadano")
+    response = client.get(url, {"query": str(ciudadano.documento)})
+    assert response.status_code == 200
+    data = response.json()
+    assert "html" in data
+    assert "Perez" in data["html"]

--- a/centrodefamilia/views/participante.py
+++ b/centrodefamilia/views/participante.py
@@ -7,6 +7,7 @@ from django.http import JsonResponse
 from django.template.loader import render_to_string
 from ciudadanos.models import Ciudadano
 
+
 def buscar_ciudadano(request):
     query = request.GET.get("query", "")
     data = {"html": ""}
@@ -14,13 +15,14 @@ def buscar_ciudadano(request):
     if len(query) >= 4:
         ciudadanos = Ciudadano.objects.filter(documento__icontains=query)[:10]
         html = render_to_string(
-            "centros/partials/ciudadano_resultado_busqueda.html",
+            "centros/ciudadano_resultado_busqueda.html",
             {"ciudadanos": ciudadanos},
-            request=request
+            request=request,
         )
         data["html"] = html
 
     return JsonResponse(data)
+
 
 class ParticipanteActividadCreateView(CreateView):
     model = ParticipanteActividad


### PR DESCRIPTION
## Summary
- fix template path in `buscar_ciudadano`
- add regression test for `buscar_ciudadano` view

## Testing
- `black .` *(fails: reformatted other files, reverted)*
- `pylint **/*.py --rcfile=.pylintrc` *(fails: command not found)*
- `djlint . --configuration=.djlintrc --reformat` *(fails: command not found)*
- `pytest` *(fails: django not installed)*

------
https://chatgpt.com/codex/tasks/task_e_685e65175d28832d9e422a84b58f7f62