### PR TITLE
Mejorar tablas de cupo por provincia

### DIFF
--- a/celiaquia/templates/celiaquia/cupo_provincia.html
+++ b/celiaquia/templates/celiaquia/cupo_provincia.html
@@ -90,33 +90,37 @@
         </div>
         <div class="card-body p-0">
             <div class="table-responsive">
-                <table class="table table-hover align-middle mb-0" id="tabla-ocupados">
+                <table class="table table-striped table-sm table-hover align-middle mb-0"
+                       id="tabla-ocupados">
                     <thead class="table-light">
                         <tr>
-                            <th style="width: 80px;">DNI</th>
+                            <th class="text-nowrap" style="width: 80px;">DNI</th>
                             <th>Nombre</th>
                             <th>Apellido</th>
-                            <th>Expediente</th>
-                            <th>Revisión</th>
-                            <th>Resultado</th>
+                            <th class="text-nowrap">Expediente</th>
+                            <th class="d-none d-md-table-cell">Revisión</th>
+                            <th class="d-none d-md-table-cell">Resultado</th>
                             <th>Estado cupo</th>
                             <th>Activo</th>
-                            <th class="text-end" style="width: 180px;">Acciones</th>
+                            <th class="text-end text-nowrap" style="width: 180px;">Acciones</th>
                         </tr>
                     </thead>
                     <tbody>
                         {% for leg in ocupados %}
                             <tr data-row>
-                                <td data-text="{{ leg.ciudadano.documento|default_if_none:'' }}">{{ leg.ciudadano.documento }}</td>
+                                <td class="text-nowrap"
+                                    data-text="{{ leg.ciudadano.documento|default_if_none:'' }}">
+                                    {{ leg.ciudadano.documento }}
+                                </td>
                                 <td data-text="{{ leg.ciudadano.nombre|default_if_none:'' }}">{{ leg.ciudadano.nombre }}</td>
                                 <td data-text="{{ leg.ciudadano.apellido|default_if_none:'' }}">{{ leg.ciudadano.apellido }}</td>
-                                <td data-text="{{ leg.expediente.codigo }}">{{ leg.expediente.codigo }}</td>
-                                <td>
+                                <td class="text-nowrap" data-text="{{ leg.expediente.codigo }}">{{ leg.expediente.codigo }}</td>
+                                <td class="d-none d-md-table-cell">
                                     <span class="badge bg-{% if leg.revision_tecnico == 'APROBADO' %}success{% elif leg.revision_tecnico == 'RECHAZADO' %}danger{% else %}secondary{% endif %}">
                                         {{ leg.revision_tecnico }}
                                     </span>
                                 </td>
-                                <td>
+                                <td class="d-none d-md-table-cell">
                                     <span class="badge bg-{% if leg.resultado_sintys == 'MATCH' %}success{% elif leg.resultado_sintys == 'NO_MATCH' %}danger{% else %}secondary{% endif %}">
                                         {{ leg.resultado_sintys }}
                                     </span>
@@ -133,11 +137,14 @@
                                         <span class="badge bg-secondary">No</span>
                                     {% endif %}
                                 </td>
-                                <td class="text-end">
+                                <td class="text-end text-nowrap">
                                     <div class="btn-group btn-group-sm">
-                                        <button class="btn btn-outline-warning btn-suspender"
-                                                data-legajo-id="{{ leg.id }}">Suspender</button>
-                                        <button class="btn btn-outline-danger btn-baja" data-legajo-id="{{ leg.id }}">Baja</button>
+                                        <button class="btn btn-outline-warning btn-suspender bi bi-pause-circle"
+                                                title="Suspender"
+                                                data-legajo-id="{{ leg.id }}"></button>
+                                        <button class="btn btn-outline-danger btn-baja bi bi-trash"
+                                                title="Baja"
+                                                data-legajo-id="{{ leg.id }}"></button>
                                     </div>
                                 </td>
                             </tr>
