### PR TITLE
Refactor cupo tables for dark theme with aligned filters

### DIFF
--- a/celiaquia/templates/celiaquia/cupo_provincia.html
+++ b/celiaquia/templates/celiaquia/cupo_provincia.html
@@ -78,96 +78,27 @@
         </div>
     {% endif %}
     <div id="alerts"></div>
-    <!-- Titulares activos -->
-    <div class="card">
-        <div class="card-header bg-light">
-            <div class="row align-items-center">
-                <div class="col">
-                    <span class="fw-semibold">Cupos ocupados (titulares activos)</span>
-                </div>
-                <div class="col-md-auto">
-                    <label for="filtro-ocupados" class="visually-hidden">Filtrar cupos ocupados</label>
-                    <input type="search"
-                           id="filtro-ocupados"
-                           class="form-control form-control-sm w-100 w-md-auto ms-md-auto"
-                           placeholder="Filtrar por DNI, nombre o expediente" />
-                </div>
-            </div>
-        </div>
-        <div class="card-body p-0">
-            <div class="table-responsive">
-                <table class="table table-hover align-middle mb-0" id="tabla-ocupados">
-                    <thead class="table-light">
-                        <tr>
-                            <th style="width: 80px;">DNI</th>
-                            <th>Nombre</th>
-                            <th>Apellido</th>
-                            <th>Expediente</th>
-                            <th>Revisión</th>
-                            <th>Resultado</th>
-                            <th>Estado cupo</th>
-                            <th>Activo</th>
-                            <th class="text-end" style="width: 180px;">Acciones</th>
-                        </tr>
-                    </thead>
-                    <tbody>
-                        {% for leg in ocupados %}
-                            <tr data-row>
-                                <td data-text="{{ leg.ciudadano.documento|default_if_none:'' }}">{{ leg.ciudadano.documento }}</td>
-                                <td data-text="{{ leg.ciudadano.nombre|default_if_none:'' }}">{{ leg.ciudadano.nombre }}</td>
-                                <td data-text="{{ leg.ciudadano.apellido|default_if_none:'' }}">{{ leg.ciudadano.apellido }}</td>
-                                <td data-text="{{ leg.expediente.codigo }}">{{ leg.expediente.codigo }}</td>
-                                <td>
-                                    <span class="badge bg-{% if leg.revision_tecnico == 'APROBADO' %}success{% elif leg.revision_tecnico == 'RECHAZADO' %}danger{% else %}secondary{% endif %}">
-                                        {{ leg.revision_tecnico }}
-                                    </span>
-                                </td>
-                                <td>
-                                    <span class="badge bg-{% if leg.resultado_sintys == 'MATCH' %}success{% elif leg.resultado_sintys == 'NO_MATCH' %}danger{% else %}secondary{% endif %}">
-                                        {{ leg.resultado_sintys }}
-                                    </span>
-                                </td>
-                                <td>
-                                    <span class="badge bg-{% if leg.estado_cupo == 'DENTRO' %}primary{% else %}secondary{% endif %}">
-                                        {{ leg.estado_cupo }}
-                                    </span>
-                                </td>
-                                <td>
-                                    {% if leg.es_titular_activo %}
-                                        <span class="badge bg-success">Sí</span>
-                                    {% else %}
-                                        <span class="badge bg-secondary">No</span>
-                                    {% endif %}
-                                </td>
-                                <td class="text-end">
-                                    <div class="btn-group btn-group-sm">
-                                        <button class="btn btn-outline-warning btn-suspender"
-                                                data-legajo-id="{{ leg.id }}">Suspender</button>
-                                        <button class="btn btn-outline-danger btn-baja" data-legajo-id="{{ leg.id }}">Baja</button>
-                                    </div>
-                                </td>
-                            </tr>
-                        {% empty %}
-                            <tr>
-                                <td colspan="9" class="text-center text-muted py-4">No hay titulares ocupando cupo.</td>
-                            </tr>
-                        {% endfor %}
-                    </tbody>
-                </table>
-            </div>
-        </div>
-    </div>
+    {% include 'celiaquia/partials/cupo_table.html' with
+    title='Cupos ocupados (titulares activos)'
+    table_id='tabla-ocupados'
+    filter_id='filtro-ocupados'
+    filter_label='Filtrar cupos ocupados'
+    filter_placeholder='Filtrar por DNI, nombre o expediente'
+    rows=ocupados
+    empty_message='No hay titulares ocupando cupo.'
+    show_revision=True
+    show_resultado=True
+    show_activo=True
+    show_actions=True
+    colspan=9 %}
     {% include 'celiaquia/partials/cupo_table.html' with
     title='Suspendidos (cupo ocupado, no activos)'
     table_id='tabla-suspendidos'
     filter_id='filtro-suspendidos'
-
     filter_label='Filtrar suspendidos'
-
+    filter_placeholder='Filtrar por DNI, nombre o expediente'
     rows=suspendidos
     empty_message='No hay suspendidos.'
-    estado_badge_class='bg-primary'
-    estado_badge_text='DENTRO'
     show_activo=True
     show_actions=True
     colspan=7 %}
