### PR TITLE
Expediente legales 811

### DIFF
--- a/admisiones/forms/admisiones_forms.py
+++ b/admisiones/forms/admisiones_forms.py
@@ -418,7 +418,11 @@ class LegalesNumIFForm(forms.ModelForm):
         super().__init__(*args, **kwargs)
 
         # Precargar legales_num_if desde num_expediente si está vacío
-        if self.instance and self.instance.num_expediente and not self.instance.legales_num_if:
+        if (
+            self.instance
+            and self.instance.num_expediente
+            and not self.instance.legales_num_if
+        ):
             self.initial["legales_num_if"] = self.instance.num_expediente
 
         for field in self.fields.values():
@@ -427,7 +431,9 @@ class LegalesNumIFForm(forms.ModelForm):
         # Hacer campo readonly para evitar errores de carga
         if self.instance and self.instance.num_expediente:
             self.fields["legales_num_if"].widget.attrs["readonly"] = True
-            self.fields["legales_num_if"].help_text = "Este número fue precargado desde el Informe Técnico"
+            self.fields["legales_num_if"].help_text = (
+                "Este número fue precargado desde el Informe Técnico"
+            )
 
 
 class DocumentosExpedienteForm(forms.ModelForm):

--- a/admisiones/forms/admisiones_forms.py
+++ b/admisiones/forms/admisiones_forms.py
@@ -414,8 +414,18 @@ class LegalesNumIFForm(forms.ModelForm):
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
+
+        # Precargar legales_num_if desde num_expediente si está vacío
+        if self.instance and self.instance.num_expediente and not self.instance.legales_num_if:
+            self.initial["legales_num_if"] = self.instance.num_expediente
+
         for field in self.fields.values():
             field.required = True
+
+        # Hacer campo readonly para evitar errores de carga
+        if self.instance and self.instance.num_expediente:
+            self.fields["legales_num_if"].widget.attrs["readonly"] = True
+            self.fields["legales_num_if"].help_text = "Este número fue precargado desde el Informe Técnico"
 
 
 class DocumentosExpedienteForm(forms.ModelForm):

--- a/admisiones/models/admisiones.py
+++ b/admisiones/models/admisiones.py
@@ -132,6 +132,7 @@ class Admision(models.Model):
         verbose_name="Tipo de observación",
     )
     informe_sga = models.BooleanField(default=False, verbose_name="Estados Informe SGA")
+    numero_if_tecnico = models.CharField(max_length=100, blank=True, default="", verbose_name="Número IF Informe Técnico")
     numero_convenio = models.CharField(max_length=100, blank=True, null=True)
     archivo_convenio = models.FileField(
         upload_to="admisiones/convenios/", null=True, blank=True

--- a/admisiones/models/admisiones.py
+++ b/admisiones/models/admisiones.py
@@ -132,7 +132,9 @@ class Admision(models.Model):
         verbose_name="Tipo de observación",
     )
     informe_sga = models.BooleanField(default=False, verbose_name="Estados Informe SGA")
-    numero_if_tecnico = models.CharField(max_length=100, blank=True, default="", verbose_name="Número IF Informe Técnico")
+    numero_if_tecnico = models.CharField(
+        max_length=100, blank=True, default="", verbose_name="Número IF Informe Técnico"
+    )
     numero_convenio = models.CharField(max_length=100, blank=True, null=True)
     archivo_convenio = models.FileField(
         upload_to="admisiones/convenios/", null=True, blank=True


### PR DESCRIPTION
# Información de la Tarea
Vincular el #811 

### **Resumen de la Solución:** 
-Ahora el numero de expediente que se carga en Admisiones-tecnico a la hora de volver a cargarlo en la parte de admision-legales de forma manual, el sistema lo pre carga con el expediente cargado previamente en admisiones-tecnico

### **Información Adicional:**
-

# Descripción de los Cambios

### **Cambios:**
-

# Cómo Testear los Cambios

### **Pruebas Automáticas:**
-

### **Prubeas Manuales:**
-

# Capturas de Pantalla
<img width="720" height="479" alt="image" src="https://github.com/user-attachments/assets/0d4d32d9-907f-49e0-8adb-ed4af6f1811c" />
