### PR TITLE
Validate default TipoDocumento before import

### DIFF
--- a/celiaquia/services/ciudadano_service.py
+++ b/celiaquia/services/ciudadano_service.py
@@ -1,5 +1,7 @@
 import logging
 from datetime import datetime, date
+from functools import lru_cache
+
 from django.core.exceptions import ValidationError
 from django.contrib.auth import get_user_model
 from django.db import transaction, IntegrityError  # ← agregado
@@ -21,6 +23,20 @@ from ciudadanos.models import (
 from celiaquia.models import ExpedienteCiudadano
 
 logger = logging.getLogger(__name__)
+
+
+@lru_cache(maxsize=1)
+def _tipo_doc_por_defecto():
+    """Retorna el TipoDocumento por defecto (DNI).
+
+    Se cachea para evitar consultas repetidas. Si el registro no existe
+    se lanza un ValidationError.
+    """
+
+    try:
+        return TipoDocumento.objects.get(nombre__iexact="DNI")
+    except TipoDocumento.DoesNotExist as exc:
+        raise ValidationError("Falta TipoDocumento por defecto (DNI)") from exc
 
 
 class CiudadanoService:
@@ -88,9 +104,7 @@ class CiudadanoService:
             raise ValidationError("El número de documento es obligatorio.")
 
         # 5) Buscar por clave real (tipo_documento + documento)
-        ciudadano = Ciudadano.objects.filter(
-            tipo_documento=td, documento=doc
-        ).first()
+        ciudadano = Ciudadano.objects.filter(tipo_documento=td, documento=doc).first()
 
         created = False
         if ciudadano is None:

--- a/celiaquia/services/importacion_service.py
+++ b/celiaquia/services/importacion_service.py
@@ -109,7 +109,10 @@ class ImportacionService:
         expedientes abiertos para evitar consultas repetidas dentro del bucle.
         """
 
-        from celiaquia.services.ciudadano_service import CiudadanoService
+        from celiaquia.services.ciudadano_service import (
+            CiudadanoService,
+            _tipo_doc_por_defecto,
+        )
 
         try:
             archivo_excel.open()
@@ -142,6 +145,9 @@ class ImportacionService:
             df["fecha_nacimiento"] = df["fecha_nacimiento"].apply(
                 lambda x: x.date() if hasattr(x, "date") else x
             )
+
+        # Validar la existencia del TipoDocumento por defecto antes de procesar filas
+        _tipo_doc_por_defecto()
 
         estado_id = _estado_doc_pendiente_id()
         validos = errores = 0


### PR DESCRIPTION
## Summary
- cache lookup for default TipoDocumento (DNI) in ciudadano_service
- ensure importacion_service checks for default document type before reading rows

## Testing
- `black celiaquia/services/ciudadano_service.py celiaquia/services/importacion_service.py`
- `pylint celiaquia/services/ciudadano_service.py celiaquia/services/importacion_service.py --rcfile=.pylintrc` *(fails: Unable to import Django modules)*
- `djlint . --configuration=.djlintrc --check` *(aborted: KeyboardInterrupt)*
- `docker compose exec django pytest -n auto` *(fails: command not found: docker)*

------
https://chatgpt.com/codex/tasks/task_e_68b9d532d068832da9d6cd548b70e349