### PR TITLE
Eliminar temporizador en recarga de expediente

### DIFF
--- a/static/custom/js/celiaquia_list.js
+++ b/static/custom/js/celiaquia_list.js
@@ -175,11 +175,15 @@
           }
           const created = (data && data.creados) ?? 'los';
           const errs = (data && data.errores) ? ` (${data.errores} errores)` : '';
-          showAlert('success', `Expediente procesado. Se crearon ${created} legajos.${errs} Pasó a <strong>EN ESPERA</strong>.`);
-          setTimeout(() => window.location.reload(), 900);
+          showAlert(
+            'success',
+            `Expediente procesado. Se crearon ${created} legajos.${errs} Pasó a <strong>EN ESPERA</strong>.`
+          );
         } catch (err) {
           console.error('Procesar expediente:', err);
           showAlert('danger', 'No se pudo procesar el expediente. ' + err.message);
+        } finally {
+          window.location.reload();
         }
       })();
     });


### PR DESCRIPTION
## Summary
- Usar bloque `finally` para recargar la página tras procesar expedientes sin `setTimeout`

## Testing
- `node --check static/custom/js/celiaquia_list.js`
- `curl -I http://localhost:8000/static/custom/js/celiaquia_list.js`
- `pytest` *(falla: AttributeError: 'NoneType' object has no attribute 'startswith')*

------
https://chatgpt.com/codex/tasks/task_e_68bec997c750832d963ee4d1b7a8bf4f