### PR TITLE
Var v2

### DIFF
--- a/VAT/api_views.py
+++ b/VAT/api_views.py
@@ -407,6 +407,18 @@ class InstitucionUbicacionViewSet(viewsets.ModelViewSet):
             description="Filtra cursos por centro.",
         ),
         OpenApiParameter(
+            "provincia_id",
+            OpenApiTypes.INT,
+            OpenApiParameter.QUERY,
+            description="Filtra cursos por provincia del centro.",
+        ),
+        OpenApiParameter(
+            "municipio_id",
+            OpenApiTypes.INT,
+            OpenApiParameter.QUERY,
+            description="Filtra cursos por municipio del centro.",
+        ),
+        OpenApiParameter(
             "modalidad_id",
             OpenApiTypes.INT,
             OpenApiParameter.QUERY,
@@ -445,11 +457,17 @@ class CursoViewSet(SoftDeleteDestroyMixin, viewsets.ModelViewSet):
     def get_queryset(self):
         queryset = super().get_queryset()
         centro_id = self.request.query_params.get("centro_id")
+        provincia_id = self.request.query_params.get("provincia_id")
+        municipio_id = self.request.query_params.get("municipio_id")
         modalidad_id = self.request.query_params.get("modalidad_id")
         programa_id = self.request.query_params.get("programa_id")
         estado = self.request.query_params.get("estado")
         if centro_id:
             queryset = queryset.filter(centro_id=centro_id)
+        if provincia_id:
+            queryset = queryset.filter(centro__provincia_id=provincia_id)
+        if municipio_id:
+            queryset = queryset.filter(centro__municipio_id=municipio_id)
         if modalidad_id:
             queryset = queryset.filter(modalidad_id=modalidad_id)
         if programa_id:
@@ -487,6 +505,18 @@ class CursoViewSet(SoftDeleteDestroyMixin, viewsets.ModelViewSet):
             description="Filtra comisiones por centro (via curso).",
         ),
         OpenApiParameter(
+            "provincia_id",
+            OpenApiTypes.INT,
+            OpenApiParameter.QUERY,
+            description="Filtra comisiones por provincia del centro del curso.",
+        ),
+        OpenApiParameter(
+            "municipio_id",
+            OpenApiTypes.INT,
+            OpenApiParameter.QUERY,
+            description="Filtra comisiones por municipio del centro del curso.",
+        ),
+        OpenApiParameter(
             "estado",
             OpenApiTypes.STR,
             OpenApiParameter.QUERY,
@@ -505,11 +535,17 @@ class ComisionCursoViewSet(SoftDeleteDestroyMixin, viewsets.ModelViewSet):
         queryset = super().get_queryset()
         curso_id = self.request.query_params.get("curso_id")
         centro_id = self.request.query_params.get("centro_id")
+        provincia_id = self.request.query_params.get("provincia_id")
+        municipio_id = self.request.query_params.get("municipio_id")
         estado = self.request.query_params.get("estado")
         if curso_id:
             queryset = queryset.filter(curso_id=curso_id)
         if centro_id:
             queryset = queryset.filter(curso__centro_id=centro_id)
+        if provincia_id:
+            queryset = queryset.filter(curso__centro__provincia_id=provincia_id)
+        if municipio_id:
+            queryset = queryset.filter(curso__centro__municipio_id=municipio_id)
         if estado:
             queryset = queryset.filter(estado=estado)
         return queryset

--- a/VAT/serializers.py
+++ b/VAT/serializers.py
@@ -38,9 +38,6 @@ class CentroSerializer(serializers.ModelSerializer):
     provincia_nombre = serializers.CharField(source="provincia.nombre", read_only=True)
     municipio_nombre = serializers.CharField(source="municipio.nombre", read_only=True)
     localidad_nombre = serializers.CharField(source="localidad.nombre", read_only=True)
-    modalidad_institucional_nombre = serializers.CharField(
-        source="modalidad_institucional.nombre", read_only=True
-    )
 
     class Meta:
         model = Centro
@@ -63,12 +60,9 @@ class CentroSerializer(serializers.ModelSerializer):
             "correo",
             "nombre_referente",
             "apellido_referente",
-            "modalidad_institucional",
-            "modalidad_institucional_nombre",
             "tipo_gestion",
             "clase_institucion",
             "situacion",
-            "fecha_alta",
         ]
 
 

--- a/VAT/tests.py
+++ b/VAT/tests.py
@@ -8,6 +8,8 @@ from django.contrib.contenttypes.models import ContentType
 from django.core.exceptions import ValidationError
 from django.test import RequestFactory
 from django.urls import reverse
+from rest_framework.test import APIClient
+from rest_framework_api_key.models import APIKey
 
 from VAT import serializers as vat_serializers
 from VAT.api_views import CursoViewSet
@@ -67,6 +69,19 @@ def vat_admin_client(client, db):
         password="test1234",
     )
     client.force_login(user)
+    return client
+
+
+@pytest.fixture
+def vat_api_key(db):
+    _, key = APIKey.objects.create_key(name="vat-tests")
+    return key
+
+
+@pytest.fixture
+def vat_api_client(vat_api_key):
+    client = APIClient()
+    client.credentials(HTTP_AUTHORIZATION=f"Api-Key {vat_api_key}")
     return client
 
 
@@ -1939,6 +1954,67 @@ def vat_curso_base(db, vat_geo_data):
         es_principal=True,
     )
     return centro, ubicacion, modalidad
