### PR TITLE
Refactor cupo search filter layout

### DIFF
--- a/celiaquia/templates/celiaquia/cupo_provincia.html
+++ b/celiaquia/templates/celiaquia/cupo_provincia.html
@@ -80,13 +80,18 @@
     <div id="alerts"></div>
     <!-- Titulares activos -->
     <div class="card">
-        <div class="card-header bg-light d-flex justify-content-between align-items-center">
-            <span class="fw-semibold">Cupos ocupados (titulares activos)</span>
-            <input type="search"
-                   id="filtro"
-                   class="form-control form-control-sm"
-                   placeholder="Filtrar por DNI, nombre o expediente"
-                   style="max-width: 280px" />
+        <div class="card-header bg-light">
+            <div class="row align-items-center">
+                <div class="col">
+                    <span class="fw-semibold">Cupos ocupados (titulares activos)</span>
+                </div>
+                <div class="col-md-auto">
+                    <input type="search"
+                           id="filtro-ocupados"
+                           class="form-control form-control-sm w-100 w-md-auto ms-md-auto"
+                           placeholder="Filtrar por DNI, nombre o expediente" />
+                </div>
+            </div>
         </div>
         <div class="card-body p-0">
             <div class="table-responsive">

--- a/static/custom/js/cupo_provincia.js
+++ b/static/custom/js/cupo_provincia.js
@@ -77,14 +77,14 @@
         if (btn && spin) { btn.disabled = false; spin.classList.add("d-none"); }
       }
     });
-  }
-
-  // --- Filtro tabla ocupados ---
-  const filtro = document.getElementById("filtro");
-  if (filtro) {
-    filtro.addEventListener("input", (e) => {
-      const q = (e.target.value || "").toLowerCase();
-      document.querySelectorAll("#tabla-ocupados tbody tr[data-row]").forEach((tr) => {
+    }
+    
+    // --- Filtro tabla ocupados ---
+    const filtro = document.getElementById("filtro-ocupados");
+    if (filtro) {
+        filtro.addEventListener("input", (e) => {
+            const q = (e.target.value || "").toLowerCase();
+            document.querySelectorAll("#tabla-ocupados tbody tr[data-row]").forEach((tr) => {
         const hay = Array.from(tr.querySelectorAll("td[data-text]")).some((td) =>
           (td.getAttribute("data-text") || "").toLowerCase().includes(q)
         );


### PR DESCRIPTION
## Summary
- Revamp cupo table header using Bootstrap grid
- Apply responsive classes to filter input and drop inline style
- Point cupo JS filter logic to the new input ID

## Testing
- `black .` *(fails: command not found)*
- `pylint **/*.py --rcfile=.pylintrc` *(fails: command not found)*
- `djlint . --configuration=.djlintrc --reformat` *(fails: command not found)*
- `docker compose exec django pytest -n auto` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c029d1fc18832d99f06fb0424bb016