### PR TITLE
Fix nomina view validation and handle missing location

### DIFF
--- a/comedores/templates/comedor/nomina_detail.html
+++ b/comedores/templates/comedor/nomina_detail.html
@@ -3,7 +3,11 @@
 {% block title %}Nómina – {{ object.nombre }}{% endblock %}
 {% block titulo-pagina %}
     Nómina de {{ object.nombre }}
-    <span class="ml-2 h5">| {{ object.provincia.nombre | default_if_none:"-" }}, {{ object.municipio.nombre | default_if_none:"-" }}</span>
+    <span class="ml-2 h5">
+        |
+        {% if object.provincia %}{{ object.provincia.nombre }}{% else %}-{% endif %},
+        {% if object.municipio %}{{ object.municipio.nombre }}{% else %}-{% endif %}
+    </span>
 {% endblock %}
 {% block breadcrumb %}
     <ol class="breadcrumb float-sm-right">

--- a/comedores/views.py
+++ b/comedores/views.py
@@ -188,8 +188,21 @@ class NominaCreateView(CreateView):
 
         if ciudadano_id:
             # Agregar ciudadano existente
-            estado_id = request.POST.get("estado")
-            observaciones = request.POST.get("observaciones", "")
+            form_nomina_extra = NominaExtraForm(request.POST)
+
+            if not form_nomina_extra.is_valid():
+                messages.error(
+                    request,
+                    "Datos inválidos para agregar ciudadano a la nómina.",
+                )
+                context = self.get_context_data(
+                    form_nomina_extra=form_nomina_extra,
+                )
+                return self.render_to_response(context)
+
+            estado = form_nomina_extra.cleaned_data.get("estado")
+            estado_id = estado.id if estado else None
+            observaciones = form_nomina_extra.cleaned_data.get("observaciones", "")
 
             ok, msg = ComedorService.agregar_ciudadano_a_nomina(
                 comedor_id=self.kwargs["pk"],
@@ -203,6 +216,7 @@ class NominaCreateView(CreateView):
                 messages.success(request, msg)
             else:
                 messages.warning(request, msg)
+
             return redirect(self.get_success_url())
         else:
             # Crear ciudadano nuevo


### PR DESCRIPTION
## Summary
- avoid AttributeError in the nómina detail header by checking for optional provincia/municipio relations before accessing their names
- reuse `NominaExtraForm` validation when adding an existing ciudadano to the nómina so we only submit cleaned data to the service

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e3e71374d4832da1badaedb5607768