### PR TITLE
Fix search bar name and restore card spacing

### DIFF
--- a/acompanamientos/templates/lista_comedores.html
+++ b/acompanamientos/templates/lista_comedores.html
@@ -16,7 +16,7 @@
             {% endwith %}
         {% endwith %}
     {% endwith %}
-    <div class="row mt- max-width-100">
+    <div class="row mt-5 max-width-100">
         <div class="col-12">
             <div class="card">
                 <div class="card-header">

--- a/templates/components/search_bar.html
+++ b/templates/components/search_bar.html
@@ -75,6 +75,7 @@ Modo búsqueda AJAX dinámica: {% include 'components/search_bar.html' with titu
                         <div class="input-group input-group-lg">
                             <input type="search"
                                    id="ajax-search-input"
+                                   name="busqueda"
                                    class="form-control form-control-lg"
                                    placeholder="{{ placeholder|default:'Buscar' }}"
                                    title="{{ help_text|default:'Ingrese términos de búsqueda' }}"


### PR DESCRIPTION
## Summary
- restore the `name` attribute on the simple search input so query params are submitted
- fix the comedor list layout by reinstating the missing top margin class

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68de6f28583c832dbcd22b01f2667f85