### PR TITLE
Prevent file path usage in CruceService

### DIFF
--- a/celiaquia/tests/test_cruce_service.py
+++ b/celiaquia/tests/test_cruce_service.py
@@ -1,0 +1,17 @@
+import pytest
+from django.core.exceptions import ValidationError
+from django.core.files.uploadedfile import SimpleUploadedFile
+
+from celiaquia.services.cruce_service import CruceService
+
+
+def test_read_file_bytes_disallows_paths():
+    with pytest.raises(ValidationError):
+        CruceService._read_file_bytes("/etc/passwd")
+
+
+def test_read_file_bytes_accepts_uploaded_file():
+    contenido = b"col1,col2\n1,2"
+    archivo = SimpleUploadedFile("test.csv", contenido)
+    resultado = CruceService._read_file_bytes(archivo)
+    assert resultado == contenido


### PR DESCRIPTION
## Summary
- refuse path strings in `_read_file_bytes` and validate file-like inputs
- add tests for safe file byte reading

## Testing
- `black .`
- `djlint . --configuration=.djlintrc --reformat`
- `pylint **/*.py --rcfile=.pylintrc`
- `pytest -q` *(fails: AttributeError 'NoneType' object has no attribute 'startswith')*
- `codeql database analyze codeql-db python-code-scanning.qls --format=sarifv2 --output=codeql-results.sarif` *(command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bb37551c34832da9e7da82e5cac2be