### PR TITLE
refactor: extract cupo table partial

### DIFF
--- a/celiaquia/templates/celiaquia/cupo_provincia.html
+++ b/celiaquia/templates/celiaquia/cupo_provincia.html
@@ -156,108 +156,26 @@
             </div>
         </div>
     </div>
-    <!-- NUEVO: Suspendidos -->
-    <div class="card mt-3">
-        <div class="card-header bg-light d-flex justify-content-between align-items-center">
-            <span class="fw-semibold">Suspendidos (cupo ocupado, no activos)</span>
-            <input type="search"
-                   id="filtro-suspendidos"
-                   class="form-control form-control-sm"
-                   placeholder="Filtrar por DNI, nombre o expediente"
-                   style="max-width: 280px" />
-        </div>
-        <div class="card-body p-0">
-            <div class="table-responsive">
-                <table class="table table-striped table-sm table-hover align-middle mb-0" id="tabla-suspendidos">
-                    <thead class="table-light">
-                        <tr>
-                            <th style="width: 80px;">DNI</th>
-                            <th>Nombre</th>
-                            <th>Apellido</th>
-                            <th>Expediente</th>
-                            <th class="d-none d-md-table-cell">Estado cupo</th>
-                            <th class="d-none d-md-table-cell">Activo</th>
-                            <th class="text-end" style="width: 120px;">Acciones</th>
-                        </tr>
-                    </thead>
-                    <tbody>
-                        {% for leg in suspendidos %}
-                            <tr data-row>
-                                <td data-text="{{ leg.ciudadano.documento }}">{{ leg.ciudadano.documento }}</td>
-                                <td data-text="{{ leg.ciudadano.nombre }}">{{ leg.ciudadano.nombre }}</td>
-                                <td data-text="{{ leg.ciudadano.apellido }}">{{ leg.ciudadano.apellido }}</td>
-                                <td data-text="{{ leg.expediente.codigo|default:leg.expediente.id }}">
-                                    {{ leg.expediente.codigo|default:leg.expediente.id }}
-                                </td>
-                                <td data-text="{{ leg.estado_cupo }}" class="d-none d-md-table-cell">
-                                    <span class="badge bg-primary">DENTRO</span>
-                                </td>
-                                <td data-text="{% if leg.es_titular_activo %}Sí{% else %}No{% endif %}" class="d-none d-md-table-cell">
-                                    <span class="badge bg-secondary">No</span>
-                                </td>
-                                <td class="text-end">
-                                    <div class="btn-group btn-group-sm">
-                                        <button class="btn btn-outline-success btn-reactivar"
-                                                data-legajo-id="{{ leg.id }}">Reactivar</button>
-                                        <button class="btn btn-outline-danger btn-baja" data-legajo-id="{{ leg.id }}">Baja</button>
-                                    </div>
-                                </td>
-                            </tr>
-                        {% empty %}
-                            <tr>
-                                <td colspan="7" class="text-center text-muted py-3">No hay suspendidos.</td>
-                            </tr>
-                        {% endfor %}
-                    </tbody>
-                </table>
-            </div>
-        </div>
-    </div>
-    <!-- NUEVO: Lista de espera (Fuera de cupo) -->
-    <div class="card mt-3">
-        <div class="card-header bg-light d-flex justify-content-between align-items-center">
-            <span class="fw-semibold">Lista de espera (Fuera de cupo)</span>
-            <input type="search"
-                   id="filtro-lista-espera"
-                   class="form-control form-control-sm"
-                   placeholder="Filtrar por DNI, nombre o expediente"
-                   style="max-width: 280px" />
-        </div>
-        <div class="card-body p-0">
-            <div class="table-responsive">
-                <table class="table table-striped table-sm table-hover align-middle mb-0" id="tabla-lista-espera">
-                    <thead class="table-light">
-                        <tr>
-                            <th style="width: 80px;">DNI</th>
-                            <th>Nombre</th>
-                            <th>Apellido</th>
-                            <th>Expediente</th>
-                            <th class="d-none d-md-table-cell">Estado cupo</th>
-                        </tr>
-                    </thead>
-                    <tbody>
-                        {% for leg in lista_espera %}
-                            <tr data-row>
-                                <td data-text="{{ leg.ciudadano.documento }}">{{ leg.ciudadano.documento }}</td>
-                                <td data-text="{{ leg.ciudadano.nombre }}">{{ leg.ciudadano.nombre }}</td>
-                                <td data-text="{{ leg.ciudadano.apellido }}">{{ leg.ciudadano.apellido }}</td>
-                                <td data-text="{{ leg.expediente.codigo|default:leg.expediente.id }}">
-                                    {{ leg.expediente.codigo|default:leg.expediente.id }}
-                                </td>
-                                <td data-text="{{ leg.estado_cupo }}" class="d-none d-md-table-cell">
-                                    <span class="badge bg-warning text-dark">FUERA</span>
-                                </td>
-                            </tr>
-                        {% empty %}
-                            <tr>
-                                <td colspan="5" class="text-center text-muted py-3">Sin lista de espera.</td>
-                            </tr>
-                        {% endfor %}
-                    </tbody>
-                </table>
-            </div>
-        </div>
-    </div>
+    {% include 'celiaquia/partials/cupo_table.html' with
+    title='Suspendidos (cupo ocupado, no activos)'
+    table_id='tabla-suspendidos'
+    filter_id='filtro-suspendidos'
+    rows=suspendidos
+    empty_message='No hay suspendidos.'
+    estado_badge_class='bg-primary'
+    estado_badge_text='DENTRO'
+    show_activo=True
+    show_actions=True
+    colspan=7 %}
+    {% include 'celiaquia/partials/cupo_table.html' with
+    title='Lista de espera (Fuera de cupo)'
+    table_id='tabla-lista-espera'
+    filter_id='filtro-lista-espera'
+    rows=lista_espera
+    empty_message='Sin lista de espera.'
+    estado_badge_class='bg-warning text-dark'
+    estado_badge_text='FUERA'
+    colspan=5 %}
     <!-- Modal Configurar Cupo -->
     <div class="modal fade"
          id="modalConfigCupo"

