### PR TITLE
refactor: handle RENAPER API timeouts per request

### DIFF
--- a/centrodefamilia/services/consulta_renaper.py
+++ b/centrodefamilia/services/consulta_renaper.py
@@ -19,7 +19,6 @@ class APIClient:
         self.username = settings.RENAPER_API_USERNAME
         self.password = settings.RENAPER_API_PASSWORD
         self.session = requests.Session()  # Reutilizar conexiones
-        self.session.timeout = 10
 
     def get_token(self):
         # Cache del token por 50 minutos (tokens duran 1 hora)
@@ -32,7 +31,9 @@ class APIClient:
     def _login_and_cache_token(self):
         try:
             response = self.session.post(
-                LOGIN_URL, json={"username": self.username, "password": self.password}
+                LOGIN_URL,
+                json={"username": self.username, "password": self.password},
+                timeout=10,
             )
             response.raise_for_status()
         except ConnectionError:
@@ -59,7 +60,9 @@ class APIClient:
         params = {"dni": dni, "sexo": sexo.upper()}
 
         try:
-            response = self.session.get(CONSULTA_URL, headers=headers, params=params)
+            response = self.session.get(
+                CONSULTA_URL, headers=headers, params=params, timeout=10
+            )
             response.raise_for_status()
         except ConnectionError:
             logger.error(f"Error de conexión RENAPER para DNI {dni}")


### PR DESCRIPTION
## Summary
- remove global session timeout in RENAPER API client
- set 10-second timeout individually for login and citizen query requests

## Testing
- `black centrodefamilia/services/consulta_renaper.py`
- `pylint centrodefamilia/services/consulta_renaper.py --rcfile=.pylintrc`
- `docker compose exec django pytest -n auto` *(fails: command not found: docker)*

------
https://chatgpt.com/codex/tasks/task_e_68ba257eb220832d9223bb15a4537b49