### PR TITLE
Track Expediente state changes and display history

### DIFF
--- a/celiaquia/admin.py
+++ b/celiaquia/admin.py
@@ -7,6 +7,7 @@ from .models import (
     Expediente,
     ExpedienteCiudadano,
     AsignacionTecnico,
+    ExpedienteEstadoHistorial,
 )
 
 
@@ -54,3 +55,15 @@ class AsignacionTecnicoAdmin(admin.ModelAdmin):
     list_display = ("expediente", "tecnico", "fecha_asignacion")
     list_filter = ("fecha_asignacion",)
     search_fields = ("expediente__id", "tecnico__username")
+
+
+@admin.register(ExpedienteEstadoHistorial)
+class ExpedienteEstadoHistorialAdmin(admin.ModelAdmin):
+    list_display = (
+        "expediente",
+        "estado_anterior",
+        "estado_nuevo",
+        "usuario",
+        "fecha",
+    )
+    list_filter = ("expediente", "estado_nuevo")

--- a/celiaquia/apps.py
+++ b/celiaquia/apps.py
@@ -4,3 +4,6 @@ from django.apps import AppConfig
 class CeliaquiaConfig(AppConfig):
     default_auto_field = "django.db.models.BigAutoField"
     name = "celiaquia"
+
+    def ready(self):  # pragma: no cover - Django startup
+        from . import signals  # pylint: disable=import-outside-toplevel, unused-import

--- a/celiaquia/migrations/0005_expedienteestadohistorial.py
+++ b/celiaquia/migrations/0005_expedienteestadohistorial.py
@@ -1,0 +1,69 @@
+# Generated manually for ExpedienteEstadoHistorial model
+from django.conf import settings
+from django.db import migrations, models
+import django.db.models.deletion
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        migrations.swappable_dependency(settings.AUTH_USER_MODEL),
+        ("celiaquia", "0004_pagoexpediente_pagonomina_and_more"),
+    ]
+
+    operations = [
+        migrations.CreateModel(
+            name="ExpedienteEstadoHistorial",
+            fields=[
+                (
+                    "id",
+                    models.BigAutoField(
+                        auto_created=True,
+                        primary_key=True,
+                        serialize=False,
+                        verbose_name="ID",
+                    ),
+                ),
+                ("fecha", models.DateTimeField(auto_now_add=True)),
+                ("observaciones", models.TextField(blank=True, null=True)),
+                (
+                    "expediente",
+                    models.ForeignKey(
+                        on_delete=django.db.models.deletion.CASCADE,
+                        related_name="historial",
+                        to="celiaquia.expediente",
+                    ),
+                ),
+                (
+                    "estado_anterior",
+                    models.ForeignKey(
+                        on_delete=django.db.models.deletion.PROTECT,
+                        related_name="+",
+                        to="celiaquia.estadoexpediente",
+                    ),
+                ),
+                (
+                    "estado_nuevo",
+                    models.ForeignKey(
+                        on_delete=django.db.models.deletion.PROTECT,
+                        related_name="+",
+                        to="celiaquia.estadoexpediente",
+                    ),
+                ),
+                (
+                    "usuario",
+                    models.ForeignKey(
+                        blank=True,
+                        null=True,
+                        on_delete=django.db.models.deletion.SET_NULL,
+                        related_name="cambios_estado",
+                        to=settings.AUTH_USER_MODEL,
+                    ),
+                ),
+            ],
+            options={
+                "verbose_name": "Historial de estado",
+                "verbose_name_plural": "Historial de estados",
+                "ordering": ("-fecha",),
+            },
+        ),
+    ]

--- a/celiaquia/models.py
+++ b/celiaquia/models.py
@@ -135,6 +135,37 @@ class Expediente(models.Model):
             return None
 
 
