### PR TITLE
Remove duplicate context update in expediente detail

### DIFF
--- a/celiaquia/views/expediente.py
+++ b/celiaquia/views/expediente.py
@@ -365,8 +365,6 @@ class ExpedienteDetailView(DetailView):
 
         preview = preview_error = None
         preview_limit_actual = None
-        ctx = super().get_context_data(**kwargs)
-        exp = self.object
 
         q = expediente.expediente_ciudadanos.select_related("ciudadano")
         ctx["hay_subsanar"] = q.filter(


### PR DESCRIPTION
## Summary
- Avoid redundant context retrieval in `ExpedienteDetailView` and drop unused variable

## Testing
- `black celiaquia/views/expediente.py`
- `pylint celiaquia/views/expediente.py --rcfile=.pylintrc` *(fails: Unable to import celiaquia.services.*)*
- `djlint . --configuration=.djlintrc --reformat`
- `pytest -q` *(fails: AttributeError: 'NoneType' object has no attribute 'startswith')*


------
https://chatgpt.com/codex/tasks/task_e_68bf76e1e2b0832d9926a072331f4591