### PR TITLE
359 debug toolbar

### DIFF
--- a/config/urls.py
+++ b/config/urls.py
@@ -5,7 +5,6 @@ from django.contrib.staticfiles.urls import staticfiles_urlpatterns
 from django.urls import include, path
 
 urlpatterns = [
-    path("__debug__/", include("debug_toolbar.urls")),
     path("admin/doc/", include("django.contrib.admindocs.urls")),
     path("admin/", admin.site.urls),
     path("", include("django.contrib.auth.urls")),
@@ -28,6 +27,9 @@ urlpatterns = [
     path("", include("relevamientos.urls")),
     path("rendicioncuentasmensual/", include("rendicioncuentasmensual.urls")),
 ]
+
+if settings.DEBUG:
+    urlpatterns = [path("__debug__/", include("debug_toolbar.urls"))] + urlpatterns
 
 urlpatterns += staticfiles_urlpatterns()
 urlpatterns += static(settings.MEDIA_URL, document_root=settings.MEDIA_ROOT)


### PR DESCRIPTION




# Información de la Tarea
Vincular el #ISSUE

### **Resumen de la Solución:** 
Removí la línea path("__debug__/", include("debug_toolbar.urls")) de la lista principal de urlpatterns
Agregué una condición condicional al final que solo incluye estas rutas cuando el proyecto está en modo DEBUG:

### **Información Adicional:**
-

# Descripción de los Cambios

### **Cambios:**
-

# Cómo Testear los Cambios

### **Pruebas Automáticas:**
-

### **Prubeas Manuales:**
-

# Capturas de Pantalla
