### PR TITLE
Mostrar provincia e ID en listado de expedientes

### DIFF
--- a/celiaquia/templates/celiaquia/expediente_list.html
+++ b/celiaquia/templates/celiaquia/expediente_list.html
@@ -44,7 +44,9 @@
             <table class="table table-hover table-striped mb-0">
                 <thead class="table-light">
                     <tr>
+                        <th>ID</th>
                         <th>Fecha creación</th>
+                        <th>Provincia</th>
                         <th>Estado</th>
                         {% if request.user|has_group:"CoordinadorCeliaquia" or request.user|has_group:"TecnicoCeliaquia" %}
                             <th>Técnico</th>
@@ -55,7 +57,9 @@
                 <tbody>
                     {% for exp in expedientes %}
                         <tr data-exp-id="{{ exp.pk }}">
+                            <td>{{ exp.pk }}</td>
                             <td>{{ exp.fecha_creacion|date:"d/m/Y H:i" }}</td>
+                            <td>{{ exp.provincia }}</td>
                             <td>
                                 <span class="badge {% if exp.estado.nombre == 'CREADO' %}bg-secondary {% elif exp.estado.nombre == 'EN_ESPERA' %}bg-info {% elif exp.estado.nombre == 'CONFIRMACION_DE_ENVIO' %}bg-warning {% elif exp.estado.nombre == 'RECEPCIONADO' %}bg-secondary {% elif exp.estado.nombre == 'ASIGNADO' %}bg-primary {% elif exp.estado.nombre == 'PROCESO_DE_CRUCE' %}bg-dark {% elif exp.estado.nombre == 'CRUCE_FINALIZADO' %}bg-success {% else %}bg-light text-dark{% endif %}">
                                     {{ exp.estado.display_name }}
@@ -135,7 +139,7 @@
                         </tr>
                     {% empty %}
                         <tr>
-                            <td colspan="{% if request.user|has_group:'CoordinadorCeliaquia' or request.user|has_group:'TecnicoCeliaquia' %}5{% else %}4{% endif %}"
+                            <td colspan="{% if request.user|has_group:'CoordinadorCeliaquia' or request.user|has_group:'TecnicoCeliaquia' %}6{% else %}5{% endif %}"
                                 class="text-center text-muted py-3">No hay expedientes registrados.</td>
                         </tr>
                     {% endfor %}

--- a/celiaquia/tests/test_expediente_list.py
+++ b/celiaquia/tests/test_expediente_list.py
@@ -1,0 +1,25 @@
+import pytest
+from django.urls import reverse
+from django.contrib.auth.models import User, Group
+
+from users.models import Profile
+from core.models import Provincia
+from celiaquia.models import Expediente, EstadoExpediente
+
+
+@pytest.mark.django_db
+def test_expediente_list_displays_id_and_provincia(client):
+    grupo = Group.objects.create(name="ProvinciaCeliaquia")
+    provincia = Provincia.objects.create(nombre="Buenos Aires")
+    user = User.objects.create_user(username="prov", password="pass")
+    Profile.objects.create(user=user, es_usuario_provincial=True, provincia=provincia)
+    user.groups.add(grupo)
+    estado = EstadoExpediente.objects.create(nombre="CREADO")
+    expediente = Expediente.objects.create(usuario_provincia=user, estado=estado)
+
+    client.force_login(user)
+    response = client.get(reverse("expediente_list"))
+
+    content = response.content.decode()
+    assert str(expediente.pk) in content
+    assert provincia.nombre in content

--- a/celiaquia/views/expediente.py
+++ b/celiaquia/views/expediente.py
@@ -93,12 +93,18 @@ class ExpedienteListView(ListView):
     def get_queryset(self):
         user = self.request.user
         qs = Expediente.objects.select_related(
-            "estado", "asignacion_tecnico__tecnico", "usuario_provincia"
+            "estado",
+            "asignacion_tecnico__tecnico",
+            "usuario_provincia__profile__provincia",
         ).only(
             "id",
             "fecha_creacion",
             "estado__nombre",
             "usuario_provincia_id",
+            "usuario_provincia__profile__id",
+            "usuario_provincia__profile__provincia_id",
+            "usuario_provincia__profile__provincia__id",
+            "usuario_provincia__profile__provincia__nombre",
             "asignacion_tecnico__tecnico_id",
         )
         if _is_admin(user):


### PR DESCRIPTION
## Summary
- Muestra el ID y la provincia del expediente en la tabla de listados
- Optimiza la consulta para traer los datos de provincia de forma eficiente
- Agrega prueba que verifica la presencia de ID y provincia en la vista de listados

## Testing
- `black .`
- `djlint . --configuration=.djlintrc --reformat`
- `pylint celiaquia/views/expediente.py celiaquia/tests/test_expediente_list.py --rcfile=.pylintrc`
- `pytest celiaquia/tests/test_expediente_list.py -n auto` *(falla: AttributeError: 'NoneType' object has no attribute 'startswith')*


------
https://chatgpt.com/codex/tasks/task_e_68bf04e6e65c832dab77dd9a03302983