### PR TITLE
Agregado autenticacion a ambos enpoints Ajax

### DIFF
--- a/core/urls.py
+++ b/core/urls.py
@@ -9,6 +9,6 @@ from .views import (
 
 urlpatterns = [
     path("inicio/", login_required(inicio_view), name="inicio"),
-    path("ajax/load-municipios/", load_municipios, name="ajax_load_municipios"),
-    path("ajax/load-localidades/", load_localidad, name="ajax_load_localidades"),
+    path("ajax/load-municipios/", login_required(load_municipios), name="ajax_load_municipios"),
+    path("ajax/load-localidades/", login_required(load_localidad), name="ajax_load_localidades"),
 ]

--- a/core/urls.py
+++ b/core/urls.py
@@ -9,6 +9,14 @@ from .views import (
 
 urlpatterns = [
     path("inicio/", login_required(inicio_view), name="inicio"),
-    path("ajax/load-municipios/", login_required(load_municipios), name="ajax_load_municipios"),
-    path("ajax/load-localidades/", login_required(load_localidad), name="ajax_load_localidades"),
+    path(
+        "ajax/load-municipios/",
+        login_required(load_municipios),
+        name="ajax_load_municipios",
+    ),
+    path(
+        "ajax/load-localidades/",
+        login_required(load_localidad),
+        name="ajax_load_localidades",
+    ),
 ]


### PR DESCRIPTION
# Información de la Tarea
Vincular el #690 

### **Resumen de la Solución:** 
Agregué login_required a ambos endpoints AJAX en core/urls.py:12-13:
- ✅ ajax/load-municipios/ ahora requiere autenticación
- ✅ ajax/load-localidades/ ahora requiere autenticación
Los catálogos internos ya no están expuestos públicamente.

### **Información Adicional:**
-

# Descripción de los Cambios

### **Cambios:**
-

# Cómo Testear los Cambios

### **Pruebas Automáticas:**
-

### **Prubeas Manuales:**
-

# Capturas de Pantalla
