### PR TITLE
fix(vat): corregir hallazgos criticos del review del pr 1408

### DIFF
--- a/VAT/management/commands/recargar_vouchers.py
+++ b/VAT/management/commands/recargar_vouchers.py
@@ -11,13 +11,15 @@ Cron (día 1 de cada mes a las 00:30):
 
 import logging
 from datetime import date
+
+from django.contrib.auth import get_user_model
 from django.core.management.base import BaseCommand, CommandError
-from django.contrib.auth.models import User
 
 from VAT.models import VoucherParametria, Voucher
-from VAT.services.voucher_service.impl import VoucherService
+from VAT.services.voucher_service import VoucherService
 
 logger = logging.getLogger("django")
+User = get_user_model()
 
 
 class Command(BaseCommand):

--- a/VAT/services/inscripcion_service.py
+++ b/VAT/services/inscripcion_service.py
@@ -5,7 +5,7 @@ from django.contrib.auth import get_user_model
 from django.db import transaction
 
 from VAT.models import Inscripcion, Voucher
-from VAT.services.voucher_service.impl import VoucherService
+from VAT.services.voucher_service import VoucherService
 
 User = get_user_model()
 
@@ -47,6 +47,16 @@ class InscripcionService:
             User.objects.filter(is_staff=True).first()
             or User.objects.filter(is_superuser=True).first()
         )
+
+    @staticmethod
+    def _resolver_cantidad_debito(costo) -> int:
+        monto = Decimal(costo or 0)
+        if monto != monto.to_integral_value():
+            raise ValueError(
+                "El costo de la oferta debe ser un numero entero de creditos "
+                "para poder debitarse del voucher."
+            )
+        return int(monto)
 
     @staticmethod
     def validar_inscripcion_unica(ciudadano, programa) -> tuple[bool, str]:
@@ -153,7 +163,9 @@ class InscripcionService:
                         f"{ciudadano} no tiene voucher activo para el programa {oferta.programa}."
                     )
 
-                cantidad_debito = int(Decimal(oferta.costo or 0))
+                cantidad_debito = InscripcionService._resolver_cantidad_debito(
+                    oferta.costo
+                )
                 usuario_auditoria = InscripcionService._resolver_usuario_auditoria(
                     usuario
                 )

--- a/VAT/services/oferta_service/impl.py
+++ b/VAT/services/oferta_service/impl.py
@@ -1,1 +1,14 @@
-# OfertaService eliminado — OfertaFormativa reemplazada por Comision + OfertaInstitucional
+"""Compatibilidad minima para imports legacy del servicio de oferta."""
+
+
+class OfertaService:  # pragma: no cover - shim defensivo para imports legacy
+    """
+    Shim temporal para evitar errores de importacion mientras el codigo migra
+    a Comision + OfertaInstitucional.
+    """
+
+    def __init__(self, *args, **kwargs):
+        raise NotImplementedError(
+            "OfertaService fue reemplazado por Comision + OfertaInstitucional. "
+            "Actualiza el import consumidor antes de instanciar este servicio."
+        )

--- a/VAT/services/sesion_comision_service/impl.py
+++ b/VAT/services/sesion_comision_service/impl.py
@@ -7,7 +7,7 @@ por cada ocurrencia de ese día dentro del rango fecha_inicio/fecha_fin de la Co
 Ejemplo:
   Comision: 22/03/2026 → 22/04/2026
   Horario: Lunes 10:00-12:00
