### PR TITLE
Hot Fix

### DIFF
--- a/celiaquia/services/cruce_service.py
+++ b/celiaquia/services/cruce_service.py
@@ -54,9 +54,17 @@ DOCUMENTO_COL_CANDIDATAS = {
     "doc",
     "nro_doc",
     "num_doc",
+    "cuit",
+    "c.u.i.t",
+    "nro_cuit",
+    "numero_cuit",
+    "número_cuit",
+    "cuit_nro",
+    "cuit_número",
     "dni",
     "nro_dni",
     "numero_dni",
+    "número_dni",
 }
 
 
@@ -192,7 +200,7 @@ class CruceService:
     ) -> str | None:
         cols = set(df.columns)
 
-        # Orden de prioridad: documento tiene prioridad sobre dni
+        # Orden de prioridad: documento tiene prioridad sobre cuit y dni
         prioridad = [
             "documento",
             "nro_documento",
@@ -201,9 +209,17 @@ class CruceService:
             "doc",
             "nro_doc",
             "num_doc",
+            "cuit",
+            "c.u.i.t",
+            "nro_cuit",
+            "numero_cuit",
+            "número_cuit",
+            "cuit_nro",
+            "cuit_número",
             "dni",
             "nro_dni",
             "numero_dni",
+            "número_dni",
         ]
 
         # Buscar en orden de prioridad
@@ -230,7 +246,11 @@ class CruceService:
         if not col_documento:
             raise ValidationError(
                 "El archivo debe tener una columna válida de documento. "
-                "Columnas aceptadas: documento, nro_documento, dni, doc, etc."
+                "Columnas aceptadas: documento, nro_documento, numero_documento, "
+                "número_documento, doc, nro_doc, num_doc, cuit, c.u.i.t, "
+                "nro_cuit, numero_cuit, número_cuit, cuit_nro, cuit_número (cuit "
+                "número), dni, "
+                "nro_dni, numero_dni, número_dni."
             )
 
         for raw in df[col_documento].fillna(""):

--- a/celiaquia/services/cruce_service.py
+++ b/celiaquia/services/cruce_service.py
@@ -91,14 +91,14 @@ class CruceService:
                 val = CruceService._normalize_cuit_str(val)
                 if len(val) == 11:
                     return val
-        
+
         # Si no hay campos específicos, usar el campo documento si tiene 11 dígitos
         documento = getattr(ciudadano, "documento", "")
         if documento:
             documento_str = CruceService._normalize_cuit_str(str(documento))
             if len(documento_str) == 11:
                 return documento_str
-        
+
         return ""
 
     @staticmethod
@@ -191,19 +191,26 @@ class CruceService:
         df: pd.DataFrame, candidatas: set, palabra_clave: str
     ) -> str | None:
         cols = set(df.columns)
-        
+
         # Orden de prioridad: documento tiene prioridad sobre dni
         prioridad = [
-            "documento", "nro_documento", "numero_documento", "número_documento",
-            "doc", "nro_doc", "num_doc",
-            "dni", "nro_dni", "numero_dni"
+            "documento",
+            "nro_documento",
+            "numero_documento",
+            "número_documento",
+            "doc",
+            "nro_doc",
+            "num_doc",
+            "dni",
+            "nro_dni",
+            "numero_dni",
         ]
-        
+
         # Buscar en orden de prioridad
         for cand in prioridad:
             if cand in candidatas and cand in cols:
                 return cand
-                
+
         # Fallback: buscar por palabra clave
         for c in df.columns:
             if palabra_clave in c:
@@ -213,14 +220,16 @@ class CruceService:
     @staticmethod
     def _leer_identificadores(archivo_excel) -> dict:
         df = CruceService._leer_tabla(archivo_excel)
-        col_documento = CruceService._col_por_preferencias(df, DOCUMENTO_COL_CANDIDATAS, "documento")
-        
+        col_documento = CruceService._col_por_preferencias(
+            df, DOCUMENTO_COL_CANDIDATAS, "documento"
+        )
+
         cuits = set()
         dnis = set()
