### PR TITLE
fix(VAT): corregir hallazgos criticos del PR 1419

### DIFF
--- a/VAT/migrations/0024_remove_curso_cupo_fechas.py
+++ b/VAT/migrations/0024_remove_curso_cupo_fechas.py
@@ -1,11 +1,61 @@
 from django.db import migrations
 
 
+LEGACY_CURSO_COLUMNS = ("cupo_total", "fecha_inicio", "fecha_fin")
+CURSO_ESTADO_TO_COMISION = {
+    "planificado": "planificada",
+    "activo": "activa",
+    "finalizado": "cerrada",
+    "cancelado": "suspendida",
+}
+
+
+def _map_curso_estado_to_comision(estado):
+    return CURSO_ESTADO_TO_COMISION.get(estado, "planificada")
+
+
+def _backfill_comision_curso_if_needed(
+    curso_model, comision_curso_model, existing_columns
+):
+    required_columns = set(LEGACY_CURSO_COLUMNS)
+    if not required_columns.issubset(existing_columns):
+        return
+
+    cursos_con_comision = set(
+        comision_curso_model.objects.values_list("curso_id", flat=True)
+    )
+    cursos_legacy = (
+        curso_model.objects.exclude(cupo_total__isnull=True)
+        .exclude(fecha_inicio__isnull=True)
+        .exclude(fecha_fin__isnull=True)
+    )
+
+    comisiones_creadas = []
+    for curso in cursos_legacy.iterator():
+        if curso.pk in cursos_con_comision:
+            continue
+        comisiones_creadas.append(
+            comision_curso_model(
+                curso_id=curso.pk,
+                codigo_comision=f"LEG-{curso.pk}",
+                nombre=curso.nombre,
+                cupo_total=curso.cupo_total,
+                fecha_inicio=curso.fecha_inicio,
+                fecha_fin=curso.fecha_fin,
+                estado=_map_curso_estado_to_comision(curso.estado),
+                observaciones=getattr(curso, "observaciones", None),
+            )
+        )
+
+    if comisiones_creadas:
+        comision_curso_model.objects.bulk_create(comisiones_creadas)
+
+
 def _drop_curso_columns_if_present(apps, schema_editor):
-    """Drop legacy Curso columns only when they exist (backend-agnostic)."""
+    """Backfill legacy Curso data into ComisionCurso before dropping columns."""
     curso_model = apps.get_model("VAT", "Curso")
+    comision_curso_model = apps.get_model("VAT", "ComisionCurso")
     table_name = curso_model._meta.db_table
-    columns = ("cupo_total", "fecha_inicio", "fecha_fin")
     connection = schema_editor.connection
     introspection = connection.introspection
 
@@ -14,12 +64,11 @@ def _drop_curso_columns_if_present(apps, schema_editor):
             return
 
         description = introspection.get_table_description(cursor, table_name)
-        existing = {
-            getattr(column, "name", column[0])
-            for column in description
-        }
+        existing = {getattr(column, "name", column[0]) for column in description}
 
-    for column_name in columns:
+    _backfill_comision_curso_if_needed(curso_model, comision_curso_model, existing)
+
+    for column_name in LEGACY_CURSO_COLUMNS:
         if column_name in existing:
             field = curso_model._meta.get_field(column_name)
             schema_editor.remove_field(curso_model, field)

--- a/VAT/migrations/0030_add_comision_curso_integrity_constraints.py
+++ b/VAT/migrations/0030_add_comision_curso_integrity_constraints.py
@@ -21,7 +21,6 @@ class Migration(migrations.Migration):
             model_name="comisionhorario",
             constraint=models.UniqueConstraint(
                 fields=("comision_curso", "dia_semana", "hora_desde", "hora_hasta"),
-                condition=models.Q(comision_curso__isnull=False),
                 name="vat_comhor_comisioncurso_horario_uniq",
             ),
         ),
@@ -39,7 +38,6 @@ class Migration(migrations.Migration):
             model_name="sesioncomision",
             constraint=models.UniqueConstraint(
                 fields=("comision_curso", "horario", "fecha"),
-                condition=models.Q(comision_curso__isnull=False),
                 name="vat_sesion_comisioncurso_horario_fecha_uniq",
             ),
         ),
@@ -57,7 +55,6 @@ class Migration(migrations.Migration):
             model_name="inscripcion",
             constraint=models.UniqueConstraint(
                 fields=("ciudadano", "comision_curso"),
-                condition=models.Q(comision_curso__isnull=False),
                 name="vat_inscripcion_ciudadano_comisioncurso_uniq",
             ),
         ),

