### PR TITLE
Add hidden labels for search inputs

### DIFF
--- a/celiaquia/templates/celiaquia/cupo_provincia.html
+++ b/celiaquia/templates/celiaquia/cupo_provincia.html
@@ -86,6 +86,7 @@
                     <span class="fw-semibold">Cupos ocupados (titulares activos)</span>
                 </div>
                 <div class="col-md-auto">
+                    <label for="filtro-ocupados" class="visually-hidden">Filtrar cupos ocupados</label>
                     <input type="search"
                            id="filtro-ocupados"
                            class="form-control form-control-sm w-100 w-md-auto ms-md-auto"
@@ -160,6 +161,7 @@
     <div class="card mt-3">
         <div class="card-header bg-light d-flex justify-content-between align-items-center">
             <span class="fw-semibold">Suspendidos (cupo ocupado, no activos)</span>
+            <label for="filtro-suspendidos" class="visually-hidden">Filtrar suspendidos</label>
             <input type="search"
                    id="filtro-suspendidos"
                    class="form-control form-control-sm"
@@ -168,7 +170,8 @@
         </div>
         <div class="card-body p-0">
             <div class="table-responsive">
-                <table class="table table-striped table-sm table-hover align-middle mb-0" id="tabla-suspendidos">
+                <table class="table table-striped table-sm table-hover align-middle mb-0"
+                       id="tabla-suspendidos">
                     <thead class="table-light">
                         <tr>
                             <th style="width: 80px;">DNI</th>
@@ -192,7 +195,8 @@
                                 <td data-text="{{ leg.estado_cupo }}" class="d-none d-md-table-cell">
                                     <span class="badge bg-primary">DENTRO</span>
                                 </td>
-                                <td data-text="{% if leg.es_titular_activo %}Sí{% else %}No{% endif %}" class="d-none d-md-table-cell">
+                                <td data-text="{% if leg.es_titular_activo %}Sí{% else %}No{% endif %}"
+                                    class="d-none d-md-table-cell">
                                     <span class="badge bg-secondary">No</span>
                                 </td>
                                 <td class="text-end">
@@ -217,6 +221,7 @@
     <div class="card mt-3">
         <div class="card-header bg-light d-flex justify-content-between align-items-center">
             <span class="fw-semibold">Lista de espera (Fuera de cupo)</span>
+            <label for="filtro-lista-espera" class="visually-hidden">Filtrar lista de espera</label>
             <input type="search"
                    id="filtro-lista-espera"
                    class="form-control form-control-sm"
@@ -225,7 +230,8 @@
         </div>
         <div class="card-body p-0">
             <div class="table-responsive">
-                <table class="table table-striped table-sm table-hover align-middle mb-0" id="tabla-lista-espera">
+                <table class="table table-striped table-sm table-hover align-middle mb-0"
+                       id="tabla-lista-espera">
                     <thead class="table-light">
                         <tr>
                             <th style="width: 80px;">DNI</th>
@@ -316,6 +322,7 @@
                 <div class="modal-body">
                     <div class="d-flex justify-content-between align-items-center mb-2">
                         <small class="text-muted">Se listan altas/bajas/ajustes y estado actual de cada legajo.</small>
+                        <label for="filtro-historico" class="visually-hidden">Filtrar histórico</label>
                         <input type="search"
                                id="filtro-historico"
                                class="form-control form-control-sm"

--- a/celiaquia/templates/celiaquia/cupo_provincia.html
+++ b/celiaquia/templates/celiaquia/cupo_provincia.html
@@ -157,113 +157,28 @@
             </div>
         </div>
     </div>
