### PR TITLE
feat(centrodeinfancia): agregar columna de nomina en listado CDI

### DIFF
--- a/centrodeinfancia/templates/centrodeinfancia/centrodeinfancia_list.html
+++ b/centrodeinfancia/templates/centrodeinfancia/centrodeinfancia_list.html
@@ -98,6 +98,11 @@
                                                     Organización
                                                     <i class="fas fa-sort sort-icon"></i>
                                                 </th>
+                                            {% elif column_key == "tiene_nomina" %}
+                                                <th class="sortable" data-column="tiene_nomina">
+                                                    Tiene nómina
+                                                    <i class="fas fa-sort sort-icon"></i>
+                                                </th>
                                             {% elif column_key == "provincia" %}
                                                 <th class="sortable" data-column="provincia">
                                                     Provincia

--- a/centrodeinfancia/templates/centrodeinfancia/partials/rows.html
+++ b/centrodeinfancia/templates/centrodeinfancia/partials/rows.html
@@ -8,6 +8,10 @@
                 </td>
             {% elif column_key == "organizacion" %}
                 <td data-organizacion="{{ item.organizacion|default:'' }}">{{ item.organizacion|default:"-" }}</td>
+            {% elif column_key == "tiene_nomina" %}
+                <td data-tiene-nomina="{% if item.tiene_nomina %}Si{% else %}No{% endif %}">
+                    {% if item.tiene_nomina %}Si{% else %}No{% endif %}
+                </td>
             {% elif column_key == "provincia" %}
                 <td data-provincia="{{ item.provincia|default:'' }}">{{ item.provincia|default:"-" }}</td>
             {% elif column_key == "municipio" %}

--- a/centrodeinfancia/tests/test_centrodeinfancia_list.py
+++ b/centrodeinfancia/tests/test_centrodeinfancia_list.py
@@ -1,0 +1,59 @@
+from datetime import date
+
+import pytest
+from django.contrib.auth.models import Permission, User
+from django.urls import reverse
+
+from ciudadanos.models import Ciudadano
+from centrodeinfancia.models import CentroDeInfancia, NominaCentroInfancia
+from core.models import Provincia
+
+
+@pytest.mark.django_db
+def test_listado_cdi_muestra_si_tiene_nomina(client):
+    user = User.objects.create_user(username="listado-cdi", password="test1234")
+    user.user_permissions.add(
+        Permission.objects.get(codename="view_centrodeinfancia")
+    )
+    client.force_login(user)
+
+    provincia = Provincia.objects.create(nombre="Buenos Aires")
+    centro_con_nomina = CentroDeInfancia.objects.create(
+        nombre="CDI con nomina",
+        provincia=provincia,
+    )
+    centro_sin_nomina = CentroDeInfancia.objects.create(
+        nombre="CDI sin nomina",
+        provincia=provincia,
+    )
+    ciudadano = Ciudadano.objects.create(
+        apellido="Gomez",
+        nombre="Luz",
+        fecha_nacimiento=date(2018, 6, 1),
+        documento=44444444,
+    )
+    NominaCentroInfancia.objects.create(
+        centro=centro_con_nomina,
+        ciudadano=ciudadano,
+        estado=NominaCentroInfancia.ESTADO_ACTIVO,
+    )
+
+    response = client.get(reverse("centrodeinfancia"))
+    content = response.content.decode("utf-8")
+
+    assert response.status_code == 200
+    assert "tiene_nomina" in response.context["active_columns"]
+    assert response.context["centros"][0].tiene_nomina is True
+    assert response.context["centros"][1].tiene_nomina is False
+
+    tiene_nomina_column = next(
+        col
+        for col in response.context["column_config"]["available"]
+        if col["key"] == "tiene_nomina"
+    )
+    assert tiene_nomina_column["default"] is True
+    assert tiene_nomina_column["required"] is False
+
+    assert "Tiene nómina" in content
+    assert 'data-tiene-nomina="Si"' in content
+    assert 'data-tiene-nomina="No"' in content

