### PR TITLE
update sidebar permissions to include 'CDF SSE' group for navigation …

### DIFF
--- a/templates/includes/sidebar/new_opciones.html
+++ b/templates/includes/sidebar/new_opciones.html
@@ -125,7 +125,7 @@
                     </a>
                 </li>
             {% endif %}
-            {% if request.user|has_group:"superadmin" or request.user|has_group:"ReferenteCentro" or user %}
+            {% if request.user|has_group:"superadmin" or request.user|has_group:"ReferenteCentro" or request.user|has_group:"CDF SSE" %}
                 <li class="nav-item">
                     <a href="{% url 'centro_list' %}"
                        class="nav-link {% if 'centros/' in pagina_actual %}active{% endif %}">

--- a/templates/includes/sidebar/opciones.html
+++ b/templates/includes/sidebar/opciones.html
@@ -546,7 +546,7 @@
                 </li>
             {% endif %}
             <!-- CENTRO DE FAMILIA -->
-            {% if request.user|has_group:"superadmin" or request.user|has_group:"ReferenteCentro" %}
+            {% if request.user|has_group:"superadmin" or request.user|has_group:"ReferenteCentro" or request.user|has_group:"CDF SSE" %}
                 <li class="nav-item {% if 'centros' in pagina_actual %}menu-open{% endif %}">
                     <a href="#"
                        class="nav-link nav-dot {% if 'centros' in pagina_actual %}active{% endif %} ms-2">


### PR DESCRIPTION
Fix: Agregar grupo CDF SSE al menú Centro de Familia
Información de la Tarea
Vincular el #ISSUE

Resumen de la Solución:
Se agregó el grupo "CDF SSE" a las condiciones de visibilidad del menú "Centro de Familia" en los templates del sidebar

Información Adicional:
El rol CDF SSE ya tenía permisos en las vistas pero no podía acceder al menú lateral

Se identificó que las vistas de centrodefamilia ya verifican correctamente el grupo "CDF SSE"

Descripción de los Cambios
Cambios:
templates/includes/sidebar/opciones.html: Agregado request.user|has_group:"CDF SSE" a la condición del menú Centro de Familia (línea 398)

templates/includes/sidebar/new_opciones.html: Agregado request.user|has_group:"CDF SSE" y corregida condición errónea or user

Cómo Testear los Cambios
Pruebas Automáticas:
No aplica (cambio de template)

Pruebas Manuales:
Crear/asignar usuario al grupo "CDF SSE"

Iniciar sesión con ese usuario

Verificar que aparece la opción "Centro de Familia" en el menú lateral

Confirmar acceso a todas las subopciones:

Centros

Nuevo Preinscripto

Lista de Preinscriptos

Lista Responsables