+
+
+@pytest.mark.django_db
+def test_api_vat_centros_lista_con_api_key(vat_api_client, vat_curso_base):
+    centro, _, _ = vat_curso_base
+
+    response = vat_api_client.get("/api/vat/centros/?activo=true")
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["count"] >= 1
+    assert payload["results"][0]["id"] == centro.id
+    assert payload["results"][0]["provincia"] == centro.provincia_id
+
+
+@pytest.mark.django_db
+def test_api_vat_cursos_lista_por_centro(vat_api_client, vat_curso_base):
+    centro, _, modalidad = vat_curso_base
+    curso = Curso.objects.create(
+        centro=centro,
+        nombre="Curso API VAT",
+        modalidad=modalidad,
+        estado="activo",
+    )
+
+    response = vat_api_client.get(f"/api/vat/cursos/?centro_id={centro.id}")
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["count"] == 1
+    assert payload["results"][0]["id"] == curso.id
+    assert payload["results"][0]["centro"] == centro.id
+
+
+@pytest.mark.django_db
+def test_api_vat_comisiones_curso_lista_por_curso(vat_api_client, vat_curso_base):
+    centro, ubicacion, modalidad = vat_curso_base
+    curso = Curso.objects.create(
+        centro=centro,
+        nombre="Curso API Comision VAT",
+        modalidad=modalidad,
+        estado="activo",
+    )
+    comision = ComisionCurso.objects.create(
+        curso=curso,
+        ubicacion=ubicacion,
+        codigo_comision="API-COM-01",
+        nombre="Comision API VAT",
+        cupo_total=20,
+        fecha_inicio=date(2026, 4, 1),
+        fecha_fin=date(2026, 4, 30),
+        estado="activa",
+    )
+
+    response = vat_api_client.get(f"/api/vat/comisiones-curso/?curso_id={curso.id}")
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["count"] == 1
+    assert payload["results"][0]["id"] == comision.id
+    assert payload["results"][0]["curso"] == curso.id
 
 
 @pytest.mark.django_db

--- a/VAT/tests.py
+++ b/VAT/tests.py
@@ -2762,7 +2762,7 @@ def test_centro_cursos_panel_renderiza_marcadores_para_filtrar_comisiones_por_cu
         modalidad=modalidad,
         estado="planificado",
     )
