### PR TITLE
Update ciudadano search results layout

### DIFF
--- a/centrodefamilia/templates/centros/ciudadano_resultado_busqueda.html
+++ b/centrodefamilia/templates/centros/ciudadano_resultado_busqueda.html
@@ -1,9 +1,22 @@
-{% for c in ciudadanos %}
-    <div class="card mb-2">
-        <div class="card-body">
-            <strong>{{ c.apellido }}, {{ c.nombre }}</strong> - DNI: {{ c.documento }}
-        </div>
-    </div>
-{% empty %}
-    <p>No se encontraron coincidencias.</p>
-{% endfor %}
+<table class="table table-bordered">
+    <thead>
+        <tr>
+            <th>Apellido</th>
+            <th>Nombre</th>
+            <th>DNI</th>
+        </tr>
+    </thead>
+    <tbody>
+        {% for c in ciudadanos %}
+            <tr>
+                <td>{{ c.apellido }}</td>
+                <td>{{ c.nombre }}</td>
+                <td>{{ c.documento }}</td>
+            </tr>
+        {% empty %}
+            <tr>
+                <td colspan="3">No se encontraron coincidencias.</td>
+            </tr>
+        {% endfor %}
+    </tbody>
+</table>


### PR DESCRIPTION
## Summary
- show ciudadano search results in a table

## Testing
- `black . --quiet`
- `pylint **/*.py --rcfile=.pylintrc` *(fails: command not found)*
- `djlint . --configuration=.djlintrc --reformat` *(fails: command not found)*
- `docker compose exec django pytest -n auto` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685e6831c754832d983c8107c64883c2