### PR TITLE
Use storage API for legajo photo deletion

### DIFF
--- a/comedores/services/comedor_service.py
+++ b/comedores/services/comedor_service.py
@@ -12,9 +12,9 @@ from django.shortcuts import get_object_or_404
 
 from relevamientos.models import Relevamiento, ClasificacionComedor
 from relevamientos.service import RelevamientoService
+from ciudadanos.models import Ciudadano, HistorialCiudadanoProgramas, CiudadanoPrograma
 from comedores.forms.comedor_form import ImagenComedorForm
 from comedores.models import Comedor, ImagenComedor, Nomina, Observacion, Referente
-from ciudadanos.models import Ciudadano, HistorialCiudadanoProgramas, CiudadanoPrograma
 from comedores.utils import (
     get_object_by_filter,
     get_id_by_nombre,
@@ -77,19 +77,13 @@ class ComedorService:
     def borrar_foto_legajo(post, comedor_instance):
         """Eliminar la foto del legajo si está marcada para borrar"""
         if "foto_legajo_borrar" in post and comedor_instance.foto_legajo:
-            # Eliminar el archivo físico
-            if comedor_instance.foto_legajo:
-                try:
-                    import os
-
-                    file_path = comedor_instance.foto_legajo.path
-                    if os.path.exists(file_path):
-                        os.remove(file_path)
-
-                except Exception:
-                    pass
-
-            # Limpiar el campo en la base de datos
+            try:
+                comedor_instance.foto_legajo.delete(save=False)
+            except Exception:
+                logger.exception(
+                    "Error al eliminar la foto de legajo del comedor %s",
+                    comedor_instance.pk,
+                )
             comedor_instance.foto_legajo = None
             comedor_instance.save(update_fields=["foto_legajo"])
 

--- a/comedores/test_borrar_foto_legajo.py
+++ b/comedores/test_borrar_foto_legajo.py
@@ -1,0 +1,23 @@
+import pytest
+from django.core.files.base import ContentFile
+from django.core.files.storage import default_storage
+
+from comedores.models import Comedor
+from comedores.services.comedor_service import ComedorService
+
+
+@pytest.mark.django_db
+def test_borrar_foto_legajo_elimina_archivo_y_nullea_campo(settings, tmp_path):
+    settings.MEDIA_ROOT = tmp_path
+    comedor = Comedor.objects.create(nombre="Test")
+    file_content = ContentFile(b"data", "legajo.jpg")
+    comedor.foto_legajo.save("legajo.jpg", file_content)
+    file_name = comedor.foto_legajo.name
+
+    assert default_storage.exists(file_name)
+
+    ComedorService.borrar_foto_legajo({"foto_legajo_borrar": "1"}, comedor)
+
+    assert not default_storage.exists(file_name)
+    comedor.refresh_from_db()
+    assert comedor.foto_legajo is None

--- a/requirements.txt
+++ b/requirements.txt
@@ -117,3 +117,4 @@ xlrd==2.0.1
 xlwt==1.3.0
 zopfli==0.2.3.post1
 num2words==0.5.12
+python-json-logger==2.0.7


### PR DESCRIPTION
## Summary
- Use Django storage to delete `foto_legajo` and log exceptions
- Add `python-json-logger` dependency
- Add unit test verifying photo removal clears field

## Testing
- `black comedores/services/comedor_service.py comedores/test_borrar_foto_legajo.py`
- `pylint comedores/services/comedor_service.py --rcfile=.pylintrc` *(import errors: Unable to import modules)*
- `pylint comedores/test_borrar_foto_legajo.py --rcfile=.pylintrc`
- `djlint . --configuration=.djlintrc --reformat`
- `docker compose exec django pytest -n auto` *(command not found)*
- `pytest comedores/test_borrar_foto_legajo.py -q` *(fails: database settings missing)*

------
https://chatgpt.com/codex/tasks/task_e_68a33d5c6928832da598b73b9a2d2804