### PR TITLE
Sanitize alert messages in celiaquia list

### DIFF
--- a/static/custom/js/celiaquia_list.js
+++ b/static/custom/js/celiaquia_list.js
@@ -31,8 +31,25 @@
  * -------------------------------------------------------------------------
  */
 
+// Added escapeHtml helper and sanitized alert messages to prevent HTML injection.
+
 (function () {
   // ---------- Utils ----------
+  function escapeHtml(str) {
+    return String(str)
+      .replace(/&/g, '&amp;')
+      .replace(/</g, '&lt;')
+      .replace(/>/g, '&gt;')
+      .replace(/"/g, '&quot;')
+      .replace(/'/g, '&#39;')
+      .replace(/`/g, '&#96;');
+  }
+  if (typeof window !== 'undefined') {
+    window.escapeHtml = escapeHtml;
+  }
+  if (typeof module !== 'undefined' && module.exports) {
+    module.exports.escapeHtml = escapeHtml;
+  }
   function getCookie(name) {
     const m = document.cookie.match(new RegExp('(^| )' + name + '=([^;]+)'));
     return m ? m[2] : null;
@@ -52,9 +69,10 @@
   }
   function showAlert(type, message) {
     const zone = alertsZone();
+    const safeMessage = escapeHtml(message);
     zone.innerHTML = `
       <div class="alert alert-${type} alert-dismissible fade show" role="alert">
-        ${message}
+        ${safeMessage}
         <button type="button" class="btn-close" data-bs-dismiss="alert"></button>
       </div>`;
   }

--- a/tests/test_escape_html.js
+++ b/tests/test_escape_html.js
@@ -1,0 +1,9 @@
+const assert = require('assert');
+// Stub minimal document to satisfy celiaquia_list.js when required in Node
+global.document = { addEventListener: () => {} };
+const { escapeHtml } = require('../static/custom/js/celiaquia_list.js');
+
+const raw = '<strong>hi</strong> & `test`';
+const expected = '&lt;strong&gt;hi&lt;/strong&gt; &amp; &#96;test&#96;';
+assert.strictEqual(escapeHtml(raw), expected);
+console.log('escapeHtml escapes HTML tags correctly');


### PR DESCRIPTION
## Summary
- escape HTML in celiaquia list alerts via new escapeHtml helper
- add node test verifying HTML escaping

## Testing
- `black .`
- `djlint .`
- `pylint **/*.py --rcfile=.pylintrc`
- `pytest -q` *(fails: AttributeError: 'NoneType' object has no attribute 'startswith')*
- `node tests/test_escape_html.js`
- `codeql database create codeql-db --language=python --source-root .` *(command not found: codeql)*

------
https://chatgpt.com/codex/tasks/task_e_68bb37598434832db403ea5eec1385ca