### PR TITLE
Reintroduce aliases de CUIT y número de DNI en CruceService

### DIFF
--- a/celiaquia/services/cruce_service.py
+++ b/celiaquia/services/cruce_service.py
@@ -54,9 +54,17 @@ DOCUMENTO_COL_CANDIDATAS = {
     "doc",
     "nro_doc",
     "num_doc",
+    "cuit",
+    "c.u.i.t",
+    "nro_cuit",
+    "numero_cuit",
+    "número_cuit",
+    "cuit_nro",
+    "cuit_número",
     "dni",
     "nro_dni",
     "numero_dni",
+    "número_dni",
 }
 
 
@@ -192,7 +200,7 @@ class CruceService:
     ) -> str | None:
         cols = set(df.columns)
 
-        # Orden de prioridad: documento tiene prioridad sobre dni
+        # Orden de prioridad: documento tiene prioridad sobre cuit y dni
         prioridad = [
             "documento",
             "nro_documento",
@@ -201,9 +209,17 @@ class CruceService:
             "doc",
             "nro_doc",
             "num_doc",
+            "cuit",
+            "c.u.i.t",
+            "nro_cuit",
+            "numero_cuit",
+            "número_cuit",
+            "cuit_nro",
+            "cuit_número",
             "dni",
             "nro_dni",
             "numero_dni",
+            "número_dni",
         ]
 
         # Buscar en orden de prioridad
@@ -230,7 +246,11 @@ class CruceService:
         if not col_documento:
             raise ValidationError(
                 "El archivo debe tener una columna válida de documento. "
-                "Columnas aceptadas: documento, nro_documento, dni, doc, etc."
+                "Columnas aceptadas: documento, nro_documento, numero_documento, "
+                "número_documento, doc, nro_doc, num_doc, cuit, c.u.i.t, "
+                "nro_cuit, numero_cuit, número_cuit, cuit_nro, cuit_número (cuit "
+                "número), dni, "
+                "nro_dni, numero_dni, número_dni."
             )
 
         for raw in df[col_documento].fillna(""):


### PR DESCRIPTION
## Summary
- readd Excel header aliases for CUIT and número_dni when reading identificadores
- ensure prioritization prefers documento headers before CUIT and DNI variants
- clarify validation error message with the accepted column names

## Testing
- pytest celiaquia/tests/test_cruce_service.py

------
https://chatgpt.com/codex/tasks/task_e_68d1ddfa78a4832d9aa40b6ccd6588e6