### PR TITLE
Add localidades lookup modal for expedientes

### DIFF
--- a/celiaquia/templates/celiaquia/expediente_form.html
+++ b/celiaquia/templates/celiaquia/expediente_form.html
@@ -1,4 +1,4 @@
-{# templates/celiaquia/expediente_form.html - incluye botón para descargar plantilla #}
+{# templates/celiaquia/expediente_form.html - incluye botón para descargar plantilla y buscador de IDs #}
 {% extends "includes/main.html" %}
 {% load static crispy_forms_tags %}
 {% block title %}
@@ -26,7 +26,15 @@
                         {# Contenedor de error para la previsualización #}
                         <div id="preview-error" class="text-danger mt-2"></div>
                         <div class="d-flex justify-content-between mt-3">
-                            <button type="button" id="btn-preview" class="btn btn-outline-secondary">Previsualizar Excel</button>
+                            <div>
+                                <button type="button"
+                                        class="btn btn-outline-info me-2"
+                                        data-bs-toggle="modal"
+                                        data-bs-target="#localidadesModal">
+                                    <i class="bi bi-search"></i>
+                                </button>
+                                <button type="button" id="btn-preview" class="btn btn-outline-secondary">Previsualizar Excel</button>
+                            </div>
                             <div>
                                 <a class="btn btn-outline-primary me-2"
                                    href="{% url 'expediente_plantilla_excel' %}">Descargar plantilla</a>
@@ -52,9 +60,64 @@
             </div>
         </div>
     </div>
+    <!-- Modal con buscador de localidades e IDs -->
+    <div class="modal fade"
+         id="localidadesModal"
+         tabindex="-1"
+         aria-hidden="true">
+        <div class="modal-dialog modal-lg">
+            <div class="modal-content">
+                <div class="modal-header">
+                    <h5 class="modal-title">Buscar Localidades</h5>
+                    <button type="button"
+                            class="btn-close"
+                            data-bs-dismiss="modal"
+                            aria-label="Close"></button>
+                </div>
+                <div class="modal-body">
+                    <div class="row mb-3">
+                        <div class="col">
+                            <select id="filtro-provincia" class="form-select"></select>
+                        </div>
+                        <div class="col">
+                            <select id="filtro-municipio" class="form-select"></select>
+                        </div>
+                        <div class="col">
+                            <select id="filtro-localidad" class="form-select"></select>
+                        </div>
+                    </div>
+                    <div class="table-responsive">
+                        <table class="table table-striped">
+                            <thead>
+                                <tr>
+                                    <th>ID</th>
+                                    <th>Nombre</th>
+                                    <th>Municipio</th>
+                                    <th>Provincia</th>
+                                </tr>
+                            </thead>
+                            <tbody id="tabla-localidades">
+                            </tbody>
+                        </table>
+                    </div>
+                </div>
+                <div class="modal-footer">
+                    <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Cerrar</button>
+                </div>
+            </div>
+        </div>
+    </div>
 {% endblock %}
 {% block customJS %}
-    {# Inyectamos la URL de preview antes del script #}
-    <script type="text/javascript">window.PREVIEW_URL = "{% url 'expediente_preview_excel' %}";</script>
+    {# Datos de provincias para el buscador #}
+    <script id="provincias-data" type="application/json">[
+        {% for p in provincias %}{"id": {{ p.id }}, "nombre": "{{ p.nombre }}"}{% if not forloop.last %},{% endif %}{% endfor %}
+    ]
+    </script>
+    <script type="text/javascript">
+        window.PREVIEW_URL = "{% url 'expediente_preview_excel' %}";
+        window.EXPEDIENTE_LOCALIDADES_URL = "{% url 'expediente_localidades_lookup' %}";
+    </script>
+    <script src="{% static 'custom/js/localidades_modal.js' %}"></script>
     <script src="{% static 'custom/js/celiaquia.js' %}"></script>
 {% endblock %}

--- a/celiaquia/tests/test_localidades_lookup.py
+++ b/celiaquia/tests/test_localidades_lookup.py
@@ -1,0 +1,44 @@
+import pytest
+from django.urls import reverse
+from django.contrib.auth.models import Group, User
+
+from core.models import Provincia, Municipio, Localidad
+from users.models import Profile
+
+
+@pytest.mark.django_db
+def test_localidades_lookup_filters(client):
+    grupo = Group.objects.create(name="ProvinciaCeliaquia")
+
+    prov1 = Provincia.objects.create(nombre="Buenos Aires")
+    muni1 = Municipio.objects.create(nombre="La Plata", provincia=prov1)
+    loc1 = Localidad.objects.create(nombre="Centro", municipio=muni1)
+
+    prov2 = Provincia.objects.create(nombre="Cordoba")
+    muni2 = Municipio.objects.create(nombre="Capital", provincia=prov2)
+    Localidad.objects.create(nombre="Cba Centro", municipio=muni2)
+
+    user = User.objects.create_user(username="prov", password="pass")
+    Profile.objects.create(user=user, es_usuario_provincial=True, provincia=prov1)
+    user.groups.add(grupo)
+    client.force_login(user)
+
+    url = reverse("expediente_localidades_lookup")
+
+    resp = client.get(url)
+    data = resp.json()
+    assert any(item["localidad_id"] == loc1.id for item in data)
+
+    resp = client.get(url, {"provincia": prov1.id})
+    data = resp.json()
+    assert len(data) == 1
+    assert data[0]["localidad_id"] == loc1.id
+    assert data[0]["provincia_id"] == prov1.id
+    assert data[0]["municipio_id"] == muni1.id
+    assert data[0]["provincia_nombre"] == prov1.nombre
+    assert data[0]["municipio_nombre"] == muni1.nombre
+
+    resp = client.get(url, {"provincia": prov1.id, "municipio": muni1.id})
+    data = resp.json()
+    assert len(data) == 1
+    assert data[0]["localidad_id"] == loc1.id

--- a/celiaquia/urls.py
+++ b/celiaquia/urls.py
@@ -24,6 +24,7 @@ from celiaquia.views.expediente import (
     RecepcionarExpedienteView,
     RevisarLegajoView,
     SubirCruceExcelView,
+    LocalidadesLookupView,
 )
 from celiaquia.views.confirm_envio import ExpedienteConfirmView
 from celiaquia.views.legajo import (
@@ -72,6 +73,11 @@ urlpatterns = [
         "expedientes/plantilla_excel/",
         group_required(["ProvinciaCeliaquia"])(ExpedientePlantillaExcelView.as_view()),
         name="expediente_plantilla_excel",
+    ),
+    path(
+        "expedientes/localidades_lookup/",
+        group_required(["ProvinciaCeliaquia"])(LocalidadesLookupView.as_view()),
+        name="expediente_localidades_lookup",
     ),
     path(
         "expedientes/<int:pk>/",

--- a/static/custom/js/localidades_modal.js
+++ b/static/custom/js/localidades_modal.js
@@ -1,0 +1,104 @@
+/**
+ * Funcionalidades para el modal de búsqueda de localidades.
+ */
+
+document.addEventListener('DOMContentLoaded', () => {
+  const provinciasDataEl = document.getElementById('provincias-data');
+  let provincias = [];
+  if (provinciasDataEl) {
+    try {
+      provincias = JSON.parse(provinciasDataEl.textContent);
+    } catch (e) {
+      console.error('Error al parsear provincias', e);
+    }
+  }
+
+  const provinciaSelect = document.getElementById('filtro-provincia');
+  const municipioSelect = document.getElementById('filtro-municipio');
+  const localidadSelect = document.getElementById('filtro-localidad');
+  const tablaLocalidades = document.getElementById('tabla-localidades');
+
+  /**
+   * Llena el select de provincias con los datos del contexto.
+   */
+  function poblarProvincias() {
+    if (!provinciaSelect) return;
+    provinciaSelect.innerHTML = '<option value="">Todas</option>';
+    provincias.forEach((p) => {
+      const opt = document.createElement('option');
+      opt.value = p.id;
+      opt.textContent = p.nombre;
+      provinciaSelect.appendChild(opt);
+    });
+  }
+
+  /**
+   * Renderiza la tabla de localidades y actualiza selects de municipio y localidad.
+   *
+   * @param {Array} data - Datos recibidos del servidor.
+   */
+  function renderLocalidades(data) {
+    tablaLocalidades.innerHTML = '';
+    municipioSelect.innerHTML = '<option value="">Todos</option>';
+    localidadSelect.innerHTML = '<option value="">Todas</option>';
+
+    const municipiosUnicos = new Map();
+
+    data.forEach((item) => {
+      const tr = document.createElement('tr');
+      tr.innerHTML = `<td>${item.localidad_id}</td><td>${item.localidad_nombre}</td><td>${item.municipio_nombre}</td><td>${item.provincia_nombre}</td>`;
+      tablaLocalidades.appendChild(tr);
+
+      if (!municipiosUnicos.has(item.municipio_id)) {
+        municipiosUnicos.set(item.municipio_id, item.municipio_nombre);
+      }
+
+      const locOpt = document.createElement('option');
+      locOpt.value = item.localidad_id;
+      locOpt.textContent = item.localidad_nombre;
+      localidadSelect.appendChild(locOpt);
+    });
+
+    municipiosUnicos.forEach((nombre, id) => {
+      const opt = document.createElement('option');
+      opt.value = id;
+      opt.textContent = nombre;
+      municipioSelect.appendChild(opt);
+    });
+  }
+
+  /**
+   * Solicita al servidor las localidades filtradas y actualiza la tabla.
+   */
+  function actualizarLocalidades() {
+    const params = new URLSearchParams();
+    if (provinciaSelect.value) params.append('provincia', provinciaSelect.value);
+    if (municipioSelect.value) params.append('municipio', municipioSelect.value);
+
+    fetch(`${window.EXPEDIENTE_LOCALIDADES_URL}?${params.toString()}`)
+      .then((resp) => resp.json())
+      .then((data) => renderLocalidades(data));
+  }
+
+  poblarProvincias();
+  provinciaSelect.addEventListener('change', () => {
+    municipioSelect.innerHTML = '<option value="">Todos</option>';
+    localidadSelect.innerHTML = '<option value="">Todas</option>';
+    actualizarLocalidades();
+  });
+  municipioSelect.addEventListener('change', actualizarLocalidades);
+});
+
+/**
+ * Obtiene el valor de una cookie dada su clave.
+ *
+ * @param {string} name - Nombre de la cookie.
+ * @returns {string|null} Valor de la cookie o null si no existe.
+ */
+function getCookie(name) {
+  const match = document.cookie.match(new RegExp('(^|; )' + name + '=([^;]*)'));
+  return match ? decodeURIComponent(match[2]) : null;
+}
+
+// Exponer getCookie por si se requieren encabezados CSRF.
+window.getCookie = getCookie;


### PR DESCRIPTION
## Summary
- Add `LocalidadesLookupView` and URL for AJAX locality search
- Show locality lookup modal in expediente form and expose provinces in context
- Include JS helper and tests for locality filtering

## Testing
- `black .`
- `pylint celiaquia/views/expediente.py celiaquia/urls.py celiaquia/tests/test_localidades_lookup.py`
- `djlint . --configuration=.djlintrc --reformat`
- `pytest` *(fails: AttributeError: 'NoneType' object has no attribute 'startswith')*

------
https://chatgpt.com/codex/tasks/task_e_68bf12738804832dbe5ff829717bac6e