### PR TITLE
Fix equipo técnico navigation highlights

### DIFF
--- a/comedores/templates/comedor/comedor_detail.html
+++ b/comedores/templates/comedor/comedor_detail.html
@@ -38,8 +38,8 @@
                         data-bs-target="#modalAdmision">
                     <i class="bi bi-box-arrow-in-right me-1"></i> Comenzar Admisión
                 </button>
-                <a href="{% url 'dupla_asignar' pk=comedor.id %}"
-                   class="btn btn-primary me-1">Modificar Dupla</a>
+            <a href="{% url 'dupla_asignar' pk=comedor.id %}"
+               class="btn btn-primary me-1">Modificar Equipo Técnico</a>
             {% endif %}
             <a href="{% url 'comedor_intervencion_ver' comedor.id %}"
                class="btn btn-primary me-1">Intervenciones</a>

--- a/templates/includes/sidebar/new_opciones.html
+++ b/templates/includes/sidebar/new_opciones.html
@@ -29,7 +29,7 @@
                         <p>Grupos</p>
                     </a>
                     <a href="{% url 'dupla_list' %}"
-                       class="nav-link {% if 'grupos' in pagina_actual %}active{% endif %}">
+                       class="nav-link {% if 'dupla' in pagina_actual or 'equipo-tecnico' in pagina_actual %}active{% endif %}">
                         <i class="fas fa-arrow-alt-circle-right nav-icon"></i>
                         <p>Equipos Técnicos</p>
                     </a>

--- a/templates/includes/sidebar/opciones.html
+++ b/templates/includes/sidebar/opciones.html
@@ -67,7 +67,7 @@
                 </li>
                 <li class="nav-item">
                     <a href="{% url 'dupla_list' %}"
-                       class="nav-link nav-dot ms-2 {% if 'dupla' in pagina_actual %}active{% endif %}">
+                       class="nav-link nav-dot ms-2 {% if 'dupla' in pagina_actual or 'equipo-tecnico' in pagina_actual %}active{% endif %}">
                         <p>Equipos Técnicos</p>
                     </a>
                 </li>


### PR DESCRIPTION
## Summary
- update both sidebar templates to recognize the new `equipo-tecnico` slug when marking the menu item active
- align the comedor detail action label with the "Equipo Técnico" naming

## Testing
- not run (template-only changes)


------
https://chatgpt.com/codex/tasks/task_e_690cfddf8bcc832d83e1f1a0f168e157