### PR TITLE
Fix test iam

### DIFF
--- a/tests/test_comunicados_views_unit.py
+++ b/tests/test_comunicados_views_unit.py
@@ -239,7 +239,7 @@ def test_gestion_oculta_boton_editar_si_usuario_no_puede_editar(client):
     creador = _create_user("creador_no_edit")
     usuario_gestion = _create_user(
         "gestion_sin_editar",
-        groups=[UserGroups.COMUNICADO_PUBLICAR],
+        groups=[UserGroups.COMUNICADO_CREAR],
     )
     comunicado = _create_comunicado(
         usuario_creador=creador,

--- a/tests/test_legajo_views_unit.py
+++ b/tests/test_legajo_views_unit.py
@@ -15,6 +15,12 @@ pytestmark = pytest.mark.django_db
 
 def _user(auth=True, superuser=False, groups=None):
     groups = set(groups or [])
+
+    def _has_perm(perm, obj=None):
+        if not auth:
+            return False
+        return superuser or True
+
     return SimpleNamespace(
         id=1,
         is_authenticated=auth,
@@ -22,16 +28,12 @@ def _user(auth=True, superuser=False, groups=None):
         groups=SimpleNamespace(
             filter=lambda **k: SimpleNamespace(exists=lambda: k.get("name") in groups)
         ),
+        has_perm=_has_perm,
     )
 
 
 def _call_post_unwrapped(view, request, *args, **kwargs):
     return view.__class__.post.__wrapped__(view, request, *args, **kwargs)
-
-
-def test_in_group():
-    assert module._in_group(_user(groups={"A"}), "A") is True
-    assert module._in_group(_user(groups={"A"}), "B") is False
 
 
 def test_archivo_upload_dispatch_and_post_paths(mocker):

--- a/tests/test_users_signals_unit.py
+++ b/tests/test_users_signals_unit.py
@@ -142,6 +142,7 @@ def test_ensure_inherited_groups_reverse_mode_assigns_per_user(mocker):
         "users.signals.User.objects.filter", return_value=users
     )
     mock_assign = mocker.patch("users.signals._assign_inherited_groups")
