### PR TITLE
Cache estado previo de admision y agregar tests

### DIFF
--- a/admisiones/models/admisiones.py
+++ b/admisiones/models/admisiones.py
@@ -199,14 +199,13 @@ class Admision(models.Model):
     estado_mostrar = models.CharField(max_length=255, blank=True, null=True)
     fecha_estado_mostrar = models.DateField(null=True, blank=True)
 
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self._estado_mostrar_inicial = self.estado_mostrar
+
     def save(self, *args, **kwargs):
         # Obtener el estado anterior si existe
-        estado_anterior = None
-        if self.pk:
-            try:
-                estado_anterior = Admision.objects.get(pk=self.pk).estado_mostrar
-            except Admision.DoesNotExist:
-                pass
+        estado_anterior = None if self._state.adding else self._estado_mostrar_inicial
         
         # Si el estado es "Descartado" en cualquier campo, marcar como inactiva
         if self.estado_legales == "Descartado" or self.estado_admision == "descartado":
@@ -239,8 +238,9 @@ class Admision(models.Model):
             update_fields.add('fecha_estado_mostrar')
             update_fields.add('activa')
             kwargs['update_fields'] = list(update_fields)
-        
+
         super().save(*args, **kwargs)
+        self._estado_mostrar_inicial = self.estado_mostrar
 
     @property
     def tipo_informe(self):

--- a/admisiones/tests/test_admision_model.py
+++ b/admisiones/tests/test_admision_model.py
@@ -1,0 +1,83 @@
+from datetime import datetime, timedelta
+from unittest import mock
+
+from django.contrib.auth import get_user_model
+from django.test import TestCase
+from django.utils import timezone
+
+from admisiones.models.admisiones import Admision
+from comedores.models import Comedor
+from duplas.models import Dupla
+
+
+User = get_user_model()
+
+
+class AdmisionModelSaveTest(TestCase):
+    def setUp(self):
+        self.abogado = User.objects.create_user(
+            username="abogado", first_name="Ana", last_name="Abogada"
+        )
+        self.tecnico_1 = User.objects.create_user(username="tecnico1")
+        self.tecnico_2 = User.objects.create_user(username="tecnico2")
+
+        self.dupla = Dupla.objects.create(
+            nombre="Dupla Test", estado="Activo", abogado=self.abogado
+        )
+        self.dupla.tecnico.add(self.tecnico_1, self.tecnico_2)
+
+        self.comedor = Comedor.objects.create(nombre="Comedor Test", dupla=self.dupla)
+
+    def _create_admision_with_date(self, current_datetime: datetime) -> Admision:
+        with mock.patch("django.utils.timezone.now", return_value=current_datetime):
+            return Admision.objects.create(comedor=self.comedor)
+
+    def test_updates_estado_mostrar_and_fecha_when_estado_changes(self):
+        initial_datetime = timezone.make_aware(
+            datetime(2023, 1, 1, 10, 0, 0), timezone.get_current_timezone()
+        )
+        update_datetime = initial_datetime + timedelta(days=1)
+        admision = self._create_admision_with_date(initial_datetime)
+
+        with mock.patch("django.utils.timezone.now", return_value=update_datetime):
+            admision.estado_admision = "enviado_a_legales"
+            admision.save(update_fields=["estado_admision"])
+
+        admision.refresh_from_db()
+
+        self.assertEqual(admision.estado_mostrar, "Enviado a legales")
+        self.assertEqual(admision.fecha_estado_mostrar, update_datetime.date())
+
+    def test_keeps_fecha_estado_mostrar_when_estado_does_not_change(self):
+        initial_datetime = timezone.make_aware(
+            datetime(2023, 2, 1, 10, 0, 0), timezone.get_current_timezone()
+        )
+        later_datetime = initial_datetime + timedelta(days=3)
+        admision = self._create_admision_with_date(initial_datetime)
+        initial_fecha_estado = admision.fecha_estado_mostrar
+
+        with mock.patch("django.utils.timezone.now", return_value=later_datetime):
+            admision.observaciones = "Sin cambios en el estado"
+            admision.save(update_fields=["observaciones"])
+
+        admision.refresh_from_db()
+
+        self.assertEqual(admision.fecha_estado_mostrar, initial_fecha_estado)
+        self.assertEqual(admision.estado_mostrar, "Iniciada")
+
+    def test_update_fields_includes_estado_and_activa(self):
+        initial_datetime = timezone.make_aware(
+            datetime(2023, 3, 1, 10, 0, 0), timezone.get_current_timezone()
+        )
+        discard_datetime = initial_datetime + timedelta(days=2)
+        admision = self._create_admision_with_date(initial_datetime)
+
+        with mock.patch("django.utils.timezone.now", return_value=discard_datetime):
+            admision.estado_admision = "descartado"
+            admision.save(update_fields=["estado_admision"])
+
+        admision.refresh_from_db()
+
+        self.assertFalse(admision.activa)
+        self.assertEqual(admision.estado_mostrar, "Descartado")
+        self.assertEqual(admision.fecha_estado_mostrar, discard_datetime.date())


### PR DESCRIPTION
## Summary
- cachear el estado_mostrar inicial en Admision para evitar una consulta extra en save y mantener coherencia tras cada guardado
- añadir pruebas del modelo que validan actualizaciones de estado, fecha_estado_mostrar y campos forzados en update_fields
- eliminar el archivo PR_REVIEW.md usado para la revisión previa

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692d8c5201fc832db196941f22bd933d)