### PR TITLE
Refactor _parse_limit and show IDs in localidades modal

### DIFF
--- a/celiaquia/templates/celiaquia/expediente_form.html
+++ b/celiaquia/templates/celiaquia/expediente_form.html
@@ -90,8 +90,7 @@
                         <table class="table table-striped">
                             <thead>
                                 <tr>
-                                    <th>ID</th>
-                                    <th>Nombre</th>
+                                    <th>Localidad</th>
                                     <th>Municipio</th>
                                     <th>Provincia</th>
                                 </tr>

--- a/celiaquia/views/expediente.py
+++ b/celiaquia/views/expediente.py
@@ -74,6 +74,16 @@ def _user_provincia(user):
 def _parse_limit(value, default=5, max_cap=5000):
     if value is None:
         return default
+    txt = str(value).strip().lower()
+    if txt in ("all", "todos", "0", "none"):
+        return None
+    try:
+        n = int(txt)
+        if n <= 0:
+            return None
+        return min(n, max_cap)
+    except Exception:
+        return default
 
 
 class LocalidadesLookupView(View):
@@ -107,17 +117,6 @@ class LocalidadesLookupView(View):
             )
         ]
         return JsonResponse(data, safe=False)
-
-    txt = str(value).strip().lower()
-    if txt in ("all", "todos", "0", "none"):
-        return None
-    try:
-        n = int(txt)
-        if n <= 0:
-            return None
-        return min(n, max_cap)
-    except Exception:
-        return default
 
 
 class ExpedienteListView(ListView):

--- a/static/custom/js/localidades_modal.js
+++ b/static/custom/js/localidades_modal.js
@@ -27,7 +27,7 @@ document.addEventListener('DOMContentLoaded', () => {
     provincias.forEach((p) => {
       const opt = document.createElement('option');
       opt.value = p.id;
-      opt.textContent = p.nombre;
+      opt.textContent = `${p.id} - ${p.nombre}`;
       provinciaSelect.appendChild(opt);
     });
   }
@@ -46,7 +46,7 @@ document.addEventListener('DOMContentLoaded', () => {
 
     data.forEach((item) => {
       const tr = document.createElement('tr');
-      tr.innerHTML = `<td>${item.localidad_id}</td><td>${item.localidad_nombre}</td><td>${item.municipio_nombre}</td><td>${item.provincia_nombre}</td>`;
+      tr.innerHTML = `<td>${item.localidad_id} - ${item.localidad_nombre}</td><td>${item.municipio_id} - ${item.municipio_nombre}</td><td>${item.provincia_id} - ${item.provincia_nombre}</td>`;
       tablaLocalidades.appendChild(tr);
 
       if (!municipiosUnicos.has(item.municipio_id)) {
@@ -55,14 +55,14 @@ document.addEventListener('DOMContentLoaded', () => {
 
       const locOpt = document.createElement('option');
       locOpt.value = item.localidad_id;
-      locOpt.textContent = item.localidad_nombre;
+      locOpt.textContent = `${item.localidad_id} - ${item.localidad_nombre}`;
       localidadSelect.appendChild(locOpt);
     });
 
     municipiosUnicos.forEach((nombre, id) => {
       const opt = document.createElement('option');
       opt.value = id;
-      opt.textContent = nombre;
+      opt.textContent = `${id} - ${nombre}`;
       municipioSelect.appendChild(opt);
     });
   }


### PR DESCRIPTION
## Summary
- consolidate limit parsing into `_parse_limit`
- tidy spacing before `LocalidadesLookupView`
- show record IDs alongside province, municipality and locality names in modal lookups

## Testing
- `djlint celiaquia/templates/celiaquia/expediente_form.html --configuration=.djlintrc --reformat`
- `pytest celiaquia/tests/test_localidades_lookup.py::test_localidades_lookup_filters -q` *(fails: AttributeError: 'NoneType' object has no attribute 'startswith')*

------
https://chatgpt.com/codex/tasks/task_e_68bf179f5024832da88172dd7a3545a9