### PR TITLE
Suspender legajo mantiene cupo ocupado

### DIFF
--- a/celiaquia/views/legajo.py
+++ b/celiaquia/views/legajo.py
@@ -236,7 +236,7 @@ class LegajoSuspenderView(View):
             ExpedienteCiudadano, pk=pk, expediente__pk=expediente_id
         )
         try:
-            CupoService.liberar_slot(
+            CupoService.suspender_slot(
                 legajo=legajo, usuario=request.user, motivo="Suspensión administrativa"
             )
             legajo.es_titular_activo = False
@@ -244,7 +244,7 @@ class LegajoSuspenderView(View):
             return JsonResponse(
                 {
                     "success": True,
-                    "message": "Legajo suspendido y cupo liberado (si correspondía).",
+                    "message": "Legajo suspendido; el cupo permanece ocupado (si correspondía).",
                 }
             )
         except CupoNoConfigurado as e:


### PR DESCRIPTION
## Summary
- Reemplaza `CupoService.liberar_slot` por `CupoService.suspender_slot` en la suspensión de legajos para que el cupo se mantenga ocupado.
- Actualiza el mensaje de confirmación indicando que el cupo queda ocupado.

## Testing
- `black celiaquia/views/legajo.py`
- `pylint celiaquia/views/legajo.py --rcfile=.pylintrc` *(falla: Unable to import 'celiaquia.models', etc.)*
- `docker compose exec django pytest -n auto` *(falla: command not found: docker)*

------
https://chatgpt.com/codex/tasks/task_e_68bf76d24584832dba2bc839f88023f7