### PR TITLE
fix(VAT): corregir migracion 0021 en MySQL

### DIFF
--- a/VAT/migrations/0021_invert_titulo_plan_relation.py
+++ b/VAT/migrations/0021_invert_titulo_plan_relation.py
@@ -109,39 +109,47 @@ def _drop_titulo_referencia(apps, schema_editor):
     db = schema_editor.connection
     cursor = db.cursor()
 
-    # Buscar y eliminar FK constraints que involucren titulo_referencia_id
+    # En MySQL primero debe caer la FK antes que cualquier índice que la
+    # respalde; si no, DROP INDEX falla con OperationalError 1553.
     cursor.execute(
         """
-        SELECT tc.CONSTRAINT_NAME, tc.CONSTRAINT_TYPE
+        SELECT DISTINCT tc.CONSTRAINT_NAME
         FROM information_schema.TABLE_CONSTRAINTS tc
+        INNER JOIN information_schema.KEY_COLUMN_USAGE kcu
+            ON tc.TABLE_SCHEMA = kcu.TABLE_SCHEMA
+            AND tc.TABLE_NAME = kcu.TABLE_NAME
+            AND tc.CONSTRAINT_NAME = kcu.CONSTRAINT_NAME
         WHERE tc.TABLE_SCHEMA = DATABASE()
         AND tc.TABLE_NAME = 'VAT_planversioncurricular'
-        AND tc.CONSTRAINT_TYPE IN ('UNIQUE', 'FOREIGN KEY')
+        AND tc.CONSTRAINT_TYPE = 'FOREIGN KEY'
+        AND kcu.COLUMN_NAME = 'titulo_referencia_id'
         """
     )
-    constraints = cursor.fetchall()
-    for constraint_name, constraint_type in constraints:
+    for (constraint_name,) in cursor.fetchall():
         cursor.execute(
-            """
-            SELECT COUNT(*) FROM information_schema.KEY_COLUMN_USAGE
-            WHERE TABLE_SCHEMA = DATABASE()
-            AND TABLE_NAME = 'VAT_planversioncurricular'
-            AND CONSTRAINT_NAME = %s
-            AND COLUMN_NAME = 'titulo_referencia_id'
-            """,
-            [constraint_name],
+            f"ALTER TABLE `VAT_planversioncurricular` "
+            f"DROP FOREIGN KEY `{constraint_name}`"
         )
