### PR TITLE
test(sidebar): desacoplar validacion del changelog

### DIFF
--- a/core/tests/test_sidebar_menu.py
+++ b/core/tests/test_sidebar_menu.py
@@ -1,3 +1,5 @@
+import re
+
 import pytest
 from django.contrib.auth import get_user_model
 from django.urls import reverse
@@ -41,14 +43,9 @@ def test_sidebar_separa_administracion_de_configuracion_comedores(client):
     assert reverse("usuarios") not in config_block
     assert reverse("grupos") not in config_block
 
-    assert 'style="order: 1;"' in content
-    assert 'style="order: 2;"' in content
-    assert 'style="order: 3;"' in content
-    assert 'style="order: 4;"' in content
-    assert 'style="order: 5;"' in content
-    assert (
-        'style="order: 6; border-bottom: 1px solid var(--lte-sidebar-color);"'
-        in content
-    )
-    assert "v06.04.26" in content
+    for expected_order in range(1, 7):
+        assert f'order: {expected_order}' in content
+
+    assert reverse("changelog") in content
     assert 'class="footer-secondary-link"' in content
+    assert re.search(r">v\d{2}\.\d{2}\.\d{2}<", content)

--- a/docs/registro/cambios/2026-04-07-sidebar-test-estable-pr1462.md
+++ b/docs/registro/cambios/2026-04-07-sidebar-test-estable-pr1462.md
@@ -1,0 +1,16 @@
+# Estabilización del test del sidebar para la reorganización del menú
+
+## Contexto
+
+El test agregado para validar la reorganización del menú principal dependía de la versión exacta publicada en `CHANGELOG.md` y de una cadena inline de estilos completa.
+
+## Cambio realizado
+
+- Se ajustó `core/tests/test_sidebar_menu.py` para seguir validando la estructura funcional del menú.
+- Se reemplazó la aserción sobre `v06.04.26` por una validación basada en patrón para la etiqueta de versión mostrada en el footer.
+- Se simplificó la validación del orden visual para evitar acoplarla al formateo exacto del atributo `style`.
+
+## Impacto esperado
+
+- El test sigue cubriendo la reorganización del menú y el acceso al footer de versiones.
+- La prueba deja de fallar por cada nueva release del changelog o por cambios menores de formateo HTML.


### PR DESCRIPTION
why: el test de sidebar dependia de la version exacta publicada y del style inline completo.

what:
- valida el orden visual por presencia de order declarados
- reemplaza la version fija por un patron estable en el footer
- registra el ajuste en docs/registro/cambios

tests: no ejecutados en este entorno; no hay python ni pytest disponibles en PATH

# Información de la Tarea
Vincular el #ISSUE

### **Resumen de la Solución:** 
-

### **Información Adicional:**
-

# Descripción de los Cambios

### **Cambios:**
-

# Cómo Testear los Cambios

### **Pruebas Automáticas:**
-

### **Prubeas Manuales:**
-

# Metadata para documentación automática

- Contexto funcional:
- Tipo de cambio:
- Área principal:
- Resumen para changelog:
- Impacto usuario:
- Riesgos / rollback:

# Capturas de Pantalla
