### PR TITLE
fix(pwa): corregir warning mysql de push subscriptions

### DIFF
--- a/docs/registro/cambios/2026-04-08-pwa-push-endpoint-hash.md
+++ b/docs/registro/cambios/2026-04-08-pwa-push-endpoint-hash.md
@@ -1,0 +1,27 @@
+# Fix de warnings de migraciones PWA/MySQL
+
+## Contexto
+
+Al iniciar Django en entornos MySQL aparecía el warning:
+
+- `pwa.PushSubscriptionPWA.endpoint: (mysql.W003) MySQL may not allow unique CharFields to have a max_length > 255`
+
+Además, en checkouts atrasados respecto de `origin/development` podía aparecer:
+
+- `Your models in app(s): 'users' have changes that are not yet reflected in a migration`
+
+Ese segundo warning no requería un cambio nuevo en `users`: la causa era no tener incorporada la migración `users/0027_bulk_credentials_jobs.py`, ya presente en la base actualizada de `development`.
+
+## Cambio realizado
+
+- `pwa.PushSubscriptionPWA` deja de depender de un `unique=True` sobre `endpoint`.
+- Se agrega `endpoint_hash` (`sha256`, longitud fija 64) como nueva clave única indexable en MySQL.
+- El alta/baja de suscripciones push se resuelve por `endpoint_hash`, manteniendo `endpoint` completo para interoperar con Web Push y para auditoría/admin.
+- Se agrega migración para backfill de hashes existentes.
+- Se agrega test de regresión para endpoints largos.
+
+## Impacto esperado
+
+- Desaparece el warning `mysql.W003` para suscripciones push PWA.
+- Se preserva el comportamiento de `upsert`/baja lógica por endpoint, incluso con endpoints largos.
+- Para eliminar el warning de `users` en un checkout viejo, alcanza con sincronizar `development` actualizado y correr migraciones.

--- a/pwa/migrations/0014_pushsubscriptionpwa_endpoint_hash.py
+++ b/pwa/migrations/0014_pushsubscriptionpwa_endpoint_hash.py
@@ -1,0 +1,52 @@
+import hashlib
+
+from django.db import migrations, models
+
+
+def populate_push_subscription_endpoint_hash(apps, schema_editor):
+    PushSubscriptionPWA = apps.get_model("pwa", "PushSubscriptionPWA")
+
+    for subscription in PushSubscriptionPWA.objects.all().iterator():
+        endpoint = (subscription.endpoint or "").strip()
+        subscription.endpoint = endpoint
+        subscription.endpoint_hash = hashlib.sha256(
+            endpoint.encode("utf-8")
+        ).hexdigest()
+        subscription.save(update_fields=["endpoint", "endpoint_hash"])
+
+
+def noop_reverse(apps, schema_editor):
+    """La reversión no requiere transformar datos."""
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("pwa", "0013_pushsubscriptionpwa"),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name="pushsubscriptionpwa",
+            name="endpoint_hash",
+            field=models.CharField(
+                blank=True,
+                editable=False,
+                max_length=64,
+                null=True,
+            ),
+        ),
+        migrations.RunPython(
+            populate_push_subscription_endpoint_hash,
+            noop_reverse,
+        ),
+        migrations.AlterField(
+            model_name="pushsubscriptionpwa",
+            name="endpoint",
+            field=models.URLField(max_length=500),
+        ),
+        migrations.AlterField(
+            model_name="pushsubscriptionpwa",
+            name="endpoint_hash",
+            field=models.CharField(editable=False, max_length=64, unique=True),
+        ),
+    ]

--- a/pwa/models.py
+++ b/pwa/models.py
@@ -1,3 +1,4 @@
+import hashlib
 import uuid
 
 from django.contrib.auth.models import User
@@ -124,6 +125,15 @@ class AuditoriaOperacionPWA(models.Model):
         return f"{self.entidad}#{self.entidad_id} {self.accion} {self.fecha_evento:%Y-%m-%d %H:%M:%S}"
 
 
+def normalize_push_endpoint(endpoint: str) -> str:
+    return (endpoint or "").strip()
+
+
+def build_push_endpoint_hash(endpoint: str) -> str:
+    normalized_endpoint = normalize_push_endpoint(endpoint)
+    return hashlib.sha256(normalized_endpoint.encode("utf-8")).hexdigest()
+
+
 class LecturaMensajePWA(models.Model):
     """Estado de lectura de mensajes PWA originados en comunicados."""
 
@@ -184,7 +194,8 @@ class PushSubscriptionPWA(models.Model):
         on_delete=models.CASCADE,
         related_name="push_subscriptions_pwa",
     )
-    endpoint = models.URLField(max_length=500, unique=True)
+    endpoint = models.URLField(max_length=500)
+    endpoint_hash = models.CharField(max_length=64, unique=True, editable=False)
     p256dh = models.CharField(max_length=255)
     auth = models.CharField(max_length=255)
     content_encoding = models.CharField(max_length=30, default="aes128gcm")
@@ -208,6 +219,19 @@ class PushSubscriptionPWA(models.Model):
 
     def __str__(self):
         return f"Push user {self.user_id} activo={self.activo}"
