### PR TITLE
Handle missing database configuration when loading dashboard signals

### DIFF
--- a/dashboard/utils.py
+++ b/dashboard/utils.py
@@ -1,21 +1,44 @@
-# TODO: Esto deberia ir a parar un service/config.utils dependiendo el contexto
+"""Utilidades de dashboard con manejo defensivo de la base de datos."""
+
+import logging
+
+from django.conf import settings
 from django.core.cache import cache
+from django.core.exceptions import ImproperlyConfigured
 from django.db import connection
 from django.db.models import Sum
-from django.conf import settings
+from django.db.utils import OperationalError, ProgrammingError
 
 from relevamientos.models import Relevamiento
 from comedores.models import Comedor, ValorComida
 
 
-def table_exists(table_name):
-    vendor = connection.vendor
-    if vendor == "mysql":
-        with connection.cursor() as cursor:
-            cursor.execute("SHOW TABLES LIKE %s", [table_name])
-            return cursor.fetchone() is not None
+logger = logging.getLogger(__name__)
 
-    return table_name in connection.introspection.table_names()
+
+def table_exists(table_name):
+    """Check if a DB table exists without exploding when DB is unavailable."""
+
+    try:
+        vendor = connection.vendor
+    except ImproperlyConfigured:
+        logger.debug("Base de datos no configurada; omitiendo chequeo de %s", table_name)
+        return False
+
+    try:
+        if vendor == "mysql":
+            with connection.cursor() as cursor:
+                cursor.execute("SHOW TABLES LIKE %s", [table_name])
+                return cursor.fetchone() is not None
+
+        return table_name in connection.introspection.table_names()
+    except (OperationalError, ProgrammingError, AttributeError) as error:
+        logger.debug(
+            "No se pudo comprobar la existencia de %s (%s); se asume ausente",
+            table_name,
+            error,
+        )
+        return False
 
 
 # Usar el timeout de settings en lugar de hardcodeado


### PR DESCRIPTION
## Summary
- prevent the dashboard table existence helper from crashing when the database configuration is incomplete or unavailable
- add defensive logging so signal registration is skipped safely until the tables are ready

## Testing
- PYTEST_RUNNING=1 python manage.py makemigrations --check --dry-run

------
https://chatgpt.com/codex/tasks/task_e_68ef8f0332f8832d96047534f43d8a70