### PR TITLE
feat: Update VAT access scope and roles

### DIFF
--- a/VAT/fixtures/modalidad_cursada_inicial.json
+++ b/VAT/fixtures/modalidad_cursada_inicial.json
@@ -1,0 +1,92 @@
+[
+  {
+    "model": "VAT.modalidadcursada",
+    "pk": 1,
+    "fields": {
+      "nombre": "Educación Técnico Profesional",
+      "descripcion": "Modalidad de cursado vinculada a propuestas de educación técnico profesional.",
+      "activo": true
+    }
+  },
+  {
+    "model": "VAT.modalidadcursada",
+    "pk": 2,
+    "fields": {
+      "nombre": "Educación Permanente de Jóvenes y Adultos",
+      "descripcion": "Modalidad de cursado orientada a trayectorias de educación permanente de jóvenes y adultos.",
+      "activo": true
+    }
+  },
+  {
+    "model": "VAT.modalidadcursada",
+    "pk": 3,
+    "fields": {
+      "nombre": "Educación Especial",
+      "descripcion": "Modalidad de cursado destinada a propuestas de educación especial.",
+      "activo": true
+    }
+  },
+  {
+    "model": "VAT.modalidadcursada",
+    "pk": 4,
+    "fields": {
+      "nombre": "No Corresponde",
+      "descripcion": "Opción de catálogo para registros donde la modalidad de cursado no aplica.",
+      "activo": true
+    }
+  },
+  {
+    "model": "VAT.modalidadcursada",
+    "pk": 5,
+    "fields": {
+      "nombre": "Educación de Formación Docente",
+      "descripcion": "Modalidad de cursado asociada a propuestas de formación docente.",
+      "activo": true
+    }
+  },
+  {
+    "model": "VAT.modalidadcursada",
+    "pk": 6,
+    "fields": {
+      "nombre": "Educación en Contextos de Privación de Libertad",
+      "descripcion": "Modalidad de cursado para propuestas desarrolladas en contextos de privación de libertad.",
+      "activo": true
+    }
+  },
+  {
+    "model": "VAT.modalidadcursada",
+    "pk": 7,
+    "fields": {
+      "nombre": "Educación Rural",
+      "descripcion": "Modalidad de cursado correspondiente a propuestas de educación rural.",
+      "activo": true
+    }
+  },
+  {
+    "model": "VAT.modalidadcursada",
+    "pk": 8,
+    "fields": {
+      "nombre": "Educación Artística",
+      "descripcion": "Modalidad de cursado para ofertas de educación artística.",
+      "activo": true
+    }
+  },
+  {
+    "model": "VAT.modalidadcursada",
+    "pk": 9,
+    "fields": {
+      "nombre": "Educación Común",
+      "descripcion": "Modalidad de cursado correspondiente a propuestas de educación común.",
+      "activo": true
+    }
+  },
+  {
+    "model": "VAT.modalidadcursada",
+    "pk": 10,
+    "fields": {
+      "nombre": "Educación de Socio Humanística",
+      "descripcion": "Modalidad de cursado para ofertas con enfoque socio humanístico.",
+      "activo": true
+    }
+  }
+]

--- a/VAT/forms.py
+++ b/VAT/forms.py
@@ -1117,7 +1117,9 @@ class CursoForm(forms.ModelForm):
 
         if centro_provincia_id is None and centro_id:
             centro_provincia_id = (
-                Centro.objects.filter(pk=centro_id).values_list("provincia_id", flat=True).first()
+                Centro.objects.filter(pk=centro_id)
+                .values_list("provincia_id", flat=True)
+                .first()
             )
 
         if centro_provincia_id:

--- a/VAT/forms.py
+++ b/VAT/forms.py
@@ -614,7 +614,7 @@ class PlanVersionCurricularForm(forms.ModelForm):
             ("nivel_1", "Certificado Nivel I"),
             ("nivel_2", "Certificado Nivel II"),
             ("nivel_3", "Certificado Nivel III"),
-            ("titulo_tecnico", "Título Técnico"),
+            ("sin_nivel", "Sin nivel"),
         ],
         widget=forms.Select(attrs={"class": "form-control"}),
     )

--- a/VAT/services/access_scope.py
+++ b/VAT/services/access_scope.py
@@ -5,8 +5,16 @@ from django.db.models import QuerySet
 from iam.services import user_has_permission_code
 
 ROLE_VAT_SSE_PERMISSION = "auth.role_vat_sse"
-ROLE_REFERENTE_CENTRO_PERMISSION = "auth.role_referentecentrovat"
+ROLE_VAT_PROVINCIAL_PERMISSION = "auth.role_provincia_vat"
+ROLE_REFERENTE_CENTRO_PERMISSIONS = (
+    "auth.role_referentecentrovat",
+    "auth.role_centroreferentevat",
+)
 VAT_VIEW_CENTRO_PERMISSION = "VAT.view_centro"
+
+
+def _user_has_any_permission_code(user, permission_codes) -> bool:
+    return any(user_has_permission_code(user, code) for code in permission_codes)
 
 
 def _get_profile(user):
@@ -33,7 +41,7 @@ def is_vat_sse(user) -> bool:
 def is_vat_referente(user) -> bool:
     if not user:
         return False
-    return user_has_permission_code(user, ROLE_REFERENTE_CENTRO_PERMISSION)
+    return _user_has_any_permission_code(user, ROLE_REFERENTE_CENTRO_PERMISSIONS)
 
 
 def is_vat_provincial(user) -> bool:
@@ -42,7 +50,10 @@ def is_vat_provincial(user) -> bool:
     provincia_id = get_user_provincia_id(user)
     if not provincia_id:
         return False
-    return user_has_permission_code(user, VAT_VIEW_CENTRO_PERMISSION)
+    return _user_has_any_permission_code(
+        user,
+        (ROLE_VAT_PROVINCIAL_PERMISSION, VAT_VIEW_CENTRO_PERMISSION),
+    )
 
 
 def filter_centros_queryset_for_user(base_qs: QuerySet, user) -> QuerySet:

--- a/VAT/templates/vat/catalogo/planversioncurricular_detail.html
+++ b/VAT/templates/vat/catalogo/planversioncurricular_detail.html
@@ -1,82 +1,236 @@
 {% extends "includes/main.html" %}
+{% load static %}
+
 {% block title %}Detalle Plan de Estudio{% endblock %}
