### PR TITLE
refactor: limpiar importaciones en consulta RENAPER

### DIFF
--- a/centrodefamilia/services/consulta_renaper.py
+++ b/centrodefamilia/services/consulta_renaper.py
@@ -1,9 +1,8 @@
 from django.conf import settings
 from django.core.cache import cache
 import requests
-import datetime
 import unicodedata
-from ciudadanos.models import Sexo, TipoDocumento, Provincia
+from ciudadanos.models import Sexo, TipoDocumento
 from requests.exceptions import RequestException, ConnectionError
 import logging
 


### PR DESCRIPTION
## Summary
- remove unused `datetime` import in RENAPER service
- drop `Provincia` from `ciudadanos.models` import

## Testing
- `black centrodefamilia/services/consulta_renaper.py`
- `pylint centrodefamilia/services/consulta_renaper.py --rcfile=.pylintrc`
- `djlint centrodefamilia/services/consulta_renaper.py --configuration=.djlintrc --check`
- `docker compose exec django pytest -n auto` *(fails: command not found)*
- `pytest -n auto` *(fails: AttributeError: 'NoneType' object has no attribute 'startswith')*


------
https://chatgpt.com/codex/tasks/task_e_68ba25785344832dbc0642b2deebc7d7