### PR TITLE
chore: upgrade to Python 3.11

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -19,7 +19,7 @@ jobs:
               id: python-version
               uses: actions/setup-python@v5.2.0
               with:
-                  python-version: '3.9.19'
+                  python-version: '3.11.9'
 
             - name: Install dependencies
               run: |

--- a/docker/django/Dockerfile
+++ b/docker/django/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.9.19-bullseye
+FROM python:3.11.9-bullseye
 
 WORKDIR /sisoc
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.black]
 line-length = 88
-target-version = ['py38', 'py39', 'py310'] 
+target-version = ['py311']
 skip-string-normalization = false
 exclude = '''
 /(


### PR DESCRIPTION
## Summary
- use Python 3.11 base image for Django container
- run CI linting on Python 3.11
- update Black configuration to target Python 3.11

## Testing
- `black . --check --config pyproject.toml` *(fails: would reformat core/management/commands/load_fixtures.py)*
- `pylint $(git ls-files '*.py') --rcfile=.pylintrc` *(fails: Unable to import 'admisiones.models.admisiones' and others)*
- `djlint . --check --configuration=.djlintrc` *(fails: Aborted)*
- `docker compose exec django pytest -n auto` *(fails: command not found: docker)*

------
https://chatgpt.com/codex/tasks/task_e_689a54abc924832da5e731974f9d3371