### PR TITLE
Sanitize alert text in expediente detail

### DIFF
--- a/static/custom/js/utils.js
+++ b/static/custom/js/utils.js
@@ -1,0 +1,24 @@
+/* Shared utility helpers */
+/**
+ * escapeHtml converts a string to its HTML-escaped representation.
+ * This prevents browsers from interpreting user-controlled content
+ * as markup, mitigating XSS.
+ * @param {string} str
+ * @returns {string}
+ */
+function escapeHtml(str) {
+  return String(str ?? '')
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&#39;');
+}
+
+// Expose helper to browser globals and Node tests
+if (typeof window !== 'undefined') {
+  window.escapeHtml = escapeHtml;
+}
+if (typeof module !== 'undefined') {
+  module.exports = { escapeHtml };
+}

--- a/tests/js/showAlert.test.js
+++ b/tests/js/showAlert.test.js
@@ -1,0 +1,52 @@
+const { escapeHtml } = require('../../static/custom/js/utils.js');
+
+// Minimal DOM stubs
+const documentStub = {
+  elements: {},
+  body: {
+    prepend(el) {
+      // no-op for test
+    },
+  },
+  getElementById(id) {
+    return this.elements[id] || null;
+  },
+  createElement(tag) {
+    const el = {
+      tagName: tag,
+      innerHTML: '',
+      style: {},
+      prepend() {},
+      querySelector() { return null; },
+      set id(value) {
+        this._id = value;
+        documentStub.elements[value] = this;
+      },
+      get id() {
+        return this._id;
+      },
+    };
+    return el;
+  },
+  querySelector() {
+    return null;
+  },
+  addEventListener() {},
+};
+
+global.document = documentStub;
+global.escapeHtml = escapeHtml;
+
+const { showAlert } = require('../../static/custom/js/expediente_detail.js');
+
+// Test that malicious HTML is rendered as text
+const payload = '<img src=x onerror=alert(1) />';
+showAlert('danger', payload);
+const zone = documentStub.getElementById('expediente-alerts');
+if (!zone || zone.innerHTML.includes('<img')) {
+  throw new Error('HTML was not escaped');
+}
+if (!zone.innerHTML.includes('&lt;img')) {
+  throw new Error('Escaped text missing');
+}
+console.log('showAlert escaped HTML correctly');


### PR DESCRIPTION
## Summary
- add shared `escapeHtml` helper and use it across the expediente detail alerts
- refactor `showAlert` to escape dynamic parts and accept multiple text segments
- include Node-based test verifying malicious HTML is rendered as plain text

## Testing
- `node tests/js/showAlert.test.js`
- `black .`
- `djlint .` *(errors: Tag seems to be an orphan, Duplicate attribute found, Empty tag pair found)*
- `pylint **/*.py --rcfile=.pylintrc`
- `pytest -q` *(fails: AttributeError: 'NoneType' object has no attribute 'startswith' from Django database setup)*
- `codeql --version` *(command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bb375bc06c832db61b07aa343997e9