### PR TITLE
feat: sanitize alerta messages

### DIFF
--- a/static/custom/js/cupo_provincia.js
+++ b/static/custom/js/cupo_provincia.js
@@ -1,4 +1,5 @@
 // static/custom/js/cupo_provincia.js
+// Added escapeHtml utility to sanitize alert messages and avoid XSS.
 (function () {
   // --- Config tomada del HTML (data-*) ---
   const root = document.getElementById("cupo-root");
@@ -17,12 +18,20 @@
   }
   const csrftoken = getCookie("csrftoken");
 
+  // --- Utilidades ---
+  const escapeHtml = (str) =>
+    String(str).replace(
+      /[&<>"']/g,
+      (c) =>
+        ({ "&": "&amp;", "<": "&lt;", ">": "&gt;", '"': "&quot;", "'": "&#39;" }[c])
+    );
+
   // --- Alertas ---
   const alerta = (msg, kind = "success") => {
     const el = document.getElementById("alerts");
     if (!el) return;
     el.innerHTML = `<div class="alert alert-${kind} alert-dismissible fade show" role="alert">
-      ${msg}
+      ${escapeHtml(msg)}
       <button type="button" class="btn-close" data-bs-dismiss="alert" aria-label="Cerrar"></button>
     </div>`;
   };

--- a/tests/escape_html.test.js
+++ b/tests/escape_html.test.js
@@ -1,0 +1,14 @@
+// Manual test for escapeHtml utility in cupo_provincia.js
+// Run with: node tests/escape_html.test.js
+const escapeHtml = (str) =>
+  String(str).replace(/[&<>"']/g, (c) => ({
+    '&': '&amp;',
+    '<': '&lt;',
+    '>': '&gt;',
+    '"': '&quot;',
+    "'": '&#39;',
+  }[c]));
+
+const unsafe = '<script>alert("xss")</script>';
+const safe = escapeHtml(unsafe);
+console.log('Escaped output:', safe);


### PR DESCRIPTION
## Summary
- prevent XSS by escaping messages in `alerta`
- add manual JS test for escapeHtml utility

## Testing
- `node tests/escape_html.test.js`
- `black .`
- `djlint .`
- `pylint **/*.py --rcfile=.pylintrc`
- `pytest -q` *(fails: AttributeError: 'NoneType' object has no attribute 'startswith')*
- `codeql version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bb375aa1ac832da0701327be57003c