### PR TITLE
Prevent coordinators without duplas from accessing unrelated data

### DIFF
--- a/acompanamientos/acompanamiento_service.py
+++ b/acompanamientos/acompanamiento_service.py
@@ -391,9 +391,12 @@ class AcompanamientoService:
             )
             qs = qs.filter(Exists(admision_subq))
             if not user.is_superuser:
-                if is_coordinador and duplas_ids:
-                    # Coordinador: ver comedores de sus duplas asignadas
-                    qs = qs.filter(dupla_id__in=duplas_ids)
+                if is_coordinador:
+                    if not duplas_ids:
+                        qs = qs.none()
+                    else:
+                        # Coordinador: ver comedores de sus duplas asignadas
+                        qs = qs.filter(dupla_id__in=duplas_ids)
                 elif is_dupla:
                     qs = qs.filter(
                         Exists(dupla_abogado_subq) | Exists(dupla_tecnico_subq)

--- a/admisiones/services/legales_service.py
+++ b/admisiones/services/legales_service.py
@@ -945,8 +945,11 @@ class LegalesService:
                 is_coordinador, duplas_ids = (
                     UserPermissionService.get_coordinador_duplas(user)
                 )
-                if is_coordinador and duplas_ids:
-                    queryset = queryset.filter(comedor__dupla_id__in=duplas_ids)
+                if is_coordinador:
+                    if not duplas_ids:
+                        queryset = queryset.none()
+                    else:
+                        queryset = queryset.filter(comedor__dupla_id__in=duplas_ids)
 
             if query:
                 query = query.strip().lower()

--- a/comedores/services/comedor_service.py
+++ b/comedores/services/comedor_service.py
@@ -32,6 +32,7 @@ from acompanamientos.models.hitos import Hitos
 from admisiones.models.admisiones import Admision
 from rendicioncuentasmensual.models import RendicionCuentaMensual
 from intervenciones.models.intervenciones import Intervencion
+from duplas.models import Dupla
 
 logger = logging.getLogger("django")
 
@@ -160,9 +161,12 @@ class ComedorService:
             is_dupla = UserPermissionService.es_tecnico_o_abogado(user)
 
             # Aplicar filtros según el rol
-            if is_coordinador and duplas_ids:
-                # Coordinador: ver comedores de sus duplas asignadas
-                base_qs = base_qs.filter(dupla_id__in=duplas_ids)
+            if is_coordinador:
+                if not duplas_ids:
+                    base_qs = base_qs.none()
+                else:
+                    # Coordinador: ver comedores de sus duplas asignadas
+                    base_qs = base_qs.filter(dupla_id__in=duplas_ids)
             elif is_dupla:
                 # Técnico o Abogado: ver comedores donde está asignado
                 from django.db.models import Exists, OuterRef

--- a/rendicioncuentasfinal/rendicion_cuentas_final_service.py
+++ b/rendicioncuentasfinal/rendicion_cuentas_final_service.py
@@ -117,8 +117,13 @@ class RendicionCuentasFinalService:
             qs = DocumentoRendicionFinal.objects.filter(filtros_validador)
 
             # Filtrar por duplas asignadas si es coordinador
-            if is_coordinador and duplas_ids and not user.is_superuser:
-                qs = qs.filter(rendicion_final__comedor__dupla_id__in=duplas_ids)
+            if is_coordinador and not user.is_superuser:
+                if not duplas_ids:
+                    qs = qs.none()
+                else:
+                    qs = qs.filter(
+                        rendicion_final__comedor__dupla_id__in=duplas_ids
+                    )
 
             if query:
                 qs = qs.filter(


### PR DESCRIPTION
## Summary
- guard coordinator filtering helpers across services to return no results when no duplas are assigned
- import Dupla in the comedor service to avoid runtime NameError when building subqueries
- align rendicion and admisiones listings with tightened coordinator scoping

## Testing
- pytest comedores acompanamientos admisiones rendicioncuentasfinal *(fails: TypeError: can only concatenate str (not "NoneType") to str due to missing database NAME in settings)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691232f53030832d8dadad54a175a0e5)