### PR TITLE
fix(celiaquia): quitar obligatoriedad de responsable en mayores

### DIFF
--- a/celiaquia/services/importacion_service/impl.py
+++ b/celiaquia/services/importacion_service/impl.py
@@ -1705,8 +1705,24 @@ def _tiene_datos_responsable_importacion(payload):
     )
 
 
+def _beneficiario_requiere_responsable_importacion(payload):
+    edad = ValidacionEdadService.calcular_edad(payload.get("fecha_nacimiento"))
+    return edad is not None and edad < 18
+
+
+def _responsable_completo_importacion(payload):
+    return all(
+        _valor_tiene_contenido_importacion(payload.get(field))
+        for field in IMPORTACION_RESPONSABLE_REQUIRED_FIELDS
+    )
+
+
 def _debe_validarse_responsable_importacion(payload):
-    return _tiene_datos_responsable_importacion(payload)
+    if not _tiene_datos_responsable_importacion(payload):
+        return False
+    if _beneficiario_requiere_responsable_importacion(payload):
+        return True
+    return _responsable_completo_importacion(payload)
 
 
 IMPORTACION_NUMERIC_FIELDS = {

--- a/celiaquia/templates/celiaquia/expediente_detail.html
+++ b/celiaquia/templates/celiaquia/expediente_detail.html
@@ -518,7 +518,7 @@
                                                 <!-- Col 3: Archivos y Comentarios -->
                                                 <div class="col-lg-5">
                                                     {% include 'components/legajo_archivos_requeridos.html' with legajo=leg is_prov=is_prov expediente=expediente %}
- 
+
                                                     <!-- Comentarios Técnicos -->
                                                     {% if is_tec or is_coord or is_prov and leg.revision_tecnico == 'SUBSANAR' %}
                                                         {% include 'components/legajo_comentarios.html' with legajo=leg is_tec=is_tec is_coord=is_coord %}
@@ -1034,41 +1034,58 @@
                                             </h6>
                                             <div class="row g-2">
                                                 <div class="col-md-4">
-                                                    <label class="form-label">Apellido Responsable *</label>
+                                                    <label class="form-label">
+                                                        Apellido Responsable
+                                                        {% if registro.responsable_requerido %}*{% endif %}
+                                                    </label>
                                                     <input type="text"
                                                            class="form-control"
                                                            name="apellido_responsable"
                                                            value="{{ registro.datos_raw.apellido_responsable|default:'' }}"
-                                                           required />
+                                                           {% if registro.responsable_requerido %}required{% endif %} />
                                                 </div>
                                                 <div class="col-md-4">
-                                                    <label class="form-label">Nombre Responsable *</label>
+                                                    <label class="form-label">
+                                                        Nombre Responsable
+                                                        {% if registro.responsable_requerido %}*{% endif %}
+                                                    </label>
                                                     <input type="text"
                                                            class="form-control"
                                                            name="nombre_responsable"
                                                            value="{{ registro.datos_raw.nombre_responsable|default:'' }}"
-                                                           required />
+                                                           {% if registro.responsable_requerido %}required{% endif %} />
                                                 </div>
                                                 <div class="col-md-4">
-                                                    <label class="form-label">CUIT/Documento Responsable *</label>
+                                                    <label class="form-label">
+                                                        CUIT/Documento Responsable
+                                                        {% if registro.responsable_requerido %}*{% endif %}
+                                                    </label>
                                                     <input type="text"
                                                            class="form-control"
                                                            name="documento_responsable"
                                                            value="{{ registro.datos_raw.documento_responsable|default:'' }}"
-                                                           required />
+                                                           {% if registro.responsable_requerido %}required{% endif %} />
                                                 </div>
                                                 <div class="col-md-4">
-                                                    <label class="form-label">Fecha Nac. Responsable *</label>
+                                                    <label class="form-label">
+                                                        Fecha Nac. Responsable
+                                                        {% if registro.responsable_requerido %}*{% endif %}
+                                                    </label>
                                                     <input type="text"
                                                            class="form-control"
                                                            name="fecha_nacimiento_responsable"
                                                            value="{{ registro.datos_raw.fecha_nacimiento_responsable|default:'' }}"
                                                            placeholder="DD/MM/YYYY"
-                                                           required />
+                                                           {% if registro.responsable_requerido %}required{% endif %} />
                                                 </div>
                                                 <div class="col-md-4">
-                                                    <label class="form-label">Sexo Responsable *</label>
-                                                    <select class="form-select" name="sexo_responsable" required>
+                                                    <label class="form-label">
+                                                        Sexo Responsable
+                                                        {% if registro.responsable_requerido %}*{% endif %}
+                                                    </label>
+                                                    <select class="form-select"
+                                                            name="sexo_responsable"
+                                                            {% if registro.responsable_requerido %}required{% endif %}>
                                                         <option value="">Seleccionar...</option>
                                                         {% for sexo in sexos %}
                                                             <option value="{{ sexo.id }}"
@@ -1093,16 +1110,24 @@
                                                            value="{{ registro.datos_raw.email_responsable|default:'' }}" />
                                                 </div>
                                                 <div class="col-md-6">
-                                                    <label class="form-label">Domicilio Responsable *</label>
+                                                    <label class="form-label">
+                                                        Domicilio Responsable
+                                                        {% if registro.responsable_requerido %}*{% endif %}
+                                                    </label>
                                                     <input type="text"
                                                            class="form-control"
                                                            name="domicilio_responsable"
                                                            value="{{ registro.datos_raw.domicilio_responsable|default:'' }}"
-                                                           required />
+                                                           {% if registro.responsable_requerido %}required{% endif %} />
                                                 </div>
                                                 <div class="col-md-6">
-                                                    <label class="form-label">Localidad Responsable *</label>
-                                                    <select class="form-select" name="localidad_responsable" required>
+                                                    <label class="form-label">
+                                                        Localidad Responsable
+                                                        {% if registro.responsable_requerido %}*{% endif %}
+                                                    </label>
+                                                    <select class="form-select"
+                                                            name="localidad_responsable"
+                                                            {% if registro.responsable_requerido %}required{% endif %}>
                                                         <option value="">Seleccionar...</option>
                                                         {% for loc in localidades %}
                                                             <option value="{{ loc.id }}"

--- a/celiaquia/tests/test_registros_erroneos_obligatorios.py
+++ b/celiaquia/tests/test_registros_erroneos_obligatorios.py
@@ -185,6 +185,50 @@ def test_detalle_expediente_muestra_campos_responsable_para_registros_erroneos(c
 
 
 @pytest.mark.django_db
+def test_detalle_expediente_no_marca_responsable_como_obligatorio_para_mayor(client):
+    user, provincia = _crear_usuario_provincial("prov_detail_adulto")
+    permission = Permission.objects.get(
+        content_type__app_label="celiaquia",
+        codename="view_expediente",
+    )
+    user.user_permissions.add(permission)
+
+    expediente = _crear_contexto_expediente(user)
+    municipio = Municipio.objects.create(nombre="La Plata", provincia=provincia)
+    localidad = Localidad.objects.create(nombre="Centro", municipio=municipio)
+    Nacionalidad.objects.create(nacionalidad="Argentina")
+    Sexo.objects.create(sexo="Masculino")
+    RegistroErroneo.objects.create(
+        expediente=expediente,
+        fila_excel=2,
+        datos_raw={
+            "apellido": "Perez",
+            "nombre": "Ana",
+            "documento": "12345678",
+            "fecha_nacimiento": "01/01/1990",
+            "sexo": "Masculino",
+            "nacionalidad": "Argentina",
+            "municipio": str(municipio.pk),
+            "localidad": str(localidad.pk),
+            "calle": "Calle 1",
+            "altura": "123",
+            "codigo_postal": "1000",
+            "apellido_responsable": "Gomez",
+        },
+        mensaje_error="Registro con datos pendientes",
+    )
+
+    client.force_login(user)
+    response = client.get(reverse("expediente_detail", args=[expediente.pk]))
+
+    assert response.status_code == 200
+    content = response.content.decode()
+    assert "Apellido Responsable *" not in content
+    assert re.search(r'name="apellido_responsable"[^>]*required', content) is None
+    assert re.search(r'name="localidad_responsable"[^>]*required', content) is None
+
+
+@pytest.mark.django_db
 def test_detalle_expediente_autocompleta_sexo_m_f_en_registros_erroneos(client):
     user, provincia = _crear_usuario_provincial("prov_detail_sexo_mf")
     permission = Permission.objects.get(
@@ -346,6 +390,52 @@ def test_actualizar_registro_erroneo_rechaza_campos_obligatorios_faltantes(clien
     registro.refresh_from_db()
     assert registro.datos_raw["sexo"] == "1"
     assert "sexo" in registro.mensaje_error.lower()
+
+
+@pytest.mark.django_db
+def test_actualizar_registro_erroneo_permite_mayor_con_responsable_incompleto(client):
+    user, provincia = _crear_usuario_provincial("prov_update_adulto")
+    user.is_superuser = True
+    user.save(update_fields=["is_superuser"])
+    expediente = _crear_contexto_expediente(user)
+    municipio = Municipio.objects.create(nombre="La Plata", provincia=provincia)
+    localidad = Localidad.objects.create(nombre="Centro", municipio=municipio)
+    argentina = Nacionalidad.objects.create(nacionalidad="Argentina")
+    sexo = Sexo.objects.create(sexo="Masculino")
+    registro = RegistroErroneo.objects.create(
+        expediente=expediente,
+        fila_excel=6,
+        datos_raw={
+            "apellido": "Perez",
+            "nombre": "Ana",
+            "documento": "12345678",
+            "fecha_nacimiento": "01/01/1990",
+            "sexo": str(sexo.pk),
+            "nacionalidad": str(argentina.pk),
+            "municipio": str(municipio.pk),
+            "localidad": str(localidad.pk),
+            "calle": "Calle 1",
+            "altura": "123",
+            "codigo_postal": "1000",
+            "apellido_responsable": "Gomez",
+        },
+        mensaje_error="Faltan campos obligatorios: nombre_responsable",
+    )
+
+    payload = dict(registro.datos_raw)
+
+    client.force_login(user)
+    response = client.post(
+        reverse("registro_erroneo_actualizar", args=[expediente.pk, registro.pk]),
+        data=json.dumps(payload),
+        content_type="application/json",
+    )
+
+    assert response.status_code == 200
+    assert response.json()["success"] is True
+
+    registro.refresh_from_db()
+    assert registro.datos_raw["apellido_responsable"] == "Gomez"
 
 
 @pytest.mark.django_db
@@ -666,7 +756,7 @@ def test_importacion_menor_sin_responsable_genera_error():
 
 
 @pytest.mark.django_db
-def test_importacion_mayor_con_datos_parciales_de_responsable_exige_completar_obligatorios():
+def test_importacion_mayor_con_datos_parciales_de_responsable_no_bloquea_importacion():
     user, provincia = _crear_usuario_provincial("prov_mayor_resp_parcial")
     expediente = _crear_contexto_expediente(user)
     EstadoLegajo.objects.create(nombre="DOCUMENTO_PENDIENTE")
@@ -733,15 +823,10 @@ def test_importacion_mayor_con_datos_parciales_de_responsable_exige_completar_ob
         usuario=user,
     )
 
-    assert resultado["validos"] == 0
-    assert resultado["errores"] == 1
-    assert ExpedienteCiudadano.objects.count() == 0
-
-    registro = RegistroErroneo.objects.get(expediente=expediente)
-    mensaje = registro.mensaje_error.lower()
-    assert "faltan campos obligatorios" in mensaje
-    assert "apellido_responsable" in mensaje
-    assert "documento_responsable" in mensaje
+    assert resultado["validos"] == 1
+    assert resultado["errores"] == 0
+    assert ExpedienteCiudadano.objects.count() == 1
+    assert not RegistroErroneo.objects.filter(expediente=expediente).exists()
 
 
 @pytest.mark.django_db

--- a/celiaquia/views/expediente.py
+++ b/celiaquia/views/expediente.py
@@ -42,6 +42,7 @@ from celiaquia.services.importacion_service import (
     ImportacionService,
     IMPORTACION_EDITABLE_FIELDS,
     IMPORTACION_RESPONSABLE_FIELDS,
+    _beneficiario_requiere_responsable_importacion,
     validar_y_normalizar_payloads_importacion,
 )
 from celiaquia.services.cruce_service import CruceService
@@ -215,6 +216,20 @@ def _validar_datos_registro_erroneo(payload, provincia_id, fila_excel=0):
         provincia_usuario_id=provincia_id,
         offset=fila_excel,
     )
+
+
+def _registro_erroneo_responsable_requerido(payload):
+    fecha_nacimiento = payload.get("fecha_nacimiento")
+    if fecha_nacimiento in (None, ""):
+        return False
+    try:
+        payload_normalizado = dict(payload)
+        payload_normalizado["fecha_nacimiento"] = CiudadanoService._to_date(
+            fecha_nacimiento
+        )
+    except ValidationError:
+        return False
+    return _beneficiario_requiere_responsable_importacion(payload_normalizado)
 
 
 def _user_provincia(user):
@@ -872,6 +887,9 @@ class ExpedienteDetailView(DetailView):
         for registro in registros_erroneos:
             datos_render = _aplicar_defaults_registro_erroneo(
                 _normalizar_datos_registro_erroneo(registro.datos_raw or {})
+            )
+            registro.responsable_requerido = _registro_erroneo_responsable_requerido(
+                datos_render
             )
             registro.nacionalidad_default_id = datos_render.get(
                 "nacionalidad", nacionalidad_argentina_id

--- a/docs/registro/cambios/2026-04-11-fix-celiaquia-responsable-obligatorio-solo-menores.md
+++ b/docs/registro/cambios/2026-04-11-fix-celiaquia-responsable-obligatorio-solo-menores.md
@@ -1,0 +1,26 @@
+# 2026-04-11 - Celiaquía: responsable obligatorio solo para menores en registros erróneos
+
+## Qué se cambió
+
+- El importador de expedientes ya no bloquea a beneficiarios mayores de edad cuando el bloque de responsable está incompleto.
+- Para mayores, el responsable queda opcional: solo se valida y procesa si el bloque obligatorio del responsable está completo.
+- El editor de registros erróneos ahora marca los campos de responsable como obligatorios únicamente cuando el beneficiario es menor de edad.
+
+## Decisión de diseño
+
+Se mantuvo una sola regla funcional en backend:
+
+- Menor de edad: responsable obligatorio.
+- Mayor de edad: responsable opcional.
+
+La UI replica esa misma decisión mostrando `required` solo cuando corresponde, para evitar que el formulario pida completar datos de responsable en adultos con errores no relacionados.
+
+## Validación
+
+- `uv run --with-requirements requirements.txt pytest tests/test_importacion_service_helpers_unit.py tests/test_celiaquia_expediente_view_helpers_unit.py -q`
+- `uv run --with black black --check celiaquia/services/importacion_service/impl.py celiaquia/views/expediente.py celiaquia/tests/test_registros_erroneos_obligatorios.py tests/test_importacion_service_helpers_unit.py tests/test_celiaquia_expediente_view_helpers_unit.py`
+- `uv run --with djlint djlint celiaquia/templates/celiaquia/expediente_detail.html --check --configuration=.djlintrc`
+
+## Limitaciones de validación en este entorno
+
+- No se pudo ejecutar la suite de views/integración que usa `reverse(...)` porque el entorno local no tiene disponibles las librerías nativas requeridas por WeasyPrint (`libgobject-2.0-0`) durante la carga del árbol completo de URLs.

--- a/tests/test_celiaquia_expediente_view_helpers_unit.py
+++ b/tests/test_celiaquia_expediente_view_helpers_unit.py
@@ -72,6 +72,27 @@ def test_resolver_provincia_registro_erroneo_fallback_a_usuario_expediente():
     assert provincia_id == 33
 
 
+def test_registro_erroneo_responsable_requerido_depende_de_edad():
+    assert (
+        module._registro_erroneo_responsable_requerido(
+            {"fecha_nacimiento": "01/01/2010"}
+        )
+        is True
+    )
+    assert (
+        module._registro_erroneo_responsable_requerido(
+            {"fecha_nacimiento": "01/01/1990"}
+        )
+        is False
+    )
+    assert (
+        module._registro_erroneo_responsable_requerido(
+            {"fecha_nacimiento": "fecha-invalida"}
+        )
+        is False
+    )
+
+
 def test_aplicar_defaults_registro_erroneo_fuerza_argentina_y_municipio_por_localidad(
     mocker,
 ):

--- a/tests/test_importacion_service_helpers_unit.py
+++ b/tests/test_importacion_service_helpers_unit.py
@@ -933,6 +933,39 @@ def test_importacion_helpers_orquesta_beneficiario_y_detecta_responsable(mocker)
         )
         is True
     )
+    assert (
+        module._debe_validarse_responsable_importacion(
+            {
+                "fecha_nacimiento": date.today() - timedelta(days=30 * 365),
+                "apellido_responsable": "Gomez",
+            }
+        )
+        is False
+    )
+    assert (
+        module._debe_validarse_responsable_importacion(
+            {
+                "fecha_nacimiento": date.today() - timedelta(days=10 * 365),
+                "apellido_responsable": "Gomez",
+            }
+        )
+        is True
+    )
+    assert (
+        module._debe_validarse_responsable_importacion(
+            {
+                "fecha_nacimiento": date.today() - timedelta(days=30 * 365),
+                "apellido_responsable": "Gomez",
+                "nombre_responsable": "Laura",
+                "documento_responsable": "20123456789",
+                "fecha_nacimiento_responsable": date.today() - timedelta(days=50 * 365),
+                "sexo_responsable": "F",
+                "domicilio_responsable": "Calle Resp 123",
+                "localidad_responsable": "Centro",
+            }
+        )
+        is True
+    )
 
 
 def test_importacion_helpers_procesar_responsable_same_document():
@@ -1451,6 +1484,10 @@ def test_importar_legajos_orquesta_loop_principal_y_postprocesos(mocker):
     )
     mocker.patch(
         "celiaquia.services.importacion_service._tiene_datos_responsable_importacion",
+        side_effect=lambda payload: bool(payload.get("tiene_resp")),
+    )
+    mocker.patch(
+        "celiaquia.services.importacion_service._debe_validarse_responsable_importacion",
         side_effect=lambda payload: bool(payload.get("tiene_resp")),
     )
     mocker.patch(


### PR DESCRIPTION
why: los registros erroneos del importador seguian exigiendo datos de responsable al editar beneficiarios mayores de edad.

what:
- hace opcional la validacion del responsable para mayores salvo bloque completo
- refleja la misma regla en el editor de registros erroneos
- agrega regresiones unitarias y documentacion spec-as-source

tests:
- uv run --with-requirements requirements.txt pytest tests/test_importacion_service_helpers_unit.py tests/test_celiaquia_expediente_view_helpers_unit.py -q
- uv run --with black black --check celiaquia/services/importacion_service/impl.py celiaquia/views/expediente.py celiaquia/tests/test_registros_erroneos_obligatorios.py tests/test_importacion_service_helpers_unit.py tests/test_celiaquia_expediente_view_helpers_unit.py
- uv run --with djlint djlint celiaquia/templates/celiaquia/expediente_detail.html --check --configuration=.djlintrc

# Información de la Tarea
Vincular el #ISSUE

### **Resumen de la Solución:** 
-

### **Información Adicional:**
-

# Descripción de los Cambios

### **Cambios:**
-

# Cómo Testear los Cambios

### **Pruebas Automáticas:**
-

### **Prubeas Manuales:**
-

# Metadata para documentación automática

- Contexto funcional:
- Tipo de cambio:
- Área principal:
- Resumen para changelog:
- Impacto usuario:
- Riesgos / rollback:

# Capturas de Pantalla
