### PR TITLE
Agregar listado de expedientes de pago por provincia

### DIFF
--- a/celiaquia/templates/celiaquia/cupo_provincia.html
+++ b/celiaquia/templates/celiaquia/cupo_provincia.html
@@ -26,6 +26,8 @@
             <button class="btn btn-outline-primary btn-sm"
                     data-bs-toggle="modal"
                     data-bs-target="#modalHistorico">Historico</button>
+            <a href="{% url 'pago_expediente_list' provincia.id %}"
+               class="btn btn-outline-success btn-sm">Ver expedientes de pago</a>
             <form action="{% url 'pago_expediente_create' provincia.id %}"
                   method="post"
                   class="d-inline">

--- a/celiaquia/templates/celiaquia/pago_expediente_list.html
+++ b/celiaquia/templates/celiaquia/pago_expediente_list.html
@@ -1,0 +1,58 @@
+{% extends "includes/main.html" %}
+{% block title %}Pagos — {{ provincia }}{% endblock %}
+{% block content %}
+    <div class="d-flex justify-content-between align-items-center mb-3">
+        <h4 class="mb-0">Expedientes de pago — {{ provincia }}</h4>
+        <div class="d-flex gap-2">
+            <a href="{% url 'cupo_provincia_detail' provincia.id %}"
+               class="btn btn-outline-secondary btn-sm">← Volver</a>
+            <form action="{% url 'pago_expediente_create' provincia.id %}"
+                  method="post"
+                  class="d-inline">
+                {% csrf_token %}
+                <button class="btn btn-success btn-sm">Generar expediente de pago</button>
+            </form>
+        </div>
+    </div>
+    <div class="card">
+        <div class="card-body p-0">
+            <div class="table-responsive">
+                <table class="table table-hover mb-0">
+                    <thead class="table-light">
+                        <tr>
+                            <th>ID</th>
+                            <th>Período</th>
+                            <th>Estado</th>
+                            <th>Candidatos</th>
+                            <th>Validados</th>
+                            <th>Excluidos</th>
+                            <th>Creado</th>
+                            <th></th>
+                        </tr>
+                    </thead>
+                    <tbody>
+                        {% for p in pagos %}
+                            <tr>
+                                <td>{{ p.id }}</td>
+                                <td>{{ p.periodo }}</td>
+                                <td>{{ p.estado }}</td>
+                                <td>{{ p.total_candidatos }}</td>
+                                <td>{{ p.total_validados }}</td>
+                                <td>{{ p.total_excluidos }}</td>
+                                <td>{{ p.creado_en|date:"Y-m-d" }}</td>
+                                <td>
+                                    <a class="btn btn-sm btn-primary"
+                                       href="{% url 'pago_expediente_detail' p.id %}">Ver detalle</a>
+                                </td>
+                            </tr>
+                        {% empty %}
+                            <tr>
+                                <td colspan="8" class="text-center text-muted py-3">No hay expedientes de pago.</td>
+                            </tr>
+                        {% endfor %}
+                    </tbody>
+                </table>
+            </div>
+        </div>
+    </div>
+{% endblock %}

--- a/celiaquia/tests/test_pago_expediente_list.py
+++ b/celiaquia/tests/test_pago_expediente_list.py
@@ -1,0 +1,25 @@
+import pytest
+from django.urls import reverse
+from django.contrib.auth.models import User
+
+from users.models import Profile
+from core.models import Provincia
+from celiaquia.models import PagoExpediente, PagoEstado
+
+
+@pytest.mark.django_db
+def test_pago_expediente_list_shows_pagos(client):
+    provincia = Provincia.objects.create(nombre="Test")
+    user = User.objects.create_user(username="user", password="pass")
+    Profile.objects.create(user=user, es_usuario_provincial=True, provincia=provincia)
+    PagoExpediente.objects.create(
+        provincia=provincia,
+        periodo="2024-01",
+        estado=PagoEstado.BORRADOR,
+        creado_por=user,
+    )
+    client.force_login(user)
+    url = reverse("pago_expediente_list", args=[provincia.id])
+    response = client.get(url)
+    assert response.status_code == 200
+    assert "2024-01" in response.content.decode()

--- a/celiaquia/urls.py
+++ b/celiaquia/urls.py
@@ -8,6 +8,7 @@ from celiaquia.views.pago import (
     PagoExpedienteCreateView,
     PagoExpedienteDetailView,
     PagoExpedienteExportView,
+    PagoExpedienteListView,
     PagoNominaExportActualView,
 )
 from celiaquia.views.expediente import (
@@ -165,6 +166,11 @@ urlpatterns = [
         "cupo/<int:provincia_id>/legajo/<int:legajo_id>/reactivar/",
         CupoReactivarLegajoView.as_view(),
         name="cupo_legajo_reactivar",
+    ),
+    path(
+        "pagos/provincia/<int:provincia_id>/",
+        PagoExpedienteListView.as_view(),
+        name="pago_expediente_list",
     ),
     path(
         "pagos/provincia/<int:provincia_id>/crear/",

--- a/celiaquia/views/pago.py
+++ b/celiaquia/views/pago.py
@@ -1,5 +1,6 @@
 import io
 import logging
+
 from django.contrib import messages
 from django.core.exceptions import ValidationError
 from django.http import FileResponse, HttpResponseRedirect
@@ -7,14 +8,36 @@ from django.shortcuts import get_object_or_404, redirect, render
 from django.urls import reverse
 from django.views import View
 from django.views.decorators.csrf import csrf_protect
+from django.views.generic import ListView
 from django.utils.decorators import method_decorator
 
 from ciudadanos.models import Provincia
-from celiaquia.models import PagoExpediente, PagoEstado
+from celiaquia.models import PagoExpediente
 from celiaquia.forms import PagoRespuestaUploadForm
 from celiaquia.services.pago_service import PagoService
 
 logger = logging.getLogger(__name__)
+
+
+class PagoExpedienteListView(ListView):
+    """Lista los expedientes de pago de una provincia."""
+
+    model = PagoExpediente
+    template_name = "celiaquia/pago_expediente_list.html"
+    context_object_name = "pagos"
+
+    def get_queryset(self):
+        provincia_id = self.kwargs.get("provincia_id")
+        return PagoExpediente.objects.filter(provincia_id=provincia_id).order_by(
+            "-creado_en"
+        )
+
+    def get_context_data(self, **kwargs):
+        context = super().get_context_data(**kwargs)
+        context["provincia"] = get_object_or_404(
+            Provincia, pk=self.kwargs.get("provincia_id")
+        )
+        return context
 
 
 class PagoExpedienteCreateView(View):


### PR DESCRIPTION
## Resumen
- mostrar expedientes de pago por provincia en nueva vista con tabla y botón de detalle
- añadir acceso desde la pantalla de cupo provincial y enlace para generar nuevos expedientes
- cubrir la nueva vista con prueba básica

## Testing
- `black celiaquia/views/pago.py celiaquia/tests/test_pago_expediente_list.py`
- `pylint celiaquia/views/pago.py celiaquia/tests/test_pago_expediente_list.py --rcfile=.pylintrc`
- `djlint celiaquia/templates/celiaquia/pago_expediente_list.html celiaquia/templates/celiaquia/cupo_provincia.html --configuration=.djlintrc --reformat`
- `docker compose exec django pytest -n auto` *(falló: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c0706f0218832d8ce152e94e7131dd