### PR TITLE
fix: handle missing Firmante role in string representation

### DIFF
--- a/organizaciones/models.py
+++ b/organizaciones/models.py
@@ -73,7 +73,8 @@ class Firmante(models.Model):
     cuit = models.BigIntegerField(null=True, blank=True)
 
     def __str__(self):
-        return f"{self.nombre} ({self.get_rol_display()})"
+        rol = self.rol.nombre if self.rol else "-"
+        return f"{self.nombre} ({rol})"
 
 
 class Aval1(models.Model):


### PR DESCRIPTION
## Summary
- ensure Firmante.__str__ works when rol is null

## Testing
- `pylint organizaciones/models.py --rcfile=.pylintrc`
- `djlint organizaciones/templates --configuration=.djlintrc --check`
- `pytest -n auto` *(fails: AttributeError: 'NoneType' object has no attribute 'startswith')*

------
https://chatgpt.com/codex/tasks/task_e_68c467206f3c832dbc96164976828250