--- a/VAT/migrations/0030_add_comision_curso_integrity_constraints.py
+++ b/VAT/migrations/0030_add_comision_curso_integrity_constraints.py
@@ -1,0 +1,64 @@
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("VAT", "0029_planversioncurricular_provincia"),
+    ]
+
+    operations = [
+        migrations.AddConstraint(
+            model_name="comisionhorario",
+            constraint=models.CheckConstraint(
+                check=(
+                    models.Q(comision__isnull=False, comision_curso__isnull=True)
+                    | models.Q(comision__isnull=True, comision_curso__isnull=False)
+                ),
+                name="vat_comhor_xor_comision_refs",
+            ),
+        ),
+        migrations.AddConstraint(
+            model_name="comisionhorario",
+            constraint=models.UniqueConstraint(
+                fields=("comision_curso", "dia_semana", "hora_desde", "hora_hasta"),
+                condition=models.Q(comision_curso__isnull=False),
+                name="vat_comhor_comisioncurso_horario_uniq",
+            ),
+        ),
+        migrations.AddConstraint(
+            model_name="sesioncomision",
+            constraint=models.CheckConstraint(
+                check=(
+                    models.Q(comision__isnull=False, comision_curso__isnull=True)
+                    | models.Q(comision__isnull=True, comision_curso__isnull=False)
+                ),
+                name="vat_sesion_xor_comision_refs",
+            ),
+        ),
+        migrations.AddConstraint(
+            model_name="sesioncomision",
+            constraint=models.UniqueConstraint(
+                fields=("comision_curso", "horario", "fecha"),
+                condition=models.Q(comision_curso__isnull=False),
+                name="vat_sesion_comisioncurso_horario_fecha_uniq",
+            ),
+        ),
+        migrations.AddConstraint(
+            model_name="inscripcion",
+            constraint=models.CheckConstraint(
+                check=(
+                    models.Q(comision__isnull=False, comision_curso__isnull=True)
+                    | models.Q(comision__isnull=True, comision_curso__isnull=False)
+                ),
+                name="vat_inscripcion_xor_comision_refs",
+            ),
+        ),
+        migrations.AddConstraint(
+            model_name="inscripcion",
+            constraint=models.UniqueConstraint(
+                fields=("ciudadano", "comision_curso"),
+                condition=models.Q(comision_curso__isnull=False),
+                name="vat_inscripcion_ciudadano_comisioncurso_uniq",
+            ),
+        ),
+    ]

--- a/VAT/models.py
+++ b/VAT/models.py
@@ -1368,6 +1368,20 @@ class ComisionHorario(models.Model):
             "hora_desde",
             "hora_hasta",
         )
+        constraints = [
+            models.CheckConstraint(
+                check=(
+                    models.Q(comision__isnull=False, comision_curso__isnull=True)
+                    | models.Q(comision__isnull=True, comision_curso__isnull=False)
+                ),
+                name="vat_comhor_xor_comision_refs",
+            ),
+            models.UniqueConstraint(
+                fields=("comision_curso", "dia_semana", "hora_desde", "hora_hasta"),
+                condition=models.Q(comision_curso__isnull=False),
+                name="vat_comhor_comisioncurso_horario_uniq",
+            ),
+        ]
 
 
 class SesionComision(models.Model):
@@ -1470,6 +1484,20 @@ class SesionComision(models.Model):
         indexes = [
             models.Index(
                 fields=["comision", "estado"], name="vat_sesion_comision_estado_idx"
+            ),
+        ]
+        constraints = [
+            models.CheckConstraint(
+                check=(
+                    models.Q(comision__isnull=False, comision_curso__isnull=True)
+                    | models.Q(comision__isnull=True, comision_curso__isnull=False)
+                ),
+                name="vat_sesion_xor_comision_refs",
+            ),
+            models.UniqueConstraint(
+                fields=("comision_curso", "horario", "fecha"),
+                condition=models.Q(comision_curso__isnull=False),
+                name="vat_sesion_comisioncurso_horario_fecha_uniq",
             ),
         ]
 
@@ -1604,6 +1632,20 @@ class Inscripcion(SoftDeleteModelMixin, models.Model):
             models.Index(
                 fields=["ciudadano", "estado"],
                 name="vat_insc_ciu_est_idx",
+            ),
+        ]
+        constraints = [
+            models.CheckConstraint(
+                check=(
+                    models.Q(comision__isnull=False, comision_curso__isnull=True)
+                    | models.Q(comision__isnull=True, comision_curso__isnull=False)
+                ),
+                name="vat_inscripcion_xor_comision_refs",
+            ),
+            models.UniqueConstraint(
+                fields=("ciudadano", "comision_curso"),
+                condition=models.Q(comision_curso__isnull=False),
+                name="vat_inscripcion_ciudadano_comisioncurso_uniq",
             ),
         ]
 