+class ExpedienteEstadoHistorial(models.Model):
+    """Historial de cambios de estado para un expediente."""
+
+    expediente = models.ForeignKey(
+        "Expediente", on_delete=models.CASCADE, related_name="historial"
+    )
+    estado_anterior = models.ForeignKey(
+        EstadoExpediente, on_delete=models.PROTECT, related_name="+"
+    )
+    estado_nuevo = models.ForeignKey(
+        EstadoExpediente, on_delete=models.PROTECT, related_name="+"
+    )
+    usuario = models.ForeignKey(
+        User,
+        null=True,
+        blank=True,
+        on_delete=models.SET_NULL,
+        related_name="cambios_estado",
+    )
+    fecha = models.DateTimeField(auto_now_add=True)
+    observaciones = models.TextField(null=True, blank=True)
+
+    class Meta:
+        verbose_name = "Historial de estado"
+        verbose_name_plural = "Historial de estados"
+        ordering = ("-fecha",)
+
+    def __str__(self):
+        return f"{self.expediente_id} {self.estado_anterior} -> {self.estado_nuevo}"
+
+
 class ExpedienteCiudadano(models.Model):
     expediente = models.ForeignKey(
         Expediente, on_delete=models.CASCADE, related_name="expediente_ciudadanos"

--- a/celiaquia/signals.py
+++ b/celiaquia/signals.py
@@ -1,0 +1,23 @@
+from django.db.models.signals import pre_save
+from django.dispatch import receiver
+
+from config.middlewares.threadlocals import get_current_user
+from .models import Expediente, ExpedienteEstadoHistorial
+
+
+@receiver(pre_save, sender=Expediente)
+def registrar_historial_estado(sender, instance, **_):
+    """Registra el historial cuando cambia el estado de un expediente."""
+    if not instance.pk:
+        return
+    try:
+        previous = sender.objects.get(pk=instance.pk)
+    except sender.DoesNotExist:  # pragma: no cover - race condition
+        return
+    if previous.estado_id != instance.estado_id:
+        ExpedienteEstadoHistorial.objects.create(
+            expediente=instance,
+            estado_anterior=previous.estado,
+            estado_nuevo=instance.estado,
+            usuario=get_current_user(),
+        )

--- a/celiaquia/templates/celiaquia/expediente_detail.html
+++ b/celiaquia/templates/celiaquia/expediente_detail.html
@@ -135,6 +135,23 @@
                 </div>
             </div>
         </div>
+        <div class="p-3 rounded shadow mb-4"
+             style="background-color:#1c2a3a;
+                    color:#e0e0e0">
+            <h5 class="mb-3">Historial de estados</h5>
+            <ul class="list-unstyled mb-0">
+                {% for h in expediente.historial.order_by('-fecha') %}
+                    <li>
+                        <strong>{{ h.fecha|date:"d/m/Y H:i" }}</strong>:
+                        {{ h.estado_anterior.display_name }} → {{ h.estado_nuevo.display_name }}
+                        {% if h.usuario %}- {{ h.usuario.get_full_name|default:h.usuario.username }}{% endif %}
+                        {% if h.observaciones %}({{ h.observaciones }}){% endif %}
+                    </li>
+                {% empty %}
+                    <li class="text-muted">Sin cambios de estado.</li>
+                {% endfor %}
+            </ul>
+        </div>
         {% if fuera_de_cupo %}
             <div class="p-3 rounded shadow mb-4"
                  style="background-color:#1c2a3a;

--- a/celiaquia/views/confirm_envio.py
+++ b/celiaquia/views/confirm_envio.py
@@ -97,7 +97,7 @@ class ExpedienteConfirmView(LoginRequiredMixin, View):
 
         # 4) Transición de estado / lógica de confirmación
         try:
-            result = ExpedienteService.confirmar_envio(expediente)
+            result = ExpedienteService.confirmar_envio(expediente, request.user)
             logger.info(
                 "Confirmación de envío OK. Expediente %s por %s",
                 expediente.pk,


### PR DESCRIPTION
## Summary
- Add `ExpedienteEstadoHistorial` model and admin to track expediente state transitions
- Log state changes via pre_save signal and refactor services/views to pass user for history
- Show expediente state history in detail view

## Testing
- `black celiaquia/apps.py celiaquia/services/expediente_service.py celiaquia/views/expediente.py`
- `djlint celiaquia/templates/celiaquia/expediente_detail.html --configuration=.djlintrc --reformat`
- `pylint celiaquia/apps.py celiaquia/services/expediente_service.py celiaquia/views/expediente.py`
- `python manage.py makemigrations celiaquia` *(fails: AttributeError: 'NoneType' object has no attribute 'startswith')*
- `python manage.py migrate` *(fails: AttributeError: 'NoneType' object has no attribute 'startswith')*
- `pytest` *(fails: AttributeError: 'NoneType' object has no attribute 'startswith')*

------
https://chatgpt.com/codex/tasks/task_e_68c18bf54038832d85c812a397d04558