### PR TITLE
Fix validation reset middleware and service method

### DIFF
--- a/comedores/middleware.py
+++ b/comedores/middleware.py
@@ -26,20 +26,20 @@ class AutoResetValidacionesMiddleware:
                 # Verificar si necesita reset mensual (cualquier día del mes nuevo)
                 reset_key = f'reset_validaciones_{hoy.strftime("%Y_%m")}'
                 if not cache.get(reset_key):
-                try:
-                    comedores_actualizados = (
-                        ValidacionService.resetear_validaciones()
-                    )
-                    logger.info(
-                        "Auto-reset middleware: %s comedores reseteados (mes %s, día %s)",
-                        comedores_actualizados,
-                        hoy.strftime("%Y-%m"),
-                        hoy.day,
-                    )
-                    # Marcar como ejecutado este mes
-                    cache.set(reset_key, True, 60 * 60 * 24 * 32)
-                except Exception as exc:  # pragma: no cover
-                    logger.error("Error en auto-reset middleware: %s", exc)
+                    try:
+                        comedores_actualizados = (
+                            ValidacionService.resetear_validaciones()
+                        )
+                        logger.info(
+                            "Auto-reset middleware: %s comedores reseteados (mes %s, día %s)",
+                            comedores_actualizados,
+                            hoy.strftime("%Y-%m"),
+                            hoy.day,
+                        )
+                        # Marcar como ejecutado este mes
+                        cache.set(reset_key, True, 60 * 60 * 24 * 32)
+                    except Exception as exc:  # pragma: no cover
+                        logger.error("Error en auto-reset middleware: %s", exc)
 
             # Actualizar último check
             cache.set(cache_key, hoy, 60 * 60 * 24)

--- a/comedores/services/validacion_service.py
+++ b/comedores/services/validacion_service.py
@@ -59,4 +59,12 @@ class ValidacionService:
 
         return True, mensaje
 
+    @staticmethod
+    def resetear_validaciones():
+        """Resetea el estado de validación de todos los comedores a Pendiente."""
+
+        return Comedor.objects.filter(
+            estado_validacion__in=["Validado", "No Validado"]
+        ).update(estado_validacion="Pendiente", fecha_validado=None)
+
 


### PR DESCRIPTION
## Summary
- fix auto-reset middleware indentation to execute reset logic safely
- restore `resetear_validaciones` in validation service to update dining hall states

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691c8bc41124832d82dcb77337337c50)