### PR TITLE
Enforce POST-only for import/delete actions

### DIFF
--- a/importarexpediente/views.py
+++ b/importarexpediente/views.py
@@ -12,7 +12,7 @@ from django.shortcuts import redirect, get_object_or_404
 from django.contrib.auth.decorators import login_required
 from django.contrib.auth.mixins import LoginRequiredMixin
 from django.views.generic import ListView
-from django.http import JsonResponse
+from django.http import JsonResponse, HttpResponseNotAllowed
 from django.core.paginator import Paginator
 from django.template.loader import render_to_string
 from django.db.models import Q
@@ -652,9 +652,8 @@ class ImportDatosView(LoginRequiredMixin, FormView):
             )
         return redirect(self.success_url)
 
-    # Permitir importación vía GET (desde el botón en el detalle)
     def get(self, request, *args, **kwargs):
-        return self.post(request, *args, **kwargs)
+        return HttpResponseNotAllowed(["POST"])
 
 
 class BorrarDatosImportadosView(LoginRequiredMixin, FormView):
@@ -701,6 +700,5 @@ class BorrarDatosImportadosView(LoginRequiredMixin, FormView):
         )
         return redirect(self.success_url)
 
-    # Permitir borrado vía GET (desde el botón en el detalle)
     def get(self, request, *args, **kwargs):
-        return self.post(request, *args, **kwargs)
+        return HttpResponseNotAllowed(["POST"])


### PR DESCRIPTION
### Motivation
- Prevent accidental or malicious execution of destructive operations via GET so CSRF protection remains effective.
- The `get()` methods for import and delete previously delegated to `post()`, which allowed side effects on GET requests and must be blocked.

### Description
- Replace the `get()` implementations in `ImportDatosView` and `BorrarDatosImportadosView` to return `HttpResponseNotAllowed(["POST"])` instead of calling `post()`.
- Add the `HttpResponseNotAllowed` import to `importarexpediente/views.py` and remove the GET-to-POST behavior.
- This enforces `POST`-only semantics for the import and delete endpoints, preserving CSRF protection for those actions.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696111317914832d916d98587bd93c57)