+
+    def save(self, *args, **kwargs):
+        self.endpoint = normalize_push_endpoint(self.endpoint)
+        self.endpoint_hash = build_push_endpoint_hash(self.endpoint)
+
+        update_fields = kwargs.get("update_fields")
+        if update_fields is not None:
+            kwargs["update_fields"] = set(update_fields) | {
+                "endpoint",
+                "endpoint_hash",
+            }
+
+        super().save(*args, **kwargs)
 
 
 class ColaboradorEspacioPWA(models.Model):

--- a/pwa/services/push_service.py
+++ b/pwa/services/push_service.py
@@ -6,7 +6,11 @@ from django.contrib.auth import get_user_model
 from django.utils import timezone
 
 from iam.services import user_has_permission_code
-from pwa.models import PushSubscriptionPWA
+from pwa.models import (
+    PushSubscriptionPWA,
+    build_push_endpoint_hash,
+    normalize_push_endpoint,
+)
 from users.services_pwa import get_accessible_comedor_ids
 from users.models import AccesoComedorPWA
 
@@ -34,9 +38,12 @@ def upsert_push_subscription(
     user_agent: str | None = None,
 ):
     now = timezone.now()
+    normalized_endpoint = normalize_push_endpoint(endpoint)
+    endpoint_hash = build_push_endpoint_hash(normalized_endpoint)
     subscription, created = PushSubscriptionPWA.objects.update_or_create(
-        endpoint=endpoint,
+        endpoint_hash=endpoint_hash,
         defaults={
+            "endpoint": normalized_endpoint,
             "user": user,
             "p256dh": p256dh,
             "auth": auth,
@@ -51,9 +58,10 @@ def upsert_push_subscription(
 
 
 def deactivate_push_subscription(*, user, endpoint: str) -> bool:
+    endpoint_hash = build_push_endpoint_hash(endpoint)
     updated = PushSubscriptionPWA.objects.filter(
         user=user,
-        endpoint=endpoint,
+        endpoint_hash=endpoint_hash,
         activo=True,
     ).update(
         activo=False,

--- a/tests/test_pwa_push_api.py
+++ b/tests/test_pwa_push_api.py
@@ -125,6 +125,49 @@ def test_push_subscription_endpoints_create_and_delete(
 
 
 @pytest.mark.django_db
+def test_push_subscription_upsert_soporta_endpoint_largo_en_mysql(
+    espacios_push,
+):
+    espacio_1, _, _ = espacios_push
+    user = _create_pwa_user(comedor=espacio_1, username="push_long_endpoint_user")
+    authed_client = _auth_client_for_user(user)
+    long_endpoint = "https://push.example.com/subscription/" + ("x" * 320)
+
+    create_response = authed_client.post(
+        "/api/pwa/push/subscriptions/",
+        {
+            "endpoint": long_endpoint,
+            "p256dh": "p256dh-key",
+            "auth": "auth-key",
+            "content_encoding": "aes128gcm",
+        },
+        format="json",
+    )
+
+    assert create_response.status_code == 201
+
+    update_response = authed_client.post(
+        "/api/pwa/push/subscriptions/",
+        {
+            "endpoint": long_endpoint,
+            "p256dh": "p256dh-key-updated",
+            "auth": "auth-key-updated",
+            "content_encoding": "aes128gcm",
+        },
+        format="json",
+    )
+
+    assert update_response.status_code == 200
+    assert PushSubscriptionPWA.objects.count() == 1
+
+    subscription = PushSubscriptionPWA.objects.get(user=user)
+    assert subscription.endpoint == long_endpoint
+    assert len(subscription.endpoint_hash) == 64
+    assert subscription.p256dh == "p256dh-key-updated"
+    assert subscription.auth == "auth-key-updated"
+
+
+@pytest.mark.django_db
 def test_revision_de_rendicion_envia_push_a_usuarios_del_scope_con_permiso(
     monkeypatch,
     espacios_push,


### PR DESCRIPTION
why: el modelo PushSubscriptionPWA usaba un endpoint unico de 500 caracteres y Django advertia incompatibilidad potencial con MySQL.

what:\n- agrega endpoint_hash sha256 como clave unica compatible con MySQL\n- ajusta alta y baja de suscripciones para resolver por hash\n- incorpora migracion de backfill y test de regresion para endpoints largos\n- documenta que el warning de users en checkouts viejos se resuelve al sincronizar development

impact: requiere aplicar la nueva migracion pwa/0014_pushsubscriptionpwa_endpoint_hash.py

tests: py -3 -m py_compile pwa\\models.py pwa\\services\\push_service.py tests\\test_pwa_push_api.py pwa\\migrations\\0014_pushsubscriptionpwa_endpoint_hash.py

# Información de la Tarea
Vincular el #ISSUE

### **Resumen de la Solución:** 
-

### **Información Adicional:**
-

# Descripción de los Cambios

### **Cambios:**
-

# Cómo Testear los Cambios

### **Pruebas Automáticas:**
-

### **Prubeas Manuales:**
-

# Metadata para documentación automática

- Contexto funcional:
- Tipo de cambio:
- Área principal:
- Resumen para changelog:
- Impacto usuario:
- Riesgos / rollback:

# Capturas de Pantalla
