### PR TITLE
Fix default TipoDocumento lookup

### DIFF
--- a/celiaquia/services/ciudadano_service.py
+++ b/celiaquia/services/ciudadano_service.py
@@ -39,7 +39,7 @@ def _tipo_doc_por_defecto():
     """
 
     try:
-        return TipoDocumento.objects.get(nombre__iexact="DNI")
+        return TipoDocumento.objects.get(tipo__iexact="DNI")
     except TipoDocumento.DoesNotExist as exc:
         raise ValidationError("Falta TipoDocumento por defecto (DNI)") from exc
 


### PR DESCRIPTION
## Summary
- Fix default document type retrieval in ciudadano service

## Testing
- `pylint celiaquia/services/ciudadano_service.py --rcfile=.pylintrc`
- `pytest -q` *(fails: AttributeError: 'NoneType' object has no attribute 'startswith' due to missing MySQL configuration)*

------
https://chatgpt.com/codex/tasks/task_e_68b9dc48f6dc832d8b3ea98335247128