-        
+
         if not col_documento:
             raise ValidationError("El archivo debe tener columna 'documento'.")
-            
+
         for raw in df[col_documento].fillna(""):
             norm = CruceService._normalize_dni_str(raw)
             if not norm:
@@ -234,7 +243,7 @@ class CruceService:
             else:
                 # Tratarlo como DNI
                 dnis.add(norm)
-                
+
         if not cuits and not dnis:
             raise ValidationError(
                 "El archivo no contiene documentos válidos en la columna 'documento'."

--- a/celiaquia/services/cruce_service.py
+++ b/celiaquia/services/cruce_service.py
@@ -228,7 +228,10 @@ class CruceService:
         dnis = set()
 
         if not col_documento:
-            raise ValidationError("El archivo debe tener columna 'documento'.")
+            raise ValidationError(
+                "El archivo debe tener una columna válida de documento. "
+                "Columnas aceptadas: documento, nro_documento, dni, doc, etc."
+            )
 
         for raw in df[col_documento].fillna(""):
             norm = CruceService._normalize_dni_str(raw)
@@ -239,7 +242,10 @@ class CruceService:
                 cuits.add(norm)
                 dni = CruceService._extraer_dni_de_cuit(norm)
                 if dni:
-                    dnis.add(dni)
+                    # Normalizar DNI extraído para evitar problemas con ceros iniciales
+                    dni_normalizado = CruceService._normalize_dni_str(dni)
+                    if dni_normalizado:
+                        dnis.add(dni_normalizado)
             else:
                 # Tratarlo como DNI
                 dnis.add(norm)

--- a/celiaquia/templates/celiaquia/expediente_detail.html
+++ b/celiaquia/templates/celiaquia/expediente_detail.html
@@ -47,7 +47,7 @@
                                 class="btn btn-success btn-sm me-2"
                                 data-bs-toggle="modal"
                                 data-bs-target="#modalCruceCuit"
-                                data-mode="new">Subir Excel de CUITs (Cruce)</button>
+                                data-mode="new">Subir Excel de Documentos (Cruce)</button>
                     {% endif %}
                     {% if expediente.cruce_excel %}
                         {% if expediente.estado.nombre == 'ASIGNADO' or expediente.estado.nombre == 'PROCESO_DE_CRUCE' %}
@@ -650,7 +650,7 @@
                     <form id="form-cruce-cuit" method="post" enctype="multipart/form-data">
                         {% csrf_token %}
                         <div class="modal-header">
-                            <h5 class="modal-title" id="modalCruceCuitLabel">Subir Excel de CUITs (con encabezado)</h5>
+                            <h5 class="modal-title" id="modalCruceCuitLabel">Subir Excel de Documentos (con encabezado)</h5>
                             <button type="button"
                                     class="btn-close"
                                     data-bs-dismiss="modal"
@@ -660,7 +660,7 @@
                             <div id="cruce-alertas" class="mb-2"></div>
                             <div class="form-group">
                                 <label for="id_excel_cuit">
-                                    Archivo Excel (.xlsx) con columna <code>cuit</code> o <code>dni</code>
+                                    Archivo Excel (.xlsx) con columna <code>documento</code>
                                 </label>
                                 <input type="file"
                                        name="excel_cuit"
@@ -669,7 +669,7 @@
                                        required
                                        accept=".xlsx,.xls,.csv" />
                                 <small id="cruce-help" class="text-muted">
-                                    Debe incluir encabezado; columnas válidas: <strong>cuit</strong> o <strong>dni</strong>.
+                                    Debe incluir encabezado; columna válida: <strong>documento</strong>.
                                 </small>
                             </div>
                         </div>

--- a/celiaquia/views/expediente.py
+++ b/celiaquia/views/expediente.py
@@ -736,7 +736,7 @@ class SubirCruceExcelView(View):
             return JsonResponse(
                 {
                     "success": False,
-                    "error": "Debe adjuntar un Excel con columna 'cuit'.",
+                    "error": "Debe adjuntar un Excel con columna 'documento'.",
                 },
                 status=400,
             )

--- a/debug_cruce.py
+++ b/debug_cruce.py
@@ -1,0 +1,89 @@
+#!/usr/bin/env python3
+"""
+Script para debuggear el proceso de cruce de SINTYS
+"""
+import os
+import sys
+import django
+
+# Configurar Django
+sys.path.append('c:/Users/DELL/Proyectos/BACKOFFICE')
+os.environ.setdefault('DJANGO_SETTINGS_MODULE', 'config.settings')
+django.setup()
+
+from celiaquia.services.cruce_service import CruceService
+from celiaquia.models import ExpedienteCiudadano
+from ciudadanos.models import Ciudadano
+
+def debug_cruce():
+    print("=== DEBUG PROCESO DE CRUCE ===")
+    
+    # Documento del archivo Excel
+    documento_excel = "20407321459"
+    print(f"Documento del archivo Excel: {documento_excel}")
+    
+    # Normalizar como CUIT y extraer DNI
+    cuit_normalizado = CruceService._normalize_cuit_str(documento_excel)
+    dni_extraido = CruceService._extraer_dni_de_cuit(cuit_normalizado)
+    
+    print(f"CUIT normalizado: {cuit_normalizado}")
+    print(f"DNI extraído del CUIT: {dni_extraido}")
+    
+    # Buscar ciudadanos con ese CUIT
+    print("\n=== BÚSQUEDA POR CUIT ===")
+    ciudadanos_cuit = []
+    for ciudadano in Ciudadano.objects.all():
+        cuit_ciudadano = CruceService._resolver_cuit_ciudadano(ciudadano)
+        if cuit_ciudadano == cuit_normalizado:
+            ciudadanos_cuit.append(ciudadano)
+            print(f"MATCH por CUIT: {ciudadano.id} - {ciudadano.nombre} {ciudadano.apellido} - CUIT: {cuit_ciudadano}")
+    
+    if not ciudadanos_cuit:
+        print("No se encontraron ciudadanos con ese CUIT")
+    
+    # Buscar ciudadanos con ese DNI
+    print("\n=== BÚSQUEDA POR DNI ===")
+    ciudadanos_dni = []
+    for ciudadano in Ciudadano.objects.all():
+        dni_ciudadano = CruceService._normalize_dni_str(getattr(ciudadano, 'documento', ''))
+        if dni_ciudadano == dni_extraido:
+            ciudadanos_dni.append(ciudadano)
+            print(f"MATCH por DNI: {ciudadano.id} - {ciudadano.nombre} {ciudadano.apellido} - DNI: {dni_ciudadano}")
+    
+    if not ciudadanos_dni:
+        print("No se encontraron ciudadanos con ese DNI")
+    
+    # Verificar si hay legajos aprobados
+    print("\n=== LEGAJOS APROBADOS ===")
+    legajos_aprobados = ExpedienteCiudadano.objects.filter(
+        revision_tecnico="APROBADO"
+    ).select_related('ciudadano')
+    
+    print(f"Total de legajos aprobados: {legajos_aprobados.count()}")
+    
+    for legajo in legajos_aprobados[:5]:  # Mostrar solo los primeros 5
+        ciudadano = legajo.ciudadano
+        cuit_ciud = CruceService._resolver_cuit_ciudadano(ciudadano)
+        dni_ciud = CruceService._normalize_dni_str(getattr(ciudadano, 'documento', ''))
+        print(f"Legajo {legajo.id}: {ciudadano.nombre} {ciudadano.apellido} - DNI: {dni_ciud} - CUIT: {cuit_ciud}")
+    
+    # Verificar campos CUIT en el modelo Ciudadano
+    print("\n=== CAMPOS CUIT EN CIUDADANO ===")
+    ciudadano_ejemplo = Ciudadano.objects.first()
+    if ciudadano_ejemplo:
+        print(f"Campos disponibles en Ciudadano:")
+        for field in ciudadano_ejemplo._meta.fields:
+            field_name = field.name
+            if 'cuit' in field_name.lower() or 'cuil' in field_name.lower():
+                print(f"  - {field_name}")
+        
+        # Verificar si tiene atributos cuit/cuil
+        for attr in ('cuit', 'cuil', 'cuil_cuit'):
+            if hasattr(ciudadano_ejemplo, attr):
+                val = getattr(ciudadano_ejemplo, attr)
+                print(f"  - {attr}: {val}")
+            else:
+                print(f"  - {attr}: NO EXISTE")
+
+if __name__ == "__main__":
+    debug_cruce()

--- a/relevamientos/management/commands/delete_relevamientos.py
+++ b/relevamientos/management/commands/delete_relevamientos.py
@@ -76,7 +76,9 @@ class Command(BaseCommand):
         missing: List[int] = []
 
         for batch_index, batch_ids in enumerate(self._chunk(ids, batch_size), start=1):
-            self.stdout.write(f"Procesando lote {batch_index}/{total_batches}: {batch_ids}")
+            self.stdout.write(
+                f"Procesando lote {batch_index}/{total_batches}: {batch_ids}"
+            )
 
             qs = Relevamiento.objects.filter(id__in=batch_ids)
             found = {obj.id: obj for obj in qs}
@@ -128,7 +130,9 @@ class Command(BaseCommand):
                     try:
                         pk = int(token)
                     except ValueError as exc:  # pragma: no cover - error path
-                        raise CommandError(f"ID inválido: '{token}'. Debe ser entero.") from exc
+                        raise CommandError(
+                            f"ID inválido: '{token}'. Debe ser entero."
+                        ) from exc
                     if pk not in ids:
                         ids.append(pk)
 
@@ -140,7 +144,9 @@ class Command(BaseCommand):
                 with open(path, encoding="utf-8") as handler:
                     file_content = handler.read()
             except OSError as exc:  # pragma: no cover - dependiente de FS
-                raise CommandError(f"No se pudo leer el archivo '{path}': {exc}") from exc
+                raise CommandError(
+                    f"No se pudo leer el archivo '{path}': {exc}"
+                ) from exc
 
             extend_from_iterable([file_content])
 
@@ -150,4 +156,3 @@ class Command(BaseCommand):
     def _chunk(values: List[int], size: int) -> Iterable[List[int]]:
         for start in range(0, len(values), size):
             yield values[start : start + size]
-

--- a/scripts/debug_cruce.py
+++ b/scripts/debug_cruce.py
@@ -6,68 +6,78 @@ import os
 import sys
 import django
 
-# Configurar Django - usar path relativo
-sys.path.append(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
-os.environ.setdefault('DJANGO_SETTINGS_MODULE', 'config.settings')
-django.setup()
-
 from celiaquia.services.cruce_service import CruceService
 from celiaquia.models import ExpedienteCiudadano
 from ciudadanos.models import Ciudadano
 
+# Configurar Django - usar path relativo
+sys.path.append(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+os.environ.setdefault("DJANGO_SETTINGS_MODULE", "config.settings")
+django.setup()
+
+
 def debug_cruce():
     print("=== DEBUG PROCESO DE CRUCE ===")
-    
+
     # Documento del archivo Excel
     documento_excel = "20407321459"
     print(f"Documento del archivo Excel: {documento_excel}")
-    
+
     # Normalizar como CUIT y extraer DNI
-    cuit_normalizado = CruceService._normalize_cuit_str(documento_excel)
-    dni_extraido = CruceService._extraer_dni_de_cuit(cuit_normalizado)
-    dni_extraido_normalizado = CruceService._normalize_dni_str(dni_extraido)
-    
+    cuit_normalizado = CruceService.normalize_cuit_str(documento_excel)
+    dni_extraido = CruceService.extraer_dni_de_cuit(cuit_normalizado)
+    dni_extraido_normalizado = CruceService.normalize_dni_str(dni_extraido)
+
     print(f"CUIT normalizado: {cuit_normalizado}")
     print(f"DNI extraído del CUIT: {dni_extraido}")
     print(f"DNI extraído normalizado: {dni_extraido_normalizado}")
-    
+
     # Buscar ciudadanos con ese CUIT
     print("\n=== BÚSQUEDA POR CUIT ===")
     ciudadanos_cuit = []
     for ciudadano in Ciudadano.objects.all():
-        cuit_ciudadano = CruceService._resolver_cuit_ciudadano(ciudadano)
+        cuit_ciudadano = CruceService.resolver_cuit_ciudadano(ciudadano)
         if cuit_ciudadano == cuit_normalizado:
             ciudadanos_cuit.append(ciudadano)
-            print(f"MATCH por CUIT: {ciudadano.id} - {ciudadano.nombre} {ciudadano.apellido} - CUIT: {cuit_ciudadano}")
-    
+            print(
+                f"MATCH por CUIT: {ciudadano.id} - {ciudadano.nombre} {ciudadano.apellido} - CUIT: {cuit_ciudadano}"
+            )
+
     if not ciudadanos_cuit:
         print("No se encontraron ciudadanos con ese CUIT")
-    
+
     # Buscar ciudadanos con ese DNI
     print("\n=== BÚSQUEDA POR DNI ===")
     ciudadanos_dni = []
     for ciudadano in Ciudadano.objects.all():
-        dni_ciudadano = CruceService._normalize_dni_str(getattr(ciudadano, 'documento', ''))
+        dni_ciudadano = CruceService.normalize_dni_str(
+            getattr(ciudadano, "documento", "")
+        )
         if dni_ciudadano == dni_extraido_normalizado:
             ciudadanos_dni.append(ciudadano)
-            print(f"MATCH por DNI: {ciudadano.id} - {ciudadano.nombre} {ciudadano.apellido} - DNI: {dni_ciudadano}")
-    
+            print(
+                f"MATCH por DNI: {ciudadano.id} - {ciudadano.nombre} {ciudadano.apellido} - DNI: {dni_ciudadano}"
+            )
+
     if not ciudadanos_dni:
         print("No se encontraron ciudadanos con ese DNI")
-    
+
     # Verificar si hay legajos aprobados
     print("\n=== LEGAJOS APROBADOS ===")
     legajos_aprobados = ExpedienteCiudadano.objects.filter(
         revision_tecnico="APROBADO"
-    ).select_related('ciudadano')
-    
+    ).select_related("ciudadano")
+
     print(f"Total de legajos aprobados: {legajos_aprobados.count()}")
-    
+
     for legajo in legajos_aprobados[:5]:  # Mostrar solo los primeros 5
         ciudadano = legajo.ciudadano
-        cuit_ciud = CruceService._resolver_cuit_ciudadano(ciudadano)
-        dni_ciud = CruceService._normalize_dni_str(getattr(ciudadano, 'documento', ''))
-        print(f"Legajo {legajo.id}: {ciudadano.nombre} {ciudadano.apellido} - DNI: {dni_ciud} - CUIT: {cuit_ciud}")
+        cuit_ciud = CruceService.resolver_cuit_ciudadano(ciudadano)
+        dni_ciud = CruceService.normalize_dni_str(getattr(ciudadano, "documento", ""))
+        print(
+            f"Legajo {legajo.id}: {ciudadano.nombre} {ciudadano.apellido} - DNI: {dni_ciud} - CUIT: {cuit_ciud}"
+        )
+
 
 if __name__ == "__main__":
     debug_cruce()

--- a/scripts/debug_cruce.py
+++ b/scripts/debug_cruce.py
@@ -6,8 +6,8 @@ import os
 import sys
 import django
 
-# Configurar Django
-sys.path.append('c:/Users/DELL/Proyectos/BACKOFFICE')
+# Configurar Django - usar path relativo
+sys.path.append(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 os.environ.setdefault('DJANGO_SETTINGS_MODULE', 'config.settings')
 django.setup()
 
@@ -25,9 +25,11 @@ def debug_cruce():
     # Normalizar como CUIT y extraer DNI
     cuit_normalizado = CruceService._normalize_cuit_str(documento_excel)
     dni_extraido = CruceService._extraer_dni_de_cuit(cuit_normalizado)
+    dni_extraido_normalizado = CruceService._normalize_dni_str(dni_extraido)
     
     print(f"CUIT normalizado: {cuit_normalizado}")
     print(f"DNI extraído del CUIT: {dni_extraido}")
+    print(f"DNI extraído normalizado: {dni_extraido_normalizado}")
     
     # Buscar ciudadanos con ese CUIT
     print("\n=== BÚSQUEDA POR CUIT ===")
@@ -46,7 +48,7 @@ def debug_cruce():
     ciudadanos_dni = []
     for ciudadano in Ciudadano.objects.all():
         dni_ciudadano = CruceService._normalize_dni_str(getattr(ciudadano, 'documento', ''))
-        if dni_ciudadano == dni_extraido:
+        if dni_ciudadano == dni_extraido_normalizado:
             ciudadanos_dni.append(ciudadano)
             print(f"MATCH por DNI: {ciudadano.id} - {ciudadano.nombre} {ciudadano.apellido} - DNI: {dni_ciudadano}")
     
@@ -66,24 +68,6 @@ def debug_cruce():
         cuit_ciud = CruceService._resolver_cuit_ciudadano(ciudadano)
         dni_ciud = CruceService._normalize_dni_str(getattr(ciudadano, 'documento', ''))
         print(f"Legajo {legajo.id}: {ciudadano.nombre} {ciudadano.apellido} - DNI: {dni_ciud} - CUIT: {cuit_ciud}")
-    
-    # Verificar campos CUIT en el modelo Ciudadano
-    print("\n=== CAMPOS CUIT EN CIUDADANO ===")
-    ciudadano_ejemplo = Ciudadano.objects.first()
-    if ciudadano_ejemplo:
-        print(f"Campos disponibles en Ciudadano:")
-        for field in ciudadano_ejemplo._meta.fields:
-            field_name = field.name
-            if 'cuit' in field_name.lower() or 'cuil' in field_name.lower():
-                print(f"  - {field_name}")
-        
-        # Verificar si tiene atributos cuit/cuil
-        for attr in ('cuit', 'cuil', 'cuil_cuit'):
-            if hasattr(ciudadano_ejemplo, attr):
-                val = getattr(ciudadano_ejemplo, attr)
-                print(f"  - {attr}: {val}")
-            else:
-                print(f"  - {attr}: NO EXISTE")
 
 if __name__ == "__main__":
     debug_cruce()


### PR DESCRIPTION
# Información de la Tarea
**Vincular el #ISSUE**

## Resumen de la Solución
- Estandarización del proceso de cruce SINTYS para usar columna **"documento"** en lugar de **"dni"**.
- Fix de resolución de **CUIT** en ciudadanos para mejorar precisión del cruce.
- Actualización de interfaz de usuario para consistencia terminológica.

## Información Adicional
- Mantiene compatibilidad hacia atrás con archivos que usen columna **"dni"**.
- Mejora la detección de **CUITs** en documentos de 11 dígitos.
- Prioriza **"documento"** sobre **"dni"** cuando ambas columnas están presentes.

## Descripción de los Cambios

### `celiaquia/services/cruce_service.py`
- Agregado soporte para columnas **"dni"**, **"nro_dni"**, **"numero_dni"** en `DOCUMENTO_COL_CANDIDATAS`.
- Modificado `_col_por_preferencias()` para priorizar **"documento"** sobre **"dni"**.
- Fix en `_resolver_cuit_ciudadano()` para usar campo **documento** cuando tiene 11 dígitos.

### `celiaquia/templates/celiaquia/expediente_detail.html`
- Actualizado texto de modal: **"CUITs" → "Documentos"**.
- Cambiado label: **"columna cuit o dni" → "columna documento"**.
- Actualizado help text y botones para consistencia.

### `celiaquia/views/expediente.py`
- Actualizado mensaje de error: **"columna 'cuit'" → "columna 'documento'"**.