-    <!-- NUEVO: Suspendidos -->
-    <div class="card mt-3">
-        <div class="card-header bg-light d-flex justify-content-between align-items-center">
-            <span class="fw-semibold">Suspendidos (cupo ocupado, no activos)</span>
-            <label for="filtro-suspendidos" class="visually-hidden">Filtrar suspendidos</label>
-            <input type="search"
-                   id="filtro-suspendidos"
-                   class="form-control form-control-sm"
-                   placeholder="Filtrar por DNI, nombre o expediente"
-                   style="max-width: 280px" />
-        </div>
-        <div class="card-body p-0">
-            <div class="table-responsive">
-                <table class="table table-striped table-sm table-hover align-middle mb-0"
-                       id="tabla-suspendidos">
-                    <thead class="table-light">
-                        <tr>
-                            <th style="width: 80px;">DNI</th>
-                            <th>Nombre</th>
-                            <th>Apellido</th>
-                            <th>Expediente</th>
-                            <th class="d-none d-md-table-cell">Estado cupo</th>
-                            <th class="d-none d-md-table-cell">Activo</th>
-                            <th class="text-end" style="width: 120px;">Acciones</th>
-                        </tr>
-                    </thead>
-                    <tbody>
-                        {% for leg in suspendidos %}
-                            <tr data-row>
-                                <td data-text="{{ leg.ciudadano.documento }}">{{ leg.ciudadano.documento }}</td>
-                                <td data-text="{{ leg.ciudadano.nombre }}">{{ leg.ciudadano.nombre }}</td>
-                                <td data-text="{{ leg.ciudadano.apellido }}">{{ leg.ciudadano.apellido }}</td>
-                                <td data-text="{{ leg.expediente.codigo|default:leg.expediente.id }}">
-                                    {{ leg.expediente.codigo|default:leg.expediente.id }}
-                                </td>
-                                <td data-text="{{ leg.estado_cupo }}" class="d-none d-md-table-cell">
-                                    <span class="badge bg-primary">DENTRO</span>
-                                </td>
-                                <td data-text="{% if leg.es_titular_activo %}Sí{% else %}No{% endif %}"
-                                    class="d-none d-md-table-cell">
-                                    <span class="badge bg-secondary">No</span>
-                                </td>
-                                <td class="text-end">
-                                    <div class="btn-group btn-group-sm">
-                                        <button class="btn btn-outline-success btn-reactivar"
-                                                data-legajo-id="{{ leg.id }}">Reactivar</button>
-                                        <button class="btn btn-outline-danger btn-baja" data-legajo-id="{{ leg.id }}">Baja</button>
-                                    </div>
-                                </td>
-                            </tr>
-                        {% empty %}
-                            <tr>
-                                <td colspan="7" class="text-center text-muted py-3">No hay suspendidos.</td>
-                            </tr>
-                        {% endfor %}
-                    </tbody>
-                </table>
-            </div>
-        </div>
-    </div>
-    <!-- NUEVO: Lista de espera (Fuera de cupo) -->
-    <div class="card mt-3">
-        <div class="card-header bg-light d-flex justify-content-between align-items-center">
-            <span class="fw-semibold">Lista de espera (Fuera de cupo)</span>
-            <label for="filtro-lista-espera" class="visually-hidden">Filtrar lista de espera</label>
-            <input type="search"
-                   id="filtro-lista-espera"
-                   class="form-control form-control-sm"
-                   placeholder="Filtrar por DNI, nombre o expediente"
-                   style="max-width: 280px" />
-        </div>
-        <div class="card-body p-0">
-            <div class="table-responsive">
-                <table class="table table-striped table-sm table-hover align-middle mb-0"
-                       id="tabla-lista-espera">
-                    <thead class="table-light">
-                        <tr>
-                            <th style="width: 80px;">DNI</th>
-                            <th>Nombre</th>
-                            <th>Apellido</th>
-                            <th>Expediente</th>
-                            <th class="d-none d-md-table-cell">Estado cupo</th>
-                        </tr>
-                    </thead>
-                    <tbody>
-                        {% for leg in lista_espera %}
-                            <tr data-row>
-                                <td data-text="{{ leg.ciudadano.documento }}">{{ leg.ciudadano.documento }}</td>
-                                <td data-text="{{ leg.ciudadano.nombre }}">{{ leg.ciudadano.nombre }}</td>
-                                <td data-text="{{ leg.ciudadano.apellido }}">{{ leg.ciudadano.apellido }}</td>
-                                <td data-text="{{ leg.expediente.codigo|default:leg.expediente.id }}">
-                                    {{ leg.expediente.codigo|default:leg.expediente.id }}
-                                </td>
-                                <td data-text="{{ leg.estado_cupo }}" class="d-none d-md-table-cell">
-                                    <span class="badge bg-warning text-dark">FUERA</span>
-                                </td>
-                            </tr>
-                        {% empty %}
-                            <tr>
-                                <td colspan="5" class="text-center text-muted py-3">Sin lista de espera.</td>
-                            </tr>
-                        {% endfor %}
-                    </tbody>
-                </table>
-            </div>
-        </div>
-    </div>
+    {% include 'celiaquia/partials/cupo_table.html' with
+    title='Suspendidos (cupo ocupado, no activos)'
+    table_id='tabla-suspendidos'
+    filter_id='filtro-suspendidos'
+    filter_label='Filtrar suspendidos'
+    rows=suspendidos
+    empty_message='No hay suspendidos.'
+    estado_badge_class='bg-primary'
+    estado_badge_text='DENTRO'
+    show_activo=True
+    show_actions=True
+    colspan=7 %}
+    {% include 'celiaquia/partials/cupo_table.html' with
+    title='Lista de espera (Fuera de cupo)'
+    table_id='tabla-lista-espera'
+    filter_id='filtro-lista-espera'
+    filter_label='Filtrar lista de espera'
+    rows=lista_espera
+    empty_message='Sin lista de espera.'
+    estado_badge_class='bg-warning text-dark'
+    estado_badge_text='FUERA'
+    colspan=5 %}
     <!-- Modal Configurar Cupo -->
     <div class="modal fade"
          id="modalConfigCupo"