+    mocker.patch("users.signals.sync_permissions_for_group")
 
     signals.ensure_inherited_groups(
         sender=None,
@@ -175,6 +176,7 @@ def test_ensure_inherited_groups_reverse_returns_when_group_has_no_inheritance(m
     group = SimpleNamespace(name="Sin herencia")
     mock_user_filter = mocker.patch("users.signals.User.objects.filter")
     mock_assign = mocker.patch("users.signals._assign_inherited_groups")
+    mocker.patch("users.signals.sync_permissions_for_group")
 
     signals.ensure_inherited_groups(
         sender=None,

--- a/tests/test_validacion_renaper_view_unit.py
+++ b/tests/test_validacion_renaper_view_unit.py
@@ -22,6 +22,12 @@ class _Groups:
         return self.last_name in self.allowed
 
 
+_PERM_TO_GROUP = {
+    "auth.role_tecnicoceliaquia": "TecnicoCeliaquia",
+    "auth.role_coordinadorceliaquia": "CoordinadorCeliaquia",
+}
+
+
 class _User:
     def __init__(self, auth=True, superuser=False, groups=None, user_id=10):
         self.is_authenticated = auth
@@ -31,6 +37,16 @@ class _User:
 
     def get_username(self):
         return "tester"
+
+    def has_perm(self, perm, obj=None):
+        if not self.is_authenticated:
+            return False
+        if self.is_superuser:
+            return True
+        group_name = _PERM_TO_GROUP.get(perm)
+        if group_name:
+            return self.groups.filter(group_name).exists()
+        return False
 
 
 class _Asignaciones:
@@ -68,7 +84,7 @@ def test_helpers_truncate(value, length, expected):
     assert module._truncate(value, length) == expected
 
 
-def test_helpers_build_log_data_and_in_group():
+def test_helpers_build_log_data():
     user = _User(groups=_Groups({"TecnicoCeliaquia"}))
     legajo = SimpleNamespace(pk=2, expediente_id=20)
     ciudadano = SimpleNamespace(id=30, sexo=SimpleNamespace(sexo="Masculino"))
@@ -85,8 +101,6 @@ def test_helpers_build_log_data_and_in_group():
     assert data["user_id"] == 10
     assert data["legajo_id"] == 2
     assert data["documento_consulta"] == "12345678"
-    assert module._in_group(user, "TecnicoCeliaquia") is True
-    assert module._in_group(user, "NoExiste") is False
 
 
 def test_dispatch_permissions():


### PR DESCRIPTION
# Información de la Tarea
Vincular el #ISSUE

### **Resumen de la Solución:**
- Se actualizaron 4 archivos de test que fallaban tras el refactor IAM, el cual reemplazó `group_required` / `_in_group` por `user_has_permission_code` (que internamente llama a `user.has_perm()`). Los mocks de usuario en tests unitarios no tenían ese método, causando `AttributeError`.

### **Información Adicional:**
- El refactor IAM cambió la forma en que se verifican permisos: ya no se chequea membresía de grupo directo sino `user.has_perm()` con codenames Django (`auth.role_*`).
- El grupo `"Comunicado Publicar"` fue mapeado en el registry a `change_comunicado`, por lo que ya no sirve para testear un usuario sin permiso de edición. Se usa `"Comunicado Crear"` que solo tiene `add_comunicado`.
- Los signals de herencia de grupos llaman a `sync_permissions_for_group()` que accede a DB, lo que rompía tests unitarios sin `@pytest.mark.django_db`.

# Descripción de los Cambios

### **Cambios:**

**`tests/test_legajo_views_unit.py`:**
- Eliminado `test_in_group` (testeaba `module._in_group` que fue removida del módulo en el refactor IAM).
- Agregado `has_perm` al helper `_user()`: retorna `True` para usuarios autenticados, `False` para anónimos.

**`tests/test_validacion_renaper_view_unit.py`:**
- Agregado `_PERM_TO_GROUP` dict que mapea `"auth.role_tecnicoceliaquia"` / `"auth.role_coordinadorceliaquia"` a sus grupos.
- Agregado método `has_perm` a la clase `_User` que usa ese mapeo para simular el comportamiento real.
- Renombrado `test_helpers_build_log_data_and_in_group` → `test_helpers_build_log_data` y removidas las aserciones de `module._in_group` (función eliminada).

**`tests/test_users_signals_unit.py`:**
- Agregado `mocker.patch("users.signals.sync_permissions_for_group")` en 2 tests (`test_ensure_inherited_groups_reverse_mode_assigns_per_user` y `test_ensure_inherited_groups_reverse_returns_when_group_has_no_inheritance`) que no tienen acceso a DB pero el signal internamente hace una query.

**`tests/test_comunicados_views_unit.py`:**
- Cambiado el grupo del usuario de prueba en `test_gestion_oculta_boton_editar_si_usuario_no_puede_editar` de `COMUNICADO_PUBLICAR` a `COMUNICADO_CREAR`. El primero ahora tiene `change_comunicado` en el registry (puede editar), el segundo solo tiene `add_comunicado` (no puede editar pero sí accede a la vista de gestión).

# Cómo Testear los Cambios

### **Pruebas Automáticas:**
```bash
pytest tests/test_legajo_views_unit.py \
       tests/test_validacion_renaper_view_unit.py \
       tests/test_users_signals_unit.py \
       tests/test_comunicados_views_unit.py \
       --tb=short -q
Resultado esperado: 41 passed.

### **Pruebas Manuales:**
- No aplica — son cambios exclusivos de tests, sin modificación de lógica de negocio.

### **Capturas de Pantalla**
- No aplica.