### PR TITLE
fix(celiaquia): independizar doble rol del orden del excel

### DIFF
--- a/celiaquia/services/importacion_service/impl.py
+++ b/celiaquia/services/importacion_service/impl.py
@@ -497,7 +497,7 @@ def _consolidar_roles_cruzados_importacion(expediente, warnings):
                 relaciones_cruzadas_creadas += 1
 
         # Consolidar beneficiarios que son responsables de otros
-        _consolidar_beneficiarios_que_son_responsables(expediente, warnings)
+        _consolidar_roles_familiares_doble_rol_importacion(expediente, warnings)
 
     except Exception as exc:  # pylint: disable=broad-exception-caught
         logger.error("Error en post-procesamiento de relaciones cruzadas: %s", exc)
@@ -530,6 +530,57 @@ def _consolidar_beneficiarios_que_son_responsables(expediente, warnings):
 
     actualizados = 0
     for legajo in legajos_beneficiarios:
+        legajo.rol = ExpedienteCiudadano.ROLE_BENEFICIARIO_Y_RESPONSABLE
+        legajo.save(update_fields=["rol"])
+        actualizados += 1
+        logger.info(
+            "Actualizado legajo %s a BENEFICIARIO_Y_RESPONSABLE (doc: %s)",
+            legajo.id,
+            legajo.ciudadano.documento,
+        )
+
+    if actualizados > 0:
+        _agregar_warning_general_importacion(
+            warnings,
+            "consolidacion_roles",
+            f"Se actualizaron {actualizados} beneficiarios a doble rol",
+        )
+
+
+def _consolidar_roles_familiares_doble_rol_importacion(expediente, warnings):
+    """Actualiza legajos a doble rol segun relaciones familiares efectivas."""
+    from ciudadanos.models import GrupoFamiliar
+
+    ciudadanos_expediente = list(
+        ExpedienteCiudadano.objects.filter(expediente=expediente).values_list(
+            "ciudadano_id", flat=True
+        )
+    )
+    if not ciudadanos_expediente:
+        return
+
+    relaciones_qs = GrupoFamiliar.objects.filter(
+        vinculo=GrupoFamiliar.RELACION_PADRE,
+        ciudadano_1_id__in=ciudadanos_expediente,
+        ciudadano_2_id__in=ciudadanos_expediente,
+    )
+    responsables_ids = set(relaciones_qs.values_list("ciudadano_1_id", flat=True))
+    beneficiarios_con_responsable_ids = set(
+        relaciones_qs.values_list("ciudadano_2_id", flat=True)
+    )
+    ciudadanos_doble_rol = responsables_ids & beneficiarios_con_responsable_ids
+    if not ciudadanos_doble_rol:
+        return
+
+    legajos_a_promover = ExpedienteCiudadano.objects.filter(
+        expediente=expediente,
+        ciudadano_id__in=ciudadanos_doble_rol,
+    ).exclude(
+        rol=ExpedienteCiudadano.ROLE_BENEFICIARIO_Y_RESPONSABLE
+    )
+
+    actualizados = 0
+    for legajo in legajos_a_promover:
         legajo.rol = ExpedienteCiudadano.ROLE_BENEFICIARIO_Y_RESPONSABLE
         legajo.save(update_fields=["rol"])
         actualizados += 1
