### PR TITLE
Handle generic validation errors in Celiaquia views

### DIFF
--- a/celiaquia/tests/__init__.py
+++ b/celiaquia/tests/__init__.py
@@ -1,0 +1,1 @@
+# Package for celiaquia tests

--- a/celiaquia/tests/test_validation_errors.py
+++ b/celiaquia/tests/test_validation_errors.py
@@ -1,0 +1,111 @@
+# celiaquia/tests/test_validation_errors.py
+"""Tests for validation error handling in celiaquia views."""
+
+import json
+from unittest.mock import MagicMock, patch
+
+from django.core.exceptions import ValidationError
+from django.test import RequestFactory
+
+from celiaquia.views.confirm_envio import ExpedienteConfirmView
+from celiaquia.views.cupo import (
+    CupoBajaLegajoView,
+    CupoProvinciaDetailView,
+    CupoSuspenderLegajoView,
+)
+
+
+class DummyUser:
+    """Simple user stub for request objects."""
+
+    is_staff = True
+    username = "tester"
+
+
+factory = RequestFactory()
+
+
+def test_confirm_envio_validation_error_returns_generic_message():
+    request = factory.post("/expediente/1/confirm/")
+    request.user = DummyUser()
+
+    dummy_exp = type("Exp", (), {"pk": 1, "usuario_provincia": object()})()
+
+    dummy_qs = MagicMock()
+    dummy_qs.select_related.return_value = dummy_qs
+    dummy_qs.filter.return_value = dummy_qs
+    dummy_qs.exists.return_value = False
+
+    with (
+        patch(
+            "celiaquia.views.confirm_envio.get_object_or_404", return_value=dummy_exp
+        ),
+        patch("celiaquia.views.confirm_envio.ExpedienteCiudadano.objects", dummy_qs),
+        patch(
+            "celiaquia.views.confirm_envio.ExpedienteService.confirmar_envio",
+            side_effect=ValidationError("err"),
+        ),
+    ):
+        response = ExpedienteConfirmView.as_view()(request, pk=1)
+
+    assert response.status_code == 400
+    assert json.loads(response.content) == {
+        "success": False,
+        "error": "No se pudo confirmar el envío: revise los datos e intente de nuevo.",
+    }
+
+
+def test_configurar_cupo_validation_error_returns_generic_message():
+    request = factory.post("/cupo/1/", {"accion": "config", "total_asignado": "1"})
+    request.user = DummyUser()
+
+    with (
+        patch("celiaquia.views.cupo.get_object_or_404", return_value=object()),
+        patch(
+            "celiaquia.views.cupo.CupoService.configurar_total",
+            side_effect=ValidationError("err"),
+        ),
+    ):
+        response = CupoProvinciaDetailView.as_view()(request, provincia_id=1)
+
+    assert response.status_code == 400
+    assert json.loads(response.content) == {
+        "success": False,
+        "message": "Error de validación.",
+    }
+
+
+def test_cupo_baja_legajo_validation_error_returns_generic_message():
+    request = factory.post("/cupo/baja/", {"motivo": "x"})
+    request.user = DummyUser()
+
+    with patch(
+        "celiaquia.views.cupo._BaseAccionLegajo._get_legajo_validado",
+        side_effect=ValidationError("err"),
+    ):
+        response = CupoBajaLegajoView.as_view()(request, provincia_id=1, legajo_id=1)
+
+    assert response.status_code == 400
+    assert json.loads(response.content) == {
+        "success": False,
+        "message": "No se pudo validar el legajo.",
+    }
+
+
+def test_cupo_suspender_legajo_validation_error_returns_generic_message():
+    request = factory.post("/cupo/suspender/", {"motivo": "x"})
+    request.user = DummyUser()
+
+    with patch(
+        "celiaquia.views.cupo._BaseAccionLegajo._get_legajo_validado",
+        side_effect=ValidationError("err"),
+    ):
+        response = CupoSuspenderLegajoView.as_view()(
+            request, provincia_id=1, legajo_id=1
+        )
+
+    assert response.status_code == 400
+    assert json.loads(response.content) == {
+        "success": False,
+        "message": "El legajo no es válido.",
+    }

--- a/celiaquia/views/confirm_envio.py
+++ b/celiaquia/views/confirm_envio.py
@@ -1,4 +1,6 @@
 # celiaquia/views/confirm_envio.py
+"""Views for confirming expediente submission."""
+
 import logging
 
 from django.contrib import messages  # ✅ import correcto
@@ -110,8 +112,9 @@ class ExpedienteConfirmView(LoginRequiredMixin, View):
                 }
             )
         except ValidationError as e:
-            logger.warning("Validación en confirmar envío falló: %s", e)
-            return JsonResponse({"success": False, "error": str(e)}, status=400)
+            logger.warning("Validación en confirmar envío falló: %s", e, exc_info=True)
+            msg = "No se pudo confirmar el envío: revise los datos e intente de nuevo."
+            return JsonResponse({"success": False, "error": msg}, status=400)
         except Exception as e:
             logger.error("Error inesperado al confirmar envío: %s", e, exc_info=True)
             return JsonResponse(

--- a/celiaquia/views/cupo.py
+++ b/celiaquia/views/cupo.py
@@ -1,3 +1,6 @@
+# celiaquia/views/cupo.py
+"""Views for cupo management."""
+
 import logging
 from django.db.models import Q
 from django.shortcuts import render, get_object_or_404
@@ -156,7 +159,12 @@ class CupoProvinciaDetailView(View):
                 }
             )
         except ValidationError as ve:
-            return JsonResponse({"success": False, "message": str(ve)}, status=400)
+            logger.warning(
+                "Error de validación al configurar cupo: %s", ve, exc_info=True
+            )
+            return JsonResponse(
+                {"success": False, "message": "Error de validación."}, status=400
+            )
         except Exception as e:
             logger.error("Error al configurar cupo: %s", e, exc_info=True)
             return JsonResponse(
@@ -207,7 +215,11 @@ class CupoBajaLegajoView(_BaseAccionLegajo):
         try:
             legajo = self._get_legajo_validado(provincia_id, legajo_id)
         except ValidationError as ve:
-            return JsonResponse({"success": False, "message": str(ve)}, status=400)
+            logger.warning("Error al validar legajo para baja: %s", ve, exc_info=True)
+            return JsonResponse(
+                {"success": False, "message": "No se pudo validar el legajo."},
+                status=400,
+            )
 
         try:
             CupoService.liberar_slot(
@@ -260,7 +272,13 @@ class CupoSuspenderLegajoView(_BaseAccionLegajo):
         try:
             legajo = self._get_legajo_validado(provincia_id, legajo_id)
         except ValidationError as ve:
-            return JsonResponse({"success": False, "message": str(ve)}, status=400)
+            logger.warning(
+                "Error al validar legajo para suspensión: %s", ve, exc_info=True
+            )
+            return JsonResponse(
+                {"success": False, "message": "El legajo no es válido."},
+                status=400,
+            )
 
         try:
             # IMPORTANTE: suspender (no liberar)


### PR DESCRIPTION
## Summary
- Log and return generic validation errors in confirm envio view
- Improve cupo views with consistent ValidationError handling
- Add tests for validation error responses

## Testing
- `black .`
- `djlint . --configuration=.djlintrc --reformat` *(fails: Aborted)*
- `pylint **/*.py --rcfile=.pylintrc` *(fails: interrupted)*
- `pytest -q` *(fails: AttributeError: 'NoneType' object has no attribute 'startswith')*
- `codeql database analyze` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bb3758d760832daabad9a2a762a068