### PR TITLE
Fix placeholder replacement for expediente detail URL templates

### DIFF
--- a/static/custom/js/expediente_detail_config.js
+++ b/static/custom/js/expediente_detail_config.js
@@ -3,6 +3,9 @@ window.PROCESS_URL = document.querySelector('meta[name="process-url"]')?.content
 window.CONFIRM_URL = document.querySelector('meta[name="confirm-url"]')?.content;
 window.CRUCE_URL = document.querySelector('meta[name="cruce-url"]')?.content;
 window.CSRF_TOKEN = document.querySelector('meta[name="csrf-token"]')?.content;
-window.REVISAR_URL_TEMPLATE = document.querySelector('meta[name="revisar-url-template"]')?.content;
+
+const revisarMeta = document.querySelector('meta[name="revisar-url-template"]');
+window.REVISAR_URL_TEMPLATE = revisarMeta?.content?.replace('/0/', '/{id}/');
 window.CONFIRM_SUBS_URL = document.querySelector('meta[name="confirm-subs-url"]')?.content;
-window.VALIDAR_RENAPER_URL_TEMPLATE = document.querySelector('meta[name="validar-renaper-url-template"]')?.content;
+const validarMeta = document.querySelector('meta[name="validar-renaper-url-template"]');
+window.VALIDAR_RENAPER_URL_TEMPLATE = validarMeta?.content?.replace('/0/', '/{id}/');


### PR DESCRIPTION
## Summary
- ensure the revisar and validar RENAPER URL templates restore the `{id}` placeholder after reading the meta tags

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68dc7e1e1de8832dbd7521bd491a3b9c