### PR TITLE
Restaurar boton de procesar tras timeout

### DIFF
--- a/static/custom/js/expediente_detail.js
+++ b/static/custom/js/expediente_detail.js
@@ -141,10 +141,11 @@ document.addEventListener('DOMContentLoaded', () => {
   if (btnProcess) {
     btnProcess.addEventListener('click', async () => {
       btnProcess.disabled = true;
-      const origHTML = btnProcess.innerHTML;
-      btnProcess.innerHTML = '<span class="spinner-border spinner-border-sm" role="status"></span> Procesando...';
-
+      let origHTML;
       try {
+        origHTML = btnProcess.innerHTML;
+        btnProcess.innerHTML = '<span class="spinner-border spinner-border-sm" role="status"></span> Procesando...';
+
         if (!window.PROCESS_URL) throw new Error('No se configuró PROCESS_URL.');
 
         const resp = await fetch(window.PROCESS_URL, {
@@ -184,12 +185,16 @@ document.addEventListener('DOMContentLoaded', () => {
         showAlert('success', '¡Listo! ', baseMsg, errorExtra);
 
         setTimeout(() => window.location.reload(), 1000);
-
       } catch (err) {
         console.error('Error procesar expediente:', err);
         showAlert('danger', 'Error al procesar el expediente: ', err.message);
-        btnProcess.disabled = false;
         btnProcess.innerHTML = origHTML;
+        btnProcess.disabled = false;
+      } finally {
+        setTimeout(() => {
+          btnProcess.innerHTML = origHTML;
+          btnProcess.disabled = false;
+        }, 1500);
       }
     });
   }


### PR DESCRIPTION
## Summary
- Restaura el botón de procesamiento tras intentar recargar el expediente, asegurando que vuelva a su estado original si la recarga no ocurre.

## Testing
- `docker compose exec django pytest -n auto` *(fails: command not found: docker)*
- `node -e "const btnProcess={innerHTML:'Process',disabled:false}; let origHTML; (async()=>{btnProcess.disabled=true; try {origHTML=btnProcess.innerHTML; btnProcess.innerHTML='Processing...'; setTimeout(()=>{},1000);} finally { setTimeout(()=>{btnProcess.innerHTML=origHTML; btnProcess.disabled=false; console.log('restored',btnProcess.innerHTML,btnProcess.disabled);},1500);} })(); setTimeout(()=>{},2000);"`


------
https://chatgpt.com/codex/tasks/task_e_68bef0c839c8832dbba448410de8f0ba