### PR TITLE
Limit image fields in Comedor update view

### DIFF
--- a/comedores/views.py
+++ b/comedores/views.py
@@ -475,7 +475,9 @@ class ComedorUpdateView(UpdateView):
             instance=self.object.referente,
             prefix="referente",
         )
-        data["imagenes_borrar"] = ImagenComedor.objects.filter(comedor=self.object.pk)
+        data["imagenes_borrar"] = ImagenComedor.objects.filter(
+            comedor=self.object.pk
+        ).only("id", "imagen")
         return data
 
     def form_valid(self, form):


### PR DESCRIPTION
## Summary
- Restrict existing image queryset in Comedor update view to only fetch `id` and `imagen` fields

## Testing
- `black .`
- `pylint **/*.py --rcfile=.pylintrc`
- `djlint . --configuration=.djlintrc --reformat`
- `docker compose exec django pytest -n auto` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a33d5fd07c832da7f9b74315bc6ba5