### PR TITLE
Fix admission creation regressions

### DIFF
--- a/admisiones/models/admisiones.py
+++ b/admisiones/models/admisiones.py
@@ -62,7 +62,6 @@ class Admision(models.Model):
         Comedor,
         on_delete=models.SET_NULL,
         null=True,
-        related_name="admisiones_admisiones",
     )
     estado = models.ForeignKey(EstadoAdmision, on_delete=models.SET_NULL, null=True)
     tipo_convenio = models.ForeignKey(

--- a/admisiones/services/admisiones_service.py
+++ b/admisiones/services/admisiones_service.py
@@ -21,8 +21,6 @@ from admisiones.forms.admisiones_forms import (
 from acompanamientos.acompanamiento_service import AcompanamientoService
 from comedores.models import Comedor
 from django.db.models import Q
-from django.shortcuts import get_object_or_404
-
 import logging
 
 
@@ -275,46 +273,17 @@ class AdmisionService:
 
     @staticmethod
     def create_admision(comedor_pk, tipo_convenio_id):
-        try:
-            # Buscar comedor
-            comedor = Comedor.objects.filter(pk=comedor_pk).first()
-            if not comedor:
-                logger.warning(
-                    "Comedor no encontrado", extra={"comedor_pk": comedor_pk}
-                )
-                return None
+        comedor = get_object_or_404(Comedor, pk=comedor_pk)
+        tipo_convenio = get_object_or_404(TipoConvenio, pk=tipo_convenio_id)
+        estado = get_object_or_404(
+            EstadoAdmision, nombre__iexact="Pendiente"
+        )
 
-            # Buscar tipo de convenio
-            tipo_convenio = TipoConvenio.objects.filter(pk=tipo_convenio_id).first()
-            if not tipo_convenio:
-                logger.warning(
-                    "TipoConvenio no encontrado",
-                    extra={"tipo_convenio_id": tipo_convenio_id},
-                )
-                return None
-
-            # Buscar estado inicial (Pendiente)
-            estado = EstadoAdmision.objects.filter(nombre__iexact="Pendiente").first()
-            if not estado:
-                logger.error("EstadoAdmision 'Pendiente' no existe en la BD")
-                return None
-
-            # Crear admisión
-            return Admision.objects.create(
-                comedor=comedor,
-                tipo_convenio=tipo_convenio,
-                estado=estado,
-            )
-
-        except Exception:
-            logger.exception(
-                "Error inesperado en create_admision",
-                extra={
-                    "comedor_pk": comedor_pk,
-                    "tipo_convenio_id": tipo_convenio_id,
-                },
-            )
-            return None
+        return Admision.objects.create(
+            comedor=comedor,
+            tipo_convenio=tipo_convenio,
+            estado=estado,
+        )
 
     @staticmethod
     def get_admision_update_context(admision):

--- a/requirements.txt
+++ b/requirements.txt
@@ -117,6 +117,6 @@ xlwt==1.3.0
 zopfli==0.2.3.post1
 num2words==0.5.12
 python-json-logger==2.0.7
-python-docx~=1.1
-htmldocx~=0.0.6
+python-docx==0.8.11
+htmldocx==0.0.6
 


### PR DESCRIPTION
## Summary
- restore the default reverse relation for `Admision.comedor`
- ensure `create_admision` raises 404 when the comedor or convenio is missing
- pin `python-docx` to a published version so dependency installation succeeds

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68dd17a4fde8832da6e58449d7a98f1a