@@ -175,13 +106,10 @@
     title='Lista de espera (Fuera de cupo)'
     table_id='tabla-lista-espera'
     filter_id='filtro-lista-espera'
-
     filter_label='Filtrar lista de espera'
-
+    filter_placeholder='Filtrar por DNI, nombre o expediente'
     rows=lista_espera
     empty_message='Sin lista de espera.'
-    estado_badge_class='bg-warning text-dark'
-    estado_badge_text='FUERA'
     colspan=5 %}
     <!-- Modal Configurar Cupo -->
     <div class="modal fade"
@@ -244,17 +172,16 @@
                         <label for="filtro-historico" class="visually-hidden">Filtrar histórico</label>
                         <input type="search"
                                id="filtro-historico"
-                               class="form-control form-control-sm"
-                               placeholder="Filtrar por DNI"
-                               style="max-width: 220px" />
+                               class="form-control form-control-sm filter-input-sm"
+                               placeholder="Filtrar por DNI" />
                     </div>
                     <div class="table-responsive">
                         <table class="table table-sm table-striped align-middle"
                                id="tabla-historico">
-                            <thead class="table-light">
+                            <thead class="table-dark">
                                 <tr>
-                                    <th style="width: 120px;">Fecha</th>
-                                    <th style="width: 90px;">DNI</th>
+                                    <th class="col-fecha">Fecha</th>
+                                    <th class="col-dni-sm">DNI</th>
                                     <th>Nombre</th>
                                     <th>Apellido</th>
                                     <th>Expediente</th>
@@ -282,7 +209,7 @@
                                                 </span>
                                                 {% if m.delta %}<small class="text-muted">({{ m.delta }})</small>{% endif %}
                                             </td>
-                                            <td class="text-break" style="max-width: 280px;">{{ m.motivo|default_if_none:'-' }}</td>
+                                            <td class="text-break col-motivo">{{ m.motivo|default_if_none:'-' }}</td>
                                             <td>{{ m.usuario.get_full_name|default:m.usuario.username }}</td>
                                             <td>
                                                 <span class="badge bg-{% if m.legajo.revision_tecnico == 'APROBADO' %}success{% elif m.legajo.revision_tecnico == 'RECHAZADO' %}danger{% else %}secondary{% endif %}">