--- a/VAT/models.py
+++ b/VAT/models.py
@@ -1378,7 +1378,6 @@ class ComisionHorario(models.Model):
             ),
             models.UniqueConstraint(
                 fields=("comision_curso", "dia_semana", "hora_desde", "hora_hasta"),
-                condition=models.Q(comision_curso__isnull=False),
                 name="vat_comhor_comisioncurso_horario_uniq",
             ),
         ]
@@ -1496,7 +1495,6 @@ class SesionComision(models.Model):
             ),
             models.UniqueConstraint(
                 fields=("comision_curso", "horario", "fecha"),
-                condition=models.Q(comision_curso__isnull=False),
                 name="vat_sesion_comisioncurso_horario_fecha_uniq",
             ),
         ]
@@ -1644,7 +1642,6 @@ class Inscripcion(SoftDeleteModelMixin, models.Model):
             ),
             models.UniqueConstraint(
                 fields=("ciudadano", "comision_curso"),
-                condition=models.Q(comision_curso__isnull=False),
                 name="vat_inscripcion_ciudadano_comisioncurso_uniq",
             ),
         ]

--- a/VAT/tests.py
+++ b/VAT/tests.py
@@ -5,6 +5,7 @@ import pytest
 from django.contrib.auth.models import Group, User
 from django.contrib.auth.models import Permission
 from django.core.exceptions import ValidationError
+from django.db import IntegrityError
 from django.urls import reverse
 
 from VAT import serializers as vat_serializers
@@ -472,6 +473,108 @@ def test_migracion_0021_droppea_fk_antes_que_indices_de_titulo_referencia():
     )
 
     assert drop_fk_index < drop_unique_index
+
+
+def test_migracion_0024_mapea_estado_de_curso_a_comision():
+    migration = importlib.import_module("VAT.migrations.0024_remove_curso_cupo_fechas")
+
+    assert migration._map_curso_estado_to_comision("planificado") == "planificada"
+    assert migration._map_curso_estado_to_comision("activo") == "activa"
+    assert migration._map_curso_estado_to_comision("finalizado") == "cerrada"
+    assert migration._map_curso_estado_to_comision("cancelado") == "suspendida"
+    assert migration._map_curso_estado_to_comision("desconocido") == "planificada"
+
+
+def test_migracion_0024_backfillea_comision_curso_si_faltaba():
+    migration = importlib.import_module("VAT.migrations.0024_remove_curso_cupo_fechas")
+
+    class FakeCurso:
+        def __init__(self, pk, nombre, cupo_total, fecha_inicio, fecha_fin, estado):
+            self.pk = pk
+            self.id = pk
+            self.nombre = nombre
+            self.cupo_total = cupo_total
+            self.fecha_inicio = fecha_inicio
+            self.fecha_fin = fecha_fin
+            self.estado = estado
+            self.observaciones = "legado"
+
+    class FakeCursoQuerySet:
+        def __init__(self, cursos):
+            self._cursos = cursos
+
+        def exclude(self, **kwargs):
+            field_name = next(iter(kwargs)).replace("__isnull", "")
+            return FakeCursoQuerySet(
+                [
+                    curso
+                    for curso in self._cursos
+                    if getattr(curso, field_name) is not None
+                ]
+            )
+
+        def iterator(self):
+            return iter(self._cursos)
+
+    class FakeCursoManager:
+        def __init__(self, cursos):
+            self._cursos = cursos
+
+        def exclude(self, **kwargs):
+            return FakeCursoQuerySet(self._cursos).exclude(**kwargs)
+
+    class FakeComisionCurso:
+        def __init__(self, **kwargs):
+            for key, value in kwargs.items():
+                setattr(self, key, value)
+
+    class FakeComisionCursoManager:
+        def __init__(self):
+            self.created = []
+
+        def values_list(self, *_args, **_kwargs):
+            return []
+
+        def bulk_create(self, rows):
+            self.created.extend(rows)
+
+    curso_model = type(
+        "CursoModel",
+        (),
+        {
+            "objects": FakeCursoManager(
+                [
+                    FakeCurso(
+                        7,
+                        "Curso legado",
+                        22,
+                        date(2026, 4, 1),
+                        date(2026, 5, 1),
+                        "activo",
+                    )
+                ]
+            )
+        },
+    )
+    comision_manager = FakeComisionCursoManager()
+    comision_model = type(
+        "ComisionCursoModel",
+        (),
+        {"objects": comision_manager},
+    )
+
+    migration._backfill_comision_curso_if_needed(
+        curso_model,
+        comision_model,
+        {"cupo_total", "fecha_inicio", "fecha_fin"},
+    )
+
+    assert len(comision_manager.created) == 1
+    comision = comision_manager.created[0]
+    assert comision.curso_id == 7
+    assert comision.codigo_comision == "LEG-7"
+    assert comision.estado == "activa"
+    assert comision.cupo_total == 22
 
 
 @pytest.fixture
