### PR TITLE
Optimize expediente detail counts with conditional aggregates

### DIFF
--- a/celiaquia/views/expediente.py
+++ b/celiaquia/views/expediente.py
@@ -20,7 +20,7 @@ from django.contrib import messages
 from django.core.exceptions import ValidationError, PermissionDenied, ObjectDoesNotExist
 from django.utils.decorators import method_decorator
 from django.contrib.auth.models import User
-from django.db.models import Q
+from django.db.models import Q, Count
 
 from celiaquia.forms import ExpedienteForm, ConfirmarEnvioForm
 from celiaquia.models import (
@@ -369,9 +369,19 @@ class ExpedienteDetailView(DetailView):
         exp = self.object
 
         q = expediente.expediente_ciudadanos.select_related("ciudadano")
-        ctx["hay_subsanar"] = q.filter(
-            revision_tecnico=RevisionTecnico.SUBSANAR
-        ).exists()
+        counts = q.aggregate(
+            c_aceptados=Count(
+                "id",
+                filter=Q(revision_tecnico="APROBADO", resultado_sintys="MATCH"),
+            ),
+            c_rech_tecnico=Count("id", filter=Q(revision_tecnico="RECHAZADO")),
+            c_rech_sintys=Count(
+                "id",
+                filter=Q(revision_tecnico="APROBADO", resultado_sintys="NO_MATCH"),
+            ),
+            c_subsanar=Count("id", filter=Q(revision_tecnico=RevisionTecnico.SUBSANAR)),
+        )
+        ctx["hay_subsanar"] = counts["c_subsanar"] > 0
         ctx["legajos_aceptados"] = q.filter(
             revision_tecnico="APROBADO", resultado_sintys="MATCH"
         )
@@ -381,10 +391,10 @@ class ExpedienteDetailView(DetailView):
         )
         ctx["legajos_subsanar"] = q.filter(revision_tecnico=RevisionTecnico.SUBSANAR)
 
-        ctx["c_aceptados"] = ctx["legajos_aceptados"].count()
-        ctx["c_rech_tecnico"] = ctx["legajos_rech_tecnico"].count()
-        ctx["c_rech_sintys"] = ctx["legajos_rech_sintys"].count()
-        ctx["c_subsanar"] = ctx["legajos_subsanar"].count()
+        ctx["c_aceptados"] = counts["c_aceptados"]
+        ctx["c_rech_tecnico"] = counts["c_rech_tecnico"]
+        ctx["c_rech_sintys"] = counts["c_rech_sintys"]
+        ctx["c_subsanar"] = counts["c_subsanar"]
 
         if expediente.estado.nombre == "CREADO" and expediente.excel_masivo:
             raw_limit = self.request.GET.get("preview_limit")


### PR DESCRIPTION
## Summary
- reduce repeated count queries in expediente detail view using a single aggregate with conditional Count
- update context assignments to use aggregated result

## Testing
- `black celiaquia/views/expediente.py`
- `pylint celiaquia/views/expediente.py --rcfile=.pylintrc` *(fails: Unable to import...)*
- `djlint celiaquia --configuration=.djlintrc --reformat`
- `pytest -q` *(fails: AttributeError: 'NoneType' object has no attribute 'startswith')*


------
https://chatgpt.com/codex/tasks/task_e_68bf76e9aaec832d94b2820259432081