@@ -158,36 +165,39 @@
         </div>
         <div class="card-body p-0">
             <div class="table-responsive">
-                <table class="table table-hover align-middle mb-0">
+                <table class="table table-striped table-sm table-hover align-middle mb-0">
                     <thead class="table-light">
                         <tr>
-                            <th style="width: 80px;">DNI</th>
+                            <th class="text-nowrap" style="width: 80px;">DNI</th>
                             <th>Nombre</th>
                             <th>Apellido</th>
-                            <th>Expediente</th>
-                            <th>Estado cupo</th>
-                            <th>Activo</th>
-                            <th class="text-end" style="width: 120px;">Acciones</th>
+                            <th class="text-nowrap">Expediente</th>
+                            <th class="d-none d-md-table-cell">Estado cupo</th>
+                            <th class="d-none d-md-table-cell">Activo</th>
+                            <th class="text-end text-nowrap" style="width: 120px;">Acciones</th>
                         </tr>
                     </thead>
                     <tbody>
                         {% for leg in suspendidos %}
                             <tr>
-                                <td>{{ leg.ciudadano.documento }}</td>
+                                <td class="text-nowrap">{{ leg.ciudadano.documento }}</td>
                                 <td>{{ leg.ciudadano.nombre }}</td>
                                 <td>{{ leg.ciudadano.apellido }}</td>
-                                <td>{{ leg.expediente.codigo|default:leg.expediente.id }}</td>
-                                <td>
+                                <td class="text-nowrap">{{ leg.expediente.codigo|default:leg.expediente.id }}</td>
+                                <td class="d-none d-md-table-cell">
                                     <span class="badge bg-primary">DENTRO</span>
                                 </td>
-                                <td>
+                                <td class="d-none d-md-table-cell">
                                     <span class="badge bg-secondary">No</span>
                                 </td>
-                                <td class="text-end">
+                                <td class="text-end text-nowrap">
                                     <div class="btn-group btn-group-sm">
-                                        <button class="btn btn-outline-success btn-reactivar"
-                                                data-legajo-id="{{ leg.id }}">Reactivar</button>
-                                        <button class="btn btn-outline-danger btn-baja" data-legajo-id="{{ leg.id }}">Baja</button>
+                                        <button class="btn btn-outline-success btn-reactivar bi bi-arrow-counterclockwise"
+                                                title="Reactivar"
+                                                data-legajo-id="{{ leg.id }}"></button>
+                                        <button class="btn btn-outline-danger btn-baja bi bi-trash"
+                                                title="Baja"
+                                                data-legajo-id="{{ leg.id }}"></button>
                                     </div>
                                 </td>
                             </tr>
@@ -208,24 +218,24 @@
         </div>
         <div class="card-body p-0">
             <div class="table-responsive">
-                <table class="table table-hover align-middle mb-0">
+                <table class="table table-striped table-sm table-hover align-middle mb-0">
                     <thead class="table-light">
                         <tr>
-                            <th style="width: 80px;">DNI</th>
+                            <th class="text-nowrap" style="width: 80px;">DNI</th>
                             <th>Nombre</th>
                             <th>Apellido</th>
-                            <th>Expediente</th>
-                            <th>Estado cupo</th>
+                            <th class="text-nowrap">Expediente</th>
+                            <th class="d-none d-md-table-cell">Estado cupo</th>
                         </tr>
                     </thead>
                     <tbody>
                         {% for leg in lista_espera %}
                             <tr>
-                                <td>{{ leg.ciudadano.documento }}</td>
+                                <td class="text-nowrap">{{ leg.ciudadano.documento }}</td>
                                 <td>{{ leg.ciudadano.nombre }}</td>
                                 <td>{{ leg.ciudadano.apellido }}</td>
-                                <td>{{ leg.expediente.codigo|default:leg.expediente.id }}</td>
-                                <td>
+                                <td class="text-nowrap">{{ leg.expediente.codigo|default:leg.expediente.id }}</td>
+                                <td class="d-none d-md-table-cell">
                                     <span class="badge bg-warning text-dark">FUERA</span>
                                 </td>
                             </tr>