--- a/centrodeinfancia/views.py
+++ b/centrodeinfancia/views.py
@@ -11,7 +11,7 @@ from django.contrib.auth.mixins import LoginRequiredMixin
 from django.contrib.contenttypes.models import ContentType
 from django.core.paginator import Paginator
 from django.db import transaction
-from django.db.models import Q
+from django.db.models import Exists, OuterRef, Q
 from django.http import JsonResponse
 from django.shortcuts import get_object_or_404, redirect, render
 from django.template.loader import render_to_string
@@ -63,6 +63,7 @@ from intervenciones.constants import PROGRAMA_ALIASES_CENTRO_INFANCIA
 CDI_LIST_HEADERS = [
     {"title": "Nombre"},
     {"title": "Organización"},
+    {"title": "Tiene nómina"},
     {"title": "Provincia"},
     {"title": "Municipio"},
     {"title": "Localidad"},
@@ -74,6 +75,7 @@ CDI_LIST_HEADERS = [
 CDI_LIST_FIELDS = [
     {"name": "nombre"},
     {"name": "organizacion"},
+    {"name": "tiene_nomina"},
     {"name": "provincia"},
     {"name": "municipio"},
     {"name": "localidad"},
@@ -182,8 +184,13 @@ class CentroDeInfanciaListView(LoginRequiredMixin, ListView):
 
     def get_queryset(self):
         query = self.request.GET.get("busqueda")
+        nomina_subquery = NominaCentroInfancia.objects.filter(
+            centro_id=OuterRef("pk")
+        )
         queryset = CentroDeInfancia.objects.select_related(
             "organizacion", "provincia", "municipio", "localidad"
+        ).annotate(
+            tiene_nomina=Exists(nomina_subquery)
         )
         queryset = _aplicar_filtro_provincia_usuario(queryset, self.request.user)
         if query:
@@ -199,7 +206,13 @@ class CentroDeInfanciaListView(LoginRequiredMixin, ListView):
             "centrodeinfancia_list",
             CDI_LIST_HEADERS,
             CDI_LIST_FIELDS,
-            default_keys=["nombre", "organizacion", "provincia", "municipio"],
+            default_keys=[
+                "nombre",
+                "organizacion",
+                "tiene_nomina",
+                "provincia",
+                "municipio",
+            ],
             required_keys=["nombre"],
         )
         context["breadcrumb_items"] = [

--- a/docs/registro/cambios/2026-03-30-cdi-listado-tiene-nomina.md
+++ b/docs/registro/cambios/2026-03-30-cdi-listado-tiene-nomina.md
@@ -1,0 +1,17 @@
+# 2026-03-30 - Columna "Tiene nómina" en listado CDI
+
+## Qué cambió
+
+- Se agregó la columna `Tiene nómina` al listado `/centrodeinfancia/listar`.
+- El valor mostrado es `Si` cuando el centro tiene al menos un registro en `nominas`.
+- El valor mostrado es `No` cuando el centro no tiene registros en nómina.
+
+## Implementación
+
+- La vista `CentroDeInfanciaListView` anota el queryset con un booleano `tiene_nomina` usando `Exists(...)`.
+- El template del listado y su partial de filas renderizan la nueva columna dentro del sistema existente de columnas configurables.
+- La columna quedó visible por defecto, pero puede ocultarse manualmente desde la configuración de columnas.
+
+## Validación
+
+- Se agregó un test de regresión para verificar que el listado distingue entre centros con y sin nómina.


### PR DESCRIPTION
what:
- anota el listado con la existencia de registros de nomina
- agrega la columna Tiene nómina al listado configurable
- suma test de regresion y registro en docs

tests:
- no ejecutados en este entorno; python/pytest no estan disponibles en PATH y docker compose falla por variables locales faltantes

# Información de la Tarea
Vincular el #ISSUE

### **Resumen de la Solución:** 
-

### **Información Adicional:**
-

# Descripción de los Cambios

### **Cambios:**
-

# Cómo Testear los Cambios

### **Pruebas Automáticas:**
-

### **Prubeas Manuales:**
-

# Metadata para documentación automática

- Contexto funcional:
- Tipo de cambio:
- Área principal:
- Resumen para changelog:
- Impacto usuario:
- Riesgos / rollback:

# Capturas de Pantalla
