### PR TITLE
fix: update state badge column in celiaquia list

### DIFF
--- a/static/custom/js/celiaquia_list.js
+++ b/static/custom/js/celiaquia_list.js
@@ -130,8 +130,8 @@
 
   // ---------- Helpers de UI ----------
   function markRowRecepcionado(row) {
-    // 1) Actualizar badge de estado (3ra columna)
-    const estadoCell = row.querySelector('td:nth-child(3) .badge');
+    // 1) Actualizar badge de estado (4ta columna)
+    const estadoCell = row.querySelector('td:nth-child(4) .badge');
     if (estadoCell) {
       estadoCell.textContent = 'Recepcionado';
       estadoCell.className = estadoCell.className
@@ -279,7 +279,7 @@
           }
           showAlert('success', 'Técnico asignado correctamente. El expediente está en ASIGNADO.');
           // Actualizamos badge a ASIGNADO sin recargar
-          const estadoCell = row.querySelector('td:nth-child(3) .badge');
+          const estadoCell = row.querySelector('td:nth-child(4) .badge');
           if (estadoCell) {
             estadoCell.textContent = 'Asignado';
             estadoCell.className = estadoCell.className.replace(/\bbg-\w+\b/g, '').trim() + ' bg-primary';


### PR DESCRIPTION
## Summary
- adjust state badge updates to new fourth column in `celiaquia_list.js`

## Testing
- `pytest -q` *(fails: AttributeError: 'NoneType' object has no attribute 'startswith')*
- `black --check static/custom/js/celiaquia_list.js` *(fails: Cannot parse: 1:0: /* static/custom/js/celiaquia_list.js)*
- `pylint static/custom/js/celiaquia_list.js` *(fails: Parsing failed: 'invalid character' error)*
- `djlint static/custom/js/celiaquia_list.js` *(fails: H037 Duplicate attribute found. class)*

------
https://chatgpt.com/codex/tasks/task_e_68bf04fe38c4832dba88c90dd182e002