### PR TITLE
fix(vat): redirigir edición de ubicaciones al centro

### DIFF
--- a/VAT/templates/vat/institucion/ubicacion_form.html
+++ b/VAT/templates/vat/institucion/ubicacion_form.html
@@ -1,5 +1,6 @@
 {% extends "includes/main.html" %}
 {% load static %}
+{% url 'vat_institucion_ubicacion_list' as ubicacion_list_url %}
 
 {% block title %}
     {% if form.instance.id %}
@@ -15,7 +16,7 @@
         <div class="row mb-4">
             <div class="col-12">
                 <div class="d-flex align-items-center gap-2 mb-4">
-                    <a href="{% url 'vat_institucion_ubicacion_list' %}"
+                    <a href="{{ return_url|default:ubicacion_list_url }}"
                        class="btn btn-light"><i class="bi bi-arrow-left"></i></a>
                     <div>
                         <h1 class="h2 mb-0" style="color: #1f3a93;">
@@ -108,7 +109,7 @@
 
                             <hr class="my-4" />
                             <div class="d-flex gap-2 justify-content-end">
-                                <a href="{% url 'vat_institucion_ubicacion_list' %}"
+                                <a href="{{ return_url|default:ubicacion_list_url }}"
                                    class="btn btn-outline-secondary"><i class="bi bi-x-lg me-2"></i>Cancelar</a>
                                 <button type="submit" class="btn btn-primary">
                                     <i class="bi bi-check-lg me-2"></i>

