### PR TITLE
Restore sidebar links for comedor support roles

### DIFF
--- a/templates/includes/sidebar/opciones.html
+++ b/templates/includes/sidebar/opciones.html
@@ -148,7 +148,7 @@
                         </p>
                     </a>
                     <ul class="nav nav-treeview">
-                        {% if request.user|has_group:"Comedores Listar" %}
+                        {% if request.user|has_group:"Comedores Listar" or request.user|has_group:"Tecnico Comedor" or request.user|has_group:"Abogado Dupla" %}
                             <li class="nav-item">
                                 <a href="{% url 'comedores' %}"
                                    class="nav-link ms-4 {% if 'comedores/listar' in pagina_actual %}active{% endif %}">
@@ -158,7 +158,7 @@
                             </li>
                         {% endif %}
                         <!-- ADMISION -->
-                        {% if request.user|has_group:"Comedores Listar" %}
+                        {% if request.user|has_group:"Comedores Listar" or request.user|has_group:"Tecnico Comedor" or request.user|has_group:"Abogado Dupla" %}
                             <li class="nav-item ms-4 {% if 'admisiones' in pagina_actual %}menu-open{% endif %}">
                                 <a href="#" class="nav-link">
                                     <i class="nav-icon bi bi-arrow-return-right"></i>


### PR DESCRIPTION
## Summary
- show the Ver Comedores shortcut to Tecnico Comedor and Abogado Dupla users again
- restore Admisión - Comedores submenu visibility for the same authorized roles

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e6611a0738832da1f5ba9b9eb9c9d8