### PR TITLE
fix(vat): acelerar busqueda de ciudadanos por documento

### DIFF
--- a/ciudadanos/models.py
+++ b/ciudadanos/models.py
@@ -1,6 +1,7 @@
 from django.contrib.auth import get_user_model
 from django.core.validators import MinValueValidator
 from django.db import models
+from django.db.models import Q
 from django.urls import reverse
 from django.utils import timezone
 from django.core.validators import MaxValueValidator as MaxValidator
@@ -124,6 +125,27 @@ class Ciudadano(SoftDeleteModelMixin, models.Model):
     def nombre_completo(self) -> str:
         return f"{self.nombre} {self.apellido}".strip()
 
+    @staticmethod
+    def documento_prefix_filter(cleaned, field_name="documento"):
+        prefix = int(cleaned)
+        prefix_len = len(cleaned)
+        max_digits = 19
+        max_bigint = 9223372036854775807
+        prefix_filter = Q(**{field_name: prefix})
+        for digits in range(prefix_len + 1, max_digits + 1):
+            multiplier = 10 ** (digits - prefix_len)
+            lower_bound = prefix * multiplier
+            upper_bound = ((prefix + 1) * multiplier) - 1
+            if lower_bound > max_bigint:
+                break
+            prefix_filter |= Q(
+                **{
+                    f"{field_name}__gte": lower_bound,
+                    f"{field_name}__lte": min(upper_bound, max_bigint),
+                }
+            )
+        return prefix_filter
+
     @classmethod
     def buscar_por_documento(cls, query, max_results=10, exclude_id=None):
         cleaned = (query or "").strip()
@@ -131,7 +153,7 @@ class Ciudadano(SoftDeleteModelMixin, models.Model):
         # generan consultas amplias y pueden degradar fuertemente en MySQL.
         if len(cleaned) < 7 or not cleaned.isdigit():
             return cls.objects.none()
-        qs = cls.objects.filter(documento__startswith=cleaned)
+        qs = cls.objects.filter(cls.documento_prefix_filter(cleaned))
         if exclude_id:
             qs = qs.exclude(pk=exclude_id)
         return qs.only("id", "nombre", "apellido", "documento").order_by("documento")[

--- a/comedores/services/comedor_service/impl.py
+++ b/comedores/services/comedor_service/impl.py
@@ -161,7 +161,9 @@ def _apply_nomina_dni_filter(qs_nomina, dni_query):
         return qs_nomina
     if not dni_clean.isdigit():
         return qs_nomina.none()
-    return qs_nomina.filter(ciudadano__documento__startswith=dni_clean)
+    return qs_nomina.filter(
+        Ciudadano.documento_prefix_filter(dni_clean, "ciudadano__documento")
+    )
 
 
 def _build_nomina_page(qs_nomina, page, per_page):

--- a/docs/registro/cambios/2026-04-09-busqueda-ciudadanos-documento-indexable.md
+++ b/docs/registro/cambios/2026-04-09-busqueda-ciudadanos-documento-indexable.md
@@ -1,0 +1,41 @@
+# 2026-04-09 - Busqueda indexable de ciudadanos por documento
+
+## Contexto
+
+La busqueda de ciudadanos desde la carga de comisiones y desde la nomina
+llamaba a `Ciudadano.buscar_por_documento`.
+
+El campo `Ciudadano.documento` es numerico y tiene indice. La busqueda previa
+usaba `documento__startswith`, lo que en MySQL puede forzar comparaciones de
+prefijo sobre texto y degradar el uso del indice. El sintoma observado era una
+consulta muy lenta al buscar por documento en el alta rapida de ciudadanos.
+
+## Cambio
+
+- Se agrego `Ciudadano.documento_prefix_filter` para construir filtros de
+  prefijo como rangos numericos sobre `documento`.
+- `Ciudadano.buscar_por_documento` usa el helper en lugar de
+  `documento__startswith`.
+- El filtro de DNI de nomina en `comedores.services.comedor_service.impl` usa
+  el mismo helper con el path relacionado `ciudadano__documento`.
+- Se agrego un test de regresion para validar que la query generada no use
+  `LIKE` ni `CAST` y mantenga condiciones de rango.
+
+## Analisis contra AGENTS/CODEX
+
+- Cumple con cambios minimos y revisables: se tocaron solo modelo, service y
+  test relacionados con la busqueda.
+- Cumple con el boundary de arquitectura: la regla de acceso a datos vive en
+  el modelo/helper reutilizable.
+- Cumple compatibilidad hacia atras: se mantiene busqueda por prefijo para
+  valores numericos de 7 o mas digitos.
+- Cumple seguridad: no se agregan logs, secretos ni exposicion nueva de PII.
+- Cumple testing minimo: se agrego test de regresion.
+
+## Riesgos y seguimiento
+
+- Confirmar en MySQL con `EXPLAIN` que el plan use el indice de
+  `ciudadanos_ciudadano.documento` en el entorno con datos reales.
+- Si la busqueda real solo debe aceptar DNI de 7 u 8 digitos, se puede evaluar
+  una regla posterior mas estricta. Este cambio preserva la semantica previa de
+  prefijo numerico.

--- a/tests/test_ciudadanos_models_unit.py
+++ b/tests/test_ciudadanos_models_unit.py
@@ -35,3 +35,15 @@ def test_buscar_por_documento_prefijo_siete_digitos_devuelve_coincidencias(db):
     resultados = list(Ciudadano.buscar_por_documento("1234567", max_results=10))
 
     assert [c.pk for c in resultados] == [ciudadano_a.pk, ciudadano_b.pk]
+
+
+def test_buscar_por_documento_usa_rangos_numericos_indexables(db):
+    qs = Ciudadano.buscar_por_documento("1234567", max_results=10)
+
+    sql = str(qs.query).lower()
+
+    assert "like" not in sql
+    assert "cast" not in sql
+    assert "documento" in sql
+    assert ">=" in sql
+    assert "<=" in sql


### PR DESCRIPTION
why: la busqueda por prefijo sobre documento estaba usando startswith y degradaba el uso del indice en MySQL.

what:

- agrega un helper numerico indexable en Ciudadano

- reutiliza el helper en el filtro de nomina

- agrega test de regresion sobre la query generada

- registra el cambio en docs/registro/cambios

tests: uv run black --check ciudadanos/models.py comedores/services/comedor_service/impl.py tests/test_ciudadanos_models_unit.py --config pyproject.toml

tests: uv run pytest tests/test_ciudadanos_models_unit.py tests/test_nomina_views_unit.py -q

tests: uv run pytest tests/test_comedor_service_characterization_db.py -k nomina_detail -q

# Información de la Tarea
Vincular el #ISSUE

### **Resumen de la Solución:** 
-

### **Información Adicional:**
-

# Descripción de los Cambios

### **Cambios:**
-

# Cómo Testear los Cambios

### **Pruebas Automáticas:**
-

### **Prubeas Manuales:**
-

# Metadata para documentación automática

- Contexto funcional:
- Tipo de cambio:
- Área principal:
- Resumen para changelog:
- Impacto usuario:
- Riesgos / rollback:

# Capturas de Pantalla
