### PR TITLE
Handle phone and postal code in Celiaquia import

### DIFF
--- a/celiaquia/services/importacion_service.py
+++ b/celiaquia/services/importacion_service.py
@@ -158,6 +158,10 @@ class ImportacionService:
             "municipio": "municipio",
             "localidad": "localidad",
             "email": "email",
+            "telefono": "telefono",
+            "codigo_postal": "codigo_postal",
+            "calle": "calle",
+            "altura": "altura",
         }
 
         present = [c for c in df.columns if c in column_map]

--- a/tests/test_importacion_codigo_postal_telefono.py
+++ b/tests/test_importacion_codigo_postal_telefono.py
@@ -1,0 +1,41 @@
+from io import BytesIO
+from datetime import date
+
+import pandas as pd
+import pytest
+from django.contrib.auth import get_user_model
+
+from celiaquia.models import EstadoExpediente, EstadoLegajo, Expediente
+from celiaquia.services.importacion_service import ImportacionService
+from ciudadanos.models import Ciudadano, TipoDocumento
+
+
+@pytest.mark.django_db
+def test_import_with_postal_code_and_phone():
+    user = get_user_model().objects.create(username="tester")
+    estado_exp = EstadoExpediente.objects.create(nombre="CREADO")
+    expediente = Expediente.objects.create(usuario_provincia=user, estado=estado_exp)
+    EstadoLegajo.objects.create(nombre="DOCUMENTO_PENDIENTE")
+    TipoDocumento.objects.create(id=1, tipo="DNI")
+
+    df = pd.DataFrame(
+        [
+            {
+                "apellido": "Perez",
+                "nombre": "Juan",
+                "documento": 12345678,
+                "fecha_nacimiento": date(1990, 1, 1),
+                "telefono": 11223344,
+                "codigo_postal": 1406,
+            }
+        ]
+    )
+    bio = BytesIO()
+    df.to_excel(bio, index=False)
+    bio.seek(0)
+
+    ImportacionService.importar_legajos_desde_excel(expediente, bio, user)
+
+    ciudadano = Ciudadano.objects.get(documento=12345678)
+    assert ciudadano.telefono == 11223344
+    assert ciudadano.codigo_postal == 1406


### PR DESCRIPTION
## Summary
- map `telefono` and `codigo_postal` (plus address fields) when importing Excel data
- test Excel import saving `telefono` and `codigo_postal` on `Ciudadano`

## Testing
- `pytest` *(fails: AttributeError: 'NoneType' object has no attribute 'startswith')*


------
https://chatgpt.com/codex/tasks/task_e_68baff85f8dc832db8ea18600a3e0e18