### PR TITLE
Actualizar generación de nómina Sintys

### DIFF
--- a/celiaquia/tests/test_nomina_sintys_export.py
+++ b/celiaquia/tests/test_nomina_sintys_export.py
@@ -1,7 +1,8 @@
-import pytest
-from django.urls import reverse
-from django.contrib.auth.models import User, Group
 from io import BytesIO
+
+import pytest
+from django.contrib.auth.models import Group, User
+from django.urls import reverse
 from openpyxl import load_workbook
 
 from celiaquia.models import (
@@ -10,7 +11,7 @@ from celiaquia.models import (
     EstadoLegajo,
     ExpedienteCiudadano,
 )
-from ciudadanos.models import Ciudadano
+from ciudadanos.models import Ciudadano, TipoDocumento
 
 
 @pytest.mark.django_db
@@ -24,11 +25,13 @@ def test_exportar_nomina_sintys(client):
     creador = User.objects.create_user(username="prov", password="pass")
     expediente = Expediente.objects.create(usuario_provincia=creador, estado=estado_exp)
 
+    tipo_doc = TipoDocumento.objects.create(tipo="DNI")
     ciudadano = Ciudadano.objects.create(
         apellido="Perez",
         nombre="Juan",
         fecha_nacimiento="2000-01-01",
         documento=12345678,
+        tipo_documento=tipo_doc,
     )
     ExpedienteCiudadano.objects.create(
         expediente=expediente, ciudadano=ciudadano, estado=estado_leg
@@ -42,6 +45,7 @@ def test_exportar_nomina_sintys(client):
     wb = load_workbook(BytesIO(response.content))
     ws = wb.active
     header = [cell.value for cell in next(ws.iter_rows(max_row=1))]
-    assert header == ["dni", "cuit", "nombre", "apellido"]
+    assert header == ["Numero_documento", "TipoDocumento", "nombre", "apellido"]
     row = [cell.value for cell in next(ws.iter_rows(min_row=2, max_row=2))]
     assert str(row[0]) == "12345678"
+    assert row[1] == "DNI"


### PR DESCRIPTION
## Summary
- Export Excel nominal data using Numero_documento and TipoDocumento columns
- Cover new columns in Sintys export test with TipoDocumento example

## Testing
- `black celiaquia/services/cruce_service.py celiaquia/tests/test_nomina_sintys_export.py`
- `pylint celiaquia/services/cruce_service.py celiaquia/tests/test_nomina_sintys_export.py --rcfile=.pylintrc`
- `DJLINT_NO_TQDM=1 djlint celiaquia/templates/celiaquia/expediente_detail.html --configuration=.djlintrc --reformat`
- `docker compose exec django pytest -n auto` *(fails: command not found)*
- `pytest -n auto` *(fails: AttributeError: 'NoneType' object has no attribute 'startswith')*

------
https://chatgpt.com/codex/tasks/task_e_68c1b311ea08832da848d9e7156789bc