### PR TITLE
Fix Celiaquia PDF generation and permissions

### DIFF
--- a/celiaquia/models.py
+++ b/celiaquia/models.py
@@ -227,11 +227,6 @@ class ExpedienteCiudadano(models.Model):
                 fields=["expediente", "es_titular_activo"], name="leg_exp_tit_idx"
             ),
             models.Index(fields=["creado_en"], name="leg_creado_idx"),
-            models.Index(
-                fields=["expediente"],
-                name="leg_subsanar_partial_idx",
-                condition=Q(revision_tecnico="SUBSANAR"),
-            ),
             models.Index(fields=["ciudadano"], name="leg_ciud_idx"),
         ]
 

--- a/celiaquia/services/cruce_service.py
+++ b/celiaquia/services/cruce_service.py
@@ -231,6 +231,8 @@ class CruceService:
 
     @staticmethod
     def _generar_prd_pdf_html(expediente: Expediente, resumen: dict) -> bytes:
+        if not _WEASY_OK:
+            raise RuntimeError("WeasyPrint no disponible")
         total_legajos = int(resumen.get("total_legajos", 0) or 0)
         matcheados = int(resumen.get("matcheados", 0) or 0)
         no_matcheados = int(resumen.get("no_matcheados", 0) or 0)

--- a/celiaquia/tests/test_cruce_service.py
+++ b/celiaquia/tests/test_cruce_service.py
@@ -3,6 +3,7 @@ from django.core.exceptions import ValidationError
 from django.core.files.uploadedfile import SimpleUploadedFile
 
 from celiaquia.services.cruce_service import CruceService
+from celiaquia.services import cruce_service
 
 
 def test_read_file_bytes_disallows_paths():
@@ -15,3 +16,9 @@ def test_read_file_bytes_accepts_uploaded_file():
     archivo = SimpleUploadedFile("test.csv", contenido)
     resultado = CruceService._read_file_bytes(archivo)
     assert resultado == contenido
+
+
+def test_generar_prd_pdf_html_error_sin_weasy(monkeypatch):
+    monkeypatch.setattr(cruce_service, "_WEASY_OK", False)
+    with pytest.raises(RuntimeError):
+        CruceService._generar_prd_pdf_html(None, {})

--- a/celiaquia/urls.py
+++ b/celiaquia/urls.py
@@ -142,7 +142,7 @@ urlpatterns = [
     ),
     path(
         "expedientes/<int:pk>/cruce/",
-        SubirCruceExcelView.as_view(),
+        group_required(["TecnicoCeliaquia"])(SubirCruceExcelView.as_view()),
         name="expediente_subir_cruce",
     ),
     path(


### PR DESCRIPTION
## Summary
- remove conditional index from ExpedienteCiudadano
- guard WeasyPrint usage and cover missing dependency
- require TecnicoCeliaquia group for Excel cruce upload

## Testing
- `black celiaquia/models.py celiaquia/services/cruce_service.py celiaquia/urls.py celiaquia/tests/test_cruce_service.py`
- `pylint celiaquia/models.py celiaquia/services/cruce_service.py celiaquia/urls.py celiaquia/tests/test_cruce_service.py`
- `djlint celiaquia/templates/celiaquia/pdf_prd_cruce.html --configuration=.djlintrc --reformat`
- `python manage.py makemigrations celiaquia` *(fails: AttributeError: 'NoneType' object has no attribute 'startswith')*
- `python manage.py migrate` *(fails: AttributeError: 'NoneType' object has no attribute 'startswith')*
- `python manage.py test` *(fails: AttributeError: 'NoneType' object has no attribute 'startswith')*


------
https://chatgpt.com/codex/tasks/task_e_68c1fc8f011c832da67b645bd93e532c