--- a/celiaquia/templates/celiaquia/partials/cupo_table.html
+++ b/celiaquia/templates/celiaquia/partials/cupo_table.html
@@ -1,92 +1,94 @@
-
-<div class="card mt-3">
-    <div class="card-header bg-light d-flex justify-content-between align-items-center">
-        <span class="fw-semibold">{{ title }}</span>
-        <label for="{{ filter_id }}" class="visually-hidden">{{ filter_label }}</label>
-
 {#
-  Fragmento reutilizable para tablas de cupo.
+  Reusable table card for cupo lists.
 
-  Parámetros esperados:
-  - title: título a mostrar en el encabezado de la tarjeta.
-  - table_id: id del elemento <table>.
-  - filter_id: id del campo de filtro.
-  - rows: iterable con los legajos a mostrar.
-  - empty_message: texto a mostrar cuando no hay filas.
-  - estado_badge_class: clases CSS para la etiqueta de estado de cupo.
-  - estado_badge_text: texto de la etiqueta de estado de cupo.
-  - show_activo (opcional): mostrar la columna "Activo".
-  - show_actions (opcional): mostrar columna de acciones (Reactivar/Baja).
-  - colspan: cantidad de columnas para la fila vacía.
+  Parameters expected:
+  - title: text for the card header.
+  - table_id: id attribute for the table element.
+  - filter_id: id attribute for the search input.
+  - filter_label: label text for accessibility.
+  - filter_placeholder: placeholder for the search input.
+  - rows: iterable of legajos to render.
+  - empty_message: text when there are no rows.
+  - show_revision (optional): include "Revisión" column.
+  - show_resultado (optional): include "Resultado" column.
+  - show_activo (optional): include "Activo" column.
+  - show_actions (optional): include actions column.
+  - colspan: number of columns for the empty message row.
 #}
 <div class="card mt-3">
-    <div class="card-header bg-light d-flex justify-content-between align-items-center">
-        <span class="fw-semibold">{{ title }}</span>
-
-        <input type="search"
-               id="{{ filter_id }}"
-               class="form-control form-control-sm"
-               placeholder="Filtrar por DNI, nombre o expediente"
-               style="max-width: 280px" />
+    <div class="card-header bg-dark">
+        <div class="d-flex justify-content-between align-items-center">
+            <span class="fw-semibold">{{ title }}</span>
+            <div class="flex-grow-1 d-flex justify-content-end ms-3">
+                <label for="{{ filter_id }}" class="visually-hidden">{{ filter_label }}</label>
+                <input type="search"
+                       id="{{ filter_id }}"
+                       class="form-control form-control-sm filter-input"
+                       placeholder="{{ filter_placeholder }}" />
+            </div>
+        </div>
     </div>
     <div class="card-body p-0">
         <div class="table-responsive">
-            <table class="table table-striped table-sm table-hover align-middle mb-0"
-                   id="{{ table_id }}">
-                <thead class="table-light">
+            <table class="table table-hover align-middle mb-0" id="{{ table_id }}">
+                <thead class="table-dark">
                     <tr>
-                        <th style="width: 80px;">DNI</th>
+                        <th class="col-dni">DNI</th>
                         <th>Nombre</th>
                         <th>Apellido</th>
                         <th>Expediente</th>
-
-                        {% if estado_badge_class %}<th class="d-none d-md-table-cell">Estado cupo</th>{% endif %}
-
-                        <th class="d-none d-md-table-cell">Estado cupo</th>
-
-                        {% if show_activo %}<th class="d-none d-md-table-cell">Activo</th>{% endif %}
-                        {% if show_actions %}<th class="text-end" style="width: 120px;">Acciones</th>{% endif %}
+                        {% if show_revision %}<th>Revisión</th>{% endif %}
+                        {% if show_resultado %}<th>Resultado</th>{% endif %}
+                        <th>Estado cupo</th>
+                        {% if show_activo %}<th>Activo</th>{% endif %}
+                        {% if show_actions %}<th class="text-end col-actions">Acciones</th>{% endif %}
                     </tr>
                 </thead>
                 <tbody>
                     {% for leg in rows %}
                         <tr data-row>
-                            <td data-text="{{ leg.ciudadano.documento }}">{{ leg.ciudadano.documento }}</td>
-                            <td data-text="{{ leg.ciudadano.nombre }}">{{ leg.ciudadano.nombre }}</td>
-                            <td data-text="{{ leg.ciudadano.apellido }}">{{ leg.ciudadano.apellido }}</td>
-                            <td data-text="{{ leg.expediente.codigo|default:leg.expediente.id }}">
-                                {{ leg.expediente.codigo|default:leg.expediente.id }}
-                            </td>
-
-                            {% if estado_badge_class %}
-                                <td data-text="{{ leg.estado_cupo }}" class="d-none d-md-table-cell">
-                                    <span class="badge {{ estado_badge_class }}">{{ estado_badge_text }}</span>
+                            <td data-text="{{ leg.ciudadano.documento|default_if_none:'' }}">{{ leg.ciudadano.documento }}</td>
+                            <td data-text="{{ leg.ciudadano.nombre|default_if_none:'' }}">{{ leg.ciudadano.nombre }}</td>
+                            <td data-text="{{ leg.ciudadano.apellido|default_if_none:'' }}">{{ leg.ciudadano.apellido }}</td>
+                            <td data-text="{{ leg.expediente.codigo }}">{{ leg.expediente.codigo }}</td>
+                            {% if show_revision %}
+                                <td>
+                                    <span class="badge bg-{% if leg.revision_tecnico == 'APROBADO' %}success{% elif leg.revision_tecnico == 'RECHAZADO' %}danger{% else %}secondary{% endif %}">
+                                        {{ leg.revision_tecnico }}
+                                    </span>
                                 </td>
                             {% endif %}
+                            {% if show_resultado %}
+                                <td>
+                                    <span class="badge bg-{% if leg.resultado_sintys == 'MATCH' %}success{% elif leg.resultado_sintys == 'NO_MATCH' %}danger{% else %}secondary{% endif %}">
+                                        {{ leg.resultado_sintys }}
+                                    </span>
+                                </td>
+                            {% endif %}
+                            <td>
+                                <span class="badge bg-{% if leg.estado_cupo == 'DENTRO' %}primary{% elif leg.estado_cupo == 'FUERA' %}warning text-dark{% else %}secondary{% endif %}">
+                                    {{ leg.estado_cupo }}
+                                </span>
+                            </td>
                             {% if show_activo %}
-                                <td data-text="{% if leg.es_titular_activo %}Sí{% else %}No{% endif %}"
-                                    class="d-none d-md-table-cell">
+                                <td>
                                     {% if leg.es_titular_activo %}
                                         <span class="badge bg-success">Sí</span>
                                     {% else %}
                                         <span class="badge bg-secondary">No</span>
                                     {% endif %}
-
-                            <td data-text="{{ leg.estado_cupo }}" class="d-none d-md-table-cell">
-                                <span class="badge {{ estado_badge_class }}">{{ estado_badge_text }}</span>
-                            </td>
-                            {% if show_activo %}
-                                <td data-text="{% if leg.es_titular_activo %}Sí{% else %}No{% endif %}"
-                                    class="d-none d-md-table-cell">
-                                    <span class="badge bg-secondary">No</span>
-
                                 </td>
                             {% endif %}
                             {% if show_actions %}
                                 <td class="text-end">
                                     <div class="btn-group btn-group-sm">
-                                        <button class="btn btn-outline-success btn-reactivar"
-                                                data-legajo-id="{{ leg.id }}">Reactivar</button>
+                                        {% if leg.es_titular_activo %}
+                                            <button class="btn btn-outline-warning btn-suspender"
+                                                    data-legajo-id="{{ leg.id }}">Suspender</button>
+                                        {% else %}
+                                            <button class="btn btn-outline-success btn-reactivar"
+                                                    data-legajo-id="{{ leg.id }}">Reactivar</button>
+                                        {% endif %}
                                         <button class="btn btn-outline-danger btn-baja" data-legajo-id="{{ leg.id }}">Baja</button>
                                     </div>
                                 </td>

--- a/static/custom/css/custom.css
+++ b/static/custom/css/custom.css
@@ -131,3 +131,37 @@ border-left-color: #fb4733 !important;
 }
 
 
+/* Celiaquia cupo tables */
+.card-header.bg-dark {
+  color: #fff;
+}
+
+.filter-input {
+  max-width: 280px;
+}
+
+.filter-input-sm {
+  max-width: 220px;
+}
+
+.col-dni {
+  width: 80px;
+}
+
+.col-dni-sm {
+  width: 90px;
+}
+
+.col-actions {
+  width: 180px;
+}
+
+.col-fecha {
+  width: 120px;
+}
+
+.col-motivo {
+  max-width: 280px;
+}
+
+


### PR DESCRIPTION
## Summary
- replace repeated cupo tables with reusable partial
- switch tables and headers to dark theme with aligned filter inputs
- move inline widths to utility classes for consistent layout

## Testing
- `black .`
- `pylint **/*.py --rcfile=.pylintrc`
- `djlint celiaquia/templates/celiaquia/cupo_provincia.html celiaquia/templates/celiaquia/partials/cupo_table.html --configuration=.djlintrc --reformat`
- `docker compose exec django pytest -n auto` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c06d36e268832db21514457a948a29