@@ -1116,3 +1219,165 @@ def test_inscripcion_rapida_comision_curso_crea_inscripcion(client, vat_geo_data
     assert payload["ok"] is True
     assert inscripcion.programa == programa
     assert inscripcion.estado == "inscripta"
+
+
+@pytest.fixture
+def vat_comision_curso_integridad_base(db, vat_geo_data):
+    provincia, municipio, localidad = vat_geo_data
+    modalidad = ModalidadCursada.objects.create(nombre="Presencial Base", activo=True)
+    programa = Programa.objects.create(nombre="Programa Integridad")
+    sexo = Sexo.objects.create(sexo="Masculino")
+    centro = Centro.objects.create(
+        nombre="CFP Integridad",
+        codigo="CFP-INT",
+        provincia=provincia,
+        municipio=municipio,
+        localidad=localidad,
+        calle="20",
+        numero=200,
+        domicilio_actividad="Calle 20 N° 200",
+        telefono="221-1002000",
+        celular="221-1002001",
+        correo="integridad@vat.test",
+        nombre_referente="Luis",
+        apellido_referente="Paz",
+        telefono_referente="221-1002002",
+        correo_referente="luis@vat.test",
+        tipo_gestion="Estatal",
+        clase_institucion="Formación Profesional",
+        situacion="Institución de ETP",
+        activo=True,
+    )
+    ubicacion = InstitucionUbicacion.objects.create(
+        centro=centro,
+        localidad=localidad,
+        rol_ubicacion="sede_principal",
+        domicilio="Calle 20 N° 200",
+        es_principal=True,
+    )
+    curso = Curso.objects.create(
+        centro=centro,
+        ubicacion=ubicacion,
+        nombre="Curso Integridad",
+        modalidad=modalidad,
+        programa=programa,
+        estado="activo",
+    )
+    comision = ComisionCurso.objects.create(
+        curso=curso,
+        codigo_comision="INT-01",
+        nombre="Comisión Integridad",
+        cupo_total=25,
+        fecha_inicio=date(2026, 4, 1),
+        fecha_fin=date(2026, 4, 30),
+        estado="activa",
+    )
+    dia = Dia.objects.create(nombre="Miércoles")
+    ciudadano = Ciudadano.objects.create(
+        apellido="Perez",
+        nombre="Carlos",
+        fecha_nacimiento=date(1999, 1, 1),
+        tipo_documento=Ciudadano.DOCUMENTO_DNI,
+        documento=33444555,
+        sexo=sexo,
+    )
+    return comision, dia, ciudadano, programa
+
+
+@pytest.mark.django_db
+def test_inscripcion_comision_curso_no_duplica_por_constraint(
+    vat_comision_curso_integridad_base,
+):
+    comision, _, ciudadano, programa = vat_comision_curso_integridad_base
+    Inscripcion.objects.create(
+        ciudadano=ciudadano,
+        comision_curso=comision,
+        programa=programa,
+        estado="inscripta",
+        origen_canal="backoffice",
+    )
+
+    with pytest.raises(IntegrityError):
+        Inscripcion.objects.create(
+            ciudadano=ciudadano,
+            comision_curso=comision,
+            programa=programa,
+            estado="inscripta",
+            origen_canal="backoffice",
+        )
+
+
+@pytest.mark.django_db
+def test_comision_horario_comision_curso_no_duplica_por_constraint(
+    vat_comision_curso_integridad_base,
+):
+    comision, dia, _, _ = vat_comision_curso_integridad_base
+    ComisionHorario.objects.create(
+        comision_curso=comision,
+        dia_semana=dia,
+        hora_desde="10:00",
+        hora_hasta="12:00",
+        aula_espacio="Aula 3",
+        vigente=True,
+    )
+
+    with pytest.raises(IntegrityError):
+        ComisionHorario.objects.create(
+            comision_curso=comision,
+            dia_semana=dia,
+            hora_desde="10:00",
+            hora_hasta="12:00",
+            aula_espacio="Aula 4",
+            vigente=True,
+        )
+
+
+@pytest.mark.django_db
+def test_sesion_comision_curso_no_duplica_por_constraint(
+    vat_comision_curso_integridad_base,
+):
+    comision, dia, _, _ = vat_comision_curso_integridad_base
+    horario = ComisionHorario.objects.create(
+        comision_curso=comision,
+        dia_semana=dia,
+        hora_desde="14:00",
+        hora_hasta="16:00",
+        aula_espacio="Aula 5",
+        vigente=True,
+    )
+    SesionComision.objects.create(
+        comision_curso=comision,
+        horario=horario,
+        numero_sesion=1,
+        fecha=date(2026, 4, 8),
+        estado="programada",
+    )
+
+    with pytest.raises(IntegrityError):
+        SesionComision.objects.create(
+            comision_curso=comision,
+            horario=horario,
+            numero_sesion=2,
+            fecha=date(2026, 4, 8),
+            estado="programada",
+        )
+
+
+@pytest.mark.django_db
+def test_sidebar_vat_recupera_links_principales(client):
+    user = User.objects.create_superuser(
+        username="sidebar-vat",
+        email="sidebar@vat.test",
+        password="test1234",
+    )
+    client.force_login(user)
+
+    response = client.get(reverse("vat_centro_list"))
+    content = response.content.decode("utf-8")
+
+    assert response.status_code == 200
+    assert reverse("vat_inscripcion_list") in content
+    assert reverse("vat_oferta_institucional_list") in content
+    assert reverse("vat_modalidad_institucional_list") in content
+    assert reverse("vat_sector_list") in content
+    assert reverse("vat_titulorreferencia_list") in content

--- a/docs/registro/cambios/2026-04-02-fix-pr1419-review-findings.md
+++ b/docs/registro/cambios/2026-04-02-fix-pr1419-review-findings.md
@@ -1,0 +1,26 @@
+# Fix review findings PR 1419
+
+## Contexto
+
+Se corrigieron tres riesgos detectados durante la revisión del PR 1419 antes de promoverlo a producción:
+
+- pérdida de datos al remover columnas legacy de `Curso`
+- falta de constraints de base para el flujo `comision_curso`
+- regresión de navegación en el sidebar de VAT
+
+## Cambios
+
+- se reforzó `VAT/migrations/0024_remove_curso_cupo_fechas.py` para crear una `ComisionCurso` legacy por cada `Curso` con datos operativos antes de eliminar `cupo_total`, `fecha_inicio` y `fecha_fin`
+- se agregó `VAT/migrations/0030_add_comision_curso_integrity_constraints.py` con constraints `CHECK` y `UNIQUE` para `ComisionHorario`, `SesionComision` e `Inscripcion` en la rama `comision_curso`
+- se actualizaron los modelos para reflejar esas garantías a nivel ORM
+- se restauraron las entradas de VAT ocultadas en `templates/includes/sidebar/opciones.html`
+- se agregaron tests de regresión para backfill, integridad y navegación
+
+## Decisión clave
+
+Se priorizó preservar compatibilidad con datos existentes de producción antes que asumir una base vacía. Por eso el backfill ocurre dentro de la migración destructiva, en el único punto donde todavía existen las columnas legacy.
+
+## Riesgo residual
+
+- si algún entorno no productivo ya ejecutó la versión vieja de `0024`, esos datos ya no pueden reconstruirse automáticamente porque las columnas legacy ya fueron eliminadas allí
+- para producción, el camino de migración del branch queda protegido mientras `0024` no se haya ejecutado previamente

--- a/templates/includes/sidebar/opciones.html
+++ b/templates/includes/sidebar/opciones.html
@@ -432,8 +432,8 @@
                                 <p>Centros de Formación</p>
                             </a>
                         </li>
-                        <!-- Inscripciones -->
-                        {% if request.user|has_perm_code:"VAT.view_inscripcion" %}
+                        <!-- Inscripciones (oculto temporalmente) -->
+                        {% if False and request.user|has_perm_code:"VAT.view_inscripcion" %}
                             <li class="nav-item">
                                 <a href="{% url 'vat_inscripcion_list' %}"
                                    class="nav-link {% if 'vat/inscripciones/' in pagina_actual %}active{% endif %} ms-4">
@@ -442,8 +442,8 @@
                                 </a>
                             </li>
                         {% endif %}
-                        <!-- Evaluaciones -->
-                        {% if request.user|has_perm_code:"VAT.view_evaluacion" %}
+                        <!-- Evaluaciones (oculto temporalmente) -->
+                        {% if False and request.user|has_perm_code:"VAT.view_evaluacion" %}
                             <li class="nav-item">
                                 <a href="{% url 'vat_evaluacion_list' %}"
                                    class="nav-link {% if 'vat/evaluaciones/' in pagina_actual %}active{% endif %} ms-4">
@@ -452,8 +452,8 @@
                                 </a>
                             </li>
                         {% endif %}
-                        <!-- Resultados de Evaluación -->
-                        {% if request.user|has_perm_code:"VAT.view_resultadoevaluacion" %}
+                        <!-- Resultados de Evaluación (oculto temporalmente) -->
+                        {% if False and request.user|has_perm_code:"VAT.view_resultadoevaluacion" %}
                             <li class="nav-item">
                                 <a href="{% url 'vat_resultado_evaluacion_list' %}"
                                    class="nav-link {% if 'vat/resultados-evaluacion/' in pagina_actual %}active{% endif %} ms-4">
@@ -462,8 +462,8 @@
                                 </a>
                             </li>
                         {% endif %}
-                        <!-- Oferta Educativa (subgrupo) -->
-                        {% if request.user|has_perm_code:"VAT.view_ofertainstitucional" or request.user|has_perm_code:"VAT.view_comision" or request.user|has_perm_code:"VAT.view_inscripcionoferta" %}
+                        <!-- Oferta Educativa (subgrupo) - oculto temporalmente -->
+                        {% if False and (request.user|has_perm_code:"VAT.view_ofertainstitucional" or request.user|has_perm_code:"VAT.view_comision" or request.user|has_perm_code:"VAT.view_inscripcionoferta") %}
                             <li class="nav-item ms-4 {% if 'vat/ofertas' in pagina_actual or 'vat/comisiones' in pagina_actual or 'vat/inscripciones-oferta' in pagina_actual %}menu-open{% endif %}">
                                 <a href="#" class="nav-link">
                                     <i class="nav-icon bi bi-arrow-return-right"></i>
@@ -500,8 +500,8 @@
                                 </ul>
                             </li>
                         {% endif %}
-                        <!-- Datos Institución (subgrupo) -->
-                        {% if request.user|has_perm_code:"VAT.view_institucioncontacto" or request.user|has_perm_code:"VAT.view_autoridadinstitucional" or request.user|has_perm_code:"VAT.view_institucionidentificadorhist" or request.user|has_perm_code:"VAT.view_institucionubicacion" %}
+                        <!-- Datos Institución (subgrupo) - oculto temporalmente -->
+                        {% if False and (request.user|has_perm_code:"VAT.view_institucioncontacto" or request.user|has_perm_code:"VAT.view_autoridadinstitucional" or request.user|has_perm_code:"VAT.view_institucionidentificadorhist" or request.user|has_perm_code:"VAT.view_institucionubicacion") %}
                             <li class="nav-item ms-4 {% if 'vat/institucion/' in pagina_actual %}menu-open{% endif %}">
                                 <a href="#" class="nav-link">
                                     <i class="nav-icon bi bi-arrow-return-right"></i>
@@ -547,7 +547,7 @@
                             </li>
                         {% endif %}
                         <!-- Catálogos (subgrupo) -->
-                        {% if request.user|has_perm_code:"VAT.view_modalidadinstitucional" or request.user|has_perm_code:"VAT.view_sector" or request.user|has_perm_code:"VAT.view_subsector" or request.user|has_perm_code:"VAT.view_modalidadcursada" or request.user|has_perm_code:"VAT.view_tituloreferencia" or request.user|has_perm_code:"VAT.view_planversioncurricular" %}
+                        {% if request.user|has_perm_code:"VAT.view_modalidadcursada" or request.user|has_perm_code:"VAT.view_planversioncurricular" %}
                             <li class="nav-item ms-4 {% if 'vat/modalidades-institucionales/' in pagina_actual or 'vat/catalogos/' in pagina_actual %}menu-open{% endif %}">
                                 <a href="#" class="nav-link">
                                     <i class="nav-icon bi bi-arrow-return-right"></i>
@@ -557,43 +557,11 @@
                                     </p>
                                 </a>
                                 <ul class="nav nav-treeview">
-                                    {% if request.user|has_perm_code:"VAT.view_modalidadinstitucional" %}
-                                        <li class="nav-item">
-                                            <a href="{% url 'vat_modalidad_institucional_list' %}"
-                                               class="nav-link nav-dot ms-4 {% if 'vat/modalidades-institucionales/' in pagina_actual %}active{% endif %}">
-                                                <p>Modalidades Institucionales</p>
-                                            </a>
-                                        </li>
-                                    {% endif %}
-                                    {% if request.user|has_perm_code:"VAT.view_sector" %}
-                                        <li class="nav-item">
-                                            <a href="{% url 'vat_sector_list' %}"
-                                               class="nav-link nav-dot ms-4 {% if 'vat/catalogos/sectores/' in pagina_actual %}active{% endif %}">
-                                                <p>Sectores</p>
-                                            </a>
-                                        </li>
-                                    {% endif %}
-                                    {% if request.user|has_perm_code:"VAT.view_subsector" %}
-                                        <li class="nav-item">
-                                            <a href="{% url 'vat_subsector_list' %}"
-                                               class="nav-link nav-dot ms-4 {% if 'vat/catalogos/subsectores/' in pagina_actual %}active{% endif %}">
-                                                <p>Subsectores</p>
-                                            </a>
-                                        </li>
-                                    {% endif %}
                                     {% if request.user|has_perm_code:"VAT.view_modalidadcursada" %}
                                         <li class="nav-item">
                                             <a href="{% url 'vat_modalidadcursada_list' %}"
                                                class="nav-link nav-dot ms-4 {% if 'vat/catalogos/modalidades-cursado/' in pagina_actual %}active{% endif %}">
                                                 <p>Modalidades de Cursado</p>
-                                            </a>
-                                        </li>
-                                    {% endif %}
-                                    {% if request.user|has_perm_code:"VAT.view_tituloreferencia" %}
-                                        <li class="nav-item">
-                                            <a href="{% url 'vat_titulorreferencia_list' %}"
-                                               class="nav-link nav-dot ms-4 {% if 'vat/catalogos/titulos-referencia/' in pagina_actual %}active{% endif %}">
-                                                <p>Títulos de Referencia</p>
                                             </a>
                                         </li>
                                     {% endif %}

--- a/templates/includes/sidebar/opciones.html
+++ b/templates/includes/sidebar/opciones.html
@@ -432,8 +432,8 @@
                                 <p>Centros de Formación</p>
                             </a>
                         </li>
-                        <!-- Inscripciones (oculto temporalmente) -->
-                        {% if False and request.user|has_perm_code:"VAT.view_inscripcion" %}
+                        <!-- Inscripciones -->
+                        {% if request.user|has_perm_code:"VAT.view_inscripcion" %}
                             <li class="nav-item">
                                 <a href="{% url 'vat_inscripcion_list' %}"
                                    class="nav-link {% if 'vat/inscripciones/' in pagina_actual %}active{% endif %} ms-4">
@@ -442,8 +442,8 @@
                                 </a>
                             </li>
                         {% endif %}
-                        <!-- Evaluaciones (oculto temporalmente) -->
-                        {% if False and request.user|has_perm_code:"VAT.view_evaluacion" %}
+                        <!-- Evaluaciones -->
+                        {% if request.user|has_perm_code:"VAT.view_evaluacion" %}
                             <li class="nav-item">
                                 <a href="{% url 'vat_evaluacion_list' %}"
                                    class="nav-link {% if 'vat/evaluaciones/' in pagina_actual %}active{% endif %} ms-4">
@@ -452,8 +452,8 @@
                                 </a>
                             </li>
                         {% endif %}
-                        <!-- Resultados de Evaluación (oculto temporalmente) -->
-                        {% if False and request.user|has_perm_code:"VAT.view_resultadoevaluacion" %}
+                        <!-- Resultados de Evaluación -->
+                        {% if request.user|has_perm_code:"VAT.view_resultadoevaluacion" %}
                             <li class="nav-item">
                                 <a href="{% url 'vat_resultado_evaluacion_list' %}"
                                    class="nav-link {% if 'vat/resultados-evaluacion/' in pagina_actual %}active{% endif %} ms-4">
@@ -462,8 +462,8 @@
                                 </a>
                             </li>
                         {% endif %}
-                        <!-- Oferta Educativa (subgrupo) - oculto temporalmente -->
-                        {% if False and (request.user|has_perm_code:"VAT.view_ofertainstitucional" or request.user|has_perm_code:"VAT.view_comision" or request.user|has_perm_code:"VAT.view_inscripcionoferta") %}
+                        <!-- Oferta Educativa (subgrupo) -->
+                        {% if request.user|has_perm_code:"VAT.view_ofertainstitucional" or request.user|has_perm_code:"VAT.view_comision" or request.user|has_perm_code:"VAT.view_inscripcionoferta" %}
                             <li class="nav-item ms-4 {% if 'vat/ofertas' in pagina_actual or 'vat/comisiones' in pagina_actual or 'vat/inscripciones-oferta' in pagina_actual %}menu-open{% endif %}">
                                 <a href="#" class="nav-link">
                                     <i class="nav-icon bi bi-arrow-return-right"></i>
@@ -500,8 +500,8 @@
                                 </ul>
                             </li>
                         {% endif %}
-                        <!-- Datos Institución (subgrupo) - oculto temporalmente -->
-                        {% if False and (request.user|has_perm_code:"VAT.view_institucioncontacto" or request.user|has_perm_code:"VAT.view_autoridadinstitucional" or request.user|has_perm_code:"VAT.view_institucionidentificadorhist" or request.user|has_perm_code:"VAT.view_institucionubicacion") %}
+                        <!-- Datos Institución (subgrupo) -->
+                        {% if request.user|has_perm_code:"VAT.view_institucioncontacto" or request.user|has_perm_code:"VAT.view_autoridadinstitucional" or request.user|has_perm_code:"VAT.view_institucionidentificadorhist" or request.user|has_perm_code:"VAT.view_institucionubicacion" %}
                             <li class="nav-item ms-4 {% if 'vat/institucion/' in pagina_actual %}menu-open{% endif %}">
                                 <a href="#" class="nav-link">
                                     <i class="nav-icon bi bi-arrow-return-right"></i>
@@ -547,7 +547,7 @@
                             </li>
                         {% endif %}
                         <!-- Catálogos (subgrupo) -->
-                        {% if request.user|has_perm_code:"VAT.view_modalidadcursada" or request.user|has_perm_code:"VAT.view_planversioncurricular" %}
+                        {% if request.user|has_perm_code:"VAT.view_modalidadinstitucional" or request.user|has_perm_code:"VAT.view_sector" or request.user|has_perm_code:"VAT.view_subsector" or request.user|has_perm_code:"VAT.view_modalidadcursada" or request.user|has_perm_code:"VAT.view_tituloreferencia" or request.user|has_perm_code:"VAT.view_planversioncurricular" %}
                             <li class="nav-item ms-4 {% if 'vat/modalidades-institucionales/' in pagina_actual or 'vat/catalogos/' in pagina_actual %}menu-open{% endif %}">
                                 <a href="#" class="nav-link">
                                     <i class="nav-icon bi bi-arrow-return-right"></i>
@@ -557,11 +557,43 @@
                                     </p>
                                 </a>
                                 <ul class="nav nav-treeview">
+                                    {% if request.user|has_perm_code:"VAT.view_modalidadinstitucional" %}
+                                        <li class="nav-item">
+                                            <a href="{% url 'vat_modalidad_institucional_list' %}"
+                                               class="nav-link nav-dot ms-4 {% if 'vat/modalidades-institucionales/' in pagina_actual %}active{% endif %}">
+                                                <p>Modalidades Institucionales</p>
+                                            </a>
+                                        </li>
+                                    {% endif %}
+                                    {% if request.user|has_perm_code:"VAT.view_sector" %}
+                                        <li class="nav-item">
+                                            <a href="{% url 'vat_sector_list' %}"
+                                               class="nav-link nav-dot ms-4 {% if 'vat/catalogos/sectores/' in pagina_actual %}active{% endif %}">
+                                                <p>Sectores</p>
+                                            </a>
+                                        </li>
+                                    {% endif %}
+                                    {% if request.user|has_perm_code:"VAT.view_subsector" %}
+                                        <li class="nav-item">
+                                            <a href="{% url 'vat_subsector_list' %}"
+                                               class="nav-link nav-dot ms-4 {% if 'vat/catalogos/subsectores/' in pagina_actual %}active{% endif %}">
+                                                <p>Subsectores</p>
+                                            </a>
+                                        </li>
+                                    {% endif %}
                                     {% if request.user|has_perm_code:"VAT.view_modalidadcursada" %}
                                         <li class="nav-item">
                                             <a href="{% url 'vat_modalidadcursada_list' %}"
                                                class="nav-link nav-dot ms-4 {% if 'vat/catalogos/modalidades-cursado/' in pagina_actual %}active{% endif %}">
                                                 <p>Modalidades de Cursado</p>
+                                            </a>
+                                        </li>
+                                    {% endif %}
+                                    {% if request.user|has_perm_code:"VAT.view_tituloreferencia" %}
+                                        <li class="nav-item">
+                                            <a href="{% url 'vat_titulorreferencia_list' %}"
+                                               class="nav-link nav-dot ms-4 {% if 'vat/catalogos/titulos-referencia/' in pagina_actual %}active{% endif %}">
+                                                <p>Títulos de Referencia</p>
                                             </a>
                                         </li>
                                     {% endif %}


### PR DESCRIPTION
why: el branch de VAT tenía riesgo de pérdida de datos, duplicados por falta de constraints y regresión de navegación antes de mergear a producción.

what:
- backfill de datos legacy de Curso antes de eliminar columnas
- constraints de integridad para comision_curso en horarios, sesiones e inscripciones
- restauración del sidebar VAT y tests de regresión

tests:
- py -3 -m black VAT\\models.py VAT\\tests.py VAT\\migrations\\0024_remove_curso_cupo_fechas.py VAT\\migrations\\0030_add_comision_curso_integrity_constraints.py
- py -3 -m py_compile VAT\\migrations\\0024_remove_curso_cupo_fechas.py VAT\\migrations\\0030_add_comision_curso_integrity_constraints.py VAT\\models.py VAT\\tests.py
- pytest no disponible localmente
- docker compose no usable sin variables de entorno del repo

# Información de la Tarea
Vincular el #ISSUE

### **Resumen de la Solución:** 
-

### **Información Adicional:**
-

# Descripción de los Cambios

### **Cambios:**
-

# Cómo Testear los Cambios

### **Pruebas Automáticas:**
-

### **Prubeas Manuales:**
-

# Metadata para documentación automática

- Contexto funcional:
- Tipo de cambio:
- Área principal:
- Resumen para changelog:
- Impacto usuario:
- Riesgos / rollback:

# Capturas de Pantalla