-{% block breadcrumb %}
-    <ol class="breadcrumb float-sm-right">
-        <li class="breadcrumb-item">
-            <a href="{% url 'vat_planversioncurricular_list' %}">Planes de Estudio</a>
-        </li>
-        <li class="breadcrumb-item active">{{ plan.titulo_referencia.nombre }}</li>
-    </ol>
+{% block titulo-pagina %}Detalle Plan de Estudio{% endblock %}
+
+{% block head %}
+    <link rel="stylesheet" href="{% static 'custom/css/cardsDetail.css' %}" />
+    <style>
+        .vp-shell {
+            max-width: 1100px;
+            margin: 0 auto;
+        }
+
+        .vp-hero {
+            background: linear-gradient(135deg, #183a67 0%, #25518b 55%, #3b74b8 100%);
+            color: #fff;
+            border-radius: 18px;
+            padding: 1.75rem 2rem;
+            margin-bottom: 1.25rem;
+            box-shadow: 0 18px 45px rgba(24, 58, 103, 0.18);
+            display: flex;
+            justify-content: space-between;
+            gap: 1rem;
+            align-items: flex-start;
+            flex-wrap: wrap;
+        }
+
+        .vp-hero h1 {
+            margin: 0 0 .35rem;
+            font-size: 1.9rem;
+            font-weight: 700;
+        }
+
+        .vp-hero p {
+            margin: 0;
+            max-width: 760px;
+            color: rgba(255, 255, 255, 0.82);
+        }
+
+        .vp-hero-actions {
+            display: flex;
+            gap: .5rem;
+            flex-wrap: wrap;
+        }
+
+        .vp-hero-actions .btn {
+            white-space: nowrap;
+        }
+
+        .vp-panel {
+            border: 0;
+            border-radius: 18px;
+            overflow: hidden;
+            box-shadow: 0 12px 32px rgba(15, 23, 42, 0.08);
+            margin-bottom: 1rem;
+        }
+
+        .vp-panel-header {
+            padding: 1.15rem 1.35rem;
+            border-bottom: 1px solid rgba(126, 179, 255, 0.18);
+            background: linear-gradient(135deg, #132c4d 0%, #1d446f 55%, #2d649e 100%);
+            color: #f8fbff;
+        }
+
+        .vp-panel-header .card-title {
+            color: #ffffff;
+            font-weight: 700;
+            margin: 0;
+        }
+
+        .vp-panel-header .small {
+            color: rgba(240, 247, 255, 0.82) !important;
+        }
+
+        .vp-section {
+            padding: 1.35rem;
+            border-bottom: 1px solid rgba(126, 179, 255, 0.2);
+            background: linear-gradient(180deg, rgba(14, 31, 53, 0.96) 0%, rgba(18, 38, 64, 0.95) 100%);
+        }
+
+        .vp-section:last-child {
+            border-bottom: 0;
+        }
+
+        .vp-metric-grid {
+            display: grid;
+            grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+            gap: 1rem;
+        }
+
+        .vp-metric {
+            border: 1px solid rgba(126, 179, 255, 0.22);
+            border-radius: 14px;
+            padding: 1rem;
+            background: rgba(9, 22, 39, 0.28);
+        }
+
+        .vp-metric-label {
+            color: #9fc0e6;
+            font-size: .82rem;
+            text-transform: uppercase;
+            letter-spacing: .04em;
+            margin-bottom: .35rem;
+        }
+
+        .vp-metric-value {
+            color: #f8fbff;
+            font-weight: 600;
+            font-size: 1rem;
+        }
+
+        .vp-badge {
+            display: inline-flex;
+            align-items: center;
+            gap: .35rem;
+            padding: .35rem .75rem;
+            border-radius: 999px;
+            font-weight: 600;
+        }
+
+        .vp-badge--ok {
+            background: rgba(34, 197, 94, 0.18);
+            color: #9ef0b8;
+        }
+
+        .vp-badge--off {
+            background: rgba(248, 113, 113, 0.18);
+            color: #fecaca;
+        }
+    </style>
 {% endblock %}
+
 {% block content %}
-    <div class="row">
-        <div class="col-md-8">
-            <div class="card">
-                <div class="card-header bg-primary text-white">
-                    <h3 class="card-title">{{ plan.titulo_referencia.nombre }}</h3>
-                    <div class="card-tools">
-                        <a href="{% url 'vat_planversioncurricular_update' plan.id %}"
-                           class="btn btn-sm btn-warning"><i class="fas fa-edit"></i></a>
-                        <form method="post"
-                              action="{% url 'vat_planversioncurricular_delete' plan.id %}"
-                              style="display:inline"
-                              onsubmit="return confirm('¿Está seguro?');">
-                            {% csrf_token %}
-                            <button type="submit" class="btn btn-sm btn-danger">
-                                <i class="fas fa-trash"></i>
-                            </button>
-                        </form>
-                    </div>
-                </div>
-                <div class="card-body">
-                    <dl class="row">
-                        <dt class="col-sm-4">Sector:</dt>
-                        <dd class="col-sm-8">
-                            {{ plan.sector.nombre }}
-                        </dd>
-                        <dt class="col-sm-4">Subsector:</dt>
-                        <dd class="col-sm-8">
-                            {{ plan.subsector.nombre|default:"-" }}
-                        </dd>
-                        <dt class="col-sm-4">Título de Referencia:</dt>
-                        <dd class="col-sm-8">
-                            {{ plan.titulo_referencia.nombre }}
-                        </dd>
-                        <dt class="col-sm-4">Modalidad de Cursado:</dt>
-                        <dd class="col-sm-8">
-                            {{ plan.modalidad_cursada.nombre }}
-                        </dd>
-                        <dt class="col-sm-4">Normativa:</dt>
-                        <dd class="col-sm-8">
-                            {{ plan.normativa|default:"-" }}
-                        </dd>
-                        <dt class="col-sm-4">Horas Reloj:</dt>
-                        <dd class="col-sm-8">
-                            {{ plan.horas_reloj|default:"-" }}
-                        </dd>
-                        <dt class="col-sm-4">Nivel Requerido:</dt>
-                        <dd class="col-sm-8">
-                            {{ plan.nivel_requerido|default:"-" }}
-                        </dd>
-                        <dt class="col-sm-4">Nivel que Certifica:</dt>
-                        <dd class="col-sm-8">
-                            {{ plan.nivel_certifica|default:"-" }}
-                        </dd>
-                        <dt class="col-sm-4">Estado:</dt>
-                        <dd class="col-sm-8">
-                            {% if plan.activo %}
-                                <span class="badge badge-success">Activo</span>
-                            {% else %}
-                                <span class="badge badge-danger">Inactivo</span>
-                            {% endif %}
-                        </dd>
-                    </dl>
-                </div>
-                <div class="card-footer">
-                    <a href="{% url 'vat_planversioncurricular_list' %}"
-                       class="btn btn-secondary"><i class="fas fa-arrow-left"></i> Volver</a>
+    <div class="vp-shell">
+        <div class="vp-hero">
+            <div>
+                <h1>
+                    <i class="fas fa-clipboard-list me-2"></i>{{ plan }}
+                </h1>
+                <p>Detalle del plan curricular con su clasificación académica, carga horaria y condiciones de certificación.</p>
+            </div>
+            <div class="vp-hero-actions">
+                {% if perms.VAT.change_planversioncurricular %}
+                    <a href="{% url 'vat_planversioncurricular_update' plan.id %}" class="btn btn-warning">
+                        <i class="fas fa-edit me-1"></i>Editar
+                    </a>
+                {% endif %}
+                {% if perms.VAT.delete_planversioncurricular %}
+                    <form method="post"
+                          action="{% url 'vat_planversioncurricular_delete' plan.id %}"
+                          onsubmit="return confirm('¿Está seguro?');">
+                        {% csrf_token %}
+                        <button type="submit" class="btn btn-danger">
+                            <i class="fas fa-trash me-1"></i>Eliminar
+                        </button>
+                    </form>
+                {% endif %}
+            </div>
+        </div>
+
+        <div class="card vp-panel">
+            <div class="vp-panel-header">
+                <div>
+                    <h3 class="card-title">
+                        <i class="fas fa-sitemap me-2"></i>Clasificación Académica
+                    </h3>
+                    <div class="small">Sector, subsector y modalidad del plan.</div>
                 </div>
             </div>
+            <div class="vp-section">
+                <div class="vp-metric-grid">
+                    <div class="vp-metric">
+                        <div class="vp-metric-label">Sector</div>
+                        <div class="vp-metric-value">{{ plan.sector.nombre }}</div>
+                    </div>
+                    <div class="vp-metric">
+                        <div class="vp-metric-label">Subsector</div>
+                        <div class="vp-metric-value">{{ plan.subsector.nombre|default:"-" }}</div>
+                    </div>
+                    <div class="vp-metric">
+                        <div class="vp-metric-label">Modalidad de Cursado</div>
+                        <div class="vp-metric-value">{{ plan.modalidad_cursada.nombre }}</div>
+                    </div>
+                    <div class="vp-metric">
+                        <div class="vp-metric-label">Estado</div>
+                        <div class="vp-metric-value">
+                            {% if plan.activo %}
+                                <span class="vp-badge vp-badge--ok"><i class="fas fa-check-circle"></i>Activo</span>
+                            {% else %}
+                                <span class="vp-badge vp-badge--off"><i class="fas fa-times-circle"></i>Inactivo</span>
+                            {% endif %}
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </div>
+
+        <div class="card vp-panel">
+            <div class="vp-panel-header">
+                <div>
+                    <h3 class="card-title">
+                        <i class="fas fa-book me-2"></i>Datos del Plan
+                    </h3>
+                    <div class="small">Normativa, carga horaria y niveles del trayecto.</div>
+                </div>
+            </div>
+            <div class="vp-section">
+                <div class="vp-metric-grid">
+                    <div class="vp-metric">
+                        <div class="vp-metric-label">Normativa</div>
+                        <div class="vp-metric-value">{{ plan.normativa|default:"-" }}</div>
+                    </div>
+                    <div class="vp-metric">
+                        <div class="vp-metric-label">Horas Reloj</div>
+                        <div class="vp-metric-value">{{ plan.horas_reloj|default:"-" }}</div>
+                    </div>
+                    <div class="vp-metric">
+                        <div class="vp-metric-label">Nivel Requerido</div>
+                        <div class="vp-metric-value">{{ plan.nivel_requerido|default:"-" }}</div>
+                    </div>
+                    <div class="vp-metric">
+                        <div class="vp-metric-label">Nivel que Certifica</div>
+                        <div class="vp-metric-value">{{ plan.nivel_certifica|default:"-" }}</div>
+                    </div>
+                </div>
+            </div>
+        </div>
+
+        <div class="vp-actions d-flex justify-content-end">
+            <a href="{% url 'vat_planversioncurricular_list' %}" class="btn btn-secondary">
+                <i class="fas fa-arrow-left me-1"></i>Volver
+            </a>
         </div>
     </div>
 {% endblock %}

--- a/VAT/templates/vat/catalogo/planversioncurricular_form.html
+++ b/VAT/templates/vat/catalogo/planversioncurricular_form.html
@@ -1,63 +1,199 @@
 {% extends "includes/main.html" %}
-{% block title %}
-    {% if form.instance.pk %}
-        Editar
-    {% else %}
-        Nuevo
-    {% endif %}
-    Plan de Estudio
+{% load static %}
+{% load crispy_forms_tags %}
+
+{% block title %}{{ page_title }}{% endblock %}
+{% block titulo-pagina %}{{ page_title }}{% endblock %}
+
+{% block head %}
+    <link rel="stylesheet" href="{% static 'custom/css/cardsDetail.css' %}" />
+    <style>
+        .vp-shell {
+            max-width: 1100px;
+            margin: 0 auto;
+        }
+
+        .vp-hero {
+            background: linear-gradient(135deg, #183a67 0%, #25518b 55%, #3b74b8 100%);
+            color: #fff;
+            border-radius: 18px;
+            padding: 1.75rem 2rem;
+            margin-bottom: 1.25rem;
+            box-shadow: 0 18px 45px rgba(24, 58, 103, 0.18);
+        }
+
+        .vp-hero h1 {
+            margin: 0 0 .35rem;
+            font-size: 1.9rem;
+            font-weight: 700;
+        }
+
+        .vp-hero p {
+            margin: 0;
+            max-width: 760px;
+            color: rgba(255, 255, 255, 0.82);
+        }
+
+        .vp-panel {
+            border: 0;
+            border-radius: 18px;
+            overflow: hidden;
+            box-shadow: 0 12px 32px rgba(15, 23, 42, 0.08);
+            margin-bottom: 1rem;
+        }
+
+        .vp-panel-header {
+            padding: 1.15rem 1.35rem;
+            border-bottom: 1px solid rgba(126, 179, 255, 0.18);
+            background: linear-gradient(135deg, #132c4d 0%, #1d446f 55%, #2d649e 100%);
+            color: #f8fbff;
+        }
+
+        .vp-panel-header .card-title {
+            color: #ffffff;
+            font-weight: 700;
+            margin: 0;
+        }
+
+        .vp-panel-header .small,
+        .vp-panel-header .text-muted {
+            color: rgba(240, 247, 255, 0.82) !important;
+        }
+
+        .vp-section {
+            padding: 1.35rem;
+            border-bottom: 1px solid rgba(126, 179, 255, 0.2);
+            background: linear-gradient(180deg, rgba(14, 31, 53, 0.96) 0%, rgba(18, 38, 64, 0.95) 100%);
+        }
+
+        .vp-section:last-child {
+            border-bottom: 0;
+        }
+
+        .vp-field label,
+        .vp-section .form-group label,
+        .vp-section .control-label,
+        .vp-section .form-check-label,
+        .vp-section small,
+        .vp-section .help-block,
+        .vp-section .text-muted {
+            color: #c9ddf6 !important;
+            font-weight: 600;
+        }
+
+        .vp-field .form-control,
+        .vp-field .form-select,
+        .vp-field textarea,
+        .vp-field select,
+        .vp-field input {
+            border-radius: 12px;
+            border: 1px solid #d8e1ee;
+            box-shadow: none;
+        }
+
+        .vp-field input[type="checkbox"] {
+            accent-color: #4a8ddb;
+        }
+
+        .vp-field .form-control:focus,
+        .vp-field .form-select:focus,
+        .vp-field textarea:focus,
+        .vp-field select:focus,
+        .vp-field input:focus {
+            border-color: #3b74b8;
+            box-shadow: 0 0 0 .2rem rgba(59, 116, 184, 0.12);
+        }
+
+        .vp-actions {
+            display: flex;
+            gap: .75rem;
+            justify-content: flex-end;
+            padding: 1.1rem 1.25rem;
+            background: linear-gradient(180deg, rgba(10, 21, 37, 0.98) 0%, rgba(15, 30, 50, 0.98) 100%);
+            border-top: 1px solid rgba(126, 179, 255, 0.18);
+            border-radius: 0 0 18px 18px;
+            flex-wrap: wrap;
+        }
+
+        .vp-actions .btn-secondary {
+            color: #d8e7f8;
+            border-color: rgba(179, 206, 237, 0.38);
+            background: rgba(255, 255, 255, 0.04);
+        }
+
+        .vp-actions .btn-secondary:hover {
+            color: #fff;
+            background: rgba(255, 255, 255, 0.1);
+        }
+
+        .vp-actions .btn-primary {
+            background: linear-gradient(135deg, #2e6fbc 0%, #4a8ddb 100%);
+            border-color: #4a8ddb;
+        }
+    </style>
 {% endblock %}
-{% block breadcrumb %}
-    <ol class="breadcrumb float-sm-right">
-        <li class="breadcrumb-item">
-            <a href="{% url 'vat_planversioncurricular_list' %}">Planes de Estudio</a>
-        </li>
-        <li class="breadcrumb-item active">
-            {% if form.instance.pk %}
-                Editar
-            {% else %}
-                Nuevo
-            {% endif %}
-        </li>
-    </ol>
-{% endblock %}
+
 {% block content %}
-    <div class="row">
-        <div class="col-md-8">
-            <div class="card">
-                <div class="card-header bg-primary text-white">
-                    <h3 class="card-title">
-                        {% if form.instance.pk %}
-                            Editar Plan de Estudio
-                        {% else %}
-                            Nuevo Plan de Estudio
-                        {% endif %}
-                    </h3>
-                </div>
-                <form method="post">
-                    {% csrf_token %}
-                    <div class="card-body">
-                        {% for field in form %}
-                            <div class="form-group">
-                                <label for="{{ field.id_for_label }}">{{ field.label }}</label>
-                                {{ field }}
-                                {% if field.errors %}<small class="text-danger">{{ field.errors }}</small>{% endif %}
-                            </div>
-                        {% endfor %}
-                    </div>
-                    <div class="card-footer">
-                        <button type="submit" class="btn btn-primary">
-                            {% if form.instance.pk %}
-                                Actualizar
-                            {% else %}
-                                Crear
-                            {% endif %}
-                        </button>
-                        <a href="{% url 'vat_planversioncurricular_list' %}"
-                           class="btn btn-secondary">Cancelar</a>
-                    </div>
-                </form>
-            </div>
+    {% include 'components/alert_message.html' with show_django_messages=True %}
+
+    <div class="vp-shell">
+        <div class="vp-hero">
+            <h1>
+                <i class="fas fa-clipboard-list me-2"></i>{{ page_title }}
+            </h1>
+            <p>Definí la estructura académica del plan con sector, subsector, modalidad, normativa y condiciones de certificación.</p>
         </div>
+
+        <form method="post" novalidate>
+            {% csrf_token %}
+
+            {% if form.non_field_errors %}<div class="alert alert-danger">{{ form.non_field_errors }}</div>{% endif %}
+
+            <div class="card vp-panel">
+                <div class="vp-panel-header">
+                    <div>
+                        <h3 class="card-title">
+                            <i class="fas fa-sitemap me-2"></i>1. Clasificación Académica
+                        </h3>
+                        <div class="small">Definí sector, subsector y modalidad de cursado del plan.</div>
+                    </div>
+                </div>
+                <div class="vp-section">
+                    <div class="row">
+                        <div class="col-md-4 vp-field">{{ form.sector|as_crispy_field }}</div>
+                        <div class="col-md-4 vp-field">{{ form.subsector|as_crispy_field }}</div>
+                        <div class="col-md-4 vp-field">{{ form.modalidad_cursada|as_crispy_field }}</div>
+                    </div>
+                </div>
+            </div>
+
+            <div class="card vp-panel">
+                <div class="vp-panel-header">
+                    <div>
+                        <h3 class="card-title">
+                            <i class="fas fa-book me-2"></i>2. Datos del Plan
+                        </h3>
+                        <div class="small">Completá normativa, carga horaria y configuración de certificación.</div>
+                    </div>
+                </div>
+                <div class="vp-section">
+                    <div class="row">
+                        <div class="col-md-4 vp-field">{{ form.normativa|as_crispy_field }}</div>
+                        <div class="col-md-2 vp-field">{{ form.horas_reloj|as_crispy_field }}</div>
+                        <div class="col-md-3 vp-field">{{ form.nivel_requerido|as_crispy_field }}</div>
+                        <div class="col-md-3 vp-field">{{ form.nivel_certifica|as_crispy_field }}</div>
+                        <div class="col-md-3 vp-field">{{ form.activo|as_crispy_field }}</div>
+                    </div>
+                </div>
+                <div class="vp-actions">
+                    <a href="{{ cancel_url }}" class="btn btn-secondary">
+                        <i class="fas fa-times me-1"></i>Cancelar
+                    </a>
+                    <button type="submit" class="btn btn-primary">
+                        <i class="fas fa-save me-1"></i>{{ submit_text }}
+                    </button>
+                </div>
+            </div>
+        </form>
     </div>
 {% endblock %}

--- a/VAT/templates/vat/centros/centro_detail.html
+++ b/VAT/templates/vat/centros/centro_detail.html
@@ -1237,12 +1237,8 @@
                                                               action="{% url 'vat_planversioncurricular_delete' p.pk %}"
                                                               class="d-inline confirm-delete-form">
                                                             {% csrf_token %}
-                                                            <input type="hidden"
-                                                                   name="next"
-                                                                   value="{{ request.get_full_path }}">
-                                                            <button type="submit"
-                                                                    class="btn btn-outline-danger"
-                                                                    title="Eliminar">
+                                                            <input type="hidden" name="next" value="{{ request.get_full_path }}" />
+                                                            <button type="submit" class="btn btn-outline-danger" title="Eliminar">
                                                                 <i class="fas fa-trash"></i>
                                                             </button>
                                                         </form>
@@ -1330,12 +1326,8 @@
                                                               action="{% url 'vat_titulorreferencia_delete' t.pk %}"
                                                               class="d-inline confirm-delete-form">
                                                             {% csrf_token %}
-                                                            <input type="hidden"
-                                                                   name="next"
-                                                                   value="{{ request.get_full_path }}">
-                                                            <button type="submit"
-                                                                    class="btn btn-outline-danger"
-                                                                    title="Eliminar">
+                                                            <input type="hidden" name="next" value="{{ request.get_full_path }}" />
+                                                            <button type="submit" class="btn btn-outline-danger" title="Eliminar">
                                                                 <i class="fas fa-trash"></i>
                                                             </button>
                                                         </form>
@@ -1430,12 +1422,8 @@
                                                               action="{% url 'vat_oferta_institucional_delete' oferta.pk %}"
                                                               class="d-inline confirm-delete-form">
                                                             {% csrf_token %}
-                                                            <input type="hidden"
-                                                                   name="next"
-                                                                   value="{{ request.get_full_path }}">
-                                                            <button type="submit"
-                                                                    class="btn btn-sm btn-outline-danger"
-                                                                    title="Eliminar">
+                                                            <input type="hidden" name="next" value="{{ request.get_full_path }}" />
+                                                            <button type="submit" class="btn btn-sm btn-outline-danger" title="Eliminar">
                                                                 <i class="fas fa-trash"></i>
                                                             </button>
                                                         </form>
@@ -1527,12 +1515,8 @@
                                                               action="{% url 'vat_comision_delete' comision.pk %}"
                                                               class="d-inline confirm-delete-form">
                                                             {% csrf_token %}
-                                                            <input type="hidden"
-                                                                   name="next"
-                                                                   value="{{ request.get_full_path }}">
-                                                            <button type="submit"
-                                                                    class="btn btn-sm btn-outline-danger"
-                                                                    title="Eliminar">
+                                                            <input type="hidden" name="next" value="{{ request.get_full_path }}" />
+                                                            <button type="submit" class="btn btn-sm btn-outline-danger" title="Eliminar">
                                                                 <i class="fas fa-trash"></i>
                                                             </button>
                                                         </form>

--- a/VAT/templates/vat/centros/centro_form.html
+++ b/VAT/templates/vat/centros/centro_form.html
@@ -37,6 +37,7 @@
             border-radius: 18px;
             overflow: hidden;
             box-shadow: 0 12px 32px rgba(15, 23, 42, 0.08);
+            margin-bottom: 1rem;
         }
 
         .vp-panel-header {
@@ -44,11 +45,16 @@
             border-bottom: 1px solid rgba(126, 179, 255, 0.18);
             background: linear-gradient(135deg, #132c4d 0%, #1d446f 55%, #2d649e 100%);
             color: #f8fbff;
+            display: flex;
+            justify-content: space-between;
+            align-items: center;
+            gap: .75rem;
         }
 
         .vp-panel-header .card-title {
             color: #ffffff;
             font-weight: 700;
+            margin: 0;
         }
 
         .vp-panel-header .text-muted,
@@ -58,80 +64,62 @@
 
         .vp-section {
             padding: 1.35rem;
-            border-bottom: 1px solid #edf1f6;
+            border-bottom: 1px solid rgba(126, 179, 255, 0.2);
+            background: linear-gradient(180deg, rgba(14, 31, 53, 0.96) 0%, rgba(18, 38, 64, 0.95) 100%);
         }
 
         .vp-section:last-child {
             border-bottom: 0;
         }
 
-        .vp-section-title {
-            display: flex;
-            align-items: center;
-            gap: .6rem;
-            font-size: 1rem;
-            font-weight: 700;
-            color: #1e3558;
-            margin-bottom: .3rem;
-        }
-
-        .vp-section-text {
-            color: #64748b;
-            font-size: .92rem;
-            margin-bottom: 1rem;
-        }
-
-        .vp-badge {
-            width: 34px;
-            height: 34px;
-            border-radius: 10px;
-            display: inline-flex;
-            align-items: center;
-            justify-content: center;
-            background: #e7effb;
-            color: #25518b;
-            flex-shrink: 0;
-        }
-
         .vp-field label {
             font-weight: 600;
-            color: #243b5e;
+            color: #dceafe;
             margin-bottom: .35rem;
+        }
+
+        .vp-section .form-group label,
+        .vp-section .control-label,
+        .vp-section .form-check-label,
+        .vp-section small,
+        .vp-section .help-block,
+        .vp-section .text-muted {
+            color: #c9ddf6 !important;
         }
 
         .vp-field .form-control,
         .vp-field .form-select,
-        .vp-field textarea {
+        .vp-field textarea,
+        .vp-field select,
+        .vp-field input {
             border-radius: 12px;
             border: 1px solid #d8e1ee;
-            padding: .75rem .95rem;
             box-shadow: none;
-            color: #243b5e;
-            background-color: #fff;
+        }
+
+        .vp-field input[type="checkbox"],
+        .vp-field input[type="radio"] {
+            accent-color: #4a8ddb;
         }
 
         .vp-field .form-control:focus,
         .vp-field .form-select:focus,
-        .vp-field textarea:focus {
+        .vp-field textarea:focus,
+        .vp-field select:focus,
+        .vp-field input:focus {
             border-color: #3b74b8;
             box-shadow: 0 0 0 .2rem rgba(59, 116, 184, 0.12);
-            color: #243b5e;
-        }
-
-        .vp-help {
-            color: #a9bdd6;
-            font-size: .82rem;
-            margin-top: .35rem;
         }
 
         .vp-actions {
             display: flex;
             gap: .75rem;
             justify-content: flex-end;
-            padding: 1.25rem 1.35rem 1.35rem;
+            padding: 1.1rem 1.25rem;
             background: linear-gradient(180deg, rgba(10, 21, 37, 0.98) 0%, rgba(15, 30, 50, 0.98) 100%);
             border-top: 1px solid rgba(126, 179, 255, 0.18);
-            margin-top: 1.5rem;
+            border-radius: 0 0 18px 18px;
+            flex-wrap: wrap;
         }
 
         .vp-actions .btn-secondary {
@@ -149,95 +137,36 @@
         .vp-actions .btn-primary {
             background: linear-gradient(135deg, #2e6fbc 0%, #4a8ddb 100%);
             border-color: #4a8ddb;
-            box-shadow: 0 10px 20px rgba(46, 111, 188, 0.28);
         }
 
-        .vp-actions .btn-primary:hover {
-            background: linear-gradient(135deg, #255d9f 0%, #3d7bc3 100%);
-            border-color: #3d7bc3;
+        .vp-actions .btn-outline-primary {
+            color: #dbe9f8;
+            border-color: rgba(179, 206, 237, 0.42);
+            background: rgba(255, 255, 255, 0.02);
         }
 
-        .form-group {
-            margin-bottom: 0.75rem;
-        }
-
-        .fieldWrapper {
-            margin-bottom: 0.75rem;
-        }
-
-        .errorlist {
-            color: #dc3545;
-            font-size: .85rem;
-        }
-
-        .helptext {
-            color: #a9bdd6;
-            font-size: .82rem;
-            display: block;
-            margin-top: .35rem;
-        }
-
-        .form-check-label {
-            font-weight: 500;
-            color: #243b5e;
-        }
-
-        .row .col-md-6:last-child:odd,
-        .row .col-md-4:last-child:nth-child(3n+1),
-        .row .col-md-3:last-child:nth-child(4n+1) {
-            margin-bottom: 0;
-        }
-
-        .header-section {
-            display: flex;
-            justify-content: space-between;
-            align-items: center;
-            margin-bottom: 1.5rem;
-        }
-
-        .header-section h2 {
-            margin: 0;
-            color: #1f3a67;
-            font-size: 1.75rem;
-            font-weight: 700;
-        }
-
-        .header-section .btn-group {
-            display: flex;
-            gap: .5rem;
+        .vp-actions .btn-outline-primary:hover {
+            background: rgba(255, 255, 255, 0.1);
+            color: #fff;
+            border-color: rgba(179, 206, 237, 0.7);
         }
 
         @media (max-width: 991px) {
             .vp-hero {
                 padding: 1.4rem 1.25rem;
             }
-            
-            .header-section {
-                flex-direction: column;
-                align-items: flex-start;
-                gap: 1rem;
-            }
-            
-            .header-section .btn-group {
-                width: 100%;
-                flex-direction: column;
-            }
-            
-            .header-section .btn-group .btn {
-                width: 100%;
-            }
         }
     </style>
 {% endblock %}
 {% block content %}
     {% include 'components/alert_message.html' with show_django_messages=True %}
- 
+
     <div class="vp-shell">
         <div class="vp-hero">
             <h1>
                 <i class="fas fa-building me-2"></i>{{ page_title }}
             </h1>
-            <p>Administrá la información general del centro, incluyendo ubicación, contacto y datos del referente responsable.</p>
+            <p>Administrá la información general del centro con la misma estructura visual del alta institucional.</p>
         </div>
 
         <form method="post"
@@ -245,188 +174,100 @@
               id="centro-form"
               novalidate>
             {% csrf_token %}
- 
+
             {% if form.non_field_errors %}<div class="alert alert-danger">{{ form.non_field_errors }}</div>{% endif %}
 
-            <!-- SECCIÓN 1: Información Básica -->
-            <div class="card vp-panel mb-4">
+            <div class="card vp-panel">
                 <div class="vp-panel-header">
-                    <h3 class="card-title mb-1">
-                        <i class="fas fa-info-circle mr-2"></i>Información Básica
-                    </h3>
-                    <div class="text-muted small">Nombre, código y estado operativo del centro.</div>
+                    <div>
+                        <h3 class="card-title">
+                            <i class="fas fa-info-circle mr-2"></i>1. Datos de la Institución
+                        </h3>
+                        <div class="small">Definí la identidad principal del centro.</div>
+                    </div>
                 </div>
                 <div class="vp-section">
-                    <div class="row g-3">
-                        <div class="col-md-6 vp-field">
-                            <label for="{{ form.nombre.id_for_label }}">
-                                {{ form.nombre.label }} <span class="text-danger">*</span>
-                            </label>
-                            {{ form.nombre }}
-                            {% if form.nombre.errors %}<div class="text-danger small mt-1">{{ form.nombre.errors|join:", " }}</div>{% endif %}
-                        </div>
-                        <div class="col-md-3 vp-field">
-                            <label for="{{ form.codigo.id_for_label }}">{{ form.codigo.label }}</label>
-                            {{ form.codigo }}
-                            {% if form.codigo.errors %}<div class="text-danger small mt-1">{{ form.codigo.errors|join:", " }}</div>{% endif %}
-                        </div>
-                        <div class="col-md-3 vp-field">
-                            <label class="form-label">Estado</label>
-                            <div class="form-check">
-                                {{ form.activo }}
-                                <label class="form-check-label" for="{{ form.activo.id_for_label }}">Centro activo</label>
-                            </div>
-                            {% if form.activo.errors %}<div class="text-danger small mt-1">{{ form.activo.errors|join:", " }}</div>{% endif %}
-                        </div>
-                        <div class="col-md-6 vp-field">
-                            <label for="{{ form.referente.id_for_label }}">{{ form.referente.label }}</label>
-                            {{ form.referente }}
-                            {% if form.referente.errors %}
-                                <div class="text-danger small mt-1">{{ form.referente.errors|join:", " }}</div>
-                            {% endif %}
-                        </div>
+                    <div class="row">
+                        <div class="col-md-8 vp-field">{{ form.nombre|as_crispy_field }}</div>
+                        <div class="col-md-4 vp-field">{{ form.codigo|as_crispy_field }}</div>
+                        <div class="col-md-4 vp-field">{{ form.clase_institucion|as_crispy_field }}</div>
+                        <div class="col-md-4 vp-field">{{ form.tipo_gestion|as_crispy_field }}</div>
+                        <div class="col-md-4 vp-field">{{ form.situacion|as_crispy_field }}</div>
+                        <div class="col-md-6 vp-field">{{ form.referente|as_crispy_field }}</div>
+                        <div class="col-md-6 vp-field">{{ form.activo|as_crispy_field }}</div>
                     </div>
                 </div>
             </div>
 
-            <!-- SECCIÓN 2: Ubicación -->
-            <div class="card vp-panel mb-4">
+            <div class="card vp-panel">
                 <div class="vp-panel-header">
-                    <h3 class="card-title mb-1">
-                        <i class="fas fa-map-marker-alt mr-2"></i>Ubicación
-                    </h3>
-                    <div class="text-muted small">Provincia, municipio, localidad y domicilio del centro.</div>
+                    <div>
+                        <h3 class="card-title">
+                            <i class="fas fa-map-marker-alt mr-2"></i>2. Ubicación
+                        </h3>
+                        <div class="small">Completá la localización física y referencias del domicilio.</div>
+                    </div>
                 </div>
                 <div class="vp-section">
-                    <div class="row g-3">
-                        <div class="col-md-4 vp-field">
-                            <label for="{{ form.provincia.id_for_label }}">{{ form.provincia.label }}</label>
-                            {{ form.provincia }}
-                            {% if form.provincia.errors %}
-                                <div class="text-danger small mt-1">{{ form.provincia.errors|join:", " }}</div>
-                            {% endif %}
-                        </div>
-                        <div class="col-md-4 vp-field">
-                            <label for="{{ form.municipio.id_for_label }}">{{ form.municipio.label }}</label>
-                            {{ form.municipio }}
-                            {% if form.municipio.errors %}
-                                <div class="text-danger small mt-1">{{ form.municipio.errors|join:", " }}</div>
-                            {% endif %}
-                        </div>
-                        <div class="col-md-4 vp-field">
-                            <label for="{{ form.localidad.id_for_label }}">{{ form.localidad.label }}</label>
-                            {{ form.localidad }}
-                            {% if form.localidad.errors %}
-                                <div class="text-danger small mt-1">{{ form.localidad.errors|join:", " }}</div>
-                            {% endif %}
-                        </div>
-                        <div class="col-md-8 vp-field">
-                            <label for="{{ form.calle.id_for_label }}">{{ form.calle.label }}</label>
-                            {{ form.calle }}
-                            {% if form.calle.errors %}<div class="text-danger small mt-1">{{ form.calle.errors|join:", " }}</div>{% endif %}
-                        </div>
-                        <div class="col-md-4 vp-field">
-                            <label for="{{ form.numero.id_for_label }}">{{ form.numero.label }}</label>
-                            {{ form.numero }}
-                            {% if form.numero.errors %}<div class="text-danger small mt-1">{{ form.numero.errors|join:", " }}</div>{% endif %}
-                        </div>
-                        <div class="col-md-12 vp-field">
-                            <label for="{{ form.domicilio_actividad.id_for_label }}">{{ form.domicilio_actividad.label }}</label>
-                            {{ form.domicilio_actividad }}
-                            {% if form.domicilio_actividad.errors %}
-                                <div class="text-danger small mt-1">{{ form.domicilio_actividad.errors|join:", " }}</div>
-                            {% endif %}
-                        </div>
+                    <div class="row">
+                        <div class="col-md-12 vp-field">{{ form.domicilio_actividad|as_crispy_field }}</div>
+                        <div class="col-md-6 vp-field">{{ form.calle|as_crispy_field }}</div>
+                        <div class="col-md-2 vp-field">{{ form.numero|as_crispy_field }}</div>
+                        <div class="col-md-4 vp-field">{{ form.codigo_postal|as_crispy_field }}</div>
+                        <div class="col-md-4 vp-field">{{ form.lote|as_crispy_field }}</div>
+                        <div class="col-md-4 vp-field">{{ form.manzana|as_crispy_field }}</div>
+                        <div class="col-md-4 vp-field">{{ form.entre_calles|as_crispy_field }}</div>
+                        <div class="col-md-4 vp-field">{{ form.provincia|as_crispy_field }}</div>
+                        <div class="col-md-4 vp-field">{{ form.municipio|as_crispy_field }}</div>
+                        <div class="col-md-4 vp-field">{{ form.localidad|as_crispy_field }}</div>
                     </div>
                 </div>
             </div>
 
-            <!-- SECCIÓN 3: Contacto -->
-            <div class="card vp-panel mb-4">
+            <div class="card vp-panel">
                 <div class="vp-panel-header">
-                    <h3 class="card-title mb-1">
-                        <i class="fas fa-phone-alt mr-2"></i>Contacto
-                    </h3>
-                    <div class="text-muted small">Teléfono, celular, correo y sitio web del centro.</div>
+                    <div>
+                        <h3 class="card-title">
+                            <i class="fas fa-phone-alt mr-2"></i>3.1 Contacto institucional
+                        </h3>
+                        <div class="small">Canales oficiales de comunicación del centro.</div>
+                    </div>
                 </div>
                 <div class="vp-section">
-                    <div class="row g-3">
-                        <div class="col-md-4 vp-field">
-                            <label for="{{ form.telefono.id_for_label }}">{{ form.telefono.label }}</label>
-                            {{ form.telefono }}
-                            {% if form.telefono.errors %}<div class="text-danger small mt-1">{{ form.telefono.errors|join:", " }}</div>{% endif %}
-                        </div>
-                        <div class="col-md-4 vp-field">
-                            <label for="{{ form.celular.id_for_label }}">{{ form.celular.label }}</label>
-                            {{ form.celular }}
-                            {% if form.celular.errors %}<div class="text-danger small mt-1">{{ form.celular.errors|join:", " }}</div>{% endif %}
-                        </div>
-                        <div class="col-md-4 vp-field">
-                            <label for="{{ form.correo.id_for_label }}">{{ form.correo.label }}</label>
-                            {{ form.correo }}
-                            {% if form.correo.errors %}<div class="text-danger small mt-1">{{ form.correo.errors|join:", " }}</div>{% endif %}
-                        </div>
-                        <div class="col-md-12 vp-field">
-                            <label for="{{ form.sitio_web.id_for_label }}">{{ form.sitio_web.label }}</label>
-                            {{ form.sitio_web }}
-                            {% if form.sitio_web.errors %}
-                                <div class="text-danger small mt-1">{{ form.sitio_web.errors|join:", " }}</div>
-                            {% endif %}
-                        </div>
+                    <div class="row">
+                        <div class="col-md-4 vp-field">{{ form.correo|as_crispy_field }}</div>
+                        <div class="col-md-4 vp-field">{{ form.telefono|as_crispy_field }}</div>
+                        <div class="col-md-4 vp-field">{{ form.celular|as_crispy_field }}</div>
+                        <div class="col-md-12 vp-field">{{ form.sitio_web|as_crispy_field }}</div>
                     </div>
                 </div>
             </div>
 
-            <!-- SECCIÓN 4: Datos del Referente -->
-            <div class="card vp-panel mb-4">
+            <div class="card vp-panel">
                 <div class="vp-panel-header">
-                    <h3 class="card-title mb-1">
-                        <i class="fas fa-user-tie mr-2"></i>Datos del Referente
-                    </h3>
-                    <div class="text-muted small">Información de contacto del referente responsable del centro.</div>
-                </div>
-                <div class="vp-section">
-                    <div class="row g-3">
-                        <div class="col-md-3 vp-field">
-                            <label for="{{ form.nombre_referente.id_for_label }}">{{ form.nombre_referente.label }}</label>
-                            {{ form.nombre_referente }}
-                            {% if form.nombre_referente.errors %}
-                                <div class="text-danger small mt-1">{{ form.nombre_referente.errors|join:", " }}</div>
-                            {% endif %}
-                        </div>
-                        <div class="col-md-3 vp-field">
-                            <label for="{{ form.apellido_referente.id_for_label }}">{{ form.apellido_referente.label }}</label>
-                            {{ form.apellido_referente }}
-                            {% if form.apellido_referente.errors %}
-                                <div class="text-danger small mt-1">{{ form.apellido_referente.errors|join:", " }}</div>
-                            {% endif %}
-                        </div>
-                        <div class="col-md-3 vp-field">
-                            <label for="{{ form.telefono_referente.id_for_label }}">{{ form.telefono_referente.label }}</label>
-                            {{ form.telefono_referente }}
-                            {% if form.telefono_referente.errors %}
-                                <div class="text-danger small mt-1">{{ form.telefono_referente.errors|join:", " }}</div>
-                            {% endif %}
-                        </div>
-                        <div class="col-md-3 vp-field">
-                            <label for="{{ form.correo_referente.id_for_label }}">{{ form.correo_referente.label }}</label>
-                            {{ form.correo_referente }}
-                            {% if form.correo_referente.errors %}
-                                <div class="text-danger small mt-1">{{ form.correo_referente.errors|join:", " }}</div>
-                            {% endif %}
-                        </div>
+                    <div>
+                        <h3 class="card-title">
+                            <i class="fas fa-user-tie mr-2"></i>4. Autoridades
+                        </h3>
+                        <div class="small">Datos del referente responsable del centro.</div>
                     </div>
                 </div>
-            </div>
-
-            <!-- Botones de acción -->
-            <div class="vp-actions">
-                <a href="{{ cancel_url }}" class="btn btn-secondary">
-                    <i class="fas fa-times mr-1"></i>Cancelar
-                </a>
-                <button type="submit" class="btn btn-primary">
-                    <i class="fas fa-save mr-1"></i>{{ submit_text|default:"Guardar" }}
-                </button>
+                <div class="vp-section">
+                    <div class="row">
+                        <div class="col-md-3 vp-field">{{ form.nombre_referente|as_crispy_field }}</div>
+                        <div class="col-md-3 vp-field">{{ form.apellido_referente|as_crispy_field }}</div>
+                        <div class="col-md-3 vp-field">{{ form.telefono_referente|as_crispy_field }}</div>
+                        <div class="col-md-3 vp-field">{{ form.correo_referente|as_crispy_field }}</div>
+                    </div>
+                </div>
+                <div class="vp-actions">
+                    <a href="{{ cancel_url }}" class="btn btn-secondary">
+                        <i class="fas fa-times mr-1"></i>Cancelar
+                    </a>
+                    <button type="submit" class="btn btn-primary">
+                        <i class="fas fa-save mr-1"></i>{{ submit_text|default:"Guardar" }}
+                    </button>
+                </div>
             </div>
         </form>
     </div>

--- a/VAT/templates/vat/curso/comision_curso_detail.html
+++ b/VAT/templates/vat/curso/comision_curso_detail.html
@@ -8,19 +8,13 @@
             <div>
                 <div class="text-muted small mb-1">Comisión de Curso</div>
                 <h1 class="h3 mb-1">{{ comision_curso.nombre }}</h1>
-                <div class="text-muted">
-                    {{ comision_curso.codigo_comision }} · {{ comision_curso.curso.nombre }}
-                </div>
+                <div class="text-muted">{{ comision_curso.codigo_comision }} · {{ comision_curso.curso.nombre }}</div>
             </div>
             <div class="d-flex gap-2">
-                <a href="{{ cancel_url }}" class="btn btn-outline-secondary">
-                    Volver al centro
-                </a>
+                <a href="{{ cancel_url }}" class="btn btn-outline-secondary">Volver al centro</a>
                 {% if perms.VAT.change_comisioncurso %}
                     <a href="{% url 'vat_comision_curso_update' comision_curso.pk %}"
-                       class="btn btn-primary">
-                        Editar comisión
-                    </a>
+                       class="btn btn-primary">Editar comisión</a>
                 {% endif %}
             </div>
         </div>

--- a/VAT/templates/vat/curso/curso_embedded_base.html
+++ b/VAT/templates/vat/curso/curso_embedded_base.html
@@ -8,7 +8,9 @@
               href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" />
         <link rel="stylesheet"
               href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.11.0/font/bootstrap-icons.min.css" />
-        <title>{% block title %}Curso{% endblock %}</title>
+        <title>
+            {% block title %}Curso{% endblock %}
+        </title>
     </head>
     <body class="bg-body-tertiary">
         {% block content %}{% endblock %}

--- a/VAT/templates/vat/curso/curso_form.html
+++ b/VAT/templates/vat/curso/curso_form.html
@@ -128,7 +128,9 @@
 
                     <div class="d-flex justify-content-end gap-2 mt-4">
                         {% if is_embedded %}
-                            <button type="button" class="btn btn-outline-secondary" id="cancelEmbeddedCursoForm">Cancelar</button>
+                            <button type="button"
+                                    class="btn btn-outline-secondary"
+                                    id="cancelEmbeddedCursoForm">Cancelar</button>
                         {% else %}
                             <a href="{{ cancel_url }}" class="btn btn-outline-secondary">Cancelar</a>
                         {% endif %}

--- a/VAT/tests.py
+++ b/VAT/tests.py
@@ -4,6 +4,7 @@ from datetime import date
 import pytest
 from django.contrib.auth.models import Group, User
 from django.contrib.auth.models import Permission
+from django.contrib.contenttypes.models import ContentType
 from django.core.exceptions import ValidationError
 from django.urls import reverse
 
@@ -27,6 +28,7 @@ from VAT.models import (
     SesionComision,
     VoucherParametria,
 )
+from VAT.services.access_scope import filter_centros_queryset_for_user, is_vat_referente
 from ciudadanos.models import Ciudadano
 from core.models import Dia, Localidad, Municipio, Provincia, Programa, Sexo
 from users.models import Profile
@@ -240,6 +242,105 @@ def test_centro_list_usuario_provincial_solo_ve_su_provincia(client):
 
 
 @pytest.mark.django_db
+def test_filter_centros_queryset_usuario_con_role_provincia_vat_aplica_scope():
+    provincia_corrientes = Provincia.objects.create(nombre="Corrientes")
+    provincia_chaco = Provincia.objects.create(nombre="Chaco")
+
+    municipio_corrientes = Municipio.objects.create(
+        nombre="Capital",
+        provincia=provincia_corrientes,
+    )
+    municipio_chaco = Municipio.objects.create(
+        nombre="Resistencia",
+        provincia=provincia_chaco,
+    )
+
+    localidad_corrientes = Localidad.objects.create(
+        nombre="Corrientes",
+        municipio=municipio_corrientes,
+    )
+    localidad_chaco = Localidad.objects.create(
+        nombre="Resistencia",
+        municipio=municipio_chaco,
+    )
+
+    user = User.objects.create_user(username="provincia-vat-role", password="test1234")
+    Profile.objects.update_or_create(
+        user=user,
+        defaults={
+            "es_usuario_provincial": True,
+            "provincia": provincia_corrientes,
+        },
+    )
+
+    permiso_role_provincia = Permission.objects.get(
+        content_type__app_label="auth",
+        codename="role_provincia_vat",
+    )
+    user.user_permissions.add(permiso_role_provincia)
+
+    centro_corrientes = Centro.objects.create(
+        nombre="Centro Corrientes",
+        codigo="CTES-001",
+        provincia=provincia_corrientes,
+        municipio=municipio_corrientes,
+        localidad=localidad_corrientes,
+        calle="Mendoza",
+        numero=100,
+        domicilio_actividad="Mendoza 100",
+        telefono="379-111111",
+        celular="379-111112",
+        correo="corrientes@vat.test",
+        nombre_referente="Ana",
+        apellido_referente="Acosta",
+        telefono_referente="379-111113",
+        correo_referente="refcorrientes@vat.test",
+        tipo_gestion="Estatal",
+        clase_institucion="Formación Profesional",
+        situacion="Institución de ETP",
+        activo=True,
+    )
+    Centro.objects.create(
+        nombre="Centro Chaco",
+        codigo="CHA-001",
+        provincia=provincia_chaco,
+        municipio=municipio_chaco,
+        localidad=localidad_chaco,
+        calle="Santa María",
+        numero=200,
+        domicilio_actividad="Santa María 200",
+        telefono="362-222221",
+        celular="362-222222",
+        correo="chaco@vat.test",
+        nombre_referente="Luis",
+        apellido_referente="Benitez",
+        telefono_referente="362-222223",
+        correo_referente="refchaco@vat.test",
+        tipo_gestion="Privada",
+        clase_institucion="Capacitación Laboral",
+        situacion="Institución de ETP",
+        activo=True,
+    )
+
+    centros = list(filter_centros_queryset_for_user(Centro.objects.all(), user))
+
+    assert centros == [centro_corrientes]
+
+
+@pytest.mark.django_db
+def test_is_vat_referente_reconoce_alias_legacy_centroreferentevat():
+    user = User.objects.create_user(username="referente-legacy", password="test1234")
+    permiso_role_referente_legacy, _ = Permission.objects.get_or_create(
+        content_type=ContentType.objects.get_for_model(Group),
+        codename="role_centroreferentevat",
+        defaults={"name": "ReferenteCentroVAT legacy"},
+    )
+    user.user_permissions.add(permiso_role_referente_legacy)
+
+    assert is_vat_referente(user) is True
+
+
+@pytest.mark.django_db
 def test_centro_create_usuario_provincial_sin_scope_global_recibe_403(client):
     provincia_ba = Provincia.objects.create(nombre="Buenos Aires")
     user = User.objects.create_user(
@@ -277,6 +378,20 @@ def test_plan_curricular_list_usuario_no_provincial_recibe_403(client):
     response = client.get(reverse("vat_planversioncurricular_list"))
 
     assert response.status_code == 403
+
+
+@pytest.mark.django_db
+def test_plan_curricular_list_superuser_puede_acceder(client):
+    user = User.objects.create_superuser(
+        username="super-plan-list",
+        email="super-plan-list@vat.test",
+        password="test1234",
+    )
+
+    client.force_login(user)
+    response = client.get(reverse("vat_planversioncurricular_list"))
+
+    assert response.status_code == 200
 
 
 @pytest.fixture

--- a/VAT/tests.py
+++ b/VAT/tests.py
@@ -273,11 +273,13 @@ def test_filter_centros_queryset_usuario_con_role_provincia_vat_aplica_scope():
         },
     )
 
-    permiso_role_provincia = Permission.objects.get(
-        content_type__app_label="auth",
+    permiso_role_provincia, _ = Permission.objects.get_or_create(
+        content_type=ContentType.objects.get_for_model(Group),
         codename="role_provincia_vat",
+        defaults={"name": "Puede role provincia vat"},
     )
     user.user_permissions.add(permiso_role_provincia)
+    user = User.objects.get(pk=user.pk)
 
     centro_corrientes = Centro.objects.create(
         nombre="Centro Corrientes",
@@ -852,6 +854,8 @@ def test_curso_form_default_costo_creditos_si_no_usa_voucher(vat_curso_base):
 def test_curso_form_guarda_plan_estudio(vat_curso_base, vat_plan_estudio_base):
     centro, ubicacion, modalidad = vat_curso_base
     _, _, _, _, titulo, _ = vat_plan_estudio_base
+    titulo.plan_estudio.provincia = centro.provincia
+    titulo.plan_estudio.save(update_fields=["provincia"])
 
     form = CursoForm(
         data={

--- a/VAT/views/catalogo.py
+++ b/VAT/views/catalogo.py
@@ -27,7 +27,11 @@ from VAT.forms import (
     ModalidadCursadaForm,
     PlanVersionCurricularForm,
 )
-from VAT.services.access_scope import get_user_provincia_id, is_vat_provincial
+from VAT.services.access_scope import (
+    get_user_provincia_id,
+    is_vat_provincial,
+    is_vat_sse,
+)
 
 
 # ============ MODALIDAD CURSADA ============
@@ -353,12 +357,30 @@ class VATProvincialOnlyMixin:
     """Restringe acceso a usuarios provinciales VAT."""
 
     def dispatch(self, request, *args, **kwargs):
-        if not is_vat_provincial(request.user):
+        if not (is_vat_sse(request.user) or is_vat_provincial(request.user)):
             raise PermissionDenied()
         return super().dispatch(request, *args, **kwargs)
 
 
-class PlanVersionCurricularListView(VATProvincialOnlyMixin, LoginRequiredMixin, ListView):
+class VATPlanScopeMixin:
+    """Aplica scope a planes curriculares según rol VAT."""
+
+    def get_scoped_plan_queryset(self, queryset=None):
+        queryset = queryset or super().get_queryset()
+        user = self.request.user
+        if is_vat_sse(user):
+            return queryset
+
+        provincia_id = get_user_provincia_id(user)
+        if provincia_id:
+            return queryset.filter(provincia_id=provincia_id)
+
+        return queryset.none()
+
+
+class PlanVersionCurricularListView(
+    VATProvincialOnlyMixin, VATPlanScopeMixin, LoginRequiredMixin, ListView
+):
     model = PlanVersionCurricular
     template_name = "vat/catalogo/planversioncurricular_list.html"
     context_object_name = "planes"
@@ -366,16 +388,10 @@ class PlanVersionCurricularListView(VATProvincialOnlyMixin, LoginRequiredMixin, 
 
     def get_queryset(self):
         queryset = (
-            super()
-            .get_queryset()
+            self.get_scoped_plan_queryset()
             .select_related("sector", "subsector", "modalidad_cursada")
             .prefetch_related("titulos")
         )
-        provincia_id = get_user_provincia_id(self.request.user)
-        if provincia_id:
-            queryset = queryset.filter(provincia_id=provincia_id)
-        else:
-            queryset = queryset.none()
         titulo_id = self.request.GET.get("titulo")
         activo = self.request.GET.get("activo")
         if titulo_id:
@@ -399,6 +415,17 @@ class PlanVersionCurricularCreateView(VATProvincialOnlyMixin, LoginRequiredMixin
     form_class = PlanVersionCurricularForm
     template_name = "vat/catalogo/planversioncurricular_form.html"
 
+    def get_context_data(self, **kwargs):
+        context = super().get_context_data(**kwargs)
+        context.update(
+            {
+                "page_title": "Nuevo Plan de Estudio",
+                "submit_text": "Crear plan",
+                "cancel_url": reverse("vat_planversioncurricular_list"),
+            }
+        )
+        return context
+
     def form_valid(self, form):
         provincia_id = get_user_provincia_id(self.request.user)
         if provincia_id:
@@ -413,30 +440,39 @@ class PlanVersionCurricularCreateView(VATProvincialOnlyMixin, LoginRequiredMixin
         )
 
 
-class PlanVersionCurricularDetailView(VATProvincialOnlyMixin, LoginRequiredMixin, DetailView):
+class PlanVersionCurricularDetailView(
+    VATProvincialOnlyMixin, VATPlanScopeMixin, LoginRequiredMixin, DetailView
+):
     model = PlanVersionCurricular
     template_name = "vat/catalogo/planversioncurricular_detail.html"
     context_object_name = "plan"
 
     def get_queryset(self):
-        provincia_id = get_user_provincia_id(self.request.user)
-        queryset = super().get_queryset()
-        if provincia_id:
-            return queryset.filter(provincia_id=provincia_id)
-        return queryset.none()
+        return self.get_scoped_plan_queryset(super().get_queryset())
 
 
-class PlanVersionCurricularUpdateView(VATProvincialOnlyMixin, LoginRequiredMixin, UpdateView):
+class PlanVersionCurricularUpdateView(
+    VATProvincialOnlyMixin, VATPlanScopeMixin, LoginRequiredMixin, UpdateView
+):
     model = PlanVersionCurricular
     form_class = PlanVersionCurricularForm
     template_name = "vat/catalogo/planversioncurricular_form.html"
 
     def get_queryset(self):
-        provincia_id = get_user_provincia_id(self.request.user)
-        queryset = super().get_queryset()
-        if provincia_id:
-            return queryset.filter(provincia_id=provincia_id)
-        return queryset.none()
+        return self.get_scoped_plan_queryset(super().get_queryset())
+
+    def get_context_data(self, **kwargs):
+        context = super().get_context_data(**kwargs)
+        context.update(
+            {
+                "page_title": "Editar Plan de Estudio",
+                "submit_text": "Guardar cambios",
+                "cancel_url": reverse(
+                    "vat_planversioncurricular_detail", kwargs={"pk": self.object.pk}
+                ),
+            }
+        )
+        return context
 
     def form_valid(self, form):
         response = super().form_valid(form)
@@ -450,18 +486,18 @@ class PlanVersionCurricularUpdateView(VATProvincialOnlyMixin, LoginRequiredMixin
 
 
 class PlanVersionCurricularDeleteView(
-    VATProvincialOnlyMixin, SoftDeleteDeleteViewMixin, LoginRequiredMixin, DeleteView
+    VATProvincialOnlyMixin,
+    VATPlanScopeMixin,
+    SoftDeleteDeleteViewMixin,
+    LoginRequiredMixin,
+    DeleteView,
 ):
     model = PlanVersionCurricular
     template_name = "vat/catalogo/planversioncurricular_confirm_delete.html"
     context_object_name = "planversioncurricular"
 
     def get_queryset(self):
-        provincia_id = get_user_provincia_id(self.request.user)
-        queryset = super().get_queryset()
-        if provincia_id:
-            return queryset.filter(provincia_id=provincia_id)
-        return queryset.none()
+        return self.get_scoped_plan_queryset(super().get_queryset())
 
     def get_success_url(self):
         next_url = self.request.POST.get("next")

--- a/VAT/views/catalogo.py
+++ b/VAT/views/catalogo.py
@@ -353,7 +353,7 @@ class TituloReferenciaDeleteView(
 
 
 class VATProvincialOnlyMixin:
-    """Restringe acceso a usuarios provinciales VAT."""
+    """Restringe acceso a usuarios VAT SSE o provinciales."""
 
     def dispatch(self, request, *args, **kwargs):
         if not (is_vat_sse(request.user) or is_vat_provincial(request.user)):
@@ -365,7 +365,8 @@ class VATPlanScopeMixin:
     """Aplica scope a planes curriculares según rol VAT."""
 
     def get_scoped_plan_queryset(self, queryset=None):
-        queryset = queryset or super().get_queryset()
+        if queryset is None:
+            queryset = super().get_queryset()
         user = self.request.user
         if is_vat_sse(user):
             return queryset

--- a/VAT/views/catalogo.py
+++ b/VAT/views/catalogo.py
@@ -33,7 +33,6 @@ from VAT.services.access_scope import (
     is_vat_sse,
 )
 
-
 # ============ MODALIDAD CURSADA ============
 
 

--- a/VAT/views/catalogo.py
+++ b/VAT/views/catalogo.py
@@ -410,7 +410,9 @@ class PlanVersionCurricularListView(
         return context
 
 
-class PlanVersionCurricularCreateView(VATProvincialOnlyMixin, LoginRequiredMixin, CreateView):
+class PlanVersionCurricularCreateView(
+    VATProvincialOnlyMixin, LoginRequiredMixin, CreateView
+):
     model = PlanVersionCurricular
     form_class = PlanVersionCurricularForm
     template_name = "vat/catalogo/planversioncurricular_form.html"

--- a/VAT/views/centro.py
+++ b/VAT/views/centro.py
@@ -344,6 +344,17 @@ class CentroUpdateView(LoginRequiredMixin, UpdateView):
         messages.success(self.request, "Centro actualizado correctamente.")
         return super().form_valid(form)
 
+    def get_context_data(self, **kwargs):
+        context = super().get_context_data(**kwargs)
+        context.update(
+            {
+                "page_title": "Editar Centro VAT",
+                "cancel_url": reverse("vat_centro_detail", kwargs={"pk": self.object.pk}),
+                "submit_text": "Guardar cambios",
+            }
+        )
+        return context
+
     def get_success_url(self):
         return reverse("vat_centro_detail", kwargs={"pk": self.object.pk})
 

--- a/VAT/views/centro.py
+++ b/VAT/views/centro.py
@@ -349,7 +349,9 @@ class CentroUpdateView(LoginRequiredMixin, UpdateView):
         context.update(
             {
                 "page_title": "Editar Centro VAT",
-                "cancel_url": reverse("vat_centro_detail", kwargs={"pk": self.object.pk}),
+                "cancel_url": reverse(
+                    "vat_centro_detail", kwargs={"pk": self.object.pk}
+                ),
                 "submit_text": "Guardar cambios",
             }
         )

--- a/docs/registro/cambios/2026-04-02-vat-access-scope-roles.md
+++ b/docs/registro/cambios/2026-04-02-vat-access-scope-roles.md
@@ -9,6 +9,7 @@ Fecha: 2026-04-02
 - El chequeo de referente ahora reconoce ambos codenames legacy detectados en producción/local:
   - `auth.role_referentecentrovat`
   - `auth.role_centroreferentevat`
+- Se amplió el seed del grupo `VAT SSE` para incluir permisos de listado y CRUD de `PlanVersionCurricular`, en línea con el acceso global ya habilitado para SSE en vistas VAT.
 
 ## Motivo
 

--- a/docs/registro/cambios/2026-04-02-vat-access-scope-roles.md
+++ b/docs/registro/cambios/2026-04-02-vat-access-scope-roles.md
@@ -1,0 +1,20 @@
+# VAT - ajuste de access scope por roles reales
+
+Fecha: 2026-04-02
+
+## Qué cambió
+
+- Se alineó `VAT/services/access_scope.py` con los roles efectivos que existen hoy en la base para VAT.
+- El chequeo provincial ahora reconoce explícitamente `auth.role_provincia_vat` además del permiso `VAT.view_centro` y del `Profile` con provincia asignada.
+- El chequeo de referente ahora reconoce ambos codenames legacy detectados en producción/local:
+  - `auth.role_referentecentrovat`
+  - `auth.role_centroreferentevat`
+
+## Motivo
+
+Había una diferencia entre los grupos/permisos reales de VAT y los codenames usados por `access_scope.py`, lo que volvía frágil la clasificación de usuarios provinciales y referentes.
+
+## Validación prevista
+
+- Test de scope provincial filtrando centros por provincia.
+- Test de reconocimiento del alias legacy de referente.

--- a/docs/registro/cambios/2026-04-02-vat-fixture-modalidad-cursada.md
+++ b/docs/registro/cambios/2026-04-02-vat-fixture-modalidad-cursada.md
@@ -1,0 +1,27 @@
+# VAT - fixture inicial de modalidades de cursado
+
+Fecha: 2026-04-02
+
+## Qué cambió
+
+- Se agregó el fixture `VAT/fixtures/modalidad_cursada_inicial.json`.
+- El fixture incorpora diez modalidades iniciales para el catálogo `ModalidadCursada`:
+  - Educación Técnico Profesional
+  - Educación Permanente de Jóvenes y Adultos
+  - Educación Especial
+  - No Corresponde
+  - Educación de Formación Docente
+  - Educación en Contextos de Privación de Libertad
+  - Educación Rural
+  - Educación Artística
+  - Educación Común
+  - Educación de Socio Humanística
+
+## Motivo
+
+- Facilitar la carga inicial del catálogo de modalidades de cursado en VAT con valores base acordados para el módulo.
+
+## Validación prevista
+
+- Validación sintáctica del JSON del fixture.
+- Carga vía `load_fixtures` cuando se necesite poblar el entorno.

--- a/templates/includes/sidebar/opciones.html
+++ b/templates/includes/sidebar/opciones.html
@@ -463,7 +463,7 @@
                             </li>
                         {% endif %}
                         <!-- Oferta Educativa (subgrupo) - oculto temporalmente -->
-                        {% if False and (request.user|has_perm_code:"VAT.view_ofertainstitucional" or request.user|has_perm_code:"VAT.view_comision" or request.user|has_perm_code:"VAT.view_inscripcionoferta") %}
+                        {% if False %}
                             <li class="nav-item ms-4 {% if 'vat/ofertas' in pagina_actual or 'vat/comisiones' in pagina_actual or 'vat/inscripciones-oferta' in pagina_actual %}menu-open{% endif %}">
                                 <a href="#" class="nav-link">
                                     <i class="nav-icon bi bi-arrow-return-right"></i>
@@ -501,7 +501,7 @@
                             </li>
                         {% endif %}
                         <!-- Datos Institución (subgrupo) - oculto temporalmente -->
-                        {% if False and (request.user|has_perm_code:"VAT.view_institucioncontacto" or request.user|has_perm_code:"VAT.view_autoridadinstitucional" or request.user|has_perm_code:"VAT.view_institucionidentificadorhist" or request.user|has_perm_code:"VAT.view_institucionubicacion") %}
+                        {% if False %}
                             <li class="nav-item ms-4 {% if 'vat/institucion/' in pagina_actual %}menu-open{% endif %}">
                                 <a href="#" class="nav-link">
                                     <i class="nav-icon bi bi-arrow-return-right"></i>

--- a/tests/test_vat_api_web_unit.py
+++ b/tests/test_vat_api_web_unit.py
@@ -9,6 +9,26 @@ from VAT.serializers import VatWebInscripcionCreateSerializer
 from VAT.services.inscripcion_service import InscripcionService
 
 
+class _QuerySetStub:
+    def __init__(self, items):
+        self._items = list(items)
+
+    def filter(self, **_kwargs):
+        return self
+
+    def order_by(self, *_args, **_kwargs):
+        return self
+
+    def first(self):
+        return self._items[0] if self._items else None
+
+    def exists(self):
+        return bool(self._items)
+
+    def __iter__(self):
+        return iter(self._items)
+
+
 def test_vat_web_inscripcion_create_serializer_resuelve_por_documento(mocker):
     ciudadano = SimpleNamespace(id=4, documento=30111222)
     programa = SimpleNamespace(id=2)
@@ -70,20 +90,33 @@ def test_inscripcion_service_crear_inscripcion_debita_voucher(mocker):
         usa_voucher=True,
         costo=Decimal("12500"),
     )
-    comision = SimpleNamespace(id=8, oferta=oferta, __str__=lambda self: "COM-8")
-    inscripcion = SimpleNamespace(id=21, comision_id=8, comision=comision)
+    comision = SimpleNamespace(
+        id=8,
+        oferta=oferta,
+        oferta_id=11,
+        __str__=lambda self: "COM-8",
+    )
+    inscripcion = SimpleNamespace(
+        id=21,
+        comision_id=8,
+        comision_curso_id=None,
+        comision=comision,
+        entidad_comision=comision,
+    )
     usuario = SimpleNamespace(is_authenticated=True)
-    voucher = SimpleNamespace(cantidad_disponible=12500)
+    voucher = SimpleNamespace(cantidad_disponible=12500, parametria=None)
 
     create_mock = mocker.patch(
         "VAT.services.inscripcion_service.Inscripcion.objects.create",
         return_value=inscripcion,
     )
     mocker.patch(
-        "VAT.services.inscripcion_service.Voucher.objects.filter",
-        return_value=SimpleNamespace(
-            order_by=lambda *_a, **_k: SimpleNamespace(first=lambda: voucher)
-        ),
+        "VAT.services.inscripcion_service.Inscripcion.objects.filter",
+        return_value=_QuerySetStub([]),
+    )
+    mocker.patch(
+        "VAT.services.inscripcion_service.Voucher.objects.select_related",
+        return_value=_QuerySetStub([voucher]),
     )
     debitar_mock = mocker.patch(
         "VAT.services.inscripcion_service.VoucherService.debitar_voucher",
@@ -111,20 +144,33 @@ def test_inscripcion_service_rechaza_costo_con_decimales_en_voucher(mocker):
         usa_voucher=True,
         costo=Decimal("10.50"),
     )
-    comision = SimpleNamespace(id=8, oferta=oferta, __str__=lambda self: "COM-8")
-    inscripcion = SimpleNamespace(id=21, comision_id=8, comision=comision)
+    comision = SimpleNamespace(
+        id=8,
+        oferta=oferta,
+        oferta_id=11,
+        __str__=lambda self: "COM-8",
+    )
+    inscripcion = SimpleNamespace(
+        id=21,
+        comision_id=8,
+        comision_curso_id=None,
+        comision=comision,
+        entidad_comision=comision,
+    )
     usuario = SimpleNamespace(is_authenticated=True)
-    voucher = SimpleNamespace(cantidad_disponible=20)
+    voucher = SimpleNamespace(cantidad_disponible=20, parametria=None)
 
     mocker.patch(
         "VAT.services.inscripcion_service.Inscripcion.objects.create",
         return_value=inscripcion,
     )
     mocker.patch(
-        "VAT.services.inscripcion_service.Voucher.objects.filter",
-        return_value=SimpleNamespace(
-            order_by=lambda *_a, **_k: SimpleNamespace(first=lambda: voucher)
-        ),
+        "VAT.services.inscripcion_service.Inscripcion.objects.filter",
+        return_value=_QuerySetStub([]),
+    )
+    mocker.patch(
+        "VAT.services.inscripcion_service.Voucher.objects.select_related",
+        return_value=_QuerySetStub([voucher]),
     )
     debitar_mock = mocker.patch(
         "VAT.services.inscripcion_service.VoucherService.debitar_voucher",
@@ -155,7 +201,9 @@ def test_inscripcion_unica_activa_bloquea_segunda_inscripcion(mocker):
     voucher = SimpleNamespace(parametria=parametria, cantidad_disponible=100)
 
     inscripcion_existente = SimpleNamespace(
+        comision_id=3,
         comision=SimpleNamespace(nombre="Electricidad I"),
+        comision_curso=None,
         get_estado_display=lambda: "Inscripta",
     )
 
@@ -165,22 +213,25 @@ def test_inscripcion_unica_activa_bloquea_segunda_inscripcion(mocker):
         usa_voucher=True,
         costo=Decimal("100"),
     )
-    comision_nueva = SimpleNamespace(id=9, oferta=oferta, __str__=lambda self: "COM-9")
+    comision_nueva = SimpleNamespace(
+        id=9,
+        oferta=oferta,
+        oferta_id=12,
+        __str__=lambda self: "COM-9",
+    )
 
     # Mock de validar_inscripcion_unica: voucher con parametria.inscripcion_unica_activa=True
     mocker.patch(
         "VAT.services.inscripcion_service.Voucher.objects.select_related",
-        return_value=SimpleNamespace(
-            filter=lambda **_k: SimpleNamespace(
-                order_by=lambda *_a: SimpleNamespace(first=lambda: voucher)
-            )
-        ),
+        return_value=_QuerySetStub([voucher]),
     )
     mocker.patch(
         "VAT.services.inscripcion_service.Inscripcion.objects.select_related",
-        return_value=SimpleNamespace(
-            filter=lambda **_k: SimpleNamespace(first=lambda: inscripcion_existente)
-        ),
+        return_value=_QuerySetStub([inscripcion_existente]),
+    )
+    mocker.patch(
+        "VAT.services.inscripcion_service.Inscripcion.objects.filter",
+        return_value=_QuerySetStub([]),
     )
 
     with pytest.raises(ValueError, match="Ya tenés una inscripción activa"):
@@ -205,37 +256,40 @@ def test_inscripcion_unica_activa_permite_si_no_hay_activa(mocker):
         usa_voucher=True,
         costo=Decimal("100"),
     )
-    comision = SimpleNamespace(id=9, oferta=oferta, __str__=lambda self: "COM-9")
-    inscripcion = SimpleNamespace(id=30, comision_id=9, comision=comision)
+    comision = SimpleNamespace(
+        id=9,
+        oferta=oferta,
+        oferta_id=13,
+        __str__=lambda self: "COM-9",
+    )
+    inscripcion = SimpleNamespace(
+        id=30,
+        comision_id=9,
+        comision_curso_id=None,
+        comision=comision,
+        entidad_comision=comision,
+    )
     usuario = SimpleNamespace(is_authenticated=True)
-    voucher_debito = SimpleNamespace(cantidad_disponible=100)
+    voucher_debito = SimpleNamespace(cantidad_disponible=100, parametria=parametria)
 
     # validar_inscripcion_unica: voucher con parametria pero sin inscripción activa
     mocker.patch(
         "VAT.services.inscripcion_service.Voucher.objects.select_related",
-        return_value=SimpleNamespace(
-            filter=lambda **_k: SimpleNamespace(
-                order_by=lambda *_a: SimpleNamespace(first=lambda: voucher_param)
-            )
-        ),
+        return_value=_QuerySetStub([voucher_param, voucher_debito]),
     )
     mocker.patch(
         "VAT.services.inscripcion_service.Inscripcion.objects.select_related",
-        return_value=SimpleNamespace(
-            filter=lambda **_k: SimpleNamespace(first=lambda: None)
-        ),
+        return_value=_QuerySetStub([]),
+    )
+    mocker.patch(
+        "VAT.services.inscripcion_service.Inscripcion.objects.filter",
+        return_value=_QuerySetStub([]),
     )
 
     # crear_inscripcion flow
     mocker.patch(
         "VAT.services.inscripcion_service.Inscripcion.objects.create",
         return_value=inscripcion,
-    )
-    mocker.patch(
-        "VAT.services.inscripcion_service.Voucher.objects.filter",
-        return_value=SimpleNamespace(
-            order_by=lambda *_a: SimpleNamespace(first=lambda: voucher_debito)
-        ),
     )
     mocker.patch(
         "VAT.services.inscripcion_service.VoucherService.debitar_voucher",
@@ -265,29 +319,34 @@ def test_inscripcion_unica_activa_desactivado_permite_multiples(mocker):
         usa_voucher=True,
         costo=Decimal("100"),
     )
-    comision = SimpleNamespace(id=9, oferta=oferta, __str__=lambda self: "COM-9")
-    inscripcion = SimpleNamespace(id=31, comision_id=9, comision=comision)
+    comision = SimpleNamespace(
+        id=9,
+        oferta=oferta,
+        oferta_id=14,
+        __str__=lambda self: "COM-9",
+    )
+    inscripcion = SimpleNamespace(
+        id=31,
+        comision_id=9,
+        comision_curso_id=None,
+        comision=comision,
+        entidad_comision=comision,
+    )
     usuario = SimpleNamespace(is_authenticated=True)
-    voucher_debito = SimpleNamespace(cantidad_disponible=100)
+    voucher_debito = SimpleNamespace(cantidad_disponible=100, parametria=parametria)
 
     mocker.patch(
         "VAT.services.inscripcion_service.Voucher.objects.select_related",
-        return_value=SimpleNamespace(
-            filter=lambda **_k: SimpleNamespace(
-                order_by=lambda *_a: SimpleNamespace(first=lambda: voucher_param)
-            )
-        ),
+        return_value=_QuerySetStub([voucher_param, voucher_debito]),
+    )
+    mocker.patch(
+        "VAT.services.inscripcion_service.Inscripcion.objects.filter",
+        return_value=_QuerySetStub([]),
     )
 
     mocker.patch(
         "VAT.services.inscripcion_service.Inscripcion.objects.create",
         return_value=inscripcion,
-    )
-    mocker.patch(
-        "VAT.services.inscripcion_service.Voucher.objects.filter",
-        return_value=SimpleNamespace(
-            order_by=lambda *_a: SimpleNamespace(first=lambda: voucher_debito)
-        ),
     )
     mocker.patch(
         "VAT.services.inscripcion_service.VoucherService.debitar_voucher",

--- a/tests/test_vat_persona_views_unit.py
+++ b/tests/test_vat_persona_views_unit.py
@@ -6,6 +6,26 @@ from VAT.services.inscripcion_service import InscripcionService
 from VAT.services.voucher_service.impl import VoucherService
 
 
+class _QuerySetStub:
+    def __init__(self, items):
+        self._items = list(items)
+
+    def filter(self, **_kwargs):
+        return self
+
+    def order_by(self, *_args, **_kwargs):
+        return self
+
+    def first(self):
+        return self._items[0] if self._items else None
+
+    def exists(self):
+        return bool(self._items)
+
+    def __iter__(self):
+        return iter(self._items)
+
+
 def test_inscripcion_create_descuenta_costo_del_voucher(mocker):
     view = persona_views.InscripcionCreateView()
     view.request = SimpleNamespace(user=SimpleNamespace(id=9, is_authenticated=True))
@@ -78,19 +98,32 @@ def test_inscripcion_service_crea_y_debita_voucher(mocker):
         usa_voucher=True,
         costo=Decimal("12500"),
     )
-    comision = SimpleNamespace(id=6, oferta=oferta, __str__=lambda self: "COM-6")
-    voucher = SimpleNamespace(cantidad_disponible=12500)
-    inscripcion = SimpleNamespace(id=8, comision_id=6, comision=comision)
+    comision = SimpleNamespace(
+        id=6,
+        oferta=oferta,
+        oferta_id=10,
+        __str__=lambda self: "COM-6",
+    )
+    voucher = SimpleNamespace(cantidad_disponible=12500, parametria=None)
+    inscripcion = SimpleNamespace(
+        id=8,
+        comision_id=6,
+        comision_curso_id=None,
+        comision=comision,
+        entidad_comision=comision,
+    )
 
     mocker.patch(
         "VAT.services.inscripcion_service.Inscripcion.objects.create",
         return_value=inscripcion,
     )
     mocker.patch(
-        "VAT.services.inscripcion_service.Voucher.objects.filter",
-        return_value=SimpleNamespace(
-            order_by=lambda *_a, **_k: SimpleNamespace(first=lambda: voucher)
-        ),
+        "VAT.services.inscripcion_service.Inscripcion.objects.filter",
+        return_value=_QuerySetStub([]),
+    )
+    mocker.patch(
+        "VAT.services.inscripcion_service.Voucher.objects.select_related",
+        return_value=_QuerySetStub([voucher]),
     )
     debitar_mock = mocker.patch(
         "VAT.services.inscripcion_service.VoucherService.debitar_voucher",

--- a/users/bootstrap/groups_seed.py
+++ b/users/bootstrap/groups_seed.py
@@ -245,6 +245,29 @@ LISTADO_DEFINED_GROUPS = (
         ),
     ),
     BootstrapGroupSeed(
+        "Provincia VAT",
+        (
+            "auth.role_provincia_vat",
+            "VAT.view_centro",
+            "VAT.view_planversioncurricular",
+            "VAT.add_planversioncurricular",
+        ),
+    ),
+    BootstrapGroupSeed(
+        "ReferenteCentroVAT",
+        (
+            "auth.role_referentecentrovat",
+            "VAT.view_centro",
+        ),
+    ),
+    BootstrapGroupSeed(
+        "VAT SSE",
+        (
+            "auth.role_vat_sse",
+            "VAT.view_centro",
+        ),
+    ),
+    BootstrapGroupSeed(
         "Tableros Total",
         (
             "auth.role_dashboard_centrodefamilia",

--- a/users/bootstrap/groups_seed.py
+++ b/users/bootstrap/groups_seed.py
@@ -265,6 +265,10 @@ LISTADO_DEFINED_GROUPS = (
         (
             "auth.role_vat_sse",
             "VAT.view_centro",
+            "VAT.view_planversioncurricular",
+            "VAT.add_planversioncurricular",
+            "VAT.change_planversioncurricular",
+            "VAT.delete_planversioncurricular",
         ),
     ),
     BootstrapGroupSeed(


### PR DESCRIPTION
- Refactor access scope checks in VAT views to align with current user roles.
- Introduce `VATPlanScopeMixin` to manage plan curricular access based on user roles.
- Enhance form templates for Plan de Estudio and Centro with improved styling and context data.
- Add tests for filtering centers by province and recognizing legacy role aliases.
- Update group seeds to include new roles for `Provincia VAT` and `ReferenteCentroVAT`.
- Document changes in access scope roles for clarity and future reference.

# Información de la Tarea
Vincular el #ISSUE

### **Resumen de la Solución:**
- Se alineó el control de acceso de VAT con los roles y permisos realmente usados en la base actual.
- Se corrigió el acceso a `Planes Curriculares` para que usuarios provinciales vean solo su provincia y superadmin/VAT SSE tengan acceso global.
- Se incorporó bootstrap de grupos VAT para que `Provincia VAT` herede correctamente permisos de centros y planes curriculares al levantar el entorno.
- Se homogeneizó el diseño visual de edición de Centros y de Planes Curriculares con el estilo moderno ya usado en otros módulos VAT.
- Se corrigieron errores de formato en archivos Python y templates detectados por los checks de CI (`black` y `djlint`).

### **Información Adicional:**
- Se mantuvo la restricción provincial para planes curriculares.
- Se preservó compatibilidad con aliases legacy de roles VAT detectados en permisos `auth.role_*`.
- Se dejó documentación en `docs/registro/cambios/` para el ajuste de roles y scope.

# Descripción de los Cambios

### **Cambios:**
- Refactor de `VAT/services/access_scope.py` para reconocer:
  - `auth.role_provincia_vat`
  - `auth.role_referentecentrovat`
  - `auth.role_centroreferentevat`
- Incorporación de `VATPlanScopeMixin` en `VAT/views/catalogo.py` para centralizar el queryset scoped de `PlanVersionCurricular`.
- Ajuste de `VATProvincialOnlyMixin` para permitir acceso a superuser / VAT SSE en planes curriculares.
- Actualización de `users/bootstrap/groups_seed.py` para definir permisos bootstrap de:
  - `Provincia VAT`
  - `ReferenteCentroVAT`
  - `VAT SSE`
- Sincronización de permisos del grupo `Provincia VAT` para incluir:
  - `VAT.view_planversioncurricular`
  - `VAT.add_planversioncurricular`
- Rediseño de:
  - `VAT/templates/vat/centros/centro_form.html`
  - `VAT/templates/vat/catalogo/planversioncurricular_form.html`
  - `VAT/templates/vat/catalogo/planversioncurricular_detail.html`
- Corrección de errores de template en el sidebar VAT.
- Agregado de tests de regresión para:
  - filtrado de centros por provincia
  - reconocimiento de alias legacy de referente
  - acceso de superuser a planes curriculares
- Aplicación de formato `black` en `VAT/views/catalogo.py` y `VAT/forms.py`.
- Aplicación de formato `djlint` en:
  - `VAT/templates/vat/centros/centro_detail.html`
  - `VAT/templates/vat/curso/comision_curso_detail.html`
  - `VAT/templates/vat/curso/curso_embedded_base.html`
  - `VAT/templates/vat/curso/curso_form.html`

# Cómo Testear los Cambios

### **Pruebas Automáticas:**
- `docker compose exec -T django pytest -m smoke -x -q`
- `docker compose exec -T django pytest VAT/tests.py -k "centro_create or centro_list_usuario_provincial" -q`
- `docker compose exec -T django pytest VAT/tests.py -k "plan_curricular_list_superuser_puede_acceder or plan_curricular_list_usuario_no_provincial_recibe_403 or plan_estudio_create_usuario_provincial_asigna_provincia" -q`
- `black --check VAT/views/catalogo.py VAT/forms.py`
- `djlint VAT/templates/vat/ --check --configuration=.djlintrc`

### **Prubeas Manuales:**
- Ingresar con usuario `Provincia VAT` con provincia asignada y validar:
  - que en `VAT > Centros de Formación` vea solo centros de su provincia
  - que vea `Catálogos > Planes Curriculares`
  - que pueda crear un plan curricular y quede con la provincia del perfil
- Ingresar con superadmin y validar:
  - acceso a `http://localhost:8001/vat/catalogos/planes-curriculares/`
  - acceso completo a detalle/edición de planes
- Validar visualmente:
  - `http://localhost:8001/vat/centros/<id>/editar/`
  - `http://localhost:8001/vat/catalogos/planes-curriculares/`
  - `http://localhost:8001/vat/catalogos/planes-curriculares/nuevo/`
  - `http://localhost:8001/vat/catalogos/planes-curriculares/<id>/`

# Metadata para documentación automática

- Contexto funcional: Backoffice VAT, control de acceso por rol/provincia, gestión de centros y planes curriculares
- Tipo de cambio: Bugfix + hardening de permisos + mejora UI + corrección de formato CI
- Área principal: VAT
- Resumen para changelog: Se corrige el scope de acceso VAT por roles/provincia, se habilita correctamente el acceso a planes curriculares para perfiles correspondientes, se unifica el diseño de formularios clave y se corrigen errores de formato detectados por CI.
- Impacto usuario: Usuarios `Provincia VAT` ven mejor configurado su menú y permisos; superadmin recupera acceso a planes curriculares; mejora visual en formularios y detalle.
- Riesgos / rollback: Riesgo bajo; rollback simple revirtiendo cambios en `access_scope.py`, `catalogo.py`, templates VAT y bootstrap de grupos.

# Capturas de Pantalla
- Pendiente adjuntar capturas de:
  - edición de Centro VAT
  - listado de Planes Curriculares
  - alta/edición de Plan de Estudio
  - detalle de Plan de Estudio