-  Resultado: 4 sesiones (23/03, 30/03, 06/04, 13/04, 20/04... según el rango)
+  Resultado: 5 sesiones (23/03, 30/03, 06/04, 13/04, 20/04... según el rango)
 """
 
 from datetime import timedelta

--- a/VAT/templates/vat/evaluacion/resultado_form.html
+++ b/VAT/templates/vat/evaluacion/resultado_form.html
@@ -22,7 +22,7 @@
                             {% if form.instance.id %}
                                 <i class="bi bi-pencil-square me-2"></i>Editar Resultado
                             {% else %}
-                                <i class="bi bi-plus-circle me-2"></i>Nueva Resultado
+                                <i class="bi bi-plus-circle me-2"></i>Nuevo Resultado
                             {% endif %}
                         </h1>
                     </div>

--- a/VAT/templates/vat/institucion/ubicacion_detail.html
+++ b/VAT/templates/vat/institucion/ubicacion_detail.html
@@ -12,7 +12,7 @@
                        class="btn btn-light"><i class="bi bi-arrow-left"></i></a>
                     <div>
                         <h1 class="h2 mb-0" style="color: #1f3a93;">
-                            <i class="bi-geo-alt me-2"></i>Ubicación
+                            <i class="bi bi-geo-alt me-2"></i>Ubicación
                         </h1>
                         <small class="text-muted">{{ ubicacion }}</small>
                     </div>

--- a/docs/registro/cambios/2026-03-31-pr-1408-fix-ci-review-comments.md
+++ b/docs/registro/cambios/2026-03-31-pr-1408-fix-ci-review-comments.md
@@ -1,0 +1,25 @@
+## Contexto
+
+Correccion acotada sobre el trabajo acumulado en `development` que alimenta el PR `#1408` hacia `main`.
+El objetivo fue atender hallazgos del review con impacto potencial en CI o en errores de ejecucion temprana.
+
+## Cambios realizados
+
+- Se agrego un shim minimo en `VAT/services/oferta_service/impl.py` para evitar errores de importacion del paquete `VAT.services.oferta_service` mientras persisten imports legacy.
+- `VAT/services/inscripcion_service.py` ahora importa `VoucherService` desde el export publico del paquete y valida que el costo de una oferta con voucher sea un entero exacto de creditos antes de debitar.
+- `VAT/management/commands/recargar_vouchers.py` dejo de depender de `django.contrib.auth.models.User` y resuelve el modelo con `get_user_model()`.
+- Se corrigieron dos detalles de UI/documentacion detectados en review:
+  - clase base `bi` faltante en `VAT/templates/vat/institucion/ubicacion_detail.html`
+  - texto `Nuevo Resultado` en `VAT/templates/vat/evaluacion/resultado_form.html`
+  - docstring consistente en `VAT/services/sesion_comision_service/impl.py`
+- Se agrego cobertura de regresion para rechazar costos decimales en el debito de voucher.
+
+## Decision clave
+
+No se revirtio el cambio en `VAT/migrations/0001_initial.py` dentro de esta tarea.
+Aunque editar una migracion historica no es ideal, en este caso la modificacion parece responder a compatibilidad de instalaciones nuevas sobre MySQL; moverlo a una migracion posterior no evita el fallo inicial en entornos frescos.
+
+## Riesgo / seguimiento
+
+- El shim de `OfertaService` es deliberadamente defensivo: evita el import error, pero mantiene el fallo explicito si alguien intenta instanciar el servicio legacy.
+- Si a futuro VAT admite costos de voucher con decimales reales, habra que redisenar `Voucher` y `VoucherService` para operar con `Decimal` end-to-end.

--- a/tests/test_vat_api_web_unit.py
+++ b/tests/test_vat_api_web_unit.py
@@ -102,6 +102,46 @@ def test_inscripcion_service_crear_inscripcion_debita_voucher(mocker):
     assert debitar_mock.call_args.kwargs["cantidad"] == 12500
 
 
+def test_inscripcion_service_rechaza_costo_con_decimales_en_voucher(mocker):
+    ciudadano = SimpleNamespace(id=3, __str__=lambda self: "Ciudadano Demo")
+    programa = SimpleNamespace(id=7)
+    oferta = SimpleNamespace(
+        programa=programa,
+        programa_id=7,
+        usa_voucher=True,
+        costo=Decimal("10.50"),
+    )
+    comision = SimpleNamespace(id=8, oferta=oferta, __str__=lambda self: "COM-8")
+    inscripcion = SimpleNamespace(id=21, comision_id=8, comision=comision)
+    usuario = SimpleNamespace(is_authenticated=True)
+    voucher = SimpleNamespace(cantidad_disponible=20)
+
+    mocker.patch(
+        "VAT.services.inscripcion_service.Inscripcion.objects.create",
+        return_value=inscripcion,
+    )
+    mocker.patch(
+        "VAT.services.inscripcion_service.Voucher.objects.filter",
+        return_value=SimpleNamespace(
+            order_by=lambda *_a, **_k: SimpleNamespace(first=lambda: voucher)
+        ),
+    )
+    debitar_mock = mocker.patch(
+        "VAT.services.inscripcion_service.VoucherService.debitar_voucher",
+        return_value=(True, "ok"),
+    )
+
+    with pytest.raises(ValueError, match="numero entero de creditos"):
+        InscripcionService.crear_inscripcion(
+            ciudadano=ciudadano,
+            comision=comision,
+            programa=programa,
+            usuario=usuario,
+        )
+
+    debitar_mock.assert_not_called()
+
+
 # ============================================================================
 # Tests: Inscripción única activa
 # ============================================================================


### PR DESCRIPTION
why: el review del PR 1408 detecto errores con potencial de romper imports y debitos de voucher en CI.

what:
- agrega shim defensivo para OfertaService legacy
- valida costos enteros antes de debitar voucher
- usa get_user_model en recargar_vouchers y export publico de VoucherService
- corrige detalles menores de template y documentacion
- suma test de regresion para costo decimal

tests:
- docker compose run --rm --no-deps -T django pytest tests/test_vat_api_web_unit.py -q
- docker compose run --rm --no-deps -T django pytest tests/test_vat_persona_views_unit.py -q

refs: Refs #1408

# Información de la Tarea
Vincular el #ISSUE

### **Resumen de la Solución:** 
-

### **Información Adicional:**
-

# Descripción de los Cambios

### **Cambios:**
-

# Cómo Testear los Cambios

### **Pruebas Automáticas:**
-

### **Prubeas Manuales:**
-

# Metadata para documentación automática

- Contexto funcional:
- Tipo de cambio:
- Área principal:
- Resumen para changelog:
- Impacto usuario:
- Riesgos / rollback:

# Capturas de Pantalla