--- a/VAT/tests.py
+++ b/VAT/tests.py
@@ -1330,6 +1330,72 @@ def test_centro_detail_muestra_boton_editar_para_referente_cfp(client, vat_geo_d
 
 
 @pytest.mark.django_db
+@override_settings(ROOT_URLCONF="config.urls")
+def test_institucion_ubicacion_update_redirige_al_detalle_del_centro(
+    client, vat_geo_data
+):
+    provincia, municipio, localidad = vat_geo_data
+    group, _ = Group.objects.get_or_create(name="CFP")
+    user = User.objects.create_superuser(
+        username="admin-ubicacion-update",
+        email="admin-ubicacion-update@vat.test",
+        password="test1234",
+    )
+    user.groups.add(group)
+    centro = Centro.objects.create(
+        nombre="Centro Ubicaciones",
+        codigo="CFP-UBI-001",
+        provincia=provincia,
+        municipio=municipio,
+        localidad=localidad,
+        calle="8",
+        numero=456,
+        domicilio_actividad="Calle 8 N° 456",
+        telefono="221-4100000",
+        celular="221-5100000",
+        correo="centro-ubicaciones@vat.test",
+        nombre_referente="Luisa",
+        apellido_referente="Martinez",
+        telefono_referente="221-6100000",
+        correo_referente="luisa@vat.test",
+        referente=user,
+        tipo_gestion="Estatal",
+        clase_institucion="Formación Profesional",
+        situacion="Institución de ETP",
+        activo=True,
+    )
+    ubicacion = InstitucionUbicacion.objects.create(
+        centro=centro,
+        localidad=localidad,
+        rol_ubicacion="anexo",
+        nombre_ubicacion="Anexo Norte",
+        domicilio="Calle 8 N° 460",
+        es_principal=False,
+    )
+
+    client.force_login(user)
+    response = client.post(
+        reverse("vat_institucion_ubicacion_update", kwargs={"pk": ubicacion.pk}),
+        data={
+            "centro": str(centro.pk),
+            "localidad": str(localidad.pk),
+            "rol_ubicacion": "anexo",
+            "nombre_ubicacion": "Anexo Norte Actualizado",
+            "domicilio": "Calle 8 N° 999",
+            "observaciones": "Actualización desde el legajo del centro",
+        },
+    )
+
+    ubicacion.refresh_from_db()
+
+    assert response.status_code == 302
+    assert response.url == reverse("vat_centro_detail", kwargs={"pk": centro.pk})
+    assert ubicacion.nombre_ubicacion == "Anexo Norte Actualizado"
+    assert ubicacion.domicilio == "Calle 8 N° 999"
+    assert ubicacion.observaciones == "Actualización desde el legajo del centro"
+
+
+@pytest.mark.django_db
 def test_plan_curricular_list_usuario_no_provincial_recibe_403(client):
     user = User.objects.create_user(username="no-provincial-plan", password="test1234")
     permiso_view_plan = Permission.objects.get(

--- a/VAT/views/institucion.py
+++ b/VAT/views/institucion.py
@@ -1,6 +1,6 @@
 import logging
 from django.contrib.auth.mixins import LoginRequiredMixin
-from django.urls import reverse_lazy
+from django.urls import reverse, reverse_lazy
 from django.views.generic import (
     ListView,
     CreateView,
@@ -239,7 +239,14 @@ class InstitucionUbicacionUpdateView(LoginRequiredMixin, UpdateView):
     model = InstitucionUbicacion
     form_class = InstitucionUbicacionForm
     template_name = "vat/institucion/ubicacion_form.html"
-    success_url = reverse_lazy("vat_institucion_ubicacion_list")
+
+    def get_success_url(self):
+        return reverse("vat_centro_detail", kwargs={"pk": self.object.centro_id})
+
+    def get_context_data(self, **kwargs):
+        context = super().get_context_data(**kwargs)
+        context["return_url"] = self.get_success_url()
+        return context
 
     def form_valid(self, form):
         messages.success(self.request, "Ubicación actualizada exitosamente.")

--- a/docs/registro/cambios/2026-04-11-vat-redirect-ubicacion-centro.md
+++ b/docs/registro/cambios/2026-04-11-vat-redirect-ubicacion-centro.md
@@ -1,0 +1,17 @@
+# VAT - retorno al centro al editar ubicaciones adicionales
+
+## Qué cambió
+
+- La actualización de una `Ubicación Adicional` ahora redirige al detalle del centro asociado en lugar de volver a la lista global de ubicaciones.
+- El formulario de edición reutiliza la misma URL de retorno para el botón superior de volver y para `Cancelar`.
+
+## Contexto
+
+- En el legajo de centros (`/vat/centros/<pk>/`) las ubicaciones adicionales se gestionan como datos hijos del centro.
+- El flujo actual ignoraba esa jerarquía y, al guardar o cancelar una edición, enviaba al usuario a `/vat/institucion/ubicaciones/`, cortando el contexto del legajo.
+
+## Validación esperada
+
+- Entrar al detalle de un centro con ubicaciones adicionales.
+- Editar una ubicación existente desde la tabla del legajo.
+- Guardar cambios y verificar que la navegación vuelve a `/vat/centros/<pk>/` mostrando los datos actualizados.


### PR DESCRIPTION
why: las ubicaciones adicionales se editan desde el legajo del centro y el flujo estaba volviendo a la lista global, perdiendo contexto.

what:
- redirige el update de ubicaciones al detalle del centro padre
- reutiliza esa URL en volver/cancelar del formulario de edición
- agrega test de regresión y registro spec-as-source

tests:
- py -3 -m black VAT/views/institucion.py VAT/tests.py --check --config pyproject.toml
- py -3 -m djlint VAT/templates/vat/institucion/ubicacion_form.html --check --configuration=.djlintrc
- py -3 -m py_compile VAT/views/institucion.py VAT/tests.py
- py -3 -m pytest VAT/tests.py -k institucion_ubicacion_update_redirige_al_detalle_del_centro (no disponible: falta el módulo pytest en el entorno)

# Información de la Tarea
Vincular el #ISSUE

### **Resumen de la Solución:** 
-

### **Información Adicional:**
-

# Descripción de los Cambios

### **Cambios:**
-

# Cómo Testear los Cambios

### **Pruebas Automáticas:**
-

### **Prubeas Manuales:**
-

# Metadata para documentación automática

- Contexto funcional:
- Tipo de cambio:
- Área principal:
- Resumen para changelog:
- Impacto usuario:
- Riesgos / rollback:

# Capturas de Pantalla
