### PR TITLE
Improve Organizacion detail context handling

### DIFF
--- a/config/settings.py
+++ b/config/settings.py
@@ -167,7 +167,7 @@ DATABASES = {
     }
 }
 
-if "pytest" in sys.argv or os.environ.get("PYTEST_RUNNING") == "1":  # DB para testing
+if any("pytest" in arg for arg in sys.argv) or os.environ.get("PYTEST_RUNNING") == "1":  # DB para testing
     DATABASES = {
         "default": {"ENGINE": "django.db.backends.sqlite3", "NAME": ":memory:"}
     }

--- a/organizaciones/tests.py
+++ b/organizaciones/tests.py
@@ -1,0 +1,51 @@
+from django.contrib.auth.models import User
+from django.test import RequestFactory, TestCase
+
+from organizaciones.models import Organizacion, TipoEntidad
+from organizaciones.views import OrganizacionDetailView
+
+
+class OrganizacionDetailViewTests(TestCase):
+    def setUp(self):
+        self.factory = RequestFactory()
+        self.user = User.objects.create_user(username="tester", password="secret")
+
+    def _get_context(self, organizacion: Organizacion):
+        request = self.factory.get("/")
+        request.user = self.user
+
+        view = OrganizacionDetailView()
+        view.setup(request)
+        view.object = organizacion
+
+        return view.get_context_data()
+
+    def test_avales_flag_true_for_asociacion_de_hecho(self):
+        tipo_entidad = TipoEntidad.objects.create(nombre="Asociación de hecho")
+        organizacion = Organizacion.objects.create(
+            nombre="Organizacion A", tipo_entidad=tipo_entidad
+        )
+
+        context = self._get_context(organizacion)
+
+        self.assertTrue(context["avales"])
+        self.assertEqual(context["tipo_entidad"], tipo_entidad)
+
+    def test_avales_flag_false_without_tipo_entidad(self):
+        organizacion = Organizacion.objects.create(nombre="Organizacion B")
+
+        context = self._get_context(organizacion)
+
+        self.assertFalse(context["avales"])
+        self.assertIsNone(context["tipo_entidad"])
+
+    def test_avales_flag_false_for_other_tipo_entidad(self):
+        tipo_entidad = TipoEntidad.objects.create(nombre="Fundación")
+        organizacion = Organizacion.objects.create(
+            nombre="Organizacion C", tipo_entidad=tipo_entidad
+        )
+
+        context = self._get_context(organizacion)
+
+        self.assertFalse(context["avales"])
+        self.assertEqual(context["tipo_entidad"], tipo_entidad)

--- a/organizaciones/views.py
+++ b/organizaciones/views.py
@@ -501,14 +501,12 @@ class OrganizacionDetailView(LoginRequiredMixin, DetailView):
             {"url_name": "aval_editar", "label": "Editar", "type": "primary"},
             {"url_name": "aval_eliminar", "label": "Eliminar", "type": "danger"},
         ]
-        try:
-            if self.object.tipo_entidad.nombre == "Asociación de hecho":
-                context["avales"] = True
-            else:
-                context["avales"] = False
-        except Exception:
-            context["tipo_entidad"] = None
-            context["avales"] = False
+        tipo_entidad = getattr(self.object, "tipo_entidad", None)
+        context["tipo_entidad"] = tipo_entidad
+        context["avales"] = bool(
+            tipo_entidad
+            and getattr(tipo_entidad, "nombre", "") == "Asociación de hecho"
+        )
 
         return context
 


### PR DESCRIPTION
## Summary
- ensure `OrganizacionDetailView` sets `avales` without broad exception handling and keeps `tipo_entidad` in context
- add unit tests covering avales flag for different `tipo_entidad` scenarios
- make pytest detection more robust so test runs default to sqlite

## Testing
- `PYTEST_RUNNING=1 pytest organizaciones/tests.py -q --maxfail=1` *(interrupted due to long migration/setup time)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6958379ba804832d90ff7ba1bbae0ea8)