### PR TITLE
Fix Chart.js script URL in centro detail template

### DIFF
--- a/centrodefamilia/templates/centros/centro_detail.html
+++ b/centrodefamilia/templates/centros/centro_detail.html
@@ -407,7 +407,7 @@
   {% endfor %}
 
 {{ cat_metrics|json_script:"catMetrics" }}
-<script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
+<script src="https://cdn.jsdelivr.net/npm/chart.js@4.4.4/dist/chart.umd.min.js"></script>
 <script src="{% static 'js/centrodefamilia.js' %}"></script>
 
 


### PR DESCRIPTION
## Summary
- update Chart.js script URL to include version and minified path

## Testing
- `docker-compose up` *(fails: command not found)*
- `docker compose exec django pytest -n auto` *(fails: command not found)*
- `black .`
- `djlint . --configuration=.djlintrc --reformat` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686998cc2fac832db736228e7c0cae7b