### PR TITLE
fix(vat): quitar filtro de modalidad en selector de plan curricular

### DIFF
--- a/VAT/templates/vat/centros/centro_detail.html
+++ b/VAT/templates/vat/centros/centro_detail.html
@@ -2972,7 +2972,6 @@
             var selectorModalEl = document.getElementById('modalPlanCurricularSelector');
             var selectorSearchInput = document.getElementById('planCurricularSelectorSearch');
             var selectorSectorInput = document.getElementById('planCurricularSelectorSector');
-            var selectorModalidadInput = document.getElementById('planCurricularSelectorModalidad');
             var selectorSummaryEl = document.getElementById('planCurricularSelectorSummary');
             var selectorButtonLabelEl = document.getElementById('planCurricularSelectorButtonLabel');
             var selectorEmptyStateEl = document.getElementById('planCurricularSelectorEmpty');
@@ -3067,31 +3066,22 @@
             }
 
             function populatePlanSelectorFilters() {
-                if (!selectorSectorInput || !selectorModalidadInput) return;
+                if (!selectorSectorInput) return;
 
                 var selectedSector = selectorSectorInput.value || '';
-                var selectedModalidad = selectorModalidadInput.value || '';
                 var sectors = [];
-                var modalidades = [];
 
                 selectorRows.forEach(function(row) {
                     var sector = row.dataset.planSector || '';
-                    var modalidad = row.dataset.planModalidad || '';
 
                     if (sector && !sectors.includes(sector)) {
                         sectors.push(sector);
                     }
-
-                    if (modalidad && !modalidades.includes(modalidad)) {
-                        modalidades.push(modalidad);
-                    }
                 });
 
                 sectors.sort();
-                modalidades.sort();
 
                 selectorSectorInput.innerHTML = '<option value="">Todos los sectores</option>';
-                selectorModalidadInput.innerHTML = '<option value="">Todas las modalidades</option>';
 
                 sectors.forEach(function(sector) {
                     var option = document.createElement('option');
@@ -3099,14 +3089,6 @@
                     option.textContent = sector;
                     option.selected = sector === selectedSector;
                     selectorSectorInput.appendChild(option);
-                });
-
-                modalidades.forEach(function(modalidad) {
-                    var option = document.createElement('option');
-                    option.value = modalidad;
-                    option.textContent = modalidad;
-                    option.selected = modalidad === selectedModalidad;
-                    selectorModalidadInput.appendChild(option);
                 });
             }
 
@@ -3149,23 +3131,18 @@
                     selectorSearchInput ? selectorSearchInput.value : ''
                 );
                 var sectorValue = selectorSectorInput ? selectorSectorInput.value : '';