-        if cursor.fetchone()[0] > 0:
-            if constraint_type == "FOREIGN KEY":
-                cursor.execute(
-                    f"ALTER TABLE `VAT_planversioncurricular` "
-                    f"DROP FOREIGN KEY `{constraint_name}`"
-                )
-            elif constraint_type == "UNIQUE":
-                cursor.execute(
-                    f"ALTER TABLE `VAT_planversioncurricular` "
-                    f"DROP INDEX `{constraint_name}`"
-                )
+
+    cursor.execute(
+        """
+        SELECT DISTINCT tc.CONSTRAINT_NAME
+        FROM information_schema.TABLE_CONSTRAINTS tc
+        INNER JOIN information_schema.KEY_COLUMN_USAGE kcu
+            ON tc.TABLE_SCHEMA = kcu.TABLE_SCHEMA
+            AND tc.TABLE_NAME = kcu.TABLE_NAME
+            AND tc.CONSTRAINT_NAME = kcu.CONSTRAINT_NAME
+        WHERE tc.TABLE_SCHEMA = DATABASE()
+        AND tc.TABLE_NAME = 'VAT_planversioncurricular'
+        AND tc.CONSTRAINT_TYPE = 'UNIQUE'
+        AND kcu.COLUMN_NAME = 'titulo_referencia_id'
+        """
+    )
+    for (constraint_name,) in cursor.fetchall():
+        cursor.execute(
+            f"ALTER TABLE `VAT_planversioncurricular` "
+            f"DROP INDEX `{constraint_name}`"
+        )
 
     # Eliminar índices restantes sobre titulo_referencia_id
     cursor.execute(

--- a/VAT/tests.py
+++ b/VAT/tests.py
@@ -354,6 +354,61 @@ def test_migracion_0021_falla_si_un_titulo_tiene_multiples_planes():
         migration._raise_if_ambiguous_title_plan_rows([(7, 2, "11,12")])
 
 
+def test_migracion_0021_droppea_fk_antes_que_indices_de_titulo_referencia():
+    migration = importlib.import_module(
+        "VAT.migrations.0021_invert_titulo_plan_relation"
+    )
+    executed_sql = []
+
+    class FakeCursor:
+        def execute(self, sql, params=None):
+            executed_sql.append((sql, params))
+            if "CONSTRAINT_TYPE = 'FOREIGN KEY'" in sql:
+                self._rows = [("vat_plan_titulo_fk",)]
+                self._row = None
+            elif "CONSTRAINT_TYPE = 'UNIQUE'" in sql:
+                self._rows = [
+                    ("VAT_planversioncurricula_titulo_referencia_id_mod_uniq",)
+                ]
+                self._row = None
+            elif "FROM information_schema.STATISTICS" in sql:
+                self._rows = []
+                self._row = None
+            elif "FROM information_schema.COLUMNS" in sql:
+                self._rows = None
+                self._row = (1,)
+            else:
+                self._rows = None
+                self._row = None
+
+        def fetchall(self):
+            return self._rows
+
+        def fetchone(self):
+            return self._row
+
+    class FakeConnection:
+        def cursor(self):
+            return FakeCursor()
+
+    schema_editor = type(
+        "FakeSchemaEditor",
+        (),
+        {"connection": FakeConnection()},
+    )()
+
+    migration._drop_titulo_referencia(None, schema_editor)
+
+    drop_fk_index = next(
+        i for i, (sql, _) in enumerate(executed_sql) if "DROP FOREIGN KEY" in sql
+    )
+    drop_unique_index = next(
+        i for i, (sql, _) in enumerate(executed_sql) if "DROP INDEX" in sql
+    )
+
+    assert drop_fk_index < drop_unique_index
+
+
 @pytest.fixture
 def vat_curso_base(db, vat_geo_data):
     provincia, municipio, localidad = vat_geo_data

--- a/docs/registro/cambios/2026-03-31-fix-mysql-compat-migration-order.md
+++ b/docs/registro/cambios/2026-03-31-fix-mysql-compat-migration-order.md
@@ -1,0 +1,22 @@
+# Fix MySQL compat en migración VAT 0021
+
+## Contexto
+
+La suite `mysql_compat` fallaba al crear la base de tests sobre MySQL real.
+El error aparecía durante la migración `VAT 0021` con:
+
+- `OperationalError (1553): Cannot drop index ... needed in a foreign key constraint`
+
+## Cambio aplicado
+
+- Se ajustó `VAT/migrations/0021_invert_titulo_plan_relation.py` para eliminar primero las `FOREIGN KEY` que usan `titulo_referencia_id` y recién después los índices/constraints `UNIQUE` asociados a esa columna.
+- Se agregó un test de regresión en `VAT/tests.py` para asegurar ese orden de borrado.
+
+## Decisión
+
+Se mantuvo el enfoque de migración manual existente y se corrigió únicamente el orden de borrado requerido por MySQL, evitando cambios más amplios en la estructura o en los workflows de CI.
+
+## Validación
+
+- `docker compose run --rm --no-deps -T -e USE_SQLITE_FOR_TESTS=1 django pytest VAT/tests.py -k migracion_0021 -q`
+- `docker compose up -d --build` + espera de MySQL + `docker compose exec -T django pytest tests/test_mysql_compatibility.py::test_mysql_backend_activo_en_suite_mysql_compat tests/test_mysql_compatibility.py::test_mysql_integridad_unicidad_username_con_rollback -q -vv`


### PR DESCRIPTION
why: la suite mysql_compat fallaba al crear la base de tests porque la migracion 0021 intentaba borrar un indice antes de soltar la foreign key que lo usaba.

what:
- separa el borrado de foreign keys y constraints unique sobre titulo_referencia_id
- garantiza el orden compatible con MySQL
- agrega test de regresion para el helper de migracion
- registra el cambio en docs/registro/cambios

tests:
- docker compose run --rm --no-deps -T -e USE_SQLITE_FOR_TESTS=1 django pytest VAT/tests.py -k migracion_0021 -q
- docker compose up -d --build + espera de MySQL + docker compose exec -T django pytest tests/test_mysql_compatibility.py::test_mysql_backend_activo_en_suite_mysql_compat tests/test_mysql_compatibility.py::test_mysql_integridad_unicidad_username_con_rollback -q -vv

# Información de la Tarea
Vincular el #ISSUE

### **Resumen de la Solución:** 
-

### **Información Adicional:**
-

# Descripción de los Cambios

### **Cambios:**
-

# Cómo Testear los Cambios

### **Pruebas Automáticas:**
-

### **Prubeas Manuales:**
-

# Metadata para documentación automática

- Contexto funcional:
- Tipo de cambio:
- Área principal:
- Resumen para changelog:
- Impacto usuario:
- Riesgos / rollback:

# Capturas de Pantalla
