### PR TITLE
fix(vat): mostrar 25 cursos por defecto en centro detalle

### DIFF
--- a/VAT/templates/vat/centros/centro_detail.html
+++ b/VAT/templates/vat/centros/centro_detail.html
@@ -2901,7 +2901,7 @@
                         cursosEstadoSelect.value = '';
                     }
                     if (cursosPageSizeSelect) {
-                        cursosPageSizeSelect.value = '10';
+                        cursosPageSizeSelect.value = '25';
                     }
                     applyCourseFilters();
                 });

--- a/VAT/templates/vat/centros/partials/centro_cursos_panel.html
+++ b/VAT/templates/vat/centros/partials/centro_cursos_panel.html
@@ -50,8 +50,8 @@
                                    style="letter-spacing:.05em">Ver</label>
                             <select id="cursosFilterPageSize" class="form-select form-select-sm">
                                 <option value="5">5</option>
-                                <option value="10" selected>10</option>
-                                <option value="25">25</option>
+                                <option value="10">10</option>
+                                <option value="25" selected>25</option>
                                 <option value="50">50</option>
                                 <option value="todos">Todos</option>
                             </select>

--- a/VAT/tests.py
+++ b/VAT/tests.py
@@ -2814,6 +2814,7 @@ def test_centro_detail_difiere_panel_cursos_hasta_abrir_solapa(client, vat_geo_d
     assert 'id="tablaCursosCentro"' not in content
     assert 'id="tablaComisionesCursoCentro"' not in content
     assert "loadCursosPanel" in content
+    assert "cursosPageSizeSelect.value = '25';" in content
 
 
 @pytest.mark.django_db
@@ -2897,6 +2898,7 @@ def test_centro_cursos_panel_renderiza_marcadores_para_filtrar_comisiones_por_cu
     assert 'id="cursosFilterSearch"' in content
     assert 'id="cursosFilterEstado"' in content
     assert 'id="cursosFilterPageSize"' in content
+    assert '<option value="25" selected>25</option>' in content
     assert 'id="cursosFilterClear"' in content
     assert 'class="curso-row"' in content
     assert f'data-curso-id="{_curso.id}"' in content

--- a/docs/registro/cambios/2026-04-11-vat-centro-cursos-default-25.md
+++ b/docs/registro/cambios/2026-04-11-vat-centro-cursos-default-25.md
@@ -1,0 +1,22 @@
+# VAT centro detalle: cursos muestran 25 por defecto
+
+Fecha: 2026-04-11
+
+## Cambio aplicado
+
+En la solapa `#cursos` del detalle de centros (`/vat/centros/<id>/`) el filtro `Ver`
+de la tabla de cursos ahora inicia en `25` registros en lugar de `10`.
+
+Tambien se alineo el boton `Limpiar` del filtro de cursos para que restablezca ese
+mismo valor por defecto.
+
+## Archivos involucrados
+
+- `VAT/templates/vat/centros/partials/centro_cursos_panel.html`
+- `VAT/templates/vat/centros/centro_detail.html`
+- `VAT/tests.py`
+
+## Validacion
+
+- Test puntual del detalle/panel de cursos para verificar el default renderizado y
+  el valor de reset del filtro.


### PR DESCRIPTION
why: la solapa de cursos del detalle de centro iniciaba y se reseteaba en 10 registros, distinto al comportamiento esperado. what:
- cambia el selector Ver de cursos para iniciar en 25
- alinea el boton Limpiar del filtro de cursos al mismo valor
- agrega cobertura puntual y registro spec-as-source

tests: no se pudo ejecutar pytest en este entorno; scripts/ai/codex_run.ps1 fallo por Docker no disponible y .env generado con linea invalida desde .env.example

# Información de la Tarea
Vincular el #ISSUE

### **Resumen de la Solución:** 
-

### **Información Adicional:**
-

# Descripción de los Cambios

### **Cambios:**
-

# Cómo Testear los Cambios

### **Pruebas Automáticas:**
-

### **Prubeas Manuales:**
-

# Metadata para documentación automática

- Contexto funcional:
- Tipo de cambio:
- Área principal:
- Resumen para changelog:
- Impacto usuario:
- Riesgos / rollback:

# Capturas de Pantalla