@@ -1308,6 +1359,51 @@ def _beneficiario_tiene_conflicto_importacion(
     return False
 
 
+def _marcar_legajo_existente_como_doble_rol_importacion(
+    *, ciudadano, expediente, legajos_crear, abiertos
+):
+    cid = ciudadano.pk
+
+    for legajo in legajos_crear:
+        legajo_ciudadano_id = getattr(legajo, "ciudadano_id", None) or getattr(
+            getattr(legajo, "ciudadano", None), "pk", None
+        )
+        if (
+            legajo_ciudadano_id == cid
+            and legajo.rol == ExpedienteCiudadano.ROLE_RESPONSABLE
+        ):
+            legajo.rol = ExpedienteCiudadano.ROLE_BENEFICIARIO_Y_RESPONSABLE
+            abiertos[cid] = {
+                "ciudadano_id": cid,
+                "estado_cupo": EstadoCupo.NO_EVAL,
+                "es_titular_activo": False,
+                "expediente_id": expediente.id,
+                "expediente__estado__nombre": expediente.estado.nombre,
+            }
+            return True
+
+    legajo_existente = ExpedienteCiudadano.objects.filter(
+        expediente=expediente,
+        ciudadano=ciudadano,
+    ).first()
+    if not legajo_existente:
+        return False
+
+    if legajo_existente.rol != ExpedienteCiudadano.ROLE_RESPONSABLE:
+        return False
+
+    legajo_existente.rol = ExpedienteCiudadano.ROLE_BENEFICIARIO_Y_RESPONSABLE
+    legajo_existente.save(update_fields=["rol"])
+    abiertos[cid] = {
+        "ciudadano_id": cid,
+        "estado_cupo": EstadoCupo.NO_EVAL,
+        "es_titular_activo": False,
+        "expediente_id": expediente.id,
+        "expediente__estado__nombre": expediente.estado.nombre,
+    }
+    return True
+
+
 def _registrar_legajo_beneficiario_importacion(
     ciudadano,
     expediente,
@@ -1570,6 +1666,17 @@ def _procesar_beneficiario_importacion(
     )
     if not ciudadano:
         return "error", None
+
+    if (
+        ciudadano.pk in existentes_ids
+        and _marcar_legajo_existente_como_doble_rol_importacion(
+            ciudadano=ciudadano,
+            expediente=expediente,
+            legajos_crear=legajos_crear,
+            abiertos=abiertos,
+        )
+    ):
+        return "ok", ciudadano.pk
 
     if _beneficiario_tiene_conflicto_importacion(
         ciudadano=ciudadano,

--- a/celiaquia/tests/test_expediente_detail.py
+++ b/celiaquia/tests/test_expediente_detail.py
@@ -12,7 +12,7 @@ from celiaquia.models import (
     Expediente,
     ExpedienteCiudadano,
 )
-from ciudadanos.models import Ciudadano
+from ciudadanos.models import Ciudadano, GrupoFamiliar
 
 
 @pytest.mark.django_db
@@ -49,3 +49,84 @@ def test_expediente_detail_no_duplica_legajos_sin_responsable(client):
     legajos_ids = [item.pk for item in response.context["legajos_enriquecidos"]]
     assert legajos_ids.count(legajo.pk) == 1
     assert len(legajos_ids) == 1
+
+
+@pytest.mark.django_db
+def test_expediente_detail_ordena_grupo_familiar_independiente_del_orden_de_carga(
+    client,
+):
+    user = User.objects.create_user(username="prov2", password="pass")
+    permission = Permission.objects.get(
+        content_type__app_label="celiaquia",
+        codename="view_expediente",
+    )
+    user.user_permissions.add(permission)
+
+    estado_expediente = EstadoExpediente.objects.create(nombre="CREADO_2")
+    estado_legajo = EstadoLegajo.objects.create(nombre="DOCUMENTO_PENDIENTE_2")
+    expediente = Expediente.objects.create(
+        usuario_provincia=user,
+        estado=estado_expediente,
+    )
+
+    abuelo = Ciudadano.objects.create(
+        apellido="Perez",
+        nombre="Roberto",
+        fecha_nacimiento=date(1970, 1, 1),
+        documento=22345670,
+    )
+    padre = Ciudadano.objects.create(
+        apellido="Perez",
+        nombre="Carlos",
+        fecha_nacimiento=date(1995, 1, 1),
+        documento=22345671,
+    )
+    hijo = Ciudadano.objects.create(
+        apellido="Perez",
+        nombre="Tomas",
+        fecha_nacimiento=date(2018, 1, 1),
+        documento=22345672,
+    )
+
+    legajo_hijo = ExpedienteCiudadano.objects.create(
+        expediente=expediente,
+        ciudadano=hijo,
+        estado=estado_legajo,
+        rol=ExpedienteCiudadano.ROLE_BENEFICIARIO,
+    )
+    legajo_padre = ExpedienteCiudadano.objects.create(
+        expediente=expediente,
+        ciudadano=padre,
+        estado=estado_legajo,
+        rol=ExpedienteCiudadano.ROLE_BENEFICIARIO_Y_RESPONSABLE,
+    )
+    legajo_abuelo = ExpedienteCiudadano.objects.create(
+        expediente=expediente,
+        ciudadano=abuelo,
+        estado=estado_legajo,
+        rol=ExpedienteCiudadano.ROLE_RESPONSABLE,
+    )
+
+    GrupoFamiliar.objects.create(
+        ciudadano_1=abuelo,
+        ciudadano_2=padre,
+        vinculo=GrupoFamiliar.RELACION_PADRE,
+        conviven=True,
+        cuidador_principal=True,
+        estado_relacion=GrupoFamiliar.ESTADO_BUENO,
+    )
+    GrupoFamiliar.objects.create(
+        ciudadano_1=padre,
+        ciudadano_2=hijo,
+        vinculo=GrupoFamiliar.RELACION_PADRE,
+        conviven=True,
+        cuidador_principal=True,
+        estado_relacion=GrupoFamiliar.ESTADO_BUENO,
+    )
+
+    client.force_login(user)
+    response = client.get(reverse("expediente_detail", args=[expediente.pk]))
+
+    assert response.status_code == 200
+    legajos_ids = [item.pk for item in response.context["legajos_enriquecidos"]]
+    assert legajos_ids == [legajo_abuelo.pk, legajo_padre.pk, legajo_hijo.pk]

--- a/docs/registro/cambios/2026-04-06-fix-celiaquia-doble-rol-orden-excel.md
+++ b/docs/registro/cambios/2026-04-06-fix-celiaquia-doble-rol-orden-excel.md
@@ -1,0 +1,27 @@
+# 2026-04-06 - Fix doble rol en Celiaquia independiente del orden del Excel
+
+## Que se corrigio
+
+- La importacion de expedientes de Celiaquia ahora conserva el rol `beneficiario_y_responsable` aunque la persona haya aparecido primero como responsable en el Excel y recien despues como beneficiaria.
+- Si durante la misma importacion una persona ya tenia un legajo `responsable` y luego aparece como beneficiaria, el legajo pendiente se promociona a `beneficiario_y_responsable` en lugar de excluirse como duplicado.
+- Se agrego una consolidacion final basada en relaciones familiares efectivas del expediente para cubrir casos donde una persona es responsable de alguien y al mismo tiempo hija/beneficiaria de otra.
+- Se agrego una regresion del detalle del expediente para asegurar que la familia se renderice jerarquicamente debajo del responsable real independientemente del orden de carga.
+
+## Causa raiz
+
+- El flujo de importacion marcaba doble rol por documento, pero al procesar la fila del beneficiario seguia usando `existentes_ids` como conflicto absoluto.
+- Cuando la misma persona ya habia sido creada antes como `responsable`, su fila como beneficiaria se descartaba como "Ya existe en este expediente", por lo que nunca se procesaba la relacion con su propio responsable.
+- Eso dejaba el legajo con etiqueta `responsable` y rompia la jerarquia visual esperada en expedientes con cadenas familiares.
+
+## Impacto funcional
+
+- El rol usado para determinar documentacion requerida ya no depende del orden de las filas en el Excel.
+- Un responsable que tambien es beneficiario queda etiquetado correctamente aunque primero haya ingresado como responsable de otro.
+- En el detalle del expediente, los integrantes de una misma cadena familiar se siguen mostrando debajo de su responsable correspondiente aun si el Excel vino desordenado.
+
+## Validacion
+
+- Se agregaron regresiones para:
+  - promocion de un responsable previo a `beneficiario_y_responsable` cuando luego aparece como beneficiario,
+  - consolidacion final por relaciones familiares reales,
+  - orden jerarquico del detalle del expediente.

--- a/tests/test_importacion_service_helpers_unit.py
+++ b/tests/test_importacion_service_helpers_unit.py
@@ -269,6 +269,93 @@ def test_consolida_beneficiario_que_tambien_es_responsable():
     ]
 
 
+def test_procesar_beneficiario_promueve_responsable_previo_a_doble_rol():
+    expediente = _crear_expediente_test()
+    estado_legajo = _crear_estado_legajo_test()
+    ciudadano = _crear_ciudadano_test(33000003)
+    legajo_responsable = ExpedienteCiudadano(
+        expediente=expediente,
+        ciudadano=ciudadano,
+        estado=estado_legajo,
+        rol=ExpedienteCiudadano.ROLE_RESPONSABLE,
+    )
+
+    detalles_errores = []
+    existentes_ids = {ciudadano.pk}
+    abiertos = {}
+    resultado, cid = module._procesar_beneficiario_importacion(
+        payload={"documento": str(ciudadano.documento)},
+        usuario=expediente.usuario_provincia,
+        expediente=expediente,
+        estado_id=estado_legajo.id,
+        offset=2,
+        detalles_errores=detalles_errores,
+        existentes_ids=existentes_ids,
+        en_programa={},
+        abiertos=abiertos,
+        excluidos=[],
+        legajos_crear=[legajo_responsable],
+        get_or_create_ciudadano=lambda **_kwargs: ciudadano,
+        es_mismo_documento_resp=False,
+    )
+
+    assert resultado == "ok"
+    assert cid == ciudadano.pk
+    assert legajo_responsable.rol == ExpedienteCiudadano.ROLE_BENEFICIARIO_Y_RESPONSABLE
+    assert abiertos[ciudadano.pk]["expediente_id"] == expediente.id
+
+
+def test_consolidacion_final_promueve_responsable_que_tambien_es_hijo():
+    expediente = _crear_expediente_test()
+    estado_legajo = _crear_estado_legajo_test()
+    ciudadano_abuelo = _crear_ciudadano_test(33000010)
+    ciudadano_padre = _crear_ciudadano_test(33000011)
+    ciudadano_hijo = _crear_ciudadano_test(33000012)
+
+    legajo_padre = ExpedienteCiudadano.objects.create(
+        expediente=expediente,
+        ciudadano=ciudadano_padre,
+        estado=estado_legajo,
+        rol=ExpedienteCiudadano.ROLE_RESPONSABLE,
+    )
+    ExpedienteCiudadano.objects.create(
+        expediente=expediente,
+        ciudadano=ciudadano_abuelo,
+        estado=estado_legajo,
+        rol=ExpedienteCiudadano.ROLE_RESPONSABLE,
+    )
+    ExpedienteCiudadano.objects.create(
+        expediente=expediente,
+        ciudadano=ciudadano_hijo,
+        estado=estado_legajo,
+        rol=ExpedienteCiudadano.ROLE_BENEFICIARIO,
+    )
+
+    GrupoFamiliar.objects.create(
+        ciudadano_1=ciudadano_abuelo,
+        ciudadano_2=ciudadano_padre,
+        vinculo=GrupoFamiliar.RELACION_PADRE,
+    )
+    GrupoFamiliar.objects.create(
+        ciudadano_1=ciudadano_padre,
+        ciudadano_2=ciudadano_hijo,
+        vinculo=GrupoFamiliar.RELACION_PADRE,
+    )
+
+    warnings = []
+    module._consolidar_roles_familiares_doble_rol_importacion(expediente, warnings)
+    legajo_padre.refresh_from_db()
+
+    assert legajo_padre.rol == ExpedienteCiudadano.ROLE_BENEFICIARIO_Y_RESPONSABLE
+    assert warnings == [
+        {
+            "fila": "general",
+            "campo": "consolidacion_roles",
+            "detalle": "Se actualizaron 1 beneficiarios a doble rol",
+        }
+    ]
+
+
 def test_importacion_helpers_payload_row_and_defaults_validation():
     warnings = []
 


### PR DESCRIPTION
why: una persona que primero entraba como responsable y luego como beneficiaria quedaba mal etiquetada y podia romper la jerarquia familiar en el detalle.

what:

- promociona a beneficiario_y_responsable cuando el legajo ya existia como responsable en la misma importacion

- agrega una consolidacion final basada en relaciones familiares efectivas

- suma regresiones para orden de carga y orden visual del detalle

tests:

- no ejecutados en este shell; solo validacion de diff

# Información de la Tarea
Vincular el #ISSUE

### **Resumen de la Solución:** 
-

### **Información Adicional:**
-

# Descripción de los Cambios

### **Cambios:**
-

# Cómo Testear los Cambios

### **Pruebas Automáticas:**
-

### **Prubeas Manuales:**
-

# Metadata para documentación automática

- Contexto funcional:
- Tipo de cambio:
- Área principal:
- Resumen para changelog:
- Impacto usuario:
- Riesgos / rollback:

# Capturas de Pantalla