--- a/celiaquia/templates/celiaquia/partials/cupo_table.html
+++ b/celiaquia/templates/celiaquia/partials/cupo_table.html
@@ -1,0 +1,69 @@
+<div class="card mt-3">
+    <div class="card-header bg-light d-flex justify-content-between align-items-center">
+        <span class="fw-semibold">{{ title }}</span>
+        <label for="{{ filter_id }}" class="visually-hidden">{{ filter_label }}</label>
+        <input type="search"
+               id="{{ filter_id }}"
+               class="form-control form-control-sm"
+               placeholder="Filtrar por DNI, nombre o expediente"
+               style="max-width: 280px" />
+    </div>
+    <div class="card-body p-0">
+        <div class="table-responsive">
+            <table class="table table-striped table-sm table-hover align-middle mb-0"
+                   id="{{ table_id }}">
+                <thead class="table-light">
+                    <tr>
+                        <th style="width: 80px;">DNI</th>
+                        <th>Nombre</th>
+                        <th>Apellido</th>
+                        <th>Expediente</th>
+                        {% if estado_badge_class %}<th class="d-none d-md-table-cell">Estado cupo</th>{% endif %}
+                        {% if show_activo %}<th class="d-none d-md-table-cell">Activo</th>{% endif %}
+                        {% if show_actions %}<th class="text-end" style="width: 120px;">Acciones</th>{% endif %}
+                    </tr>
+                </thead>
+                <tbody>
+                    {% for leg in rows %}
+                        <tr data-row>
+                            <td data-text="{{ leg.ciudadano.documento }}">{{ leg.ciudadano.documento }}</td>
+                            <td data-text="{{ leg.ciudadano.nombre }}">{{ leg.ciudadano.nombre }}</td>
+                            <td data-text="{{ leg.ciudadano.apellido }}">{{ leg.ciudadano.apellido }}</td>
+                            <td data-text="{{ leg.expediente.codigo|default:leg.expediente.id }}">
+                                {{ leg.expediente.codigo|default:leg.expediente.id }}
+                            </td>
+                            {% if estado_badge_class %}
+                                <td data-text="{{ leg.estado_cupo }}" class="d-none d-md-table-cell">
+                                    <span class="badge {{ estado_badge_class }}">{{ estado_badge_text }}</span>
+                                </td>
+                            {% endif %}
+                            {% if show_activo %}
+                                <td data-text="{% if leg.es_titular_activo %}Sí{% else %}No{% endif %}"
+                                    class="d-none d-md-table-cell">
+                                    {% if leg.es_titular_activo %}
+                                        <span class="badge bg-success">Sí</span>
+                                    {% else %}
+                                        <span class="badge bg-secondary">No</span>
+                                    {% endif %}
+                                </td>
+                            {% endif %}
+                            {% if show_actions %}
+                                <td class="text-end">
+                                    <div class="btn-group btn-group-sm">
+                                        <button class="btn btn-outline-success btn-reactivar"
+                                                data-legajo-id="{{ leg.id }}">Reactivar</button>
+                                        <button class="btn btn-outline-danger btn-baja" data-legajo-id="{{ leg.id }}">Baja</button>
+                                    </div>
+                                </td>
+                            {% endif %}
+                        </tr>
+                    {% empty %}
+                        <tr>
+                            <td colspan="{{ colspan }}" class="text-center text-muted py-3">{{ empty_message }}</td>
+                        </tr>
+                    {% endfor %}
+                </tbody>
+            </table>
+        </div>
+    </div>
+</div>


### PR DESCRIPTION
## Summary
- add visually hidden labels to search fields in cupo provincia template for accessibility

## Testing
- `djlint celiaquia/templates/celiaquia/cupo_provincia.html --configuration=.djlintrc --reformat`
- `black . --check`
- `pylint $(git ls-files '*.py') --rcfile=.pylintrc`
- `docker compose exec django pytest -n auto` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c055634a78832d9e2a60931a549365