### PR TITLE
Remove extraneous blank lines in expediente detail template

### DIFF
--- a/celiaquia/templates/celiaquia/expediente_detail.html
+++ b/celiaquia/templates/celiaquia/expediente_detail.html
@@ -143,9 +143,7 @@
                         color:#e0e0e0">
                 <h5 class="mb-3">Historial de estados</h5>
                 <div class="list-group">
-
                     {% for h in historial_page_obj %}
-
                         <div class="list-group-item border-0 mb-3 rounded shadow-sm card-dark">
                             <div class="d-flex justify-content-between">
                                 <div>
@@ -162,7 +160,6 @@
                         <p class="text-muted mb-0">Sin cambios de estado.</p>
                     {% endfor %}
                 </div>
-
                 {% if historial_page_obj.paginator.num_pages > 1 %}
                     <nav class="mt-3">
                         <ul class="pagination pagination-sm mb-0">
@@ -203,7 +200,6 @@
                         </ul>
                     </nav>
                 {% endif %}
-
             </div>
         {% endif %}
         {% if fuera_de_cupo %}


### PR DESCRIPTION
## Summary
- tidy expediente detail template by removing superfluous blank lines around history loop and pagination

## Testing
- `djlint . --check --configuration=.djlintrc`
- `black .`
- `pylint $(git ls-files '*.py') --rcfile=.pylintrc`
- `pytest -q` *(fails: AttributeError: 'NoneType' object has no attribute 'startswith')*

------
https://chatgpt.com/codex/tasks/task_e_68c1b73cfdb4832d86a06f3e32169432