### PR TITLE
Improve state history UI for coordinators

### DIFF
--- a/celiaquia/templates/celiaquia/expediente_detail.html
+++ b/celiaquia/templates/celiaquia/expediente_detail.html
@@ -135,23 +135,71 @@
                 </div>
             </div>
         </div>
-        <div class="p-3 rounded shadow mb-4"
-             style="background-color:#1c2a3a;
-                    color:#e0e0e0">
-            <h5 class="mb-3">Historial de estados</h5>
-            <ul class="list-unstyled mb-0">
-                {% for h in expediente.historial.all|dictsortreversed:"fecha" %}
-                    <li>
-                        <strong>{{ h.fecha|date:"d/m/Y H:i" }}</strong>:
-                        {{ h.estado_anterior.display_name }} → {{ h.estado_nuevo.display_name }}
-                        {% if h.usuario %}- {{ h.usuario.get_full_name|default:h.usuario.username }}{% endif %}
-                        {% if h.observaciones %}({{ h.observaciones }}){% endif %}
-                    </li>
-                {% empty %}
-                    <li class="text-muted">Sin cambios de estado.</li>
-                {% endfor %}
-            </ul>
-        </div>
+        {% if is_coord %}
+            <div class="p-3 rounded shadow mb-4"
+                 style="background-color:#1c2a3a;
+                        color:#e0e0e0">
+                <h5 class="mb-3">Historial de estados</h5>
+                <div class="list-group">
+                    {% for h in historial_page_obj %}
+                        <div class="list-group-item border-0 mb-3 rounded shadow-sm card-dark">
+                            <div class="d-flex justify-content-between">
+                                <div>
+                                    <div class="fw-semibold">{{ h.fecha|date:"d/m/Y H:i" }}</div>
+                                    <div class="small">{{ h.estado_anterior.display_name }} → {{ h.estado_nuevo.display_name }}</div>
+                                </div>
+                                <div class="text-end small">
+                                    {% if h.usuario %}{{ h.usuario.get_full_name|default:h.usuario.username }}{% endif %}
+                                    {% if h.observaciones %}<div class="text-muted mt-1">{{ h.observaciones }}</div>{% endif %}
+                                </div>
+                            </div>
+                        </div>
+                    {% empty %}
+                        <p class="text-muted mb-0">Sin cambios de estado.</p>
+                    {% endfor %}
+                </div>
+                {% if historial_page_obj.paginator.num_pages > 1 %}
+                    <nav class="mt-3">
+                        <ul class="pagination pagination-sm mb-0">
+                            {% if historial_page_obj.has_previous %}
+                                <li class="page-item">
+                                    <a class="page-link"
+                                       href="?{% for key, value in request.GET.items %}{% if key != 'historial_page' %}{{ key }}={{ value }}&{% endif %}{% endfor %}historial_page={{ historial_page_obj.previous_page_number }}"
+                                       aria-label="Anterior">&laquo;</a>
+                                </li>
+                            {% else %}
+                                <li class="page-item disabled">
+                                    <span class="page-link">&laquo;</span>
+                                </li>
+                            {% endif %}
+                            {% for num in historial_page_obj.paginator.page_range %}
+                                {% if num == historial_page_obj.number %}
+                                    <li class="page-item active">
+                                        <span class="page-link">{{ num }}</span>
+                                    </li>
+                                {% else %}
+                                    <li class="page-item">
+                                        <a class="page-link"
+                                           href="?{% for key, value in request.GET.items %}{% if key != 'historial_page' %}{{ key }}={{ value }}&{% endif %}{% endfor %}historial_page={{ num }}">{{ num }}</a>
+                                    </li>
+                                {% endif %}
+                            {% endfor %}
+                            {% if historial_page_obj.has_next %}
+                                <li class="page-item">
+                                    <a class="page-link"
+                                       href="?{% for key, value in request.GET.items %}{% if key != 'historial_page' %}{{ key }}={{ value }}&{% endif %}{% endfor %}historial_page={{ historial_page_obj.next_page_number }}"
+                                       aria-label="Siguiente">&raquo;</a>
+                                </li>
+                            {% else %}
+                                <li class="page-item disabled">
+                                    <span class="page-link">&raquo;</span>
+                                </li>
+                            {% endif %}
+                        </ul>
+                    </nav>
+                {% endif %}
+            </div>
+        {% endif %}
         {% if fuera_de_cupo %}
             <div class="p-3 rounded shadow mb-4"
                  style="background-color:#1c2a3a;


### PR DESCRIPTION
## Summary
- redesign expediente state history entries to card-style list items
- hide state history from non-coordinator users
- paginate state history with three entries per page

## Testing
- `djlint . --configuration=.djlintrc --reformat`
- `black .`
- `pylint **/*.py --rcfile=.pylintrc`
- `docker compose exec django pytest -n auto` *(fails: command not found)*
- `pytest -n auto` *(fails: AttributeError: 'NoneType' object has no attribute 'startswith')*


------
https://chatgpt.com/codex/tasks/task_e_68c1aac921bc832da4042049642bf9d1