### PR TITLE
Add Excel template export for expedientes

### DIFF
--- a/celiaquia/services/importacion_service.py
+++ b/celiaquia/services/importacion_service.py
@@ -54,6 +54,39 @@ ESTADOS_PRE_CUPO = [
 
 class ImportacionService:
     @staticmethod
+    def generar_plantilla_excel() -> bytes:
+        """Genera y devuelve un archivo de Excel vacío para importar expedientes.
+
+        Returns
+        -------
+        bytes
+            Contenido binario del archivo XLSX con las columnas necesarias
+            para la importación de legajos en un expediente.
+        """
+
+        columnas = [
+            "apellido",
+            "nombre",
+            "documento",
+            "fecha_nacimiento",
+            "tipo_documento",
+            "sexo",
+            "nacionalidad",
+            "provincia",
+            "municipio",
+            "localidad",
+            "calle",
+            "altura",
+            "codigo_postal",
+            "telefono",
+            "email",
+        ]
+        df = pd.DataFrame(columns=columnas)
+        output = BytesIO()
+        df.to_excel(output, index=False, engine="openpyxl")
+        return output.getvalue()
+
+    @staticmethod
     def preview_excel(archivo_excel, max_rows=5):
         try:
             archivo_excel.open()

--- a/celiaquia/templates/celiaquia/expediente_form.html
+++ b/celiaquia/templates/celiaquia/expediente_form.html
@@ -1,4 +1,4 @@
-{# templates/celiaquia/expediente_form.html #}
+{# templates/celiaquia/expediente_form.html - incluye botón para descargar plantilla #}
 {% extends "includes/main.html" %}
 {% load static crispy_forms_tags %}
 {% block title %}
@@ -28,6 +28,8 @@
                         <div class="d-flex justify-content-between mt-3">
                             <button type="button" id="btn-preview" class="btn btn-outline-secondary">Previsualizar Excel</button>
                             <div>
+                                <a class="btn btn-outline-primary me-2"
+                                   href="{% url 'expediente_plantilla_excel' %}">Descargar plantilla</a>
                                 <button type="submit" class="btn btn-success me-2">Guardar</button>
                                 <a href="{% url 'expediente_list' %}" class="btn btn-secondary">Cancelar</a>
                             </div>

--- a/celiaquia/tests/test_expediente_plantilla_excel.py
+++ b/celiaquia/tests/test_expediente_plantilla_excel.py
@@ -1,0 +1,42 @@
+import pytest
+from django.urls import reverse
+from django.contrib.auth.models import User, Group
+from io import BytesIO
+from openpyxl import load_workbook
+
+from users.models import Profile
+from core.models import Provincia
+
+
+@pytest.mark.django_db
+def test_descargar_plantilla_excel(client):
+    grupo = Group.objects.create(name="ProvinciaCeliaquia")
+    provincia = Provincia.objects.create(nombre="Buenos Aires")
+    user = User.objects.create_user(username="prov", password="pass")
+    Profile.objects.create(user=user, es_usuario_provincial=True, provincia=provincia)
+    user.groups.add(grupo)
+
+    client.force_login(user)
+    response = client.get(reverse("expediente_plantilla_excel"))
+    assert response.status_code == 200
+
+    wb = load_workbook(BytesIO(response.content))
+    ws = wb.active
+    header = [cell.value for cell in next(ws.iter_rows(max_row=1))]
+    assert header == [
+        "apellido",
+        "nombre",
+        "documento",
+        "fecha_nacimiento",
+        "tipo_documento",
+        "sexo",
+        "nacionalidad",
+        "provincia",
+        "municipio",
+        "localidad",
+        "calle",
+        "altura",
+        "codigo_postal",
+        "telefono",
+        "email",
+    ]

--- a/celiaquia/urls.py
+++ b/celiaquia/urls.py
@@ -16,6 +16,7 @@ from celiaquia.views.expediente import (
     ExpedienteDetailView,
     ExpedienteUpdateView,
     ExpedientePreviewExcelView,
+    ExpedientePlantillaExcelView,
     ExpedienteImportView,
     AsignarTecnicoView,
     CrearLegajosView,
@@ -66,6 +67,11 @@ urlpatterns = [
         "expedientes/preview_excel/",
         group_required(["ProvinciaCeliaquia"])(ExpedientePreviewExcelView.as_view()),
         name="expediente_preview_excel",
+    ),
+    path(
+        "expedientes/plantilla_excel/",
+        group_required(["ProvinciaCeliaquia"])(ExpedientePlantillaExcelView.as_view()),
+        name="expediente_plantilla_excel",
     ),
     path(
         "expedientes/<int:pk>/",

--- a/celiaquia/views/expediente.py
+++ b/celiaquia/views/expediente.py
@@ -10,6 +10,7 @@ from django.urls import reverse_lazy
 from django.shortcuts import get_object_or_404, redirect
 from django.http import (
     JsonResponse,
+    HttpResponse,
     HttpResponseBadRequest,
     HttpResponseNotAllowed,
 )
@@ -241,6 +242,21 @@ class CrearLegajosView(View):
             else:
                 existentes += 1
         return JsonResponse({"creados": creados, "existentes": existentes})
+
+
+class ExpedientePlantillaExcelView(View):
+    """Genera un archivo de Excel vacío con los campos requeridos para un expediente."""
+
+    def get(self, request, *args, **kwargs):
+        content = ImportacionService.generar_plantilla_excel()
+        response = HttpResponse(
+            content,
+            content_type="application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
+        )
+        response["Content-Disposition"] = (
+            'attachment; filename="plantilla_expediente.xlsx"'
+        )
+        return response
 
 
 @method_decorator(csrf_protect, name="dispatch")


### PR DESCRIPTION
## Summary
- allow generating empty Excel templates for expedientes
- expose download endpoint and link from expediente form
- cover Excel template download with a new test

## Testing
- `black .`
- `pylint **/*.py --rcfile=.pylintrc`
- `djlint . --configuration=.djlintrc --reformat`
- `pytest pytest` *(fails: OperationalError: near "SHOW": syntax error)*

------
https://chatgpt.com/codex/tasks/task_e_68bf0eb3420c832d89b9b1667f837864