### PR TITLE
refactor: fix program addition and cleanup

### DIFF
--- a/centrodefamilia/views/centro.py
+++ b/centrodefamilia/views/centro.py
@@ -14,6 +14,7 @@ from django.core.exceptions import PermissionDenied
 from django.core.paginator import Paginator
 from django.shortcuts import get_object_or_404
 from django.http import Http404
+from django.utils.html import format_html
 
 from centrodefamilia.models import (
     CabalArchivo,
@@ -364,7 +365,15 @@ class CentroDeleteView(LoginRequiredMixin, DeleteView):
                     {"text": "Eliminar", "active": True},
                 ],
                 "object_title": centro.nombre,
-                "delete_message": f"¿Estás seguro que querés eliminar este centro? <br><strong>Nombre:</strong> {centro.nombre}<br><strong>Dirección:</strong> {centro.calle}<br><strong>Tipo:</strong> {centro.get_tipo_display}",
+                "delete_message": format_html(
+                    "¿Estás seguro que querés eliminar este centro?"
+                    " <br><strong>Nombre:</strong> {}"
+                    " <br><strong>Dirección:</strong> {}"
+                    " <br><strong>Tipo:</strong> {}",
+                    centro.nombre,
+                    centro.calle,
+                    centro.get_tipo_display(),
+                ),
                 "cancel_url": reverse("centro_list"),
             }
         )

--- a/ciudadanos/views.py
+++ b/ciudadanos/views.py
@@ -222,7 +222,7 @@ def eliminar_programa(request):
             )
 
         except Exception as exc:
-            logger.exception("Error al eliminar programa", exc_info=exc)
+            logger.exception("Error al eliminar programa", extra={"body": request.POST})
             return JsonResponse(
                 {
                     "success": False,
@@ -962,35 +962,28 @@ class CiudadanosCreateView(CreateView):
             with transaction.atomic():
                 ciudadano.save()
 
-                # Crear las dimensiones
                 dimensionfamilia = DimensionFamilia.objects.create(
                     ciudadano_id=ciudadano.id
                 )
 
-                logger.info(f"dimensionfamilia {dimensionfamilia}")
                 dimensionvivienda = DimensionVivienda.objects.create(
                     ciudadano_id=ciudadano.id
                 )
 
-                logger.info(f"dimensionvivienda {dimensionvivienda}")
                 dimensiosalud = DimensionSalud.objects.create(ciudadano_id=ciudadano.id)
 
-                logger.info(f"dimensiosalud {dimensiosalud}")
 
                 dimensioneconomia = DimensionEconomia.objects.create(
                     ciudadano_id=ciudadano.id
                 )
-                logger.info(f"dimensioneconomia {dimensioneconomia}")
 
                 dimensioneducacion = DimensionEducacion.objects.create(
                     ciudadano_id=ciudadano.id
                 )
-                logger.info(f"dimensioneducacion {dimensioneducacion}")
 
                 dimensiontrabajo = DimensionTrabajo.objects.create(
                     ciudadano_id=ciudadano.id
                 )
-                logger.info(f"dimensiontrabajo {dimensiontrabajo}")
 
             # Redireccionar según el botón presionado
             if "form_ciudadanos" in self.request.POST:
@@ -1162,9 +1155,9 @@ class CiudadanosGrupoFamiliarCreateView(CreateView):
                 cuidador_principal=cuidador_principal,
             )
 
-        except Exception as exc:
-            logger.exception("Error al crear el familiar", exc_info=exc)
-            messages.error(self.request, f"Error al crear el familiar: {exc}")
+        except Exception:
+            logger.exception(f"Error al crear el familiar {pk}", extra={"form": form})
+            messages.error(self.request, f"Error al crear el familiar")
             return redirect(self.request.path_info)
 
         messages.success(self.request, "Familiar agregado correctamente.")

--- a/core/templatetags/custom_filters.py
+++ b/core/templatetags/custom_filters.py
@@ -29,7 +29,7 @@ def is_url(value):
     """
     try:
         return str(value).startswith("/")
-    except:
+    except AttributeError:
         return False
 
 


### PR DESCRIPTION
## Summary
- sanitize centro deletion confirmation with `format_html`
- avoid N+1 queries and improve error handling in citizen program update
- tighten exception logging and remove unused template
- narrow exception handling in `is_url` filter

## Testing
- `black centrodefamilia/views/centro.py ciudadanos/views.py core/templatetags/custom_filters.py`
- `pylint centrodefamilia/views/centro.py ciudadanos/views.py core/templatetags/custom_filters.py --rcfile=.pylintrc`
- `djlint templates --configuration=.djlintrc --reformat`
- `docker compose exec django pytest -n auto` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a3603f7764832d970ead1d8b6ada74