### PR TITLE
Ensure Misiones dashboard menu respects group permissions

### DIFF
--- a/templates/includes/sidebar/opciones.html
+++ b/templates/includes/sidebar/opciones.html
@@ -74,8 +74,8 @@
             </ul>
         </li>
     {% endif %}
-    {% with has_dashboard_cf=request.user|has_group:"Dashboard Centrodefamilia" has_datacalle=request.user|has_group:"Tablero DataCalle Chaco" has_datacalle_general=request.user|has_group:"Tablero DataCalle General" has_admin=request.user|has_group:"Administrador" %}
-        {% if has_dashboard_cf or has_datacalle or has_datacalle_general or has_admin %}
+    {% with has_dashboard_cf=request.user|has_group:"Dashboard Centrodefamilia" has_datacalle=request.user|has_group:"Tablero DataCalle Chaco" has_datacalle_general=request.user|has_group:"Tablero DataCalle General" has_datacalle_misiones=request.user|has_group:"Tablero DataCalle Misiones" has_admin=request.user|has_group:"Administrador" %}
+        {% if has_dashboard_cf or has_datacalle or has_datacalle_general or has_datacalle_misiones or has_admin %}
             <!-- Tableros -->
             <li class="nav-item nav-main-item {% if 'dashboard' in pagina_actual %}menu-open{% endif %}">
                 <a href="#" class="nav-link">
@@ -146,7 +146,7 @@
                             </ul>
                         </li>
                     {% endif %}
-                    {% if has_datacalle or has_admin %}
+                    {% if has_datacalle_misiones or has_admin %}
                         <li class="nav-item {% if 'dashboard/datacalle-misiones' in pagina_actual %}menu-open{% endif %}">
                             <a href="#"
                                class="nav-link nav-dot ms-2 {% if 'dashboard/datacalle-misiones' in pagina_actual %}active{% endif %}">


### PR DESCRIPTION
## Summary
- include the Tablero DataCalle Misiones group when building the sidebar Tableros menu
- gate the Misiones submenu on its dedicated group instead of the Chaco group

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691cb0754b08832d8c6ecea4bb48b4f0)