-    ComisionCurso.objects.create(
+    comision = ComisionCurso.objects.create(
         curso=_curso,
         ubicacion=ubicacion,
         codigo_comision="FIL-01",
@@ -2781,7 +2781,7 @@ def test_centro_cursos_panel_renderiza_marcadores_para_filtrar_comisiones_por_cu
     assert 'data-panel-rendered="1"' in content
     assert 'id="tablaCursosCentro"' in content
     assert 'class="curso-row"' in content
-    assert f'data-curso-id="{curso.id}"' in content
+    assert f'data-curso-id="{_curso.id}"' in content
     assert 'id="tablaComisionesCursoCentro"' in content
     assert 'class="comision-curso-row"' in content
     assert reverse("vat_comision_curso_detail", kwargs={"pk": comision.pk}) in content

--- a/VAT/tests.py
+++ b/VAT/tests.py
@@ -1989,6 +1989,63 @@ def test_api_vat_cursos_lista_por_centro(vat_api_client, vat_curso_base):
 
 
 @pytest.mark.django_db
+def test_api_vat_cursos_lista_por_provincia_y_municipio(vat_api_client, vat_curso_base):
+    centro, _, modalidad = vat_curso_base
+    curso = Curso.objects.create(
+        centro=centro,
+        nombre="Curso API VAT Geografico",
+        modalidad=modalidad,
+        estado="activo",
+    )
+    otra_provincia = Provincia.objects.create(nombre="Otra Provincia VAT")
+    otro_municipio = Municipio.objects.create(
+        nombre="Otro Municipio VAT",
+        provincia=otra_provincia,
+    )
+    otra_localidad = Localidad.objects.create(
+        nombre="Otra Localidad VAT",
+        municipio=otro_municipio,
+    )
+    otro_centro = Centro.objects.create(
+        nombre="Centro API VAT Alternativo",
+        codigo="CFP-ALT-VAT-1",
+        provincia=otra_provincia,
+        municipio=otro_municipio,
+        localidad=otra_localidad,
+        calle="9",
+        numero=10,
+        domicilio_actividad="Calle 9 N° 10",
+        telefono="221-9999991",
+        celular="221-9999992",
+        correo="alternativo@vat.test",
+        nombre_referente="Luis",
+        apellido_referente="Perez",
+        telefono_referente="221-9999993",
+        correo_referente="luis@vat.test",
+        tipo_gestion="Privada",
+        clase_institucion="Formación Profesional",
+        situacion="Institución de ETP",
+        activo=True,
+    )
+    Curso.objects.create(
+        centro=otro_centro,
+        nombre="Curso API VAT Excluido",
+        modalidad=modalidad,
+        estado="activo",
+    )
+
+    response = vat_api_client.get(
+        f"/api/vat/cursos/?provincia_id={centro.provincia_id}&municipio_id={centro.municipio_id}"
+    )
+
+    assert response.status_code == 200
+    payload = response.json()
+    result_ids = {item["id"] for item in payload["results"]}
+    assert curso.id in result_ids
+    assert all(item["centro"] == centro.id for item in payload["results"])
+
+
+@pytest.mark.django_db
 def test_api_vat_comisiones_curso_lista_por_curso(vat_api_client, vat_curso_base):
     centro, ubicacion, modalidad = vat_curso_base
     curso = Curso.objects.create(
@@ -2015,6 +2072,92 @@ def test_api_vat_comisiones_curso_lista_por_curso(vat_api_client, vat_curso_base
     assert payload["count"] == 1
     assert payload["results"][0]["id"] == comision.id
     assert payload["results"][0]["curso"] == curso.id
+
+
+@pytest.mark.django_db
+def test_api_vat_comisiones_curso_lista_por_provincia_y_municipio(
+    vat_api_client, vat_curso_base
+):
+    centro, ubicacion, modalidad = vat_curso_base
+    curso = Curso.objects.create(
+        centro=centro,
+        nombre="Curso API VAT Geografico Comision",
+        modalidad=modalidad,
+        estado="activo",
+    )
+    comision = ComisionCurso.objects.create(
+        curso=curso,
+        ubicacion=ubicacion,
+        codigo_comision="API-GEO-01",
+        nombre="Comision API VAT Geografica",
+        cupo_total=15,
+        fecha_inicio=date(2026, 4, 2),
+        fecha_fin=date(2026, 4, 29),
+        estado="activa",
+    )
+    otra_provincia = Provincia.objects.create(nombre="Provincia Geo Comision")
+    otro_municipio = Municipio.objects.create(
+        nombre="Municipio Geo Comision",
+        provincia=otra_provincia,
+    )
+    otra_localidad = Localidad.objects.create(
+        nombre="Localidad Geo Comision",
+        municipio=otro_municipio,
+    )
+    otro_centro = Centro.objects.create(
+        nombre="Centro API VAT Comision Alternativo",
+        codigo="CFP-ALT-VAT-2",
+        provincia=otra_provincia,
+        municipio=otro_municipio,
+        localidad=otra_localidad,
+        calle="10",
+        numero=20,
+        domicilio_actividad="Calle 10 N° 20",
+        telefono="221-8888881",
+        celular="221-8888882",
+        correo="alternativo-comision@vat.test",
+        nombre_referente="Laura",
+        apellido_referente="Suarez",
+        telefono_referente="221-8888883",
+        correo_referente="laura@vat.test",
+        tipo_gestion="Estatal",
+        clase_institucion="Formación Profesional",
+        situacion="Institución de ETP",
+        activo=True,
+    )
+    otra_ubicacion = InstitucionUbicacion.objects.create(
+        centro=otro_centro,
+        localidad=otra_localidad,
+        rol_ubicacion="sede_principal",
+        domicilio="Calle 10 N° 20",
+        es_principal=True,
+    )
+    otro_curso = Curso.objects.create(
+        centro=otro_centro,
+        nombre="Curso API VAT Comision Excluida",
+        modalidad=modalidad,
+        estado="activo",
+    )
+    ComisionCurso.objects.create(
+        curso=otro_curso,
+        ubicacion=otra_ubicacion,
+        codigo_comision="API-GEO-02",
+        nombre="Comision API VAT Excluida",
+        cupo_total=10,
+        fecha_inicio=date(2026, 4, 3),
+        fecha_fin=date(2026, 4, 30),
+        estado="activa",
+    )
+
+    response = vat_api_client.get(
+        f"/api/vat/comisiones-curso/?provincia_id={centro.provincia_id}&municipio_id={centro.municipio_id}"
+    )
+
+    assert response.status_code == 200
+    payload = response.json()
+    result_ids = {item["id"] for item in payload["results"]}
+    assert comision.id in result_ids
+    assert all(item["curso_centro_id"] == centro.id for item in payload["results"])
 
 
 @pytest.mark.django_db

--- a/VAT/tests.py
+++ b/VAT/tests.py
@@ -2643,9 +2643,7 @@ def test_curso_form_filtra_plan_estudio_por_provincia_del_centro(vat_curso_base)
 
 
 @pytest.mark.django_db
-def test_centro_detail_difiere_panel_cursos_hasta_abrir_solapa(
-    client, vat_geo_data
-):
+def test_centro_detail_difiere_panel_cursos_hasta_abrir_solapa(client, vat_geo_data):
     provincia, municipio, localidad = vat_geo_data
     modalidad = ModalidadCursada.objects.create(nombre="Virtual", activo=True)
     group, _ = Group.objects.get_or_create(name="CFP")
@@ -2849,9 +2847,7 @@ def test_centro_cursos_panel_renderiza_accion_para_crear_curso_desde_plan_curric
 
 
 @pytest.mark.django_db
-def test_centro_cursos_panel_filtra_y_pagina_planes_curriculares(
-    client, vat_geo_data
-):
+def test_centro_cursos_panel_filtra_y_pagina_planes_curriculares(client, vat_geo_data):
     provincia, municipio, localidad = vat_geo_data
     modalidad = ModalidadCursada.objects.create(nombre="Virtual", activo=True)
     sector = Sector.objects.create(nombre="Servicios")

--- a/VAT/urls.py
+++ b/VAT/urls.py
@@ -177,9 +177,7 @@ urlpatterns = [
     ),
     path(
         "vat/centros/<int:pk>/panel/cursos/",
-        permissions_any_required(["VAT.view_centro"])(
-            CentroCursosPanelView.as_view()
-        ),
+        permissions_any_required(["VAT.view_centro"])(CentroCursosPanelView.as_view()),
         name="vat_centro_cursos_panel",
     ),
     path(

--- a/VAT/views/centro.py
+++ b/VAT/views/centro.py
@@ -230,11 +230,11 @@ def _build_cursos_panel_context(request, centro):
     )
     comision_curso_form = ComisionCursoForm()
     comision_curso_form.fields["curso"].queryset = centro.cursos.order_by("nombre")
-    comision_curso_form.fields["ubicacion"].queryset = (
-        centro.ubicaciones.select_related("localidad").order_by(
-            "es_principal",
-            "rol_ubicacion",
-        )
+    comision_curso_form.fields[
+        "ubicacion"
+    ].queryset = centro.ubicaciones.select_related("localidad").order_by(
+        "es_principal",
+        "rol_ubicacion",
     )
 
     return {
@@ -414,9 +414,7 @@ class CentroDetailView(CentroAccessMixin, LoginRequiredMixin, DetailView):
                 "-es_principal", "nombre_contacto"
             )
         )
-        ctx["ubicaciones"] = list(
-            centro.ubicaciones.select_related("localidad").all()
-        )
+        ctx["ubicaciones"] = list(centro.ubicaciones.select_related("localidad").all())
         ctx["count_ofertas"] = centro.ofertas_institucionales.count()
         ctx["count_comisiones"] = Comision.objects.filter(
             oferta__centro_id=centro.pk

--- a/docs/registro/cambios/2026-04-06-postman-vat-operativa.md
+++ b/docs/registro/cambios/2026-04-06-postman-vat-operativa.md
@@ -1,0 +1,28 @@
+# 2026-04-06 - Coleccion Postman VAT operativa
+
+## Resumen
+
+Se agrego una coleccion de Postman orientada a consumo operativo de VAT para recorrer:
+
+- planes curriculares,
+- centros,
+- cursos por centro,
+- comisiones de curso por curso.
+
+## Archivo agregado
+
+- `postman/VAT - Planes Centros Cursos Comisiones.postman_collection.json`
+
+## Alcance
+
+La coleccion usa endpoints de `api/vat/` protegidos con API key y deja variables de coleccion para encadenar el flujo:
+
+- `sector_id`
+- `plan_id`
+- `centro_id`
+- `curso_id`
+
+## Notas
+
+- Para autenticacion, la cabecera esperada es `Authorization: Api-Key <clave>`.
+- Se dejo separado de la coleccion VAT Web porque los endpoints web no cubren planes curriculares ni comisiones de curso operativas.

--- a/docs/registro/cambios/2026-04-07-fix-api-vat-centros-postman.md
+++ b/docs/registro/cambios/2026-04-07-fix-api-vat-centros-postman.md
@@ -1,0 +1,19 @@
+# 2026-04-07 - Fix endpoint API VAT centros y validacion Postman
+
+## Resumen
+
+Se corrigio el serializer de `api/vat/centros/`, que estaba declarando campos inexistentes del modelo `Centro` y provocaba error 500 al listar centros con API key valida.
+
+## Cambios
+
+- Se removieron del serializer los campos inexistentes `modalidad_institucional`, `modalidad_institucional_nombre` y `fecha_alta`.
+- Se agregaron tests API de regresion para:
+  - `GET /api/vat/centros/`
+  - `GET /api/vat/cursos/?centro_id=...`
+  - `GET /api/vat/comisiones-curso/?curso_id=...`
+- Se agrego a la coleccion Postman un request inicial de validacion sobre `planes-curriculares` para comprobar autenticacion y disponibilidad antes del flujo completo.
+
+## Impacto
+
+- La API key ya autenticaba correctamente; el problema real era un bug interno del endpoint de centros.
+- Con este ajuste, el flujo operativo de Postman queda alineado con endpoints efectivamente utilizables.

--- a/docs/registro/cambios/2026-04-07-fix-api-vat-centros-postman.md
+++ b/docs/registro/cambios/2026-04-07-fix-api-vat-centros-postman.md
@@ -12,6 +12,7 @@ Se corrigio el serializer de `api/vat/centros/`, que estaba declarando campos in
   - `GET /api/vat/cursos/?centro_id=...`
   - `GET /api/vat/comisiones-curso/?curso_id=...`
 - Se agrego a la coleccion Postman un request inicial de validacion sobre `planes-curriculares` para comprobar autenticacion y disponibilidad antes del flujo completo.
+- Se agregaron variables `provincia_id` y `municipio_id` y requests auxiliares de ubicacion para encadenar `provincia -> municipio -> centro -> curso -> comision`.
 
 ## Impacto
 

--- a/docs/registro/cambios/2026-04-07-fix-api-vat-centros-postman.md
+++ b/docs/registro/cambios/2026-04-07-fix-api-vat-centros-postman.md
@@ -13,6 +13,7 @@ Se corrigio el serializer de `api/vat/centros/`, que estaba declarando campos in
   - `GET /api/vat/comisiones-curso/?curso_id=...`
 - Se agrego a la coleccion Postman un request inicial de validacion sobre `planes-curriculares` para comprobar autenticacion y disponibilidad antes del flujo completo.
 - Se agregaron variables `provincia_id` y `municipio_id` y requests auxiliares de ubicacion para encadenar `provincia -> municipio -> centro -> curso -> comision`.
+- Se agregaron filtros geograficos directos `provincia_id` y `municipio_id` en `GET /api/vat/cursos/` y `GET /api/vat/comisiones-curso/`.
 
 ## Impacto
 

--- a/postman/VAT - Planes Centros Cursos Comisiones.postman_collection.json
+++ b/postman/VAT - Planes Centros Cursos Comisiones.postman_collection.json
@@ -1,0 +1,423 @@
+{
+  "info": {
+    "_postman_id": "1f8a0f52-0b78-4fb5-81bf-198e6b8d45a3",
+    "name": "VAT - Planes Centros Cursos Comisiones",
+    "description": "Coleccion para consultar la API operativa de VAT con el flujo: planes curriculares, centros, cursos por centro y comisiones de curso por curso. Usa endpoints protegidos con API key.",
+    "schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json"
+  },
+  "variable": [
+    {
+      "key": "baseUrl",
+      "value": "http://localhost:8000"
+    },
+    {
+      "key": "apiPrefix",
+      "value": "/api"
+    },
+    {
+      "key": "apiKey",
+      "value": ""
+    },
+    {
+      "key": "plan_id",
+      "value": ""
+    },
+    {
+      "key": "centro_id",
+      "value": ""
+    },
+    {
+      "key": "curso_id",
+      "value": ""
+    },
+    {
+      "key": "sector_id",
+      "value": ""
+    }
+  ],
+  "item": [
+    {
+      "name": "0 - Inicio Operativo",
+      "description": "Request inicial para validar API key y disponibilidad de un endpoint operativo antes de encadenar el resto del flujo.",
+      "item": [
+        {
+          "name": "Validar autenticacion con planes curriculares",
+          "request": {
+            "method": "GET",
+            "header": [
+              {
+                "key": "Authorization",
+                "value": "Api-Key {{apiKey}}",
+                "type": "text"
+              }
+            ],
+            "url": {
+              "raw": "{{baseUrl}}{{apiPrefix}}/vat/planes-curriculares/?activo=true",
+              "host": [
+                "{{baseUrl}}{{apiPrefix}}"
+              ],
+              "path": [
+                "vat",
+                "planes-curriculares",
+                ""
+              ],
+              "query": [
+                {
+                  "key": "activo",
+                  "value": "true"
+                }
+              ]
+            }
+          },
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "pm.test('Status code is 200', function () {",
+                  "  pm.response.to.have.status(200);",
+                  "});"
+                ]
+              }
+            }
+          ],
+          "response": []
+        }
+      ]
+    },
+    {
+      "name": "1 - Planes Curriculares",
+      "description": "Obtiene planes curriculares operativos. Guarda plan_id y sector_id con el primer registro devuelto.",
+      "item": [
+        {
+          "name": "Listar planes curriculares activos",
+          "request": {
+            "method": "GET",
+            "header": [
+              {
+                "key": "Authorization",
+                "value": "Api-Key {{apiKey}}",
+                "type": "text"
+              }
+            ],
+            "url": {
+              "raw": "{{baseUrl}}{{apiPrefix}}/vat/planes-curriculares/?activo=true",
+              "host": [
+                "{{baseUrl}}{{apiPrefix}}"
+              ],
+              "path": [
+                "vat",
+                "planes-curriculares",
+                ""
+              ],
+              "query": [
+                {
+                  "key": "activo",
+                  "value": "true"
+                }
+              ]
+            }
+          },
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "pm.test('Status code is 200', function () {",
+                  "  pm.response.to.have.status(200);",
+                  "});",
+                  "const body = pm.response.json();",
+                  "const rows = Array.isArray(body) ? body : (body.results || []);",
+                  "pm.test('La respuesta contiene una lista', function () {",
+                  "  pm.expect(Array.isArray(rows)).to.eql(true);",
+                  "});",
+                  "if (rows.length && rows[0].id) {",
+                  "  pm.collectionVariables.set('plan_id', String(rows[0].id));",
+                  "}",
+                  "if (rows.length && rows[0].sector) {",
+                  "  pm.collectionVariables.set('sector_id', String(rows[0].sector));",
+                  "}"
+                ]
+              }
+            }
+          ],
+          "response": []
+        },
+        {
+          "name": "Listar planes curriculares por sector_id",
+          "request": {
+            "method": "GET",
+            "header": [
+              {
+                "key": "Authorization",
+                "value": "Api-Key {{apiKey}}",
+                "type": "text"
+              }
+            ],
+            "url": {
+              "raw": "{{baseUrl}}{{apiPrefix}}/vat/planes-curriculares/?activo=true&sector_id={{sector_id}}",
+              "host": [
+                "{{baseUrl}}{{apiPrefix}}"
+              ],
+              "path": [
+                "vat",
+                "planes-curriculares",
+                ""
+              ],
+              "query": [
+                {
+                  "key": "activo",
+                  "value": "true"
+                },
+                {
+                  "key": "sector_id",
+                  "value": "{{sector_id}}"
+                }
+              ]
+            }
+          },
+          "response": []
+        }
+      ]
+    },
+    {
+      "name": "2 - Centros",
+      "description": "Obtiene centros operativos. Guarda centro_id con el primer registro devuelto.",
+      "item": [
+        {
+          "name": "Listar centros activos",
+          "request": {
+            "method": "GET",
+            "header": [
+              {
+                "key": "Authorization",
+                "value": "Api-Key {{apiKey}}",
+                "type": "text"
+              }
+            ],
+            "url": {
+              "raw": "{{baseUrl}}{{apiPrefix}}/vat/centros/?activo=true",
+              "host": [
+                "{{baseUrl}}{{apiPrefix}}"
+              ],
+              "path": [
+                "vat",
+                "centros",
+                ""
+              ],
+              "query": [
+                {
+                  "key": "activo",
+                  "value": "true"
+                }
+              ]
+            }
+          },
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "pm.test('Status code is 200', function () {",
+                  "  pm.response.to.have.status(200);",
+                  "});",
+                  "const body = pm.response.json();",
+                  "const rows = Array.isArray(body) ? body : (body.results || []);",
+                  "pm.test('La respuesta contiene una lista', function () {",
+                  "  pm.expect(Array.isArray(rows)).to.eql(true);",
+                  "});",
+                  "if (rows.length && rows[0].id) {",
+                  "  pm.collectionVariables.set('centro_id', String(rows[0].id));",
+                  "}"
+                ]
+              }
+            }
+          ],
+          "response": []
+        }
+      ]
+    },
+    {
+      "name": "3 - Cursos por Centro",
+      "description": "Consulta cursos operativos filtrados por centro_id. Guarda curso_id con el primer registro devuelto.",
+      "item": [
+        {
+          "name": "Listar cursos por centro_id",
+          "request": {
+            "method": "GET",
+            "header": [
+              {
+                "key": "Authorization",
+                "value": "Api-Key {{apiKey}}",
+                "type": "text"
+              }
+            ],
+            "url": {
+              "raw": "{{baseUrl}}{{apiPrefix}}/vat/cursos/?centro_id={{centro_id}}",
+              "host": [
+                "{{baseUrl}}{{apiPrefix}}"
+              ],
+              "path": [
+                "vat",
+                "cursos",
+                ""
+              ],
+              "query": [
+                {
+                  "key": "centro_id",
+                  "value": "{{centro_id}}"
+                }
+              ]
+            }
+          },
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "pm.test('Status code is 200', function () {",
+                  "  pm.response.to.have.status(200);",
+                  "});",
+                  "const body = pm.response.json();",
+                  "const rows = Array.isArray(body) ? body : (body.results || []);",
+                  "pm.test('La respuesta contiene una lista', function () {",
+                  "  pm.expect(Array.isArray(rows)).to.eql(true);",
+                  "});",
+                  "if (rows.length && rows[0].id) {",
+                  "  pm.collectionVariables.set('curso_id', String(rows[0].id));",
+                  "}"
+                ]
+              }
+            }
+          ],
+          "response": []
+        },
+        {
+          "name": "Listar cursos por centro_id y estado",
+          "request": {
+            "method": "GET",
+            "header": [
+              {
+                "key": "Authorization",
+                "value": "Api-Key {{apiKey}}",
+                "type": "text"
+              }
+            ],
+            "url": {
+              "raw": "{{baseUrl}}{{apiPrefix}}/vat/cursos/?centro_id={{centro_id}}&estado=activo",
+              "host": [
+                "{{baseUrl}}{{apiPrefix}}"
+              ],
+              "path": [
+                "vat",
+                "cursos",
+                ""
+              ],
+              "query": [
+                {
+                  "key": "centro_id",
+                  "value": "{{centro_id}}"
+                },
+                {
+                  "key": "estado",
+                  "value": "activo"
+                }
+              ]
+            }
+          },
+          "response": []
+        }
+      ]
+    },
+    {
+      "name": "4 - Comisiones de Curso por Curso",
+      "description": "Consulta comisiones operativas filtradas por curso_id. También deja una variante por centro_id.",
+      "item": [
+        {
+          "name": "Listar comisiones de curso por curso_id",
+          "request": {
+            "method": "GET",
+            "header": [
+              {
+                "key": "Authorization",
+                "value": "Api-Key {{apiKey}}",
+                "type": "text"
+              }
+            ],
+            "url": {
+              "raw": "{{baseUrl}}{{apiPrefix}}/vat/comisiones-curso/?curso_id={{curso_id}}",
+              "host": [
+                "{{baseUrl}}{{apiPrefix}}"
+              ],
+              "path": [
+                "vat",
+                "comisiones-curso",
+                ""
+              ],
+              "query": [
+                {
+                  "key": "curso_id",
+                  "value": "{{curso_id}}"
+                }
+              ]
+            }
+          },
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "pm.test('Status code is 200', function () {",
+                  "  pm.response.to.have.status(200);",
+                  "});",
+                  "const body = pm.response.json();",
+                  "const rows = Array.isArray(body) ? body : (body.results || []);",
+                  "pm.test('La respuesta contiene una lista', function () {",
+                  "  pm.expect(Array.isArray(rows)).to.eql(true);",
+                  "});"
+                ]
+              }
+            }
+          ],
+          "response": []
+        },
+        {
+          "name": "Listar comisiones de curso por centro_id",
+          "request": {
+            "method": "GET",
+            "header": [
+              {
+                "key": "Authorization",
+                "value": "Api-Key {{apiKey}}",
+                "type": "text"
+              }
+            ],
+            "url": {
+              "raw": "{{baseUrl}}{{apiPrefix}}/vat/comisiones-curso/?centro_id={{centro_id}}",
+              "host": [
+                "{{baseUrl}}{{apiPrefix}}"
+              ],
+              "path": [
+                "vat",
+                "comisiones-curso",
+                ""
+              ],
+              "query": [
+                {
+                  "key": "centro_id",
+                  "value": "{{centro_id}}"
+                }
+              ]
+            }
+          },
+          "response": []
+        }
+      ]
+    }
+  ]
+}