--- a/celiaquia/templates/celiaquia/partials/cupo_table.html
+++ b/celiaquia/templates/celiaquia/partials/cupo_table.html
@@ -1,0 +1,77 @@
+{#
+  Fragmento reutilizable para tablas de cupo.
+
+  Parámetros esperados:
+  - title: título a mostrar en el encabezado de la tarjeta.
+  - table_id: id del elemento <table>.
+  - filter_id: id del campo de filtro.
+  - rows: iterable con los legajos a mostrar.
+  - empty_message: texto a mostrar cuando no hay filas.
+  - estado_badge_class: clases CSS para la etiqueta de estado de cupo.
+  - estado_badge_text: texto de la etiqueta de estado de cupo.
+  - show_activo (opcional): mostrar la columna "Activo".
+  - show_actions (opcional): mostrar columna de acciones (Reactivar/Baja).
+  - colspan: cantidad de columnas para la fila vacía.
+#}
+<div class="card mt-3">
+    <div class="card-header bg-light d-flex justify-content-between align-items-center">
+        <span class="fw-semibold">{{ title }}</span>
+        <input type="search"
+               id="{{ filter_id }}"
+               class="form-control form-control-sm"
+               placeholder="Filtrar por DNI, nombre o expediente"
+               style="max-width: 280px" />
+    </div>
+    <div class="card-body p-0">
+        <div class="table-responsive">
+            <table class="table table-striped table-sm table-hover align-middle mb-0"
+                   id="{{ table_id }}">
+                <thead class="table-light">
+                    <tr>
+                        <th style="width: 80px;">DNI</th>
+                        <th>Nombre</th>
+                        <th>Apellido</th>
+                        <th>Expediente</th>
+                        <th class="d-none d-md-table-cell">Estado cupo</th>
+                        {% if show_activo %}<th class="d-none d-md-table-cell">Activo</th>{% endif %}
+                        {% if show_actions %}<th class="text-end" style="width: 120px;">Acciones</th>{% endif %}
+                    </tr>
+                </thead>
+                <tbody>
+                    {% for leg in rows %}
+                        <tr data-row>
+                            <td data-text="{{ leg.ciudadano.documento }}">{{ leg.ciudadano.documento }}</td>
+                            <td data-text="{{ leg.ciudadano.nombre }}">{{ leg.ciudadano.nombre }}</td>
+                            <td data-text="{{ leg.ciudadano.apellido }}">{{ leg.ciudadano.apellido }}</td>
+                            <td data-text="{{ leg.expediente.codigo|default:leg.expediente.id }}">
+                                {{ leg.expediente.codigo|default:leg.expediente.id }}
+                            </td>
+                            <td data-text="{{ leg.estado_cupo }}" class="d-none d-md-table-cell">
+                                <span class="badge {{ estado_badge_class }}">{{ estado_badge_text }}</span>
+                            </td>
+                            {% if show_activo %}
+                                <td data-text="{% if leg.es_titular_activo %}Sí{% else %}No{% endif %}"
+                                    class="d-none d-md-table-cell">
+                                    <span class="badge bg-secondary">No</span>
+                                </td>
+                            {% endif %}
+                            {% if show_actions %}
+                                <td class="text-end">
+                                    <div class="btn-group btn-group-sm">
+                                        <button class="btn btn-outline-success btn-reactivar"
+                                                data-legajo-id="{{ leg.id }}">Reactivar</button>
+                                        <button class="btn btn-outline-danger btn-baja" data-legajo-id="{{ leg.id }}">Baja</button>
+                                    </div>
+                                </td>
+                            {% endif %}
+                        </tr>
+                    {% empty %}
+                        <tr>
+                            <td colspan="{{ colspan }}" class="text-center text-muted py-3">{{ empty_message }}</td>
+                        </tr>
+                    {% endfor %}
+                </tbody>
+            </table>
+        </div>
+    </div>
+</div>


### PR DESCRIPTION
## Summary
- extract reusable `cupo_table` partial with documented parameters
- simplify `cupo_provincia` by including the new partial for suspendidos and waiting list tables

## Testing
- `djlint . --configuration=.djlintrc --reformat`
- `pytest celiaquia -q` *(fails: AttributeError: 'NoneType' object has no attribute 'startswith')*


------
https://chatgpt.com/codex/tasks/task_e_68c05564d9e8832db29beee178f50c9f