### PR TITLE
Reorder locality columns in expediente form modal

### DIFF
--- a/celiaquia/templates/celiaquia/expediente_form.html
+++ b/celiaquia/templates/celiaquia/expediente_form.html
@@ -97,8 +97,8 @@
                             <thead>
                                 <tr>
                                     <th>Provincia</th>
-                                    <th>Localidad</th>
                                     <th>Municipio</th>
+                                    <th>Localidad</th>
                                 </tr>
                             </thead>
                             <tbody id="tabla-localidades">


### PR DESCRIPTION
## Summary
- Reorder the locality modal table headers to show Municipio before Localidad

## Testing
- `djlint celiaquia/templates/celiaquia/expediente_form.html --configuration=.djlintrc --reformat`
- `docker compose exec django pytest -n auto` *(fails: command not found)*
- `pytest -n auto` *(fails: AttributeError: 'NoneType' object has no attribute 'startswith')*

------
https://chatgpt.com/codex/tasks/task_e_68bf240d2064832d8df851a88e94ca6b