### PR TITLE
Handle numeric sex identifiers in Excel import

### DIFF
--- a/celiaquia/services/ciudadano_service.py
+++ b/celiaquia/services/ciudadano_service.py
@@ -112,12 +112,15 @@ class CiudadanoService:
             if td is None:
                 raise ValidationError(f"Tipo de documento inválido: {raw_td}")
 
-        # 2) Resolver FK Sexo (por nombre)
+        # 2) Resolver FK Sexo (por nombre o ID)
         raw_sex = datos.get("sexo")
         sx = None
         if raw_sex not in (None, ""):
             raw_sex_str = str(raw_sex).strip()
-            sx = Sexo.objects.filter(sexo__iexact=raw_sex_str).first()
+            if raw_sex_str.isdigit():
+                sx = Sexo.objects.filter(pk=int(raw_sex_str)).first()
+            else:
+                sx = Sexo.objects.filter(sexo__iexact=raw_sex_str).first()
             if sx is None:
                 raise ValidationError(f"Sexo inválido: {raw_sex}")
 

--- a/tests/test_ciudadano_excel_numeric.py
+++ b/tests/test_ciudadano_excel_numeric.py
@@ -1,0 +1,36 @@
+from io import BytesIO
+from datetime import date
+
+import pandas as pd
+import pytest
+
+from celiaquia.services.ciudadano_service import CiudadanoService
+from ciudadanos.models import TipoDocumento
+from core.models import Sexo
+
+
+@pytest.mark.django_db
+def test_excel_numeric_sex_assigns_masculino():
+    TipoDocumento.objects.create(id=1, tipo="DNI")
+    Sexo.objects.create(id=1, sexo="Femenino")
+    Sexo.objects.create(id=2, sexo="Masculino")
+
+    df = pd.DataFrame(
+        [
+            {
+                "tipo_documento": 1,
+                "documento": 12345678,
+                "nombre": "Juan",
+                "apellido": "Perez",
+                "fecha_nacimiento": date(1990, 1, 1),
+                "sexo": 2,
+            }
+        ]
+    )
+    bio = BytesIO()
+    df.to_excel(bio, index=False)
+    bio.seek(0)
+    parsed = pd.read_excel(bio).iloc[0].to_dict()
+
+    ciudadano = CiudadanoService.get_or_create_ciudadano(parsed)
+    assert ciudadano.sexo.sexo == "Masculino"


### PR DESCRIPTION
## Summary
- Allow `get_or_create_ciudadano` to resolve `sexo` by ID when the value is numeric
- Add regression test for Excel import assigning masculine sex from numeric value

## Testing
- `pylint celiaquia/services/ciudadano_service.py tests/test_ciudadano_excel_numeric.py --rcfile=.pylintrc` *(fails: Unable to import 'ciudadanos.models')*
- `pytest tests/test_ciudadano_excel_numeric.py -q` *(fails: No database connection: AttributeError 'NoneType' object has no attribute 'startswith')*

------
https://chatgpt.com/codex/tasks/task_e_68bafa5b9eec832d900b1591ed3156e0