--- a/postman/VAT - Planes Centros Cursos Comisiones.postman_collection.json
+++ b/postman/VAT - Planes Centros Cursos Comisiones.postman_collection.json
@@ -19,6 +19,14 @@
       "value": ""
     },
     {
+      "key": "provincia_id",
+      "value": ""
+    },
+    {
+      "key": "municipio_id",
+      "value": ""
+    },
+    {
       "key": "plan_id",
       "value": ""
     },
@@ -37,7 +45,105 @@
   ],
   "item": [
     {
-      "name": "0 - Inicio Operativo",
+      "name": "0 - Ubicacion",
+      "description": "Requests auxiliares para obtener provincia y municipio antes de filtrar centros.",
+      "item": [
+        {
+          "name": "Listar provincias",
+          "request": {
+            "method": "GET",
+            "header": [
+              {
+                "key": "Authorization",
+                "value": "Api-Key {{apiKey}}",
+                "type": "text"
+              }
+            ],
+            "url": {
+              "raw": "{{baseUrl}}{{apiPrefix}}/vat/provincias/",
+              "host": [
+                "{{baseUrl}}{{apiPrefix}}"
+              ],
+              "path": [
+                "vat",
+                "provincias",
+                ""
+              ]
+            }
+          },
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "pm.test('Status code is 200', function () {",
+                  "  pm.response.to.have.status(200);",
+                  "});",
+                  "const body = pm.response.json();",
+                  "const rows = Array.isArray(body) ? body : (body.results || []);",
+                  "if (rows.length && rows[0].id) {",
+                  "  pm.collectionVariables.set('provincia_id', String(rows[0].id));",
+                  "}"
+                ]
+              }
+            }
+          ],
+          "response": []
+        },
+        {
+          "name": "Listar municipios por provincia_id",
+          "request": {
+            "method": "GET",
+            "header": [
+              {
+                "key": "Authorization",
+                "value": "Api-Key {{apiKey}}",
+                "type": "text"
+              }
+            ],
+            "url": {
+              "raw": "{{baseUrl}}{{apiPrefix}}/vat/municipios/?provincia_id={{provincia_id}}",
+              "host": [
+                "{{baseUrl}}{{apiPrefix}}"
+              ],
+              "path": [
+                "vat",
+                "municipios",
+                ""
+              ],
+              "query": [
+                {
+                  "key": "provincia_id",
+                  "value": "{{provincia_id}}"
+                }
+              ]
+            }
+          },
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "pm.test('Status code is 200', function () {",
+                  "  pm.response.to.have.status(200);",
+                  "});",
+                  "const body = pm.response.json();",
+                  "const rows = Array.isArray(body) ? body : (body.results || []);",
+                  "if (rows.length && rows[0].id) {",
+                  "  pm.collectionVariables.set('municipio_id', String(rows[0].id));",
+                  "}"
+                ]
+              }
+            }
+          ],
+          "response": []
+        }
+      ]
+    },
+    {
+      "name": "1 - Inicio Operativo",
       "description": "Request inicial para validar API key y disponibilidad de un endpoint operativo antes de encadenar el resto del flujo.",
       "item": [
         {
@@ -87,7 +193,7 @@
       ]
     },
     {
-      "name": "1 - Planes Curriculares",
+      "name": "2 - Planes Curriculares",
       "description": "Obtiene planes curriculares operativos. Guarda plan_id y sector_id con el primer registro devuelto.",
       "item": [
         {
@@ -183,7 +289,7 @@
       ]
     },
     {
-      "name": "2 - Centros",
+      "name": "3 - Centros",
       "description": "Obtiene centros operativos. Guarda centro_id con el primer registro devuelto.",
       "item": [
         {
@@ -237,11 +343,68 @@
             }
           ],
           "response": []
+        },
+        {
+          "name": "Listar centros por provincia_id y municipio_id",
+          "request": {
+            "method": "GET",
+            "header": [
+              {
+                "key": "Authorization",
+                "value": "Api-Key {{apiKey}}",
+                "type": "text"
+              }
+            ],
+            "url": {
+              "raw": "{{baseUrl}}{{apiPrefix}}/vat/centros/?activo=true&provincia_id={{provincia_id}}&municipio_id={{municipio_id}}",
+              "host": [
+                "{{baseUrl}}{{apiPrefix}}"
+              ],
+              "path": [
+                "vat",
+                "centros",
+                ""
+              ],
+              "query": [
+                {
+                  "key": "activo",
+                  "value": "true"
+                },
+                {
+                  "key": "provincia_id",
+                  "value": "{{provincia_id}}"
+                },
+                {
+                  "key": "municipio_id",
+                  "value": "{{municipio_id}}"
+                }
+              ]
+            }
+          },
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "pm.test('Status code is 200', function () {",
+                  "  pm.response.to.have.status(200);",
+                  "});",
+                  "const body = pm.response.json();",
+                  "const rows = Array.isArray(body) ? body : (body.results || []);",
+                  "if (rows.length && rows[0].id) {",
+                  "  pm.collectionVariables.set('centro_id', String(rows[0].id));",
+                  "}"
+                ]
+              }
+            }
+          ],
+          "response": []
         }
       ]
     },
     {
-      "name": "3 - Cursos por Centro",
+      "name": "4 - Cursos por Centro",
       "description": "Consulta cursos operativos filtrados por centro_id. Guarda curso_id con el primer registro devuelto.",
       "item": [
         {
@@ -334,7 +497,7 @@
       ]
     },
     {
-      "name": "4 - Comisiones de Curso por Curso",
+      "name": "5 - Comisiones de Curso por Curso",
       "description": "Consulta comisiones operativas filtradas por curso_id. También deja una variante por centro_id.",
       "item": [
         {

--- a/postman/VAT - Planes Centros Cursos Comisiones.postman_collection.json
+++ b/postman/VAT - Planes Centros Cursos Comisiones.postman_collection.json
@@ -8,7 +8,7 @@
   "variable": [
     {
       "key": "baseUrl",
-      "value": "http://localhost:8000"
+      "value": "http://localhost:8001"
     },
     {
       "key": "apiPrefix",
@@ -405,7 +405,7 @@
     },
     {
       "name": "4 - Cursos por Centro",
-      "description": "Consulta cursos operativos filtrados por centro_id. Guarda curso_id con el primer registro devuelto.",
+      "description": "Consulta cursos operativos filtrados por centro_id o por ubicacion geografica. Guarda curso_id con el primer registro devuelto.",
       "item": [
         {
           "name": "Listar cursos por centro_id",
@@ -493,12 +493,65 @@
             }
           },
           "response": []
+        },
+        {
+          "name": "Listar cursos por provincia_id y municipio_id",
+          "request": {
+            "method": "GET",
+            "header": [
+              {
+                "key": "Authorization",
+                "value": "Api-Key {{apiKey}}",
+                "type": "text"
+              }
+            ],
+            "url": {
+              "raw": "{{baseUrl}}{{apiPrefix}}/vat/cursos/?provincia_id={{provincia_id}}&municipio_id={{municipio_id}}",
+              "host": [
+                "{{baseUrl}}{{apiPrefix}}"
+              ],
+              "path": [
+                "vat",
+                "cursos",
+                ""
+              ],
+              "query": [
+                {
+                  "key": "provincia_id",
+                  "value": "{{provincia_id}}"
+                },
+                {
+                  "key": "municipio_id",
+                  "value": "{{municipio_id}}"
+                }
+              ]
+            }
+          },
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "pm.test('Status code is 200', function () {",
+                  "  pm.response.to.have.status(200);",
+                  "});",
+                  "const body = pm.response.json();",
+                  "const rows = Array.isArray(body) ? body : (body.results || []);",
+                  "if (rows.length && rows[0].id) {",
+                  "  pm.collectionVariables.set('curso_id', String(rows[0].id));",
+                  "}"
+                ]
+              }
+            }
+          ],
+          "response": []
         }
       ]
     },
     {
       "name": "5 - Comisiones de Curso por Curso",
-      "description": "Consulta comisiones operativas filtradas por curso_id. También deja una variante por centro_id.",
+      "description": "Consulta comisiones operativas filtradas por curso_id, centro_id o ubicacion geografica.",
       "item": [
         {
           "name": "Listar comisiones de curso por curso_id",
@@ -574,6 +627,41 @@
                 {
                   "key": "centro_id",
                   "value": "{{centro_id}}"
+                }
+              ]
+            }
+          },
+          "response": []
+        },
+        {
+          "name": "Listar comisiones de curso por provincia_id y municipio_id",
+          "request": {
+            "method": "GET",
+            "header": [
+              {
+                "key": "Authorization",
+                "value": "Api-Key {{apiKey}}",
+                "type": "text"
+              }
+            ],
+            "url": {
+              "raw": "{{baseUrl}}{{apiPrefix}}/vat/comisiones-curso/?provincia_id={{provincia_id}}&municipio_id={{municipio_id}}",
+              "host": [
+                "{{baseUrl}}{{apiPrefix}}"
+              ],
+              "path": [
+                "vat",
+                "comisiones-curso",
+                ""
+              ],
+              "query": [
+                {
+                  "key": "provincia_id",
+                  "value": "{{provincia_id}}"
+                },
+                {
+                  "key": "municipio_id",
+                  "value": "{{municipio_id}}"
                 }
               ]
             }


### PR DESCRIPTION
# Información de la Tarea
Vincular el #ISSUE

### **Resumen de la Solución:** 
- Se agregaron filtros directos por provincia y municipio en los endpoints de cursos y comisiones de curso del módulo VAT.
- Se corrigió y validó la colección Postman para exponer estos nuevos filtros.
- Se actualizaron los tests automáticos para cubrir los nuevos casos de filtrado geográfico.

### **Información Adicional:**
- El backend ya soportaba filtros por centro; ahora permite filtrar directamente por provincia/municipio sin conocer el centro.
- Se ajustó el `baseUrl` de la colección Postman para facilitar pruebas locales.

# Descripción de los Cambios

### **Cambios:**
- `VAT/api_views.py`: se agregaron parámetros y lógica de filtrado por provincia_id y municipio_id en los viewsets de cursos y comisiones.
- `VAT/tests.py`: se sumaron tests automáticos para los nuevos filtros.
- `postman/VAT - Planes Centros Cursos Comisiones.postman_collection.json`: se corrigió la estructura y se agregaron requests para los nuevos filtros.
- `docs/registro/cambios/2026-04-07-fix-api-vat-centros-postman.md`: se documentó el cambio.

# Cómo Testear los Cambios

### **Pruebas Automáticas:**
- Ejecutar pytest sobre `VAT/tests.py` y verificar que pasen los tests de cursos y comisiones por provincia/municipio.

### **Pruebas Manuales:**
- En Postman, cargar la colección y setear una API key válida.
- Probar los endpoints de cursos y comisiones usando los requests por provincia_id y municipio_id.
- Validar que la respuesta sea coherente con los datos de la base.

# Metadata para documentación automática

- Contexto funcional: Exponer filtros geográficos directos en la API operativa de VAT.
- Tipo de cambio: Feature + bugfix menor (Postman).
- Área principal: VAT (cursos, comisiones), integración API externa.
- Resumen para changelog: Se agregan filtros por provincia y municipio en cursos y comisiones de VAT; colección Postman alineada.
- Impacto usuario: Permite consumir la API de manera más flexible y probar fácilmente desde Postman.
- Riesgos / rollback: Bajo; cambios acotados y con tests. Rollback simple restaurando los viewsets y la colección previa.