@@ -308,16 +318,16 @@
                                id="tabla-historico">
                             <thead class="table-light">
                                 <tr>
-                                    <th style="width: 120px;">Fecha</th>
-                                    <th style="width: 90px;">DNI</th>
+                                    <th class="text-nowrap" style="width: 120px;">Fecha</th>
+                                    <th class="text-nowrap" style="width: 90px;">DNI</th>
                                     <th>Nombre</th>
                                     <th>Apellido</th>
-                                    <th>Expediente</th>
+                                    <th class="text-nowrap">Expediente</th>
                                     <th>Movimiento</th>
                                     <th>Motivo</th>
                                     <th>Usuario</th>
-                                    <th>Revisión</th>
-                                    <th>Resultado</th>
+                                    <th class="d-none d-md-table-cell">Revisión</th>
+                                    <th class="d-none d-md-table-cell">Resultado</th>
                                     <th>Estado cupo</th>
                                     <th>Activo</th>
                                 </tr>
@@ -326,11 +336,14 @@
                                 {% if movimientos %}
                                     {% for m in movimientos %}
                                         <tr data-row>
-                                            <td data-doc="{{ m.legajo.ciudadano.documento|default_if_none:'' }}">{{ m.creado_en|date:"d/m/Y H:i" }}</td>
-                                            <td>{{ m.legajo.ciudadano.documento }}</td>
+                                            <td class="text-nowrap"
+                                                data-doc="{{ m.legajo.ciudadano.documento|default_if_none:'' }}">
+                                                {{ m.creado_en|date:"d/m/Y H:i" }}
+                                            </td>
+                                            <td class="text-nowrap">{{ m.legajo.ciudadano.documento }}</td>
                                             <td>{{ m.legajo.ciudadano.nombre }}</td>
                                             <td>{{ m.legajo.ciudadano.apellido }}</td>
-                                            <td>{{ m.expediente.codigo }}</td>
+                                            <td class="text-nowrap">{{ m.expediente.codigo }}</td>
                                             <td>
                                                 <span class="badge bg-{% if m.tipo == 'ALTA' %}success{% elif m.tipo == 'BAJA' %}danger{% elif m.tipo == 'SUSPENDIDO' %}warning text-dark{% else %}secondary{% endif %}">
                                                     {{ m.tipo }}
@@ -339,12 +352,12 @@
                                             </td>
                                             <td class="text-break" style="max-width: 280px;">{{ m.motivo|default_if_none:'-' }}</td>
                                             <td>{{ m.usuario.get_full_name|default:m.usuario.username }}</td>
-                                            <td>
+                                            <td class="d-none d-md-table-cell">
                                                 <span class="badge bg-{% if m.legajo.revision_tecnico == 'APROBADO' %}success{% elif m.legajo.revision_tecnico == 'RECHAZADO' %}danger{% else %}secondary{% endif %}">
                                                     {{ m.legajo.revision_tecnico }}
                                                 </span>
                                             </td>
-                                            <td>
+                                            <td class="d-none d-md-table-cell">
                                                 <span class="badge bg-{% if m.legajo.resultado_sintys == 'MATCH' %}success{% elif m.legajo.resultado_sintys == 'NO_MATCH' %}danger{% else %}secondary{% endif %}">
                                                     {{ m.legajo.resultado_sintys }}
                                                 </span>


### PR DESCRIPTION
## Summary
- Simplify cupo tables with `table-striped` `table-sm` classes and responsive hidden columns
- Replace text action buttons with icon buttons and tooltips
- Format template with `djlint`

## Testing
- `black .`
- `pylint **/*.py --rcfile=.pylintrc`
- `djlint celiaquia/templates/celiaquia/cupo_provincia.html --configuration=.djlintrc --reformat`
- `docker compose exec django pytest -n auto` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c029d2fe44832d80b78d88dbf95a67