### PR TITLE
chore: clean legajo imports

### DIFF
--- a/celiaquia/views/legajo.py
+++ b/celiaquia/views/legajo.py
@@ -8,9 +8,6 @@ from django.views.decorators.csrf import csrf_protect
 from celiaquia.models import EstadoLegajo, ExpedienteCiudadano, RevisionTecnico
 from celiaquia.services.legajo_service import LegajoService
 from celiaquia.services.cupo_service import CupoService, CupoNoConfigurado
-from django.core.exceptions import PermissionDenied
-from core.decorators import group_required
-from django.contrib.auth.models import Group
 
 
 logger = logging.getLogger(__name__)


### PR DESCRIPTION
## Summary
- remove duplicate PermissionDenied import
- drop unused group_required and Group imports

## Testing
- `black celiaquia/views/legajo.py`
- `pylint celiaquia/views/legajo.py --rcfile=.pylintrc`
- `djlint celiaquia/views/legajo.py --configuration=.djlintrc --check`
- `pytest` *(fails: AttributeError: 'NoneType' object has no attribute 'startswith')*


------
https://chatgpt.com/codex/tasks/task_e_68bf76d876ec832d825f7014efa312c3