### PR TITLE
Reordenar columnas de localidades en expediente

### DIFF
--- a/celiaquia/templates/celiaquia/expediente_form.html
+++ b/celiaquia/templates/celiaquia/expediente_form.html
@@ -90,9 +90,9 @@
                         <table class="table table-striped">
                             <thead>
                                 <tr>
+                                    <th>Provincia</th>
                                     <th>Localidad</th>
                                     <th>Municipio</th>
-                                    <th>Provincia</th>
                                 </tr>
                             </thead>
                             <tbody id="tabla-localidades">

--- a/static/custom/js/localidades_modal.js
+++ b/static/custom/js/localidades_modal.js
@@ -46,7 +46,7 @@ document.addEventListener('DOMContentLoaded', () => {
 
     data.forEach((item) => {
       const tr = document.createElement('tr');
-      tr.innerHTML = `<td>${item.localidad_id} - ${item.localidad_nombre}</td><td>${item.municipio_id} - ${item.municipio_nombre}</td><td>${item.provincia_id} - ${item.provincia_nombre}</td>`;
+      tr.innerHTML = `<td>${item.provincia_id} - ${item.provincia_nombre}</td><td>${item.localidad_id} - ${item.localidad_nombre}</td><td>${item.municipio_id} - ${item.municipio_nombre}</td>`;
       tablaLocalidades.appendChild(tr);
 
       if (!municipiosUnicos.has(item.municipio_id)) {


### PR DESCRIPTION
## Summary
- Reorganize columnas Provincia, Localidad y Municipio en modal de localidades
- Ajustar renderizado de filas en localidades_modal.js

## Testing
- `djlint celiaquia/templates/celiaquia/expediente_form.html --configuration=.djlintrc --reformat`
- `black static/custom/js/localidades_modal.js` (fails: Cannot parse)
- `pylint static/custom/js/localidades_modal.js --rcfile=.pylintrc` (fails: Parsing failed)
- `pytest -q` (fails: AttributeError 'NoneType' object has no attribute 'startswith')


------
https://chatgpt.com/codex/tasks/task_e_68bf1cad5954832d8da52fe359279187