### PR TITLE
Ensure utils script loads before expediente detail logic

### DIFF
--- a/celiaquia/templates/celiaquia/expediente_detail.html
+++ b/celiaquia/templates/celiaquia/expediente_detail.html
@@ -619,5 +619,6 @@
     window.REVISAR_URL_TEMPLATE  = "{% url 'legajo_revisar' expediente.pk 0 %}".replace("/0/", "/{id}/");
     window.CONFIRM_SUBS_URL      = "{% url 'expediente_confirm_subsanacion' expediente.pk %}";
     </script>
+    <script src="{% static 'custom/js/utils.js' %}"></script>
     <script src="{% static 'custom/js/expediente_detail.js' %}"></script>
 {% endblock %}


### PR DESCRIPTION
## Summary
- include `custom/js/utils.js` before `custom/js/expediente_detail.js` in expediente detail template

## Testing
- `node -e "global.window={}; require('./static/custom/js/utils.js'); console.log('escapeHtml defined:', typeof window.escapeHtml === 'function');"`
- `node -e "global.window={PROCESS_URL:'/',location:{reload:()=>console.log('reloaded')},CSRF_TOKEN:'token'};const btn={disabled:false,innerHTML:'Procesar',addEventListener:(e,cb)=>{global.btnClick=cb}};global.document={addEventListener:(e,cb)=>{if(e==='DOMContentLoaded')cb();},getElementById:(id)=>id==='btn-process-expediente'?btn:null,querySelector:()=>null,querySelectorAll:()=>[],createElement:()=>({id:'expediente-alerts',innerHTML:'',prepend:()=>{}}),body:{prepend:()=>{}}};global.fetch=async()=>({redirected:false,headers:{get:()=> 'application/json'},ok:true,json:async()=>({message:'ok'})});global.setTimeout=(cb,ms)=>{cb();};require('./static/custom/js/utils.js');global.escapeHtml=window.escapeHtml;require('./static/custom/js/expediente_detail.js');btnClick();"`
- `node tests/js/showAlert.test.js`
- `black --check celiaquia/templates/celiaquia/expediente_detail.html` *(fails: Cannot parse)*
- `pylint celiaquia/models.py --rcfile=.pylintrc`
- `djlint celiaquia/templates/celiaquia/expediente_detail.html --configuration=.djlintrc --check` *(hangs)*
- `pytest -q` *(fails: AttributeError: 'NoneType' object has no attribute 'startswith')*

------
https://chatgpt.com/codex/tasks/task_e_68bef0c65870832daf11f756eecce3ba