### PR TITLE
Register AsignacionTecnico in admin

### DIFF
--- a/celiaquia/admin.py
+++ b/celiaquia/admin.py
@@ -47,3 +47,10 @@ class ExpedienteCiudadanoAdmin(admin.ModelAdmin):
     list_display = ("ciudadano", "expediente", "estado", "creado_en")
     list_filter = ("estado",)
     search_fields = ("ciudadano__documento", "ciudadano__nombre", "ciudadano__apellido")
+
+
+@admin.register(AsignacionTecnico)
+class AsignacionTecnicoAdmin(admin.ModelAdmin):
+    list_display = ("expediente", "tecnico", "fecha_asignacion")
+    list_filter = ("fecha_asignacion",)
+    search_fields = ("expediente__id", "tecnico__username")


### PR DESCRIPTION
## Summary
- register AsignacionTecnico in admin with list display, filters and search

## Testing
- `black celiaquia/admin.py`
- `pylint celiaquia/admin.py --rcfile=.pylintrc`
- `djlint celiaquia/templates --configuration=.djlintrc --reformat`
- `docker compose exec django pytest -n auto` *(fails: command not found)*
- `pytest -n auto` *(fails: AttributeError: 'NoneType' object has no attribute 'startswith')*


------
https://chatgpt.com/codex/tasks/task_e_68bb2849ff1c832d9a3ccdd127bbf544