### PR TITLE
Fix historial ordering in expediente detail template

### DIFF
--- a/celiaquia/templates/celiaquia/expediente_detail.html
+++ b/celiaquia/templates/celiaquia/expediente_detail.html
@@ -140,7 +140,7 @@
                     color:#e0e0e0">
             <h5 class="mb-3">Historial de estados</h5>
             <ul class="list-unstyled mb-0">
-                {% for h in expediente.historial.order_by('-fecha') %}
+                {% for h in expediente.historial.all|dictsortreversed:"fecha" %}
                     <li>
                         <strong>{{ h.fecha|date:"d/m/Y H:i" }}</strong>:
                         {{ h.estado_anterior.display_name }} → {{ h.estado_nuevo.display_name }}


### PR DESCRIPTION
## Summary
- Fix `expediente_detail.html` failing due to invalid `order_by` call

## Testing
- `black .`
- `pylint **/*.py --rcfile=.pylintrc`
- `djlint . --configuration=.djlintrc --reformat`
- `docker compose exec django pytest -n auto` *(fails: command not found: docker)*

------
https://chatgpt.com/codex/tasks/task_e_68c1a76017a0832d80de19dbe1b79cc2