### PR TITLE
Add Sintys export for expedientes

### DIFF
--- a/celiaquia/templates/celiaquia/expediente_detail.html
+++ b/celiaquia/templates/celiaquia/expediente_detail.html
@@ -41,6 +41,8 @@
                 {# Subir/Reprocesar Cruce: Técnico o Coordinador, no Provincia #}
                 {% if is_tec or is_coord %}
                     {% if expediente.estado.nombre == 'ASIGNADO' or expediente.estado.nombre == 'PROCESO_DE_CRUCE' %}
+                        <a href="{% url 'expediente_nomina_sintys_export' expediente.pk %}"
+                           class="btn btn-outline-success btn-sm me-2">Descargar nómina Sintys</a>
                         <button type="button"
                                 class="btn btn-success btn-sm me-2"
                                 data-bs-toggle="modal"

--- a/celiaquia/tests/test_nomina_sintys_export.py
+++ b/celiaquia/tests/test_nomina_sintys_export.py
@@ -1,0 +1,47 @@
+import pytest
+from django.urls import reverse
+from django.contrib.auth.models import User, Group
+from io import BytesIO
+from openpyxl import load_workbook
+
+from celiaquia.models import (
+    Expediente,
+    EstadoExpediente,
+    EstadoLegajo,
+    ExpedienteCiudadano,
+)
+from ciudadanos.models import Ciudadano
+
+
+@pytest.mark.django_db
+def test_exportar_nomina_sintys(client):
+    grupo = Group.objects.create(name="TecnicoCeliaquia")
+    user = User.objects.create_user(username="tec", password="pass")
+    user.groups.add(grupo)
+
+    estado_exp = EstadoExpediente.objects.create(nombre="ASIGNADO")
+    estado_leg = EstadoLegajo.objects.create(nombre="VALIDO")
+    creador = User.objects.create_user(username="prov", password="pass")
+    expediente = Expediente.objects.create(usuario_provincia=creador, estado=estado_exp)
+
+    ciudadano = Ciudadano.objects.create(
+        apellido="Perez",
+        nombre="Juan",
+        fecha_nacimiento="2000-01-01",
+        documento=12345678,
+    )
+    ExpedienteCiudadano.objects.create(
+        expediente=expediente, ciudadano=ciudadano, estado=estado_leg
+    )
+
+    client.force_login(user)
+    url = reverse("expediente_nomina_sintys_export", args=[expediente.pk])
+    response = client.get(url)
+    assert response.status_code == 200
+
+    wb = load_workbook(BytesIO(response.content))
+    ws = wb.active
+    header = [cell.value for cell in next(ws.iter_rows(max_row=1))]
+    assert header == ["dni", "cuit", "nombre", "apellido"]
+    row = [cell.value for cell in next(ws.iter_rows(min_row=2, max_row=2))]
+    assert str(row[0]) == "12345678"

--- a/celiaquia/urls.py
+++ b/celiaquia/urls.py
@@ -24,6 +24,7 @@ from celiaquia.views.expediente import (
     ProcesarExpedienteView,
     RecepcionarExpedienteView,
     RevisarLegajoView,
+    ExpedienteNominaSintysExportView,
     SubirCruceExcelView,
     LocalidadesLookupView,
 )
@@ -126,6 +127,13 @@ urlpatterns = [
         "expedientes/<int:pk>/asignar-tecnico/",
         group_required(["CoordinadorCeliaquia"])(AsignarTecnicoView.as_view()),
         name="expediente_asignar_tecnico",
+    ),
+    path(
+        "expedientes/<int:pk>/exportar-nomina-sintys/",
+        group_required(["TecnicoCeliaquia", "CoordinadorCeliaquia"])(
+            ExpedienteNominaSintysExportView.as_view()
+        ),
+        name="expediente_nomina_sintys_export",
     ),
     path(
         "expedientes/<int:pk>/cruce-cuit/",

--- a/celiaquia/views/expediente.py
+++ b/celiaquia/views/expediente.py
@@ -2,6 +2,7 @@ import json
 import logging
 import time
 import traceback
+import io
 
 
 from django.views import View
@@ -13,6 +14,7 @@ from django.http import (
     HttpResponse,
     HttpResponseBadRequest,
     HttpResponseNotAllowed,
+    FileResponse,
 )
 from django.utils.safestring import mark_safe
 from django.views.decorators.csrf import csrf_protect
@@ -635,6 +637,16 @@ class AsignarTecnicoView(View):
             f"Técnico {tecnico.get_full_name() or tecnico.username} asignado correctamente. Estado: ASIGNADO.",
         )
         return redirect("expediente_detail", pk=pk)
+
+
+class ExpedienteNominaSintysExportView(View):
+    """Descarga la nómina del expediente en formato compatible con Sintys."""
+
+    def get(self, request, pk):
+        expediente = get_object_or_404(Expediente, pk=pk)
+        content = CruceService.generar_nomina_sintys_excel(expediente)
+        filename = f"nomina_sintys_{expediente.pk}.xlsx"
+        return FileResponse(io.BytesIO(content), as_attachment=True, filename=filename)
 
 
 class SubirCruceExcelView(View):


### PR DESCRIPTION
## Summary
- allow downloading an Excel of an expediente's nómina in Sintys format
- expose export endpoint and add download button near Cruce Sintys actions
- cover Sintys export with a regression test

## Testing
- `black celiaquia/services/cruce_service.py celiaquia/views/expediente.py celiaquia/urls.py celiaquia/tests/test_nomina_sintys_export.py`
- `pylint celiaquia/services/cruce_service.py celiaquia/views/expediente.py celiaquia/urls.py celiaquia/tests/test_nomina_sintys_export.py --rcfile=.pylintrc`
- `DJLINT_NO_TQDM=1 djlint celiaquia/templates/celiaquia/expediente_detail.html --configuration=.djlintrc --reformat` *(fails: Aborted!)*
- `docker compose exec django pytest -n auto` *(fails: command not found)*
- `pytest -n auto` *(fails: AttributeError: 'NoneType' object has no attribute 'startswith')*

------
https://chatgpt.com/codex/tasks/task_e_68c1abc7c144832da5bf497566fd30b8