### PR TITLE
Reordenar columnas de localidades en expediente

### DIFF
--- a/celiaquia/templates/celiaquia/expediente_form.html
+++ b/celiaquia/templates/celiaquia/expediente_form.html
@@ -85,14 +85,20 @@
                         <div class="col">
                             <select id="filtro-localidad" class="form-select"></select>
                         </div>
+                        <div class="col">
+                            <input id="filtro-texto"
+                                   type="text"
+                                   class="form-control"
+                                   placeholder="Buscar..." />
+                        </div>
                     </div>
                     <div class="table-responsive">
                         <table class="table table-striped">
                             <thead>
                                 <tr>
+                                    <th>Provincia</th>
                                     <th>Localidad</th>
                                     <th>Municipio</th>
-                                    <th>Provincia</th>
                                 </tr>
                             </thead>
                             <tbody id="tabla-localidades">

--- a/static/custom/js/localidades_modal.js
+++ b/static/custom/js/localidades_modal.js
@@ -17,6 +17,9 @@ document.addEventListener('DOMContentLoaded', () => {
   const municipioSelect = document.getElementById('filtro-municipio');
   const localidadSelect = document.getElementById('filtro-localidad');
   const tablaLocalidades = document.getElementById('tabla-localidades');
+  const textoBusqueda = document.getElementById('filtro-texto');
+
+  let localidadesData = [];
 
   /**
    * Llena el select de provincias con los datos del contexto.
@@ -38,17 +41,13 @@ document.addEventListener('DOMContentLoaded', () => {
    * @param {Array} data - Datos recibidos del servidor.
    */
   function renderLocalidades(data) {
-    tablaLocalidades.innerHTML = '';
+    localidadesData = data;
     municipioSelect.innerHTML = '<option value="">Todos</option>';
     localidadSelect.innerHTML = '<option value="">Todas</option>';
 
     const municipiosUnicos = new Map();
 
     data.forEach((item) => {
-      const tr = document.createElement('tr');
-      tr.innerHTML = `<td>${item.localidad_id} - ${item.localidad_nombre}</td><td>${item.municipio_id} - ${item.municipio_nombre}</td><td>${item.provincia_id} - ${item.provincia_nombre}</td>`;
-      tablaLocalidades.appendChild(tr);
-
       if (!municipiosUnicos.has(item.municipio_id)) {
         municipiosUnicos.set(item.municipio_id, item.municipio_nombre);
       }
@@ -65,6 +64,35 @@ document.addEventListener('DOMContentLoaded', () => {
       opt.textContent = `${id} - ${nombre}`;
       municipioSelect.appendChild(opt);
     });
+
+    filtrarTabla();
+  }
+
+  function pintarTabla(data) {
+    tablaLocalidades.innerHTML = '';
+    data.forEach((item) => {
+      const tr = document.createElement('tr');
+      tr.innerHTML = `<td>${item.provincia_id} - ${item.provincia_nombre}</td><td>${item.localidad_id} - ${item.localidad_nombre}</td><td>${item.municipio_id} - ${item.municipio_nombre}</td>`;
+      tablaLocalidades.appendChild(tr);
+    });
+  }
+
+  function filtrarTabla() {
+    const query = textoBusqueda ? textoBusqueda.value.toLowerCase() : '';
+    const filtradas = localidadesData.filter((item) => {
+      return (
+        `${item.provincia_id} - ${item.provincia_nombre}`
+          .toLowerCase()
+          .includes(query) ||
+        `${item.localidad_id} - ${item.localidad_nombre}`
+          .toLowerCase()
+          .includes(query) ||
+        `${item.municipio_id} - ${item.municipio_nombre}`
+          .toLowerCase()
+          .includes(query)
+      );
+    });
+    pintarTabla(filtradas);
   }
 
   /**
@@ -87,6 +115,9 @@ document.addEventListener('DOMContentLoaded', () => {
     actualizarLocalidades();
   });
   municipioSelect.addEventListener('change', actualizarLocalidades);
+  if (textoBusqueda) {
+    textoBusqueda.addEventListener('input', filtrarTabla);
+  }
 });
 
 /**


### PR DESCRIPTION
## Summary
- Reorganize columnas Provincia, Localidad y Municipio en modal de localidades
- Ajustar renderizado de filas en localidades_modal.js
- Agregar buscador de texto que filtra filas mientras se escribe

## Testing
- `djlint celiaquia/templates/celiaquia/expediente_form.html --configuration=.djlintrc --reformat`
- `black static/custom/js/localidades_modal.js` (fails: Cannot parse: 1:0: /**)
- `pylint static/custom/js/localidades_modal.js --rcfile=.pylintrc` (fails: invalid syntax)
- `pytest -q` (fails: AttributeError: 'NoneType' object has no attribute 'startswith')


------
https://chatgpt.com/codex/tasks/task_e_68bf1cad5954832d8da52fe359279187