### PR TITLE
Fix ciudadano search query in participante view

### DIFF
--- a/centrodefamilia/views/participante.py
+++ b/centrodefamilia/views/participante.py
@@ -6,6 +6,8 @@ from centrodefamilia.forms import ParticipanteActividadForm
 from django.http import JsonResponse
 from django.template.loader import render_to_string
 from ciudadanos.models import Ciudadano
+from django.db.models import CharField
+from django.db.models.functions import Cast
 
 
 def buscar_ciudadano(request):
@@ -13,7 +15,9 @@ def buscar_ciudadano(request):
     data = {"html": ""}
 
     if len(query) >= 4:
-        ciudadanos = Ciudadano.objects.filter(documento__icontains=query)[:10]
+        ciudadanos = Ciudadano.objects.annotate(
+            doc_str=Cast("documento", CharField())
+        ).filter(doc_str__startswith=query)[:10]
         html = render_to_string(
             "centros/ciudadano_resultado_busqueda.html",
             {"ciudadanos": ciudadanos},


### PR DESCRIPTION
## Summary
- ensure ciudadano search converts `documento` to string and filters with `startswith`

## Testing
- `black centrodefamilia/views/participante.py`
- `pylint centrodefamilia/views/participante.py --rcfile=.pylintrc` *(fails: command not found)*
- `djlint . --configuration=.djlintrc --reformat` *(fails: command not found)*
- `docker compose exec django pytest -n auto` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685e682f2dcc832dab6f9148fbbf41a5