### PR TITLE
feat(relevamientos): recupera alta por modal en listado

### DIFF
--- a/celiaquia/services/importacion_service/impl.py
+++ b/celiaquia/services/importacion_service/impl.py
@@ -720,9 +720,7 @@ def _resolver_nacionalidad_payload_importacion(payload):
 
     nacionalidad_str = str(nacionalidad_val).strip()
     if nacionalidad_str.isdigit():
-        nacionalidad_obj = Nacionalidad.objects.filter(
-            pk=int(nacionalidad_str)
-        ).first()
+        nacionalidad_obj = Nacionalidad.objects.filter(pk=int(nacionalidad_str)).first()
     else:
         nacionalidad_obj = Nacionalidad.objects.filter(
             nacionalidad__iexact=nacionalidad_str
@@ -1027,7 +1025,9 @@ def _resolver_localidad_responsable_payload_importacion(
                 municipio__provincia_id=provincia_usuario_id
             )
             if localidad_resp_str.isdigit():
-                coincidencias = list(localidades_qs.filter(pk=int(localidad_resp_str))[:2])
+                coincidencias = list(
+                    localidades_qs.filter(pk=int(localidad_resp_str))[:2]
+                )
             else:
                 coincidencias = list(
                     localidades_qs.filter(nombre__iexact=localidad_resp_str)[:2]
@@ -1799,7 +1799,9 @@ def _procesar_responsable_si_corresponde_importacion(
     relaciones_familiares,
     responsable_payload=None,
 ):
-    if responsable_payload is None and not _tiene_datos_responsable_importacion(payload):
+    if responsable_payload is None and not _tiene_datos_responsable_importacion(
+        payload
+    ):
         return None, False, False
 
     return _procesar_responsable_importacion(

--- a/celiaquia/views/expediente.py
+++ b/celiaquia/views/expediente.py
@@ -345,7 +345,9 @@ class ProcesarExpedienteView(View):
                     nom = d.get("nombre", "")
                     estado = d.get("estado_programa") or d.get("motivo") or "-"
                     expid = d.get("expediente_origen_id", "-")
-                    preview.append(f"â€¢ {doc} â€” {ape}, {nom} ({estado}) â€” Exp #{expid}")
+                    preview.append(
+                        f"â€¢ {doc} â€” {ape}, {nom} ({estado}) â€” Exp #{expid}"
+                    )
 
                 extra = ""
                 if len(det) > 10:
@@ -438,7 +440,9 @@ class ExpedientePreviewExcelView(View):
         logger.debug("PREVIEW: %s %s", request.method, request.get_full_path())
         archivo = request.FILES.get("excel_masivo")
         if not archivo:
-            return JsonResponse({"error": "No se recibiÃ³ ningÃºn archivo."}, status=400)
+            return JsonResponse(
+                {"error": "No se recibiÃ³ ningÃºn archivo."}, status=400
+            )
 
         raw_limit = request.POST.get("limit") or request.GET.get("limit")
         max_rows = _parse_limit(raw_limit, default=None, max_cap=5000)

--- a/docs/registro/cambios/2026-03-26-relevamientos-alta-desde-listado.md
+++ b/docs/registro/cambios/2026-03-26-relevamientos-alta-desde-listado.md
@@ -1,0 +1,21 @@
+# 2026-03-26 - Alta de relevamiento desde listado
+
+## Resumen
+- Se recupero el flujo de alta de relevamiento desde `comedores/<pk>/relevamiento/listar`.
+- El boton `Agregar` vuelve a abrir un modal para crear el relevamiento.
+- La creacion usa el endpoint existente `relevamiento_create_edit_ajax` y mantiene la logica de territorial opcional.
+
+## Cambios realizados
+- Archivo: `relevamientos/templates/relevamiento_list.html`
+  - Se reemplazo el link de `Agregar` por un boton que abre `#modalRelevamientoNuevo`.
+  - Se agrego modal con formulario `POST` a `relevamiento_create_edit_ajax`.
+  - Se incorporo select `new_territorial_select` para cargar territoriales.
+  - Se reutilizo `static/custom/js/comedordetail_territorial_cache.js` para poblar territoriales desde cache/API.
+- Archivo: `relevamientos/tests.py`
+  - Se agregaron pruebas para verificar render del modal y alta efectiva con territorial desde el listado.
+
+## Comportamiento observable
+- En `relevamiento/listar`, usuarios con permiso de alta ven el boton `Agregar`.
+- Al crear desde el modal:
+  - con territorial, el relevamiento queda en estado `Visita pendiente`;
+  - sin territorial, el servicio conserva el comportamiento previo (`Pendiente`).

--- a/relevamientos/templates/relevamiento_list.html
+++ b/relevamientos/templates/relevamiento_list.html
@@ -51,8 +51,12 @@
                                     </div>
                                 </div>
                                 <div class="col-2 d-flex justify-content-end align-items-start my-3">
-                                    <a href="{% url 'comedor_detalle' comedor.id %}"
-                                       class="btn btn-primary btn-margin-right">Agregar</a>
+                                    {% if perms.relevamientos.add_relevamiento %}
+                                        <button type="button"
+                                                class="btn btn-primary btn-margin-right"
+                                                data-bs-toggle="modal"
+                                                data-bs-target="#modalRelevamientoNuevo">Agregar</button>
+                                    {% endif %}
                                 </div>
                             </div>
                         </div>
@@ -61,4 +65,50 @@
             </div>
         </div>
     </div>
+
+    {% if perms.relevamientos.add_relevamiento %}
+        <div class="modal fade"
+             id="modalRelevamientoNuevo"
+             tabindex="-1"
+             aria-labelledby="modalRelevamientoNuevoLabel"
+             aria-hidden="true">
+            <div class="modal-dialog modal-dialog-centered">
+                <div class="modal-content">
+                    <form method="post"
+                          action="{% url 'relevamiento_create_edit_ajax' comedor.id %}">
+                        {% csrf_token %}
+                        <div class="modal-header">
+                            <h5 class="modal-title" id="modalRelevamientoNuevoLabel">Nuevo relevamiento</h5>
+                            <button type="button"
+                                    class="btn-close"
+                                    data-bs-dismiss="modal"
+                                    aria-label="Cerrar"></button>
+                        </div>
+                        <div class="modal-body">
+                            <div class="mb-2">
+                                <label for="new_territorial_select" class="form-label">Territorial asignado</label>
+                                <select id="new_territorial_select" name="territorial" class="form-select">
+                                    <option value="">Sin territorial</option>
+                                </select>
+                            </div>
+                            <small class="text-muted">Si no selecciona territorial, se crea en estado Pendiente.</small>
+                        </div>
+                        <div class="modal-footer">
+                            <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Cancelar</button>
+                            <button type="submit" class="btn btn-primary">Crear relevamiento</button>
+                        </div>
+                    </form>
+                </div>
+            </div>
+        </div>
+    {% endif %}
+{% endblock %}
+
+{% block customJS %}
+    {% if perms.relevamientos.add_relevamiento %}
+        <script nonce="{{ request.csp_nonce }}">
+        const comedorId = "{{ comedor.id }}";
+        </script>
+        <script src="{% static 'custom/js/comedordetail_territorial_cache.js' %}"></script>
+    {% endif %}
 {% endblock %}

--- a/relevamientos/templates/relevamiento_list.html
+++ b/relevamientos/templates/relevamiento_list.html
@@ -106,9 +106,7 @@
 
 {% block customJS %}
     {% if perms.relevamientos.add_relevamiento %}
-        <script nonce="{{ request.csp_nonce }}">
-        const comedorId = "{{ comedor.id }}";
-        </script>
+        <script nonce="{{ request.csp_nonce }}">const comedorId = "{{ comedor.id }}";</script>
         <script src="{% static 'custom/js/comedordetail_territorial_cache.js' %}"></script>
     {% endif %}
 {% endblock %}

--- a/relevamientos/tests.py
+++ b/relevamientos/tests.py
@@ -28,7 +28,10 @@ def test_list_view(client_logged, comedor):
     assert response.status_code == 200
     assert comedor.nombre in body
     assert 'data-bs-target="#modalRelevamientoNuevo"' in body
-    assert f'action="{reverse("relevamiento_create_edit_ajax", kwargs={"pk": comedor.pk})}"' in body
+    assert (
+        f'action="{reverse("relevamiento_create_edit_ajax", kwargs={"pk": comedor.pk})}"'
+        in body
+    )
     assert 'id="new_territorial_select"' in body
 
 

--- a/relevamientos/tests.py
+++ b/relevamientos/tests.py
@@ -24,8 +24,28 @@ def test_create_view_post_invalid(client_logged, comedor):
 def test_list_view(client_logged, comedor):
     url = reverse("relevamientos", kwargs={"comedor_pk": comedor.pk})
     response = client_logged.get(url)
+    body = response.content.decode()
     assert response.status_code == 200
-    assert comedor.nombre in response.content.decode()
+    assert comedor.nombre in body
+    assert 'data-bs-target="#modalRelevamientoNuevo"' in body
+    assert f'action="{reverse("relevamiento_create_edit_ajax", kwargs={"pk": comedor.pk})}"' in body
+    assert 'id="new_territorial_select"' in body
+
+
+@pytest.mark.django_db
+def test_create_view_post_territorial_desde_listado(client_logged, comedor):
+    url = reverse("relevamiento_create_edit_ajax", kwargs={"pk": comedor.pk})
+    territorial_json = '{"gestionar_uid":"uid-1","nombre":"Territorial Norte"}'
+    response = client_logged.post(url, {"territorial": territorial_json})
+    assert response.status_code == 302
+    created = Relevamiento.objects.filter(comedor=comedor).latest("id")
+    assert created.territorial_uid == "uid-1"
+    assert created.territorial_nombre == "Territorial Norte"
+    assert created.estado == "Visita pendiente"
+    assert response.url == reverse(
+        "relevamiento_detalle",
+        kwargs={"comedor_pk": comedor.pk, "pk": created.pk},
+    )
 
 
 @pytest.mark.django_db

--- a/tests/test_importacion_service_helpers_unit.py
+++ b/tests/test_importacion_service_helpers_unit.py
@@ -588,7 +588,11 @@ def test_importacion_helpers_crear_responsable_y_legajo(mocker):
         legajos_crear=legajos_crear,
         offset=7,
         add_warning=_add_warning,
-        validar_edad_responsable_fn=lambda *_a, **_k: (False, ["warning edad"], "error edad"),
+        validar_edad_responsable_fn=lambda *_a, **_k: (
+            False,
+            ["warning edad"],
+            "error edad",
+        ),
         get_or_create_ciudadano=lambda **_kwargs: fake_ciudadano,
     )
 
@@ -830,27 +834,29 @@ def test_importacion_helpers_procesar_responsable_same_document():
     legajos = []
     existentes_ids = set()
 
-    cid_resp, legajo_agregado, relacion_agregada = module._procesar_responsable_importacion(
-        payload=payload,
-        cid_beneficiario=77,
-        usuario=SimpleNamespace(id=1),
-        expediente=SimpleNamespace(id=9),
-        estado_id=5,
-        provincia_usuario_id=7,
-        offset=12,
-        normalizar_sexo=lambda value: 2 if value == "F" else None,
-        to_date=lambda value: value,
-        add_warning=_add_warning,
-        add_error=_add_error,
-        validar_edad_responsable_fn=lambda *_a, **_k: (True, [], None),
-        existentes_ids=existentes_ids,
-        legajos_crear=legajos,
-        relaciones_familiares_pairs=pares,
-        relaciones_familiares=relaciones,
-        get_or_create_ciudadano=lambda **_kwargs: (_ for _ in ()).throw(
-            AssertionError("No debería crear ciudadano si es mismo documento")
-        ),
-        responsable_payload={"documento": "20123456783"},
+    cid_resp, legajo_agregado, relacion_agregada = (
+        module._procesar_responsable_importacion(
+            payload=payload,
+            cid_beneficiario=77,
+            usuario=SimpleNamespace(id=1),
+            expediente=SimpleNamespace(id=9),
+            estado_id=5,
+            provincia_usuario_id=7,
+            offset=12,
+            normalizar_sexo=lambda value: 2 if value == "F" else None,
+            to_date=lambda value: value,
+            add_warning=_add_warning,
+            add_error=_add_error,
+            validar_edad_responsable_fn=lambda *_a, **_k: (True, [], None),
+            existentes_ids=existentes_ids,
+            legajos_crear=legajos,
+            relaciones_familiares_pairs=pares,
+            relaciones_familiares=relaciones,
+            get_or_create_ciudadano=lambda **_kwargs: (_ for _ in ()).throw(
+                AssertionError("No debería crear ciudadano si es mismo documento")
+            ),
+            responsable_payload={"documento": "20123456783"},
+        )
     )
 
     assert (cid_resp, legajo_agregado, relacion_agregada) == (77, False, False)


### PR DESCRIPTION
what:
- reestablece boton Agregar en /relevamiento/listar para abrir modal de alta
- reutiliza endpoint relevamiento_create_edit_ajax y selector de territorial cacheado
- agrega tests de render del modal y alta con territorial desde listado

impact:
- se recupera el flujo del legajo nuevo para crear relevamientos desde listado

# Información de la Tarea
Vincular el #ISSUE

### **Resumen de la Solución:** 
-

### **Información Adicional:**
-

# Descripción de los Cambios

### **Cambios:**
-

# Cómo Testear los Cambios

### **Pruebas Automáticas:**
-

### **Prubeas Manuales:**
-

# Metadata para documentación automática

- Contexto funcional:
- Tipo de cambio:
- Área principal:
- Resumen para changelog:
- Impacto usuario:
- Riesgos / rollback:

# Capturas de Pantalla