-                var modalidadValue = selectorModalidadInput
-                    ? selectorModalidadInput.value
-                    : '';
                 var visibleRows = 0;
 
                 selectorRows.forEach(function(row) {
                     var matchesSearch = !searchValue || [
                         row.dataset.planLabel,
                         row.dataset.planSector,
-                        row.dataset.planModalidad,
                         row.dataset.planNormativa,
                     ].some(function(value) {
                         return normalizePlanSelectorValue(value).includes(searchValue);
                     });
                     var matchesSector = !sectorValue || row.dataset.planSector === sectorValue;
-                    var matchesModalidad = !modalidadValue || row.dataset.planModalidad === modalidadValue;
-                    var isVisible = matchesSearch && matchesSector && matchesModalidad;
+                    var isVisible = matchesSearch && matchesSector;
 
                     row.classList.toggle('d-none', !isVisible);
                     if (isVisible) {
@@ -3212,10 +3189,6 @@
 
             if (selectorSectorInput) {
                 selectorSectorInput.addEventListener('change', applyPlanSelectorFilters);
-            }
-
-            if (selectorModalidadInput) {
-                selectorModalidadInput.addEventListener('change', applyPlanSelectorFilters);
             }
 
             if (selectorOpenButton && selectorModalEl && window.bootstrap && window.bootstrap.Modal) {

--- a/VAT/templates/vat/centros/partials/centro_cursos_panel.html
+++ b/VAT/templates/vat/centros/partials/centro_cursos_panel.html
@@ -422,7 +422,7 @@
                             <input type="search"
                                    id="planCurricularSelectorSearch"
                                    class="form-control form-control-sm"
-                                   placeholder="Buscar por plan, sector, modalidad o normativa"
+                                   placeholder="Buscar por plan, sector o normativa"
                                    autocomplete="off" />
                         </div>
                         <div class="col-sm-6 col-lg-3">
@@ -431,15 +431,6 @@
                                    style="letter-spacing:.05em">Sector</label>
                             <select id="planCurricularSelectorSector" class="form-select form-select-sm">
                                 <option value="">Todos los sectores</option>
-                            </select>
-                        </div>
-                        <div class="col-sm-6 col-lg-3">
-                            <label for="planCurricularSelectorModalidad"
-                                   class="form-label small fw-semibold text-uppercase mb-1"
-                                   style="letter-spacing:.05em">Modalidad</label>
-                            <select id="planCurricularSelectorModalidad"
-                                    class="form-select form-select-sm">
-                                <option value="">Todas las modalidades</option>
                             </select>
                         </div>
                     </div>
@@ -461,7 +452,6 @@
                                         data-plan-id="{{ plan.id }}"
                                         data-plan-label="{% if plan.nombre %}{{ plan.nombre }}{% elif plan.titulo_referencia %}{{ plan.titulo_referencia.nombre }}{% else %}{{ plan.sector.nombre }}{% endif %}"
                                         data-plan-sector="{{ plan.sector.nombre|default:'' }}"
-                                        data-plan-modalidad="{{ plan.modalidad_cursada.nombre|default:'' }}"
                                         data-plan-normativa="{{ plan.normativa|default:'' }}">
                                         <td class="fw-semibold">
                                             {% if plan.nombre %}

--- a/VAT/tests.py
+++ b/VAT/tests.py
@@ -2994,7 +2994,7 @@ def test_centro_cursos_panel_renderiza_selector_de_planes_en_modal_nuevo_curso(
     assert 'id="openPlanCurricularSelector"' in content
     assert 'id="planCurricularSelectorSearch"' in content
     assert 'id="planCurricularSelectorSector"' in content
-    assert 'id="planCurricularSelectorModalidad"' in content
+    assert 'id="planCurricularSelectorModalidad"' not in content
     assert 'id="tablaPlanCurricularSelector"' in content
     assert "Plan Curricular" in content
     assert (
@@ -3002,6 +3002,7 @@ def test_centro_cursos_panel_renderiza_selector_de_planes_en_modal_nuevo_curso(
         in content
     )
     assert "Seleccionar plan curricular" in content
+    assert "Buscar por plan, sector o normativa" in content
     assert f'value="{plan.id}"' in content
     assert f'value="{plan_inactivo.id}"' not in content
     assert f'value="{plan_otra_provincia.id}"' not in content

--- a/docs/registro/cambios/2026-04-11-quitar-filtro-modalidad-selector-plan-curricular.md
+++ b/docs/registro/cambios/2026-04-11-quitar-filtro-modalidad-selector-plan-curricular.md
@@ -1,0 +1,20 @@
+# Cambio VAT: selector de plan curricular sin filtro por modalidad
+
+## Fecha
+
+- 2026-04-11
+
+## Alcance
+
+- Se eliminó del front el filtro `Modalidad` del modal `Seleccionar Plan Curricular` en la sección de cursos del detalle de centros VAT.
+- Se mantuvo visible la columna `Modalidad` dentro de la tabla del listado para conservar el contexto del usuario al elegir un plan.
+
+## Decisión de implementación
+
+- El cambio se resolvió solo en el front del modal, retirando el control visual y la lógica JavaScript asociada al filtrado por modalidad.
+- Se conservaron los filtros restantes: búsqueda general y sector.
+
+## Validación esperada
+
+- Al abrir `Nuevo Curso` en `.../vat/centros/<id>/#cursos`, el modal de selección de plan curricular muestra únicamente los filtros `Buscar` y `Sector`.
+- La tabla sigue mostrando la columna `Modalidad`.


### PR DESCRIPTION
why: en el modal de seleccion de plan curricular del alta de cursos se pidio dejar disponibles solo los filtros de busqueda y sector.

what:
- elimina el select de modalidad del modal
- retira la logica JS asociada al filtrado por modalidad
- ajusta el test de render del panel de cursos
- registra el cambio en docs/registro/cambios

tests:
- validacion automatica no ejecutada por falta de docker y de pytest/black/djlint en el entorno actual

# Información de la Tarea
Vincular el #ISSUE

### **Resumen de la Solución:** 
-

### **Información Adicional:**
-

# Descripción de los Cambios

### **Cambios:**
-

# Cómo Testear los Cambios

### **Pruebas Automáticas:**
-

### **Prubeas Manuales:**
-

# Metadata para documentación automática

- Contexto funcional:
- Tipo de cambio:
- Área principal:
- Resumen para changelog:
- Impacto usuario:
- Riesgos / rollback:

# Capturas de Pantalla
