### PR TITLE
Escape foto legajo parameters in JS

### DIFF
--- a/comedores/templates/comedor/comedor_form.html
+++ b/comedores/templates/comedor/comedor_form.html
@@ -609,7 +609,7 @@
                                                         </div>
                                                         <button type="button"
                                                                 class="btn btn-outline-primary btn-sm"
-                                                                onclick="ampliarFotoLegajo('{{ form.instance.foto_legajo.url }}', '{{ form.instance.foto_legajo.name }}')">
+                                                                onclick="ampliarFotoLegajo('{{ form.instance.foto_legajo.url|escapejs }}', '{{ form.instance.foto_legajo.name|escapejs }}')">
                                                             <i class="fas fa-expand-alt mr-1"></i>
                                                             Ver completa
                                                         </button>


### PR DESCRIPTION
## Summary
- escape foto_legajo url and name with `escapejs` before passing to `ampliarFotoLegajo`

## Testing
- `black comedores`
- `pylint comedores --rcfile=.pylintrc`
- `djlint comedores/templates/comedor/comedor_form.html --configuration=.djlintrc --check`
- `pytest` *(fails: AttributeError: 'NoneType' object has no attribute 'startswith')*
- `python - <<'PY' ...`

------
https://chatgpt.com/codex/tasks/task_e_68a33d2f079c832d8c631c7907b78cf6