### PR TITLE
refactor: group celiaquia imports in urls

### DIFF
--- a/celiaquia/urls.py
+++ b/celiaquia/urls.py
@@ -1,8 +1,15 @@
 from django.urls import path
-from celiaquia.views.expediente_subsanacion import ExpedienteConfirmSubsanacionView
-from celiaquia.views.pago import PagoExpedienteCreateView, PagoExpedienteDetailView, PagoExpedienteExportView, PagoNominaExportActualView
 from core.decorators import group_required
 
+from celiaquia.views.expediente_subsanacion import (
+    ExpedienteConfirmSubsanacionView,
+)
+from celiaquia.views.pago import (
+    PagoExpedienteCreateView,
+    PagoExpedienteDetailView,
+    PagoExpedienteExportView,
+    PagoNominaExportActualView,
+)
 from celiaquia.views.expediente import (
     ExpedienteListView,
     ExpedienteCreateView,
@@ -17,10 +24,11 @@ from celiaquia.views.expediente import (
     RevisarLegajoView,
     SubirCruceExcelView,
 )
-
 from celiaquia.views.confirm_envio import ExpedienteConfirmView
-from celiaquia.views.legajo import LegajoArchivoUploadView, LegajoSubsanarView
-
+from celiaquia.views.legajo import (
+    LegajoArchivoUploadView,
+    LegajoSubsanarView,
+)
 from celiaquia.views.cupo import (
     CupoDashboardView,
     CupoProvinciaDetailView,


### PR DESCRIPTION
## Summary
- group celiaquia imports into a single block in urls

## Testing
- `black celiaquia/urls.py`
- `pylint celiaquia/urls.py --rcfile=.pylintrc`
- `docker compose exec django pytest -n auto` *(fails: command not found: docker)*

------
https://chatgpt.com/codex/tasks/task_e_68bb284afa48832db395cc5221881ce2