### PR TITLE
Use image URLs in comedor detail template

### DIFF
--- a/comedores/templates/comedor/comedor_detail.html
+++ b/comedores/templates/comedor/comedor_detail.html
@@ -632,7 +632,7 @@
                             <div class="galeria-imagenes">
                                 {% for imagen in imagenes %}
                                     <div class="imagen-item" data-index="{{ forloop.counter0 }}">
-                                        <div class="imagen-container" data-image-url="/media/{{ imagen.imagen }}">
+                                        <div class="imagen-container" data-image-url="{{ imagen.imagen.url }}">
                                             <div class="placeholder-imagen">
                                                 <i class="fas fa-image"></i>
                                                 <div class="loader">


### PR DESCRIPTION
## Summary
- Avoid hard-coded `/media/` paths in comedor detail gallery by relying on `imagen.imagen.url`

## Testing
- `python - <<'PY' ...` (custom MEDIA_URL snippet)
- `djlint comedores/templates/comedor/comedor_detail.html --configuration=.djlintrc --reformat`
- `black . --check`
- `pylint comedores --rcfile=.pylintrc`
- `pytest` *(fails: AttributeError: 'NoneType' object has no attribute 'startswith')*

------
https://chatgpt.com/codex/tasks/task_e_68a33d3f6a58832d95a3217e878d45f2