### PR TITLE
Handle optional sidebar before resizing

### DIFF
--- a/static/custom/js/sidebar.js
+++ b/static/custom/js/sidebar.js
@@ -30,9 +30,11 @@ function setupScrollListeners() {
     "scroll",
     () => {
       const visiblePx = getFooterVisiblePixels();
-      console.log(`Sidebar.js::Footer visible: ${visiblePx}px`);
       let sidebarHeight = `calc(100vh - ${visiblePx + 70}px)`;
       const sidebar = document.querySelector(".sidebar-wrapper");
+      if (!sidebar) {
+        return;
+      }
       sidebar.style.height = sidebarHeight;
     },
     { passive: true }


### PR DESCRIPTION
## Summary
- guard the sidebar height update when the wrapper is absent
- remove the noisy footer visibility log from the scroll handler

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68ee7dc2c09c832dae1de11ed77f060a