### PR TITLE
Enable Celiaquia pagination with selectable page sizes

### DIFF
--- a/celiaquia/templates/celiaquia/expediente_detail.html
+++ b/celiaquia/templates/celiaquia/expediente_detail.html
@@ -200,10 +200,12 @@
                         <select id="preview-page-size"
                                 class="form-select form-select-sm"
                                 style="width: auto">
-                            <option value="10">10</option>
-                            <option value="25" selected>25</option>
+                            <option value="5">5</option>
+                            <option value="10" selected>10</option>
+                            <option value="15">15</option>
+                            <option value="25">25</option>
                             <option value="50">50</option>
-                            <option value="100">100</option>
+                            <option value="all">Todos</option>
                         </select>
                     </div>
                 </div>
@@ -246,10 +248,12 @@
                     <select id="legajos-page-size"
                             class="form-select form-select-sm"
                             style="width: auto">
+                        <option value="5">5</option>
                         <option value="10" selected>10</option>
+                        <option value="15">15</option>
                         <option value="25">25</option>
                         <option value="50">50</option>
-                        <option value="100">100</option>
+                        <option value="all">Todos</option>
                     </select>
                 </div>
             </div>

--- a/static/custom/js/expediente_detail.js
+++ b/static/custom/js/expediente_detail.js
@@ -54,12 +54,15 @@ document.addEventListener('DOMContentLoaded', () => {
     if (!nodes.length || !pageSizeSelect || !paginationUl) return;
 
     let page = 1;
-    const readPageSize = () => parseInt(pageSizeSelect.value || '10', 10) || 10;
+    const readPageSize = () => {
+      const val = pageSizeSelect.value;
+      return val === 'all' ? Infinity : parseInt(val, 10) || 10;
+    };
 
     function render() {
       const pageSize = readPageSize();
       const total = nodes.length;
-      const totalPages = Math.max(1, Math.ceil(total / pageSize));
+      const totalPages = pageSize === Infinity ? 1 : Math.max(1, Math.ceil(total / pageSize));
       if (page > totalPages) page = totalPages;
 
       const start = (page - 1) * pageSize;


### PR DESCRIPTION
## Summary
- Allow choosing 5/10/15/25/50/todos rows in Celiaquía preview and legajo tables
- Support "Todos" option and dynamic page calculation in `expediente_detail.js`

## Testing
- `black --check .`
- `pylint celiaquia/*.py --rcfile=.pylintrc`
- `djlint celiaquia/templates/celiaquia/expediente_detail.html --configuration=.djlintrc --reformat`
- `pytest celiaquia/tests -q` *(fails: AttributeError: 'NoneType' object has no attribute 'startswith')*

------
https://chatgpt.com/codex/tasks/task_e_68c1b487c170832d9f8ddcc21161e795