### PR TITLE
Fix función load_localidad 

### DIFF
--- a/core/views.py
+++ b/core/views.py
@@ -18,12 +18,12 @@ def load_municipios(request):
 
 def load_localidad(request):
     municipio_id = request.GET.get("municipio_id")
-    departamento_id = request.GET.get("departamento_id")
 
     if municipio_id:
         localidades = Localidad.objects.filter(municipio=municipio_id)
     else:
-        localidades = Localidad.objects.filter(departamento=departamento_id)
+        localidades = Localidad.objects.none()
+
     return JsonResponse(list(localidades.values("id", "nombre")), safe=False)
 
 


### PR DESCRIPTION
# Información de la Tarea
Vincular el #687 

### **Resumen de la Solución:** 
- :white_check_mark: Eliminado el parámetro departamento_id que no se usaba correctamente
- :white_check_mark: Eliminado el filtro por Localidad.departamento (campo inexistente)
- :white_check_mark: Ahora cuando municipio_id está vacío, retorna un QuerySet vacío con .none()
- :white_check_mark: Validación implícita: solo filtra si municipio_id tiene valor
Ahora el comportamiento es:
- Con municipio_id: retorna localidades filtradas por ese municipio
- Sin municipio_id: retorna lista vacía [] (sin error)

### **Información Adicional:**
-

# Descripción de los Cambios

### **Cambios:**
-

# Cómo Testear los Cambios

### **Pruebas Automáticas:**
-

### **Prubeas Manuales:**
-

# Capturas de Pantalla
