### PR TITLE
Ajustar alto de iframe de PowerBI en dashboard

### DIFF
--- a/dashboard/templates/dashboard.html
+++ b/dashboard/templates/dashboard.html
@@ -127,11 +127,10 @@
                     <div class="card-body p-0">
                         <div class="row">
                             <div class="col-12 text-center">
-                                <div class="embed-responsive embed-responsive-16by9 text-center">
-                                    <iframe class="embed-responsive-item"
+                                <div class="powerbi-container">
+                                    <iframe class="powerbi-iframe"
                                             title="Tablero - Comedores"
                                             src="https://app.powerbi.com/reportEmbed?reportId=35d6f754-ce1d-48b8-a463-3ba9f3ac6d70&autoAuth=true&ctid=4f822cf4-6867-43fa-ae4a-03a39fe9309c"
-                                            frameborder="0"
                                             allowfullscreen></iframe>
                                 </div>
                             </div>
@@ -179,8 +178,8 @@
     </div>
     <div class="row">
         <div class="col-md-9">
-            <div class="embed-responsive embed-responsive-16by9 w-100">
-                <iframe class="embed-responsive-item"
+            <div class="powerbi-container">
+                <iframe class="powerbi-iframe"
                         title="Tablero - Comedores"
                         src="https://app.powerbi.com/reportEmbed?reportId=35d6f754-ce1d-48b8-a463-3ba9f3ac6d70&autoAuth=true&ctid=4f822cf4-6867-43fa-ae4a-03a39fe9309c"
                         allowfullscreen></iframe>

--- a/static/custom/css/dashboard.css
+++ b/static/custom/css/dashboard.css
@@ -63,8 +63,25 @@
     background-color: #67C672 !important;
   }
 
-  iframe
-  {
+  .powerbi-container {
+    position: relative;
     width: 100%;
-    height: 382px;
+  }
+
+  .powerbi-iframe {
+    width: 100%;
+    min-height: 80vh;
+    border: 0;
+  }
+
+  @media (max-width: 992px) {
+    .powerbi-iframe {
+      min-height: 70vh;
+    }
+  }
+
+  @media (max-width: 576px) {
+    .powerbi-iframe {
+      min-height: 60vh;
+    }
   }


### PR DESCRIPTION
## Summary
- reemplazar los contenedores embed por un contenedor específico para los iframe de PowerBI
- añadir estilos para que los iframe ocupen la altura disponible según el tamaño de pantalla

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68cabd385db8832d824e11243fd087b8