### PR TITLE
feat: add search and prioritization features for courses in VAT API

### DIFF
--- a/VAT/api_schema_examples.py
+++ b/VAT/api_schema_examples.py
@@ -1,0 +1,147 @@
+from drf_spectacular.utils import OpenApiExample
+
+
+CURSO_BUSCAR_EXAMPLES = [
+    OpenApiExample(
+        "Búsqueda exitosa paginada",
+        value={
+            "count": 1,
+            "next": None,
+            "previous": None,
+            "results": [
+                {
+                    "id": 120,
+                    "nombre": "Herramientas Digitales",
+                    "prioritario": True,
+                    "estado": "activo",
+                    "observaciones": None,
+                    "fecha_creacion": "2026-04-12T10:00:00Z",
+                    "fecha_modificacion": "2026-04-12T10:00:00Z",
+                    "usa_voucher": True,
+                    "costo_creditos": 2,
+                    "centro": {
+                        "id": 12,
+                        "nombre": "CFP 401",
+                        "referente": None,
+                        "referente_nombre": "",
+                        "codigo": "CFP-401",
+                        "activo": True,
+                        "provincia": {"id": 2, "nombre": "Buenos Aires"},
+                        "ciudad": {
+                            "provincia": {"id": 2, "nombre": "Buenos Aires"},
+                            "municipio": {
+                                "id": 15,
+                                "nombre": "La Plata",
+                                "provincia": 2,
+                                "provincia_nombre": "Buenos Aires",
+                            },
+                            "localidad": {
+                                "id": 120,
+                                "nombre": "Tolosa",
+                                "municipio": 15,
+                                "municipio_nombre": "La Plata",
+                                "provincia_nombre": "Buenos Aires",
+                            },
+                            "direccion": "Calle 1 Nro 123",
+                        },
+                        "telefono": "221-4000000",
+                        "celular": "221-4000001",
+                        "correo": "cfp401@example.org",
+                        "nombre_referente": "Ana",
+                        "apellido_referente": "Perez",
+                        "tipo_gestion": "Estatal",
+                        "clase_institucion": "Formación Profesional",
+                        "situacion": "Institución de ETP",
+                    },
+                    "plan_estudio": 30,
+                    "plan_estudio_nombre": "Herramientas Digitales I",
+                    "modalidad": 1,
+                    "modalidad_nombre": "Presencial",
+                    "programa": {
+                        "id": 7,
+                        "nombre": "Programa Prioridad Formación",
+                    },
+                    "voucher_parametrias": [],
+                    "comisiones": [],
+                }
+            ],
+        },
+        response_only=True,
+    ),
+    OpenApiExample(
+        "Error por texto corto",
+        value={"q": ["Debe enviar al menos 3 caracteres para buscar."]},
+        response_only=True,
+        status_codes=["400"],
+    ),
+]
+
+
+CURSO_PRIORITARIOS_EXAMPLES = [
+    OpenApiExample(
+        "Listado de prioritarios paginado",
+        value={
+            "count": 1,
+            "next": None,
+            "previous": None,
+            "results": [
+                {
+                    "id": 140,
+                    "nombre": "Herramientas de Gestión Prioritaria",
+                    "prioritario": True,
+                    "estado": "activo",
+                    "observaciones": None,
+                    "fecha_creacion": "2026-04-12T10:00:00Z",
+                    "fecha_modificacion": "2026-04-12T10:00:00Z",
+                    "usa_voucher": True,
+                    "costo_creditos": 3,
+                    "centro": {
+                        "id": 12,
+                        "nombre": "CFP 401",
+                        "referente": None,
+                        "referente_nombre": "",
+                        "codigo": "CFP-401",
+                        "activo": True,
+                        "provincia": {"id": 2, "nombre": "Buenos Aires"},
+                        "ciudad": {
+                            "provincia": {"id": 2, "nombre": "Buenos Aires"},
+                            "municipio": {
+                                "id": 15,
+                                "nombre": "La Plata",
+                                "provincia": 2,
+                                "provincia_nombre": "Buenos Aires",
+                            },
+                            "localidad": {
+                                "id": 120,
+                                "nombre": "Tolosa",
+                                "municipio": 15,
+                                "municipio_nombre": "La Plata",
+                                "provincia_nombre": "Buenos Aires",
+                            },
+                            "direccion": "Calle 1 Nro 123",
+                        },
+                        "telefono": "221-4000000",
+                        "celular": "221-4000001",
+                        "correo": "cfp401@example.org",
+                        "nombre_referente": "Ana",
+                        "apellido_referente": "Perez",
+                        "tipo_gestion": "Estatal",
+                        "clase_institucion": "Formación Profesional",
+                        "situacion": "Institución de ETP",
+                    },
+                    "plan_estudio": 30,
+                    "plan_estudio_nombre": "Gestión Administrativa",
+                    "modalidad": 1,
+                    "modalidad_nombre": "Presencial",
+                    "programa": {
+                        "id": 7,
+                        "nombre": "Programa Prioridad Formación",
+                    },
+                    "voucher_parametrias": [],
+                    "comisiones": [],
+                }
+            ],
+        },
+        response_only=True,
+    )
+]

--- a/VAT/api_views.py
+++ b/VAT/api_views.py
@@ -1,8 +1,8 @@
 import logging
 
-from django.db.models import Count, Prefetch
+from django.db.models import Count, Prefetch, Q
 from drf_spectacular.utils import extend_schema
-from drf_spectacular.utils import OpenApiParameter
+from drf_spectacular.utils import OpenApiExample, OpenApiParameter
 from drf_spectacular.types import OpenApiTypes
 from rest_framework import status, viewsets
 from rest_framework.decorators import action
@@ -49,6 +49,7 @@ from VAT.serializers import (
     InstitucionIdentificadorHistSerializer,
     InstitucionUbicacionSerializer,
     CursoSerializer,
+    CursoBusquedaSerializer,
     ComisionCursoSerializer,
     OfertaInstitucionalSerializer,
     ComisionSerializer,
@@ -461,8 +462,7 @@ class CursoViewSet(SoftDeleteDestroyMixin, viewsets.ModelViewSet):
     serializer_class = CursoSerializer
     permission_classes = [HasAPIKey]
 
-    def get_queryset(self):
-        queryset = super().get_queryset()
+    def _apply_curso_filters(self, queryset):
         centro_id = self.request.query_params.get("centro_id")
         provincia_id = self.request.query_params.get("provincia_id")
         municipio_id = self.request.query_params.get("municipio_id")
@@ -494,6 +494,353 @@ class CursoViewSet(SoftDeleteDestroyMixin, viewsets.ModelViewSet):
         if estado:
             queryset = queryset.filter(estado=estado)
         return queryset
+
+    def _get_busqueda_queryset(self):
+        return (
+            self._apply_curso_filters(Curso.objects.all())
+            .select_related(
+                "centro",
+                "centro__provincia",
+                "centro__municipio",
+                "centro__localidad",
+                "plan_estudio",
+                "modalidad",
+            )
+            .prefetch_related(
+                Prefetch(
+                    "voucher_parametrias",
+                    queryset=VoucherParametria.objects.select_related("programa").order_by(
+                        "programa_id", "id"
+                    ),
+                ),
+                Prefetch(
+                    "comisiones",
+                    queryset=(
+                        ComisionCurso.objects.select_related(
+                            "ubicacion",
+                            "ubicacion__localidad",
+                            "ubicacion__localidad__municipio",
+                            "ubicacion__localidad__municipio__provincia",
+                        )
+                        .prefetch_related(
+                            "horarios__dia_semana",
+                            "sesiones__horario__dia_semana",
+                            Prefetch(
+                                "inscripciones",
+                                queryset=Inscripcion.objects.only("id"),
+                                to_attr="inscripciones_prefetch",
+                            ),
+                        )
+                        .order_by("fecha_inicio", "codigo_comision")
+                    )
+                ),
+            )
+            .order_by("-fecha_creacion", "nombre")
+        )
+
+    def get_queryset(self):
+        return self._apply_curso_filters(super().get_queryset())
+
+    @extend_schema(
+        tags=["VAT - Cursos"],
+        summary="Buscar cursos operativos por texto",
+        description=(
+            "Busca cursos operativos por texto libre en nombre de curso, plan de estudio o "
+            "título de referencia y devuelve la información enriquecida del curso, su centro, "
+            "geografía y las comisiones con horarios y cupos. "
+            "Ejemplo base: `/api/vat/cursos/buscar/?q=Her`. "
+            "También admite los filtros opcionales de cursos, por ejemplo "
+            "`/api/vat/cursos/buscar/?q=Her&centro_id=12&estado=activo`."
+        ),
+        parameters=[
+            OpenApiParameter(
+                "q",
+                OpenApiTypes.STR,
+                OpenApiParameter.QUERY,
+                description=(
+                    "Texto a buscar en nombre de curso, plan o título. "
+                    "Debe tener al menos 3 caracteres."
+                ),
+                required=True,
+            ),
+            OpenApiParameter(
+                "centro_id",
+                OpenApiTypes.INT,
+                OpenApiParameter.QUERY,
+                description="Filtra cursos por centro.",
+            ),
+            OpenApiParameter(
+                "provincia_id",
+                OpenApiTypes.INT,
+                OpenApiParameter.QUERY,
+                description="Filtra cursos por provincia del centro.",
+            ),
+            OpenApiParameter(
+                "municipio_id",
+                OpenApiTypes.INT,
+                OpenApiParameter.QUERY,
+                description="Filtra cursos por municipio del centro.",
+            ),
+            OpenApiParameter(
+                "modalidad_id",
+                OpenApiTypes.INT,
+                OpenApiParameter.QUERY,
+                description="Filtra cursos por modalidad.",
+            ),
+            OpenApiParameter(
+                "programa_id",
+                OpenApiTypes.INT,
+                OpenApiParameter.QUERY,
+                description="Filtra cursos por programa.",
+            ),
+            OpenApiParameter(
+                "estado",
+                OpenApiTypes.STR,
+                OpenApiParameter.QUERY,
+                description="Filtra cursos por estado.",
+            ),
+        ],
+        responses=CursoBusquedaSerializer(many=True),
+        examples=[
+            OpenApiExample(
+                "Búsqueda exitosa paginada",
+                value={
+                    "count": 1,
+                    "next": None,
+                    "previous": None,
+                    "results": [
+                        {
+                            "id": 120,
+                            "nombre": "Herramientas Digitales",
+                            "prioritario": True,
+                            "estado": "activo",
+                            "observaciones": None,
+                            "fecha_creacion": "2026-04-12T10:00:00Z",
+                            "fecha_modificacion": "2026-04-12T10:00:00Z",
+                            "usa_voucher": True,
+                            "costo_creditos": 2,
+                            "centro": {
+                                "id": 12,
+                                "nombre": "CFP 401",
+                                "referente": None,
+                                "referente_nombre": "",
+                                "codigo": "CFP-401",
+                                "activo": True,
+                                "provincia": {
+                                    "id": 2,
+                                    "nombre": "Buenos Aires"
+                                },
+                                "ciudad": {
+                                    "provincia": {
+                                        "id": 2,
+                                        "nombre": "Buenos Aires"
+                                    },
+                                    "municipio": {
+                                        "id": 15,
+                                        "nombre": "La Plata",
+                                        "provincia": 2,
+                                        "provincia_nombre": "Buenos Aires"
+                                    },
+                                    "localidad": {
+                                        "id": 120,
+                                        "nombre": "Tolosa",
+                                        "municipio": 15,
+                                        "municipio_nombre": "La Plata",
+                                        "provincia_nombre": "Buenos Aires"
+                                    },
+                                    "direccion": "Calle 1 Nro 123"
+                                },
+                                "telefono": "221-4000000",
+                                "celular": "221-4000001",
+                                "correo": "cfp401@example.org",
+                                "nombre_referente": "Ana",
+                                "apellido_referente": "Perez",
+                                "tipo_gestion": "Estatal",
+                                "clase_institucion": "Formación Profesional",
+                                "situacion": "Institución de ETP"
+                            },
+                            "plan_estudio": 30,
+                            "plan_estudio_nombre": "Herramientas Digitales I",
+                            "modalidad": 1,
+                            "modalidad_nombre": "Presencial",
+                            "programa": {
+                                "id": 7,
+                                "nombre": "Programa Prioridad Formación"
+                            },
+                            "voucher_parametrias": [],
+                            "comisiones": []
+                        }
+                    ]
+                },
+                response_only=True,
+            ),
+            OpenApiExample(
+                "Error por texto corto",
+                value={"q": ["Debe enviar al menos 3 caracteres para buscar."]},
+                response_only=True,
+                status_codes=["400"],
+            ),
+        ],
+    )
+    @action(detail=False, methods=["get"], url_path="buscar")
+    def buscar(self, request, *args, **kwargs):
+        texto = (request.query_params.get("q") or "").strip()
+        if not texto:
+            raise ValidationError({"q": ["Debe enviar un texto de búsqueda."]})
+        if len(texto) < 3:
+            raise ValidationError(
+                {"q": ["Debe enviar al menos 3 caracteres para buscar."]}
+            )
+
+        queryset = (
+            self._get_busqueda_queryset()
+            .filter(
+                Q(nombre__icontains=texto)
+                | Q(plan_estudio__nombre__icontains=texto)
+                | Q(plan_estudio__titulos__nombre__icontains=texto)
+            )
+            .distinct()
+        )
+
+        page = self.paginate_queryset(queryset)
+        serializer = CursoBusquedaSerializer(page or queryset, many=True)
+        if page is not None:
+            return self.get_paginated_response(serializer.data)
+        return Response(serializer.data)
+
+    @extend_schema(
+        tags=["VAT - Cursos"],
+        summary="Listar cursos prioritarios",
+        description=(
+            "Devuelve los cursos operativos marcados como prioritarios con la misma "
+            "información enriquecida del buscador de cursos. "
+            "Ejemplo base: `/api/vat/cursos/prioritarios/`. "
+            "También admite filtros opcionales como `centro_id`, `provincia_id`, `municipio_id`, "
+            "`modalidad_id`, `programa_id` y `estado`."
+        ),
+        responses=CursoBusquedaSerializer(many=True),
+        parameters=[
+            OpenApiParameter(
+                "centro_id",
+                OpenApiTypes.INT,
+                OpenApiParameter.QUERY,
+                description="Filtra cursos por centro.",
+            ),
+            OpenApiParameter(
+                "provincia_id",
+                OpenApiTypes.INT,
+                OpenApiParameter.QUERY,
+                description="Filtra cursos por provincia del centro.",
+            ),
+            OpenApiParameter(
+                "municipio_id",
+                OpenApiTypes.INT,
+                OpenApiParameter.QUERY,
+                description="Filtra cursos por municipio del centro.",
+            ),
+            OpenApiParameter(
+                "modalidad_id",
+                OpenApiTypes.INT,
+                OpenApiParameter.QUERY,
+                description="Filtra cursos por modalidad.",
+            ),
+            OpenApiParameter(
+                "programa_id",
+                OpenApiTypes.INT,
+                OpenApiParameter.QUERY,
+                description="Filtra cursos por programa.",
+            ),
+            OpenApiParameter(
+                "estado",
+                OpenApiTypes.STR,
+                OpenApiParameter.QUERY,
+                description="Filtra cursos por estado.",
+            ),
+        ],
+        examples=[
+            OpenApiExample(
+                "Listado de prioritarios paginado",
+                value={
+                    "count": 1,
+                    "next": None,
+                    "previous": None,
+                    "results": [
+                        {
+                            "id": 140,
+                            "nombre": "Herramientas de Gestión Prioritaria",
+                            "prioritario": True,
+                            "estado": "activo",
+                            "observaciones": None,
+                            "fecha_creacion": "2026-04-12T10:00:00Z",
+                            "fecha_modificacion": "2026-04-12T10:00:00Z",
+                            "usa_voucher": True,
+                            "costo_creditos": 3,
+                            "centro": {
+                                "id": 12,
+                                "nombre": "CFP 401",
+                                "referente": None,
+                                "referente_nombre": "",
+                                "codigo": "CFP-401",
+                                "activo": True,
+                                "provincia": {
+                                    "id": 2,
+                                    "nombre": "Buenos Aires"
+                                },
+                                "ciudad": {
+                                    "provincia": {
+                                        "id": 2,
+                                        "nombre": "Buenos Aires"
+                                    },
+                                    "municipio": {
+                                        "id": 15,
+                                        "nombre": "La Plata",
+                                        "provincia": 2,
+                                        "provincia_nombre": "Buenos Aires"
+                                    },
+                                    "localidad": {
+                                        "id": 120,
+                                        "nombre": "Tolosa",
+                                        "municipio": 15,
+                                        "municipio_nombre": "La Plata",
+                                        "provincia_nombre": "Buenos Aires"
+                                    },
+                                    "direccion": "Calle 1 Nro 123"
+                                },
+                                "telefono": "221-4000000",
+                                "celular": "221-4000001",
+                                "correo": "cfp401@example.org",
+                                "nombre_referente": "Ana",
+                                "apellido_referente": "Perez",
+                                "tipo_gestion": "Estatal",
+                                "clase_institucion": "Formación Profesional",
+                                "situacion": "Institución de ETP"
+                            },
+                            "plan_estudio": 30,
+                            "plan_estudio_nombre": "Gestión Administrativa",
+                            "modalidad": 1,
+                            "modalidad_nombre": "Presencial",
+                            "programa": {
+                                "id": 7,
+                                "nombre": "Programa Prioridad Formación"
+                            },
+                            "voucher_parametrias": [],
+                            "comisiones": []
+                        }
+                    ]
+                },
+                response_only=True,
+            )
+        ],
+    )
+    @action(detail=False, methods=["get"], url_path="prioritarios")
+    def prioritarios(self, request, *args, **kwargs):
+        queryset = self._get_busqueda_queryset().filter(prioritario=True)
+
+        page = self.paginate_queryset(queryset)
+        serializer = CursoBusquedaSerializer(page or queryset, many=True)
+        if page is not None:
+            return self.get_paginated_response(serializer.data)
+        return Response(serializer.data)
 
 
 @extend_schema(

--- a/VAT/api_views.py
+++ b/VAT/api_views.py
@@ -2,8 +2,9 @@ import logging
 
 from django.db.models import Count, Prefetch, Q
 from drf_spectacular.utils import extend_schema
-from drf_spectacular.utils import OpenApiParameter
+from drf_spectacular.utils import OpenApiParameter, inline_serializer
 from drf_spectacular.types import OpenApiTypes
+from rest_framework import serializers as drf_serializers
 from rest_framework import status, viewsets
 from rest_framework.decorators import action
 from rest_framework.exceptions import ValidationError
@@ -68,6 +69,16 @@ from core.models import Localidad, Municipio, Provincia
 from core.soft_delete.view_helpers import is_soft_deletable_instance
 
 logger = logging.getLogger("django")
+
+CURSO_BUSQUEDA_PAGINATED_RESPONSE = inline_serializer(
+    name="CursoBusquedaPaginatedResponse",
+    fields={
+        "count": drf_serializers.IntegerField(),
+        "next": drf_serializers.URLField(allow_null=True),
+        "previous": drf_serializers.URLField(allow_null=True),
+        "results": CursoBusquedaSerializer(many=True),
+    },
+)
 
 
 class SoftDeleteDestroyMixin:
@@ -504,6 +515,7 @@ class CursoViewSet(SoftDeleteDestroyMixin, viewsets.ModelViewSet):
             self._apply_curso_filters(Curso.objects.all())
             .select_related(
                 "centro",
+                "centro__referente",
                 "centro__provincia",
                 "centro__municipio",
                 "centro__localidad",
@@ -526,14 +538,12 @@ class CursoViewSet(SoftDeleteDestroyMixin, viewsets.ModelViewSet):
                             "ubicacion__localidad__municipio",
                             "ubicacion__localidad__municipio__provincia",
                         )
+                        .annotate(
+                            total_inscriptos=Count("inscripciones", distinct=True)
+                        )
                         .prefetch_related(
                             "horarios__dia_semana",
                             "sesiones__horario__dia_semana",
-                            Prefetch(
-                                "inscripciones",
-                                queryset=Inscripcion.objects.only("id"),
-                                to_attr="inscripciones_prefetch",
-                            ),
                         )
                         .order_by("fecha_inicio", "codigo_comision")
                     ),
@@ -604,7 +614,7 @@ class CursoViewSet(SoftDeleteDestroyMixin, viewsets.ModelViewSet):
                 description="Filtra cursos por estado.",
             ),
         ],
-        responses=CursoBusquedaSerializer(many=True),
+        responses={200: CURSO_BUSQUEDA_PAGINATED_RESPONSE},
         examples=CURSO_BUSCAR_EXAMPLES,
     )
     @action(detail=False, methods=["get"], url_path="buscar")
@@ -628,7 +638,8 @@ class CursoViewSet(SoftDeleteDestroyMixin, viewsets.ModelViewSet):
         )
 
         page = self.paginate_queryset(queryset)
-        serializer = CursoBusquedaSerializer(page or queryset, many=True)
+        items = page if page is not None else queryset
+        serializer = CursoBusquedaSerializer(items, many=True)
         if page is not None:
             return self.get_paginated_response(serializer.data)
         return Response(serializer.data)
@@ -643,7 +654,7 @@ class CursoViewSet(SoftDeleteDestroyMixin, viewsets.ModelViewSet):
             "También admite filtros opcionales como `centro_id`, `provincia_id`, `municipio_id`, "
             "`modalidad_id`, `programa_id` y `estado`."
         ),
-        responses=CursoBusquedaSerializer(many=True),
+        responses={200: CURSO_BUSQUEDA_PAGINATED_RESPONSE},
         parameters=[
             OpenApiParameter(
                 "centro_id",
@@ -689,7 +700,8 @@ class CursoViewSet(SoftDeleteDestroyMixin, viewsets.ModelViewSet):
         queryset = self._get_busqueda_queryset().filter(prioritario=True)
 
         page = self.paginate_queryset(queryset)
-        serializer = CursoBusquedaSerializer(page or queryset, many=True)
+        items = page if page is not None else queryset
+        serializer = CursoBusquedaSerializer(items, many=True)
         if page is not None:
             return self.get_paginated_response(serializer.data)
         return Response(serializer.data)

--- a/VAT/api_views.py
+++ b/VAT/api_views.py
@@ -2,7 +2,7 @@ import logging
 
 from django.db.models import Count, Prefetch, Q
 from drf_spectacular.utils import extend_schema
-from drf_spectacular.utils import OpenApiExample, OpenApiParameter
+from drf_spectacular.utils import OpenApiParameter
 from drf_spectacular.types import OpenApiTypes
 from rest_framework import status, viewsets
 from rest_framework.decorators import action
@@ -31,6 +31,10 @@ from VAT.models import (
     Inscripcion,
     Evaluacion,
     ResultadoEvaluacion,
+)
+from VAT.api_schema_examples import (
+    CURSO_BUSCAR_EXAMPLES,
+    CURSO_PRIORITARIOS_EXAMPLES,
 )
 from VAT.serializers import (
     CentroSerializer,
@@ -509,9 +513,9 @@ class CursoViewSet(SoftDeleteDestroyMixin, viewsets.ModelViewSet):
             .prefetch_related(
                 Prefetch(
                     "voucher_parametrias",
-                    queryset=VoucherParametria.objects.select_related("programa").order_by(
-                        "programa_id", "id"
-                    ),
+                    queryset=VoucherParametria.objects.select_related(
+                        "programa"
+                    ).order_by("programa_id", "id"),
                 ),
                 Prefetch(
                     "comisiones",
@@ -532,7 +536,7 @@ class CursoViewSet(SoftDeleteDestroyMixin, viewsets.ModelViewSet):
                             ),
                         )
                         .order_by("fecha_inicio", "codigo_comision")
-                    )
+                    ),
                 ),
             )
             .order_by("-fecha_creacion", "nombre")
@@ -601,86 +605,7 @@ class CursoViewSet(SoftDeleteDestroyMixin, viewsets.ModelViewSet):
             ),
         ],
         responses=CursoBusquedaSerializer(many=True),
-        examples=[
-            OpenApiExample(
-                "Búsqueda exitosa paginada",
-                value={
-                    "count": 1,
-                    "next": None,
-                    "previous": None,
-                    "results": [
-                        {
-                            "id": 120,
-                            "nombre": "Herramientas Digitales",
-                            "prioritario": True,
-                            "estado": "activo",
-                            "observaciones": None,
-                            "fecha_creacion": "2026-04-12T10:00:00Z",
-                            "fecha_modificacion": "2026-04-12T10:00:00Z",
-                            "usa_voucher": True,
-                            "costo_creditos": 2,
-                            "centro": {
-                                "id": 12,
-                                "nombre": "CFP 401",
-                                "referente": None,
-                                "referente_nombre": "",
-                                "codigo": "CFP-401",
-                                "activo": True,
-                                "provincia": {
-                                    "id": 2,
-                                    "nombre": "Buenos Aires"
-                                },
-                                "ciudad": {
-                                    "provincia": {
-                                        "id": 2,
-                                        "nombre": "Buenos Aires"
-                                    },
-                                    "municipio": {
-                                        "id": 15,
-                                        "nombre": "La Plata",
-                                        "provincia": 2,
-                                        "provincia_nombre": "Buenos Aires"
-                                    },
-                                    "localidad": {
-                                        "id": 120,
-                                        "nombre": "Tolosa",
-                                        "municipio": 15,
-                                        "municipio_nombre": "La Plata",
-                                        "provincia_nombre": "Buenos Aires"
-                                    },
-                                    "direccion": "Calle 1 Nro 123"
-                                },
-                                "telefono": "221-4000000",
-                                "celular": "221-4000001",
-                                "correo": "cfp401@example.org",
-                                "nombre_referente": "Ana",
-                                "apellido_referente": "Perez",
-                                "tipo_gestion": "Estatal",
-                                "clase_institucion": "Formación Profesional",
-                                "situacion": "Institución de ETP"
-                            },
-                            "plan_estudio": 30,
-                            "plan_estudio_nombre": "Herramientas Digitales I",
-                            "modalidad": 1,
-                            "modalidad_nombre": "Presencial",
-                            "programa": {
-                                "id": 7,
-                                "nombre": "Programa Prioridad Formación"
-                            },
-                            "voucher_parametrias": [],
-                            "comisiones": []
-                        }
-                    ]
-                },
-                response_only=True,
-            ),
-            OpenApiExample(
-                "Error por texto corto",
-                value={"q": ["Debe enviar al menos 3 caracteres para buscar."]},
-                response_only=True,
-                status_codes=["400"],
-            ),
-        ],
+        examples=CURSO_BUSCAR_EXAMPLES,
     )
     @action(detail=False, methods=["get"], url_path="buscar")
     def buscar(self, request, *args, **kwargs):
@@ -757,80 +682,7 @@ class CursoViewSet(SoftDeleteDestroyMixin, viewsets.ModelViewSet):
                 description="Filtra cursos por estado.",
             ),
         ],
-        examples=[
-            OpenApiExample(
-                "Listado de prioritarios paginado",
-                value={
-                    "count": 1,
-                    "next": None,
-                    "previous": None,
-                    "results": [
-                        {
-                            "id": 140,
-                            "nombre": "Herramientas de Gestión Prioritaria",
-                            "prioritario": True,
-                            "estado": "activo",
-                            "observaciones": None,
-                            "fecha_creacion": "2026-04-12T10:00:00Z",
-                            "fecha_modificacion": "2026-04-12T10:00:00Z",
-                            "usa_voucher": True,
-                            "costo_creditos": 3,
-                            "centro": {
-                                "id": 12,
-                                "nombre": "CFP 401",
-                                "referente": None,
-                                "referente_nombre": "",
-                                "codigo": "CFP-401",
-                                "activo": True,
-                                "provincia": {
-                                    "id": 2,
-                                    "nombre": "Buenos Aires"
-                                },
-                                "ciudad": {
-                                    "provincia": {
-                                        "id": 2,
-                                        "nombre": "Buenos Aires"
-                                    },
-                                    "municipio": {
-                                        "id": 15,
-                                        "nombre": "La Plata",
-                                        "provincia": 2,
-                                        "provincia_nombre": "Buenos Aires"
-                                    },
-                                    "localidad": {
-                                        "id": 120,
-                                        "nombre": "Tolosa",
-                                        "municipio": 15,
-                                        "municipio_nombre": "La Plata",
-                                        "provincia_nombre": "Buenos Aires"
-                                    },
-                                    "direccion": "Calle 1 Nro 123"
-                                },
-                                "telefono": "221-4000000",
-                                "celular": "221-4000001",
-                                "correo": "cfp401@example.org",
-                                "nombre_referente": "Ana",
-                                "apellido_referente": "Perez",
-                                "tipo_gestion": "Estatal",
-                                "clase_institucion": "Formación Profesional",
-                                "situacion": "Institución de ETP"
-                            },
-                            "plan_estudio": 30,
-                            "plan_estudio_nombre": "Gestión Administrativa",
-                            "modalidad": 1,
-                            "modalidad_nombre": "Presencial",
-                            "programa": {
-                                "id": 7,
-                                "nombre": "Programa Prioridad Formación"
-                            },
-                            "voucher_parametrias": [],
-                            "comisiones": []
-                        }
-                    ]
-                },
-                response_only=True,
-            )
-        ],
+        examples=CURSO_PRIORITARIOS_EXAMPLES,
     )
     @action(detail=False, methods=["get"], url_path="prioritarios")
     def prioritarios(self, request, *args, **kwargs):

--- a/VAT/migrations/0038_curso_prioritario.py
+++ b/VAT/migrations/0038_curso_prioritario.py
@@ -1,0 +1,20 @@
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("VAT", "0037_planversioncurricular_provincia_activo_idx"),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name="curso",
+            name="prioritario",
+            field=models.BooleanField(
+                db_index=True,
+                default=False,
+                help_text="Marca si el curso debe destacarse como prioritario en las consultas operativas.",
+                verbose_name="Prioritario",
+            ),
+        ),
+    ]

--- a/VAT/models.py
+++ b/VAT/models.py
@@ -911,6 +911,12 @@ class Curso(SoftDeleteModelMixin, models.Model):
         verbose_name="Plan de Estudio",
     )
     nombre = models.CharField(max_length=255, verbose_name="Nombre")
+    prioritario = models.BooleanField(
+        default=False,
+        db_index=True,
+        verbose_name="Prioritario",
+        help_text="Marca si el curso debe destacarse como prioritario en las consultas operativas.",
+    )
     modalidad = models.ForeignKey(
         ModalidadCursada,
         on_delete=models.PROTECT,

--- a/VAT/serializers.py
+++ b/VAT/serializers.py
@@ -10,6 +10,7 @@ from VAT.models import (
     ModalidadCursada,
     PlanVersionCurricular,
     InscripcionOferta,
+    VoucherParametria,
     Voucher,
     VoucherRecarga,
     VoucherUso,
@@ -384,6 +385,7 @@ class CursoSerializer(serializers.ModelSerializer):
             "plan_estudio",
             "plan_estudio_nombre",
             "nombre",
+            "prioritario",
             "modalidad",
             "modalidad_nombre",
             "programa",
@@ -471,6 +473,170 @@ class ComisionCursoSerializer(serializers.ModelSerializer):
             "observaciones",
             "fecha_creacion",
             "fecha_modificacion",
+        ]
+
+
+class CursoBusquedaVoucherParametriaSerializer(serializers.ModelSerializer):
+    programa_nombre = serializers.CharField(source="programa.nombre", read_only=True)
+
+    class Meta:
+        model = VoucherParametria
+        fields = [
+            "id",
+            "nombre",
+            "programa",
+            "programa_nombre",
+            "cantidad_inicial",
+            "fecha_vencimiento",
+            "inscripcion_unica_activa",
+            "activa",
+        ]
+
+
+class CursoBusquedaCiudadSerializer(serializers.Serializer):
+    provincia = ProvinciaSerializer(read_only=True)
+    municipio = MunicipioSerializer(read_only=True)
+    localidad = LocalidadSerializer(read_only=True)
+    direccion = serializers.CharField(source="domicilio_actividad", read_only=True)
+
+
+class CursoBusquedaCentroSerializer(serializers.ModelSerializer):
+    referente_nombre = serializers.CharField(
+        source="referente.get_full_name", read_only=True
+    )
+    provincia = ProvinciaSerializer(read_only=True)
+    ciudad = CursoBusquedaCiudadSerializer(source="*", read_only=True)
+
+    class Meta:
+        model = Centro
+        fields = [
+            "id",
+            "nombre",
+            "referente",
+            "referente_nombre",
+            "codigo",
+            "activo",
+            "provincia",
+            "ciudad",
+            "telefono",
+            "celular",
+            "correo",
+            "nombre_referente",
+            "apellido_referente",
+            "tipo_gestion",
+            "clase_institucion",
+            "situacion",
+        ]
+
+
+class CursoBusquedaUbicacionSerializer(serializers.ModelSerializer):
+    localidad_nombre = serializers.CharField(source="localidad.nombre", read_only=True)
+    municipio_id = serializers.IntegerField(source="localidad.municipio_id", read_only=True)
+    municipio_nombre = serializers.CharField(
+        source="localidad.municipio.nombre", read_only=True
+    )
+    provincia_id = serializers.IntegerField(
+        source="localidad.municipio.provincia_id", read_only=True
+    )
+    provincia_nombre = serializers.CharField(
+        source="localidad.municipio.provincia.nombre", read_only=True
+    )
+
+    class Meta:
+        model = InstitucionUbicacion
+        fields = [
+            "id",
+            "rol_ubicacion",
+            "nombre_ubicacion",
+            "domicilio",
+            "es_principal",
+            "localidad",
+            "localidad_nombre",
+            "municipio_id",
+            "municipio_nombre",
+            "provincia_id",
+            "provincia_nombre",
+        ]
+
+
+class CursoBusquedaComisionSerializer(serializers.ModelSerializer):
+    horarios = ComisionCursoSerializer.ComisionCursoHorarioReadSerializer(
+        many=True, read_only=True
+    )
+    sesiones = ComisionCursoSerializer.ComisionCursoSesionReadSerializer(
+        many=True, read_only=True
+    )
+    ubicacion = CursoBusquedaUbicacionSerializer(read_only=True)
+    total_inscriptos = serializers.SerializerMethodField()
+    cupos_disponibles = serializers.SerializerMethodField()
+
+    def get_total_inscriptos(self, obj):
+        if hasattr(obj, "inscripciones_prefetch"):
+            return len(obj.inscripciones_prefetch)
+        return obj.inscripciones.count()
+
+    def get_cupos_disponibles(self, obj):
+        total_inscriptos = self.get_total_inscriptos(obj)
+        return max((obj.cupo_total or 0) - total_inscriptos, 0)
+
+    class Meta:
+        model = ComisionCurso
+        fields = [
+            "id",
+            "codigo_comision",
+            "nombre",
+            "estado",
+            "cupo_total",
+            "total_inscriptos",
+            "cupos_disponibles",
+            "fecha_inicio",
+            "fecha_fin",
+            "observaciones",
+            "ubicacion",
+            "horarios",
+            "sesiones",
+            "fecha_creacion",
+            "fecha_modificacion",
+        ]
+
+
+class CursoBusquedaSerializer(serializers.ModelSerializer):
+    centro = CursoBusquedaCentroSerializer(read_only=True)
+    plan_estudio_nombre = serializers.CharField(source="plan_estudio", read_only=True)
+    modalidad_nombre = serializers.CharField(source="modalidad.nombre", read_only=True)
+    programa = serializers.SerializerMethodField()
+    voucher_parametrias = CursoBusquedaVoucherParametriaSerializer(many=True, read_only=True)
+    comisiones = CursoBusquedaComisionSerializer(many=True, read_only=True)
+
+    def get_programa(self, obj):
+        programa = obj.programa
+        if programa is None:
+            return None
+        return {
+            "id": programa.id,
+            "nombre": programa.nombre,
+        }
+
+    class Meta:
+        model = Curso
+        fields = [
+            "id",
+            "nombre",
+            "prioritario",
+            "estado",
+            "observaciones",
+            "fecha_creacion",
+            "fecha_modificacion",
+            "usa_voucher",
+            "costo_creditos",
+            "centro",
+            "plan_estudio",
+            "plan_estudio_nombre",
+            "modalidad",
+            "modalidad_nombre",
+            "programa",
+            "voucher_parametrias",
+            "comisiones",
         ]
 
 

--- a/VAT/serializers.py
+++ b/VAT/serializers.py
@@ -579,12 +579,15 @@ class CursoBusquedaComisionSerializer(serializers.ModelSerializer):
     cupos_disponibles = serializers.SerializerMethodField()
 
     def get_total_inscriptos(self, obj):
+        total_inscriptos = getattr(obj, "total_inscriptos", None)
+        if total_inscriptos is not None:
+            return total_inscriptos
         if hasattr(obj, "inscripciones_prefetch"):
             return len(obj.inscripciones_prefetch)
         return obj.inscripciones.count()
 
     def get_cupos_disponibles(self, obj):
-        total_inscriptos = self.get_total_inscriptos(obj)
+        total_inscriptos = self.get_total_inscriptos(obj) or 0
         return max((obj.cupo_total or 0) - total_inscriptos, 0)
 
     class Meta:

--- a/VAT/serializers.py
+++ b/VAT/serializers.py
@@ -499,6 +499,12 @@ class CursoBusquedaCiudadSerializer(serializers.Serializer):
     localidad = LocalidadSerializer(read_only=True)
     direccion = serializers.CharField(source="domicilio_actividad", read_only=True)
 
+    def create(self, validated_data):
+        return validated_data
+
+    def update(self, instance, validated_data):
+        return instance
+
 
 class CursoBusquedaCentroSerializer(serializers.ModelSerializer):
     referente_nombre = serializers.CharField(
@@ -531,7 +537,9 @@ class CursoBusquedaCentroSerializer(serializers.ModelSerializer):
 
 class CursoBusquedaUbicacionSerializer(serializers.ModelSerializer):
     localidad_nombre = serializers.CharField(source="localidad.nombre", read_only=True)
-    municipio_id = serializers.IntegerField(source="localidad.municipio_id", read_only=True)
+    municipio_id = serializers.IntegerField(
+        source="localidad.municipio_id", read_only=True
+    )
     municipio_nombre = serializers.CharField(
         source="localidad.municipio.nombre", read_only=True
     )
@@ -605,7 +613,9 @@ class CursoBusquedaSerializer(serializers.ModelSerializer):
     plan_estudio_nombre = serializers.CharField(source="plan_estudio", read_only=True)
     modalidad_nombre = serializers.CharField(source="modalidad.nombre", read_only=True)
     programa = serializers.SerializerMethodField()
-    voucher_parametrias = CursoBusquedaVoucherParametriaSerializer(many=True, read_only=True)
+    voucher_parametrias = CursoBusquedaVoucherParametriaSerializer(
+        many=True, read_only=True
+    )
     comisiones = CursoBusquedaComisionSerializer(many=True, read_only=True)
 
     def get_programa(self, obj):

--- a/VAT/templates/vat/institucion/ubicacion_form.html
+++ b/VAT/templates/vat/institucion/ubicacion_form.html
@@ -16,8 +16,8 @@
         <div class="row mb-4">
             <div class="col-12">
                 <div class="d-flex align-items-center gap-2 mb-4">
-                          <a href="{% if return_url %}{{ return_url }}{% else %}{{ ubicacion_list_url }}{% endif %}"
-                              class="btn btn-light"><i class="bi bi-arrow-left"></i></a>
+                    <a href="{% if return_url %}{{ return_url }}{% else %}{{ ubicacion_list_url }}{% endif %}"
+                       class="btn btn-light"><i class="bi bi-arrow-left"></i></a>
                     <div>
                         <h1 class="h2 mb-0" style="color: #1f3a93;">
                             {% if form.instance.id %}
@@ -109,8 +109,8 @@
 
                             <hr class="my-4" />
                             <div class="d-flex gap-2 justify-content-end">
-                                          <a href="{% if return_url %}{{ return_url }}{% else %}{{ ubicacion_list_url }}{% endif %}"
-                                              class="btn btn-outline-secondary"><i class="bi bi-x-lg me-2"></i>Cancelar</a>
+                                <a href="{% if return_url %}{{ return_url }}{% else %}{{ ubicacion_list_url }}{% endif %}"
+                                   class="btn btn-outline-secondary"><i class="bi bi-x-lg me-2"></i>Cancelar</a>
                                 <button type="submit" class="btn btn-primary">
                                     <i class="bi bi-check-lg me-2"></i>
                                     {% if form.instance.id %}

--- a/VAT/templates/vat/institucion/ubicacion_form.html
+++ b/VAT/templates/vat/institucion/ubicacion_form.html
@@ -16,8 +16,8 @@
         <div class="row mb-4">
             <div class="col-12">
                 <div class="d-flex align-items-center gap-2 mb-4">
-                    <a href="{{ return_url|default:ubicacion_list_url }}"
-                       class="btn btn-light"><i class="bi bi-arrow-left"></i></a>
+                          <a href="{% if return_url %}{{ return_url }}{% else %}{{ ubicacion_list_url }}{% endif %}"
+                              class="btn btn-light"><i class="bi bi-arrow-left"></i></a>
                     <div>
                         <h1 class="h2 mb-0" style="color: #1f3a93;">
                             {% if form.instance.id %}
@@ -109,8 +109,8 @@
 
                             <hr class="my-4" />
                             <div class="d-flex gap-2 justify-content-end">
-                                <a href="{{ return_url|default:ubicacion_list_url }}"
-                                   class="btn btn-outline-secondary"><i class="bi bi-x-lg me-2"></i>Cancelar</a>
+                                          <a href="{% if return_url %}{{ return_url }}{% else %}{{ ubicacion_list_url }}{% endif %}"
+                                              class="btn btn-outline-secondary"><i class="bi bi-x-lg me-2"></i>Cancelar</a>
                                 <button type="submit" class="btn btn-primary">
                                     <i class="bi bi-check-lg me-2"></i>
                                     {% if form.instance.id %}

--- a/VAT/tests.py
+++ b/VAT/tests.py
@@ -2111,6 +2111,183 @@ def test_api_vat_cursos_lista_por_provincia_y_municipio(vat_api_client, vat_curs
 
 
 @pytest.mark.django_db
+def test_api_vat_cursos_buscar_por_texto_devuelve_info_enriquecida(
+    vat_api_client, vat_curso_base
+):
+    centro, ubicacion, modalidad = vat_curso_base
+    programa = Programa.objects.create(nombre="Programa API Búsqueda Curso")
+    usuario = User.objects.create_user(
+        username="api-busqueda-curso",
+        password="test1234",
+    )
+    curso = Curso.objects.create(
+        centro=centro,
+        nombre="Administración Contable Avanzada",
+        modalidad=modalidad,
+        estado="activo",
+        usa_voucher=True,
+        costo_creditos=2,
+    )
+    voucher_parametria = VoucherParametria.objects.create(
+        nombre="Voucher Búsqueda Curso",
+        programa=programa,
+        cantidad_inicial=8,
+        fecha_vencimiento=date(2026, 12, 31),
+        creado_por=usuario,
+        activa=True,
+    )
+    curso.voucher_parametrias.add(voucher_parametria)
+    comision = ComisionCurso.objects.create(
+        curso=curso,
+        ubicacion=ubicacion,
+        codigo_comision="BUSQ-CUR-01",
+        nombre="Comisión Búsqueda Curso",
+        cupo_total=12,
+        fecha_inicio=date(2026, 4, 15),
+        fecha_fin=date(2026, 5, 15),
+        estado="activa",
+    )
+    dia = Dia.objects.create(nombre="Martes")
+    horario = ComisionHorario.objects.create(
+        comision_curso=comision,
+        dia_semana=dia,
+        hora_desde=time(9, 0),
+        hora_hasta=time(11, 0),
+        aula_espacio="Aula 2",
+        vigente=True,
+    )
+    SesionComision.objects.create(
+        comision_curso=comision,
+        horario=horario,
+        numero_sesion=1,
+        fecha=date(2026, 4, 22),
+        estado="programada",
+    )
+
+    response = vat_api_client.get("/api/vat/cursos/buscar/?q=con")
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["count"] == 1
+    result = payload["results"][0]
+    assert result["id"] == curso.id
+    assert result["centro"]["id"] == centro.id
+    assert result["centro"]["provincia"]["id"] == centro.provincia_id
+    assert result["centro"]["provincia"]["nombre"] == centro.provincia.nombre
+    assert result["centro"]["ciudad"]["provincia"]["id"] == centro.provincia_id
+    assert result["centro"]["ciudad"]["municipio"]["id"] == centro.municipio_id
+    assert result["centro"]["ciudad"]["localidad"]["id"] == centro.localidad_id
+    assert result["centro"]["ciudad"]["direccion"] == centro.domicilio_actividad
+    assert result["programa"] == {"id": programa.id, "nombre": programa.nombre}
+    assert result["voucher_parametrias"][0]["id"] == voucher_parametria.id
+    assert result["comisiones"][0]["id"] == comision.id
+    assert result["comisiones"][0]["total_inscriptos"] == 0
+    assert result["comisiones"][0]["cupos_disponibles"] == 12
+    assert result["comisiones"][0]["horarios"][0]["id"] == horario.id
+    assert result["comisiones"][0]["ubicacion"]["id"] == ubicacion.id
+
+
+@pytest.mark.django_db
+def test_api_vat_cursos_buscar_requiere_texto(vat_api_client):
+    response = vat_api_client.get("/api/vat/cursos/buscar/")
+
+    assert response.status_code == 400
+    assert response.json() == {"q": ["Debe enviar un texto de búsqueda."]}
+
+
+@pytest.mark.django_db
+def test_api_vat_cursos_buscar_requiere_minimo_tres_caracteres(vat_api_client):
+    response = vat_api_client.get("/api/vat/cursos/buscar/?q=he")
+
+    assert response.status_code == 400
+    assert response.json() == {
+        "q": ["Debe enviar al menos 3 caracteres para buscar."]
+    }
+
+
+@pytest.mark.django_db
+def test_api_vat_cursos_prioritarios_devuelve_info_enriquecida(
+    vat_api_client, vat_curso_base
+):
+    centro, ubicacion, modalidad = vat_curso_base
+    programa = Programa.objects.create(nombre="Programa API Curso Prioritario")
+    usuario = User.objects.create_user(
+        username="api-prioritario-curso",
+        password="test1234",
+    )
+    curso_prioritario = Curso.objects.create(
+        centro=centro,
+        nombre="Herramientas de Gestión Prioritaria",
+        modalidad=modalidad,
+        estado="activo",
+        prioritario=True,
+        usa_voucher=True,
+        costo_creditos=3,
+    )
+    Curso.objects.create(
+        centro=centro,
+        nombre="Curso No Prioritario",
+        modalidad=modalidad,
+        estado="activo",
+        prioritario=False,
+    )
+    voucher_parametria = VoucherParametria.objects.create(
+        nombre="Voucher Curso Prioritario",
+        programa=programa,
+        cantidad_inicial=10,
+        fecha_vencimiento=date(2026, 12, 31),
+        creado_por=usuario,
+        activa=True,
+    )
+    curso_prioritario.voucher_parametrias.add(voucher_parametria)
+    comision = ComisionCurso.objects.create(
+        curso=curso_prioritario,
+        ubicacion=ubicacion,
+        codigo_comision="PRIO-CUR-01",
+        nombre="Comisión Curso Prioritario",
+        cupo_total=15,
+        fecha_inicio=date(2026, 4, 20),
+        fecha_fin=date(2026, 5, 20),
+        estado="activa",
+    )
+    dia = Dia.objects.create(nombre="Jueves")
+    horario = ComisionHorario.objects.create(
+        comision_curso=comision,
+        dia_semana=dia,
+        hora_desde=time(14, 0),
+        hora_hasta=time(16, 0),
+        aula_espacio="Aula Prioritaria",
+        vigente=True,
+    )
+    SesionComision.objects.create(
+        comision_curso=comision,
+        horario=horario,
+        numero_sesion=1,
+        fecha=date(2026, 4, 24),
+        estado="programada",
+    )
+
+    response = vat_api_client.get("/api/vat/cursos/prioritarios/")
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["count"] == 1
+    result = payload["results"][0]
+    assert result["id"] == curso_prioritario.id
+    assert result["prioritario"] is True
+    assert result["centro"]["id"] == centro.id
+    assert result["centro"]["provincia"]["id"] == centro.provincia_id
+    assert result["centro"]["ciudad"]["municipio"]["id"] == centro.municipio_id
+    assert result["centro"]["ciudad"]["localidad"]["id"] == centro.localidad_id
+    assert result["centro"]["ciudad"]["direccion"] == centro.domicilio_actividad
+    assert result["programa"] == {"id": programa.id, "nombre": programa.nombre}
+    assert result["voucher_parametrias"][0]["id"] == voucher_parametria.id
+    assert result["comisiones"][0]["id"] == comision.id
+    assert result["comisiones"][0]["horarios"][0]["id"] == horario.id
+    assert result["comisiones"][0]["ubicacion"]["id"] == ubicacion.id
+
+
+@pytest.mark.django_db
 def test_api_vat_comisiones_curso_lista_por_curso(vat_api_client, vat_curso_base):
     centro, ubicacion, modalidad = vat_curso_base
     curso = Curso.objects.create(

--- a/VAT/tests.py
+++ b/VAT/tests.py
@@ -2266,9 +2266,7 @@ def test_api_vat_cursos_buscar_requiere_minimo_tres_caracteres(vat_api_client):
     response = vat_api_client.get("/api/vat/cursos/buscar/?q=he")
 
     assert response.status_code == 400
-    assert response.json() == {
-        "q": ["Debe enviar al menos 3 caracteres para buscar."]
-    }
+    assert response.json() == {"q": ["Debe enviar al menos 3 caracteres para buscar."]}
 
 
 @pytest.mark.django_db

--- a/celiaquia/templates/celiaquia/expediente_detail.html
+++ b/celiaquia/templates/celiaquia/expediente_detail.html
@@ -1034,7 +1034,10 @@
                                             </h6>
                                             <div class="row g-2">
                                                 <div class="col-md-4">
-                                                        <label class="form-label">Apellido Responsable{% if registro.responsable_requerido %} *{% endif %}</label>
+                                                    <label class="form-label">
+                                                        Apellido Responsable
+                                                        {% if registro.responsable_requerido %}*{% endif %}
+                                                    </label>
                                                     <input type="text"
                                                            class="form-control"
                                                            name="apellido_responsable"
@@ -1042,7 +1045,10 @@
                                                            {% if registro.responsable_requerido %}required{% endif %} />
                                                 </div>
                                                 <div class="col-md-4">
-                                                        <label class="form-label">Nombre Responsable{% if registro.responsable_requerido %} *{% endif %}</label>
+                                                    <label class="form-label">
+                                                        Nombre Responsable
+                                                        {% if registro.responsable_requerido %}*{% endif %}
+                                                    </label>
                                                     <input type="text"
                                                            class="form-control"
                                                            name="nombre_responsable"
@@ -1050,7 +1056,10 @@
                                                            {% if registro.responsable_requerido %}required{% endif %} />
                                                 </div>
                                                 <div class="col-md-4">
-                                                        <label class="form-label">CUIT/Documento Responsable{% if registro.responsable_requerido %} *{% endif %}</label>
+                                                    <label class="form-label">
+                                                        CUIT/Documento Responsable
+                                                        {% if registro.responsable_requerido %}*{% endif %}
+                                                    </label>
                                                     <input type="text"
                                                            class="form-control"
                                                            name="documento_responsable"
@@ -1058,7 +1067,10 @@
                                                            {% if registro.responsable_requerido %}required{% endif %} />
                                                 </div>
                                                 <div class="col-md-4">
-                                                        <label class="form-label">Fecha Nac. Responsable{% if registro.responsable_requerido %} *{% endif %}</label>
+                                                    <label class="form-label">
+                                                        Fecha Nac. Responsable
+                                                        {% if registro.responsable_requerido %}*{% endif %}
+                                                    </label>
                                                     <input type="text"
                                                            class="form-control"
                                                            name="fecha_nacimiento_responsable"
@@ -1067,7 +1079,10 @@
                                                            {% if registro.responsable_requerido %}required{% endif %} />
                                                 </div>
                                                 <div class="col-md-4">
-                                                        <label class="form-label">Sexo Responsable{% if registro.responsable_requerido %} *{% endif %}</label>
+                                                    <label class="form-label">
+                                                        Sexo Responsable
+                                                        {% if registro.responsable_requerido %}*{% endif %}
+                                                    </label>
                                                     <select class="form-select"
                                                             name="sexo_responsable"
                                                             {% if registro.responsable_requerido %}required{% endif %}>
@@ -1095,7 +1110,10 @@
                                                            value="{{ registro.datos_raw.email_responsable|default:'' }}" />
                                                 </div>
                                                 <div class="col-md-6">
-                                                        <label class="form-label">Domicilio Responsable{% if registro.responsable_requerido %} *{% endif %}</label>
+                                                    <label class="form-label">
+                                                        Domicilio Responsable
+                                                        {% if registro.responsable_requerido %}*{% endif %}
+                                                    </label>
                                                     <input type="text"
                                                            class="form-control"
                                                            name="domicilio_responsable"
@@ -1103,7 +1121,10 @@
                                                            {% if registro.responsable_requerido %}required{% endif %} />
                                                 </div>
                                                 <div class="col-md-6">
-                                                        <label class="form-label">Localidad Responsable{% if registro.responsable_requerido %} *{% endif %}</label>
+                                                    <label class="form-label">
+                                                        Localidad Responsable
+                                                        {% if registro.responsable_requerido %}*{% endif %}
+                                                    </label>
                                                     <select class="form-select"
                                                             name="localidad_responsable"
                                                             {% if registro.responsable_requerido %}required{% endif %}>

--- a/celiaquia/templates/celiaquia/expediente_detail.html
+++ b/celiaquia/templates/celiaquia/expediente_detail.html
@@ -1034,10 +1034,7 @@
                                             </h6>
                                             <div class="row g-2">
                                                 <div class="col-md-4">
-                                                    <label class="form-label">
-                                                        Apellido Responsable
-                                                        {% if registro.responsable_requerido %}*{% endif %}
-                                                    </label>
+                                                        <label class="form-label">Apellido Responsable{% if registro.responsable_requerido %} *{% endif %}</label>
                                                     <input type="text"
                                                            class="form-control"
                                                            name="apellido_responsable"
@@ -1045,10 +1042,7 @@
                                                            {% if registro.responsable_requerido %}required{% endif %} />
                                                 </div>
                                                 <div class="col-md-4">
-                                                    <label class="form-label">
-                                                        Nombre Responsable
-                                                        {% if registro.responsable_requerido %}*{% endif %}
-                                                    </label>
+                                                        <label class="form-label">Nombre Responsable{% if registro.responsable_requerido %} *{% endif %}</label>
                                                     <input type="text"
                                                            class="form-control"
                                                            name="nombre_responsable"
@@ -1056,10 +1050,7 @@
                                                            {% if registro.responsable_requerido %}required{% endif %} />
                                                 </div>
                                                 <div class="col-md-4">
-                                                    <label class="form-label">
-                                                        CUIT/Documento Responsable
-                                                        {% if registro.responsable_requerido %}*{% endif %}
-                                                    </label>
+                                                        <label class="form-label">CUIT/Documento Responsable{% if registro.responsable_requerido %} *{% endif %}</label>
                                                     <input type="text"
                                                            class="form-control"
                                                            name="documento_responsable"
@@ -1067,10 +1058,7 @@
                                                            {% if registro.responsable_requerido %}required{% endif %} />
                                                 </div>
                                                 <div class="col-md-4">
-                                                    <label class="form-label">
-                                                        Fecha Nac. Responsable
-                                                        {% if registro.responsable_requerido %}*{% endif %}
-                                                    </label>
+                                                        <label class="form-label">Fecha Nac. Responsable{% if registro.responsable_requerido %} *{% endif %}</label>
                                                     <input type="text"
                                                            class="form-control"
                                                            name="fecha_nacimiento_responsable"
@@ -1079,10 +1067,7 @@
                                                            {% if registro.responsable_requerido %}required{% endif %} />
                                                 </div>
                                                 <div class="col-md-4">
-                                                    <label class="form-label">
-                                                        Sexo Responsable
-                                                        {% if registro.responsable_requerido %}*{% endif %}
-                                                    </label>
+                                                        <label class="form-label">Sexo Responsable{% if registro.responsable_requerido %} *{% endif %}</label>
                                                     <select class="form-select"
                                                             name="sexo_responsable"
                                                             {% if registro.responsable_requerido %}required{% endif %}>
@@ -1110,10 +1095,7 @@
                                                            value="{{ registro.datos_raw.email_responsable|default:'' }}" />
                                                 </div>
                                                 <div class="col-md-6">
-                                                    <label class="form-label">
-                                                        Domicilio Responsable
-                                                        {% if registro.responsable_requerido %}*{% endif %}
-                                                    </label>
+                                                        <label class="form-label">Domicilio Responsable{% if registro.responsable_requerido %} *{% endif %}</label>
                                                     <input type="text"
                                                            class="form-control"
                                                            name="domicilio_responsable"
@@ -1121,10 +1103,7 @@
                                                            {% if registro.responsable_requerido %}required{% endif %} />
                                                 </div>
                                                 <div class="col-md-6">
-                                                    <label class="form-label">
-                                                        Localidad Responsable
-                                                        {% if registro.responsable_requerido %}*{% endif %}
-                                                    </label>
+                                                        <label class="form-label">Localidad Responsable{% if registro.responsable_requerido %} *{% endif %}</label>
                                                     <select class="form-select"
                                                             name="localidad_responsable"
                                                             {% if registro.responsable_requerido %}required{% endif %}>

--- a/docs/registro/cambios/2026-04-11-vat-buscador-cursos-api.md
+++ b/docs/registro/cambios/2026-04-11-vat-buscador-cursos-api.md
@@ -1,0 +1,30 @@
+# Buscador de cursos operativos VAT por texto
+
+Fecha: 2026-04-11
+
+## Qué se cambió
+
+- Se agrega `GET /api/vat/cursos/buscar/?q=<texto>` en la API operativa de VAT.
+- El endpoint busca por texto libre sobre nombre del curso, plan de estudio y título de referencia.
+- La búsqueda se habilita a partir de 3 caracteres; si `q` falta o tiene menos de 3 letras devuelve `400`.
+- La respuesta devuelve información enriquecida del curso, incluyendo:
+  - centro con bloque anidado de provincia,
+  - bloque `ciudad` dentro del centro con provincia, municipio, localidad y dirección,
+  - modalidad y plan de estudio,
+  - programa derivado,
+  - parametrías de voucher,
+  - comisiones asociadas con cupos, horarios, sesiones y ubicación.
+- Se agrega el request correspondiente en la colección Postman `VAT - Planes Centros Cursos Comisiones`.
+
+## Criterio funcional
+
+- El buscador está pensado para clientes operativos que necesitan resolver cursos por texto sin hacer múltiples requests encadenadas.
+- La búsqueda reutiliza el flujo operativo actual basado en `Curso` y `ComisionCurso`.
+- El parámetro `q` es obligatorio y debe tener al menos 3 caracteres.
+
+## Validación
+
+- Se agregan tests automáticos para:
+  - búsqueda exitosa con payload enriquecido,
+  - rechazo cuando falta el parámetro `q`,
+  - rechazo cuando el texto tiene menos de 3 caracteres.

--- a/docs/registro/cambios/2026-04-11-vat-cursos-prioritarios-api.md
+++ b/docs/registro/cambios/2026-04-11-vat-cursos-prioritarios-api.md
@@ -1,0 +1,22 @@
+# Cursos prioritarios en API VAT
+
+Fecha: 2026-04-11
+
+## Qué se cambió
+
+- Se agrega el campo booleano `prioritario` en `VAT.Curso` para marcar cursos prioritarios desde base de datos.
+- Se expone `prioritario` en las respuestas de cursos operativos.
+- Se agrega `GET /api/vat/cursos/prioritarios/` con el mismo payload enriquecido del buscador de cursos.
+- Se agrega el request correspondiente en la colección Postman `VAT - Planes Centros Cursos Comisiones`.
+
+## Criterio funcional
+
+- Un curso prioritario es un curso operativo marcado explícitamente en la base con `prioritario = true`.
+- El endpoint de prioritarios reutiliza la misma estructura enriquecida del buscador: centro con provincia anidada, bloque `ciudad` con provincia/municipio/localidad/dirección, programa derivado, parametrías de voucher, comisiones, horarios, sesiones y cupos.
+- El endpoint admite los filtros ya soportados por `CursoViewSet` porque reutiliza el mismo queryset base filtrado.
+
+## Validación
+
+- Se agrega test automático para verificar que:
+  - el endpoint devuelve solo cursos prioritarios,
+  - la respuesta conserva el payload enriquecido esperado.

--- a/docs/registro/cambios/2026-04-12-vat-cursos-ejemplos-postman-swagger.md
+++ b/docs/registro/cambios/2026-04-12-vat-cursos-ejemplos-postman-swagger.md
@@ -1,0 +1,26 @@
+# Ejemplos Postman y Swagger para cursos VAT
+
+Fecha: 2026-04-12
+
+## Qué se cambió
+
+- Se crea la colección Postman `VAT - Cursos Busqueda y Prioritarios` con ejemplos específicos para:
+  - `GET /api/vat/cursos/buscar/`
+  - `GET /api/vat/cursos/prioritarios/`
+- La colección incluye casos felices, filtros combinados y errores esperados para el buscador.
+- Se corrige el bloque de cursos en la colección existente `VAT - Planes Centros Cursos Comisiones` para que los requests `Buscar cursos por texto` y `Listar cursos prioritarios` queden separados correctamente.
+- Se actualiza Swagger/OpenAPI en `VAT/api_views.py` con:
+  - ejemplos de respuesta,
+  - documentación de filtros opcionales compartidos,
+  - descripciones con URLs de uso reales.
+
+## Criterio funcional
+
+- La colección nueva está pensada como material de prueba y referencia rápida para integraciones y QA.
+- Swagger ahora expone mejor el contrato operativo real de ambos endpoints, incluyendo filtros y errores frecuentes.
+
+## Validación
+
+- Se validó que `api_views.py` no tenga errores de análisis.
+- Se validó que ambas colecciones Postman queden sin errores de estructura.
+- Se reejecuta el subset de tests de cursos VAT para asegurar que los cambios de documentación no afecten la carga del módulo.

--- a/postman/VAT - Cursos Busqueda y Prioritarios.postman_collection.json
+++ b/postman/VAT - Cursos Busqueda y Prioritarios.postman_collection.json
@@ -1,0 +1,570 @@
+{
+  "info": {
+    "_postman_id": "5d850da2-a6e9-4b0c-b28c-6fa0d35cf600",
+    "name": "VAT - Cursos Busqueda y Prioritarios",
+    "description": "Coleccion dedicada a ejemplos de uso para los endpoints operativos de cursos VAT: busqueda por texto y listado de cursos prioritarios. Incluye casos felices, filtros combinados y errores esperados.",
+    "schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json"
+  },
+  "variable": [
+    {
+      "key": "baseUrl",
+      "value": "http://localhost:8001"
+    },
+    {
+      "key": "apiPrefix",
+      "value": "/api"
+    },
+    {
+      "key": "apiKey",
+      "value": ""
+    },
+    {
+      "key": "curso_busqueda_minima",
+      "value": "Her"
+    },
+    {
+      "key": "curso_busqueda_plan",
+      "value": "Admin"
+    },
+    {
+      "key": "curso_busqueda_corta",
+      "value": "He"
+    },
+    {
+      "key": "centro_id",
+      "value": ""
+    },
+    {
+      "key": "provincia_id",
+      "value": ""
+    },
+    {
+      "key": "municipio_id",
+      "value": ""
+    },
+    {
+      "key": "modalidad_id",
+      "value": ""
+    },
+    {
+      "key": "programa_id",
+      "value": ""
+    },
+    {
+      "key": "estado_curso",
+      "value": "activo"
+    },
+    {
+      "key": "curso_id",
+      "value": ""
+    }
+  ],
+  "item": [
+    {
+      "name": "0 - Auxiliares",
+      "description": "Requests opcionales para poblar variables de filtros antes de probar busqueda o prioritarios.",
+      "item": [
+        {
+          "name": "Listar centros activos",
+          "request": {
+            "method": "GET",
+            "header": [
+              {
+                "key": "Authorization",
+                "value": "Api-Key {{apiKey}}",
+                "type": "text"
+              }
+            ],
+            "url": {
+              "raw": "{{baseUrl}}{{apiPrefix}}/vat/centros/?activo=true",
+              "host": [
+                "{{baseUrl}}{{apiPrefix}}"
+              ],
+              "path": [
+                "vat",
+                "centros",
+                ""
+              ],
+              "query": [
+                {
+                  "key": "activo",
+                  "value": "true"
+                }
+              ]
+            }
+          },
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "pm.test('Status code is 200', function () {",
+                  "  pm.response.to.have.status(200);",
+                  "});",
+                  "const body = pm.response.json();",
+                  "const rows = Array.isArray(body) ? body : (body.results || []);",
+                  "if (rows.length && rows[0].id) {",
+                  "  pm.collectionVariables.set('centro_id', String(rows[0].id));",
+                  "  pm.collectionVariables.set('provincia_id', String(rows[0].provincia || ''));",
+                  "  pm.collectionVariables.set('municipio_id', String(rows[0].municipio || ''));",
+                  "}"
+                ]
+              }
+            }
+          ],
+          "response": []
+        }
+      ]
+    },
+    {
+      "name": "1 - Buscar cursos",
+      "description": "Ejemplos del endpoint GET /api/vat/cursos/buscar/ con casos exitosos y errores esperados.",
+      "item": [
+        {
+          "name": "Buscar por 3 letras minimo",
+          "request": {
+            "method": "GET",
+            "header": [
+              {
+                "key": "Authorization",
+                "value": "Api-Key {{apiKey}}",
+                "type": "text"
+              }
+            ],
+            "url": {
+              "raw": "{{baseUrl}}{{apiPrefix}}/vat/cursos/buscar/?q={{curso_busqueda_minima}}",
+              "host": [
+                "{{baseUrl}}{{apiPrefix}}"
+              ],
+              "path": [
+                "vat",
+                "cursos",
+                "buscar",
+                ""
+              ],
+              "query": [
+                {
+                  "key": "q",
+                  "value": "{{curso_busqueda_minima}}"
+                }
+              ]
+            }
+          },
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "pm.test('Status code is 200', function () {",
+                  "  pm.response.to.have.status(200);",
+                  "});",
+                  "const body = pm.response.json();",
+                  "const rows = Array.isArray(body) ? body : (body.results || []);",
+                  "pm.test('La respuesta es paginada', function () {",
+                  "  pm.expect(Array.isArray(rows)).to.eql(true);",
+                  "});",
+                  "if (rows.length && rows[0].id) {",
+                  "  pm.collectionVariables.set('curso_id', String(rows[0].id));",
+                  "}"
+                ]
+              }
+            }
+          ],
+          "response": []
+        },
+        {
+          "name": "Buscar por texto con centro y estado",
+          "request": {
+            "method": "GET",
+            "header": [
+              {
+                "key": "Authorization",
+                "value": "Api-Key {{apiKey}}",
+                "type": "text"
+              }
+            ],
+            "url": {
+              "raw": "{{baseUrl}}{{apiPrefix}}/vat/cursos/buscar/?q={{curso_busqueda_plan}}&centro_id={{centro_id}}&estado={{estado_curso}}",
+              "host": [
+                "{{baseUrl}}{{apiPrefix}}"
+              ],
+              "path": [
+                "vat",
+                "cursos",
+                "buscar",
+                ""
+              ],
+              "query": [
+                {
+                  "key": "q",
+                  "value": "{{curso_busqueda_plan}}"
+                },
+                {
+                  "key": "centro_id",
+                  "value": "{{centro_id}}"
+                },
+                {
+                  "key": "estado",
+                  "value": "{{estado_curso}}"
+                }
+              ]
+            }
+          },
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "pm.test('Status code is 200', function () {",
+                  "  pm.response.to.have.status(200);",
+                  "});"
+                ]
+              }
+            }
+          ],
+          "response": []
+        },
+        {
+          "name": "Buscar por texto con provincia y municipio",
+          "request": {
+            "method": "GET",
+            "header": [
+              {
+                "key": "Authorization",
+                "value": "Api-Key {{apiKey}}",
+                "type": "text"
+              }
+            ],
+            "url": {
+              "raw": "{{baseUrl}}{{apiPrefix}}/vat/cursos/buscar/?q={{curso_busqueda_minima}}&provincia_id={{provincia_id}}&municipio_id={{municipio_id}}",
+              "host": [
+                "{{baseUrl}}{{apiPrefix}}"
+              ],
+              "path": [
+                "vat",
+                "cursos",
+                "buscar",
+                ""
+              ],
+              "query": [
+                {
+                  "key": "q",
+                  "value": "{{curso_busqueda_minima}}"
+                },
+                {
+                  "key": "provincia_id",
+                  "value": "{{provincia_id}}"
+                },
+                {
+                  "key": "municipio_id",
+                  "value": "{{municipio_id}}"
+                }
+              ]
+            }
+          },
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "pm.test('Status code is 200', function () {",
+                  "  pm.response.to.have.status(200);",
+                  "});"
+                ]
+              }
+            }
+          ],
+          "response": []
+        },
+        {
+          "name": "Error por faltar q",
+          "request": {
+            "method": "GET",
+            "header": [
+              {
+                "key": "Authorization",
+                "value": "Api-Key {{apiKey}}",
+                "type": "text"
+              }
+            ],
+            "url": {
+              "raw": "{{baseUrl}}{{apiPrefix}}/vat/cursos/buscar/",
+              "host": [
+                "{{baseUrl}}{{apiPrefix}}"
+              ],
+              "path": [
+                "vat",
+                "cursos",
+                "buscar",
+                ""
+              ]
+            }
+          },
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "pm.test('Status code is 400', function () {",
+                  "  pm.response.to.have.status(400);",
+                  "});"
+                ]
+              }
+            }
+          ],
+          "response": []
+        },
+        {
+          "name": "Error por menos de 3 letras",
+          "request": {
+            "method": "GET",
+            "header": [
+              {
+                "key": "Authorization",
+                "value": "Api-Key {{apiKey}}",
+                "type": "text"
+              }
+            ],
+            "url": {
+              "raw": "{{baseUrl}}{{apiPrefix}}/vat/cursos/buscar/?q={{curso_busqueda_corta}}",
+              "host": [
+                "{{baseUrl}}{{apiPrefix}}"
+              ],
+              "path": [
+                "vat",
+                "cursos",
+                "buscar",
+                ""
+              ],
+              "query": [
+                {
+                  "key": "q",
+                  "value": "{{curso_busqueda_corta}}"
+                }
+              ]
+            }
+          },
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "pm.test('Status code is 400', function () {",
+                  "  pm.response.to.have.status(400);",
+                  "});"
+                ]
+              }
+            }
+          ],
+          "response": []
+        }
+      ]
+    },
+    {
+      "name": "2 - Cursos prioritarios",
+      "description": "Ejemplos del endpoint GET /api/vat/cursos/prioritarios/ con y sin filtros opcionales.",
+      "item": [
+        {
+          "name": "Listar todos los prioritarios",
+          "request": {
+            "method": "GET",
+            "header": [
+              {
+                "key": "Authorization",
+                "value": "Api-Key {{apiKey}}",
+                "type": "text"
+              }
+            ],
+            "url": {
+              "raw": "{{baseUrl}}{{apiPrefix}}/vat/cursos/prioritarios/",
+              "host": [
+                "{{baseUrl}}{{apiPrefix}}"
+              ],
+              "path": [
+                "vat",
+                "cursos",
+                "prioritarios",
+                ""
+              ]
+            }
+          },
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "pm.test('Status code is 200', function () {",
+                  "  pm.response.to.have.status(200);",
+                  "});",
+                  "const body = pm.response.json();",
+                  "const rows = Array.isArray(body) ? body : (body.results || []);",
+                  "pm.test('La respuesta es paginada', function () {",
+                  "  pm.expect(Array.isArray(rows)).to.eql(true);",
+                  "});",
+                  "if (rows.length && rows[0].id) {",
+                  "  pm.collectionVariables.set('curso_id', String(rows[0].id));",
+                  "}"
+                ]
+              }
+            }
+          ],
+          "response": []
+        },
+        {
+          "name": "Prioritarios por centro y estado",
+          "request": {
+            "method": "GET",
+            "header": [
+              {
+                "key": "Authorization",
+                "value": "Api-Key {{apiKey}}",
+                "type": "text"
+              }
+            ],
+            "url": {
+              "raw": "{{baseUrl}}{{apiPrefix}}/vat/cursos/prioritarios/?centro_id={{centro_id}}&estado={{estado_curso}}",
+              "host": [
+                "{{baseUrl}}{{apiPrefix}}"
+              ],
+              "path": [
+                "vat",
+                "cursos",
+                "prioritarios",
+                ""
+              ],
+              "query": [
+                {
+                  "key": "centro_id",
+                  "value": "{{centro_id}}"
+                },
+                {
+                  "key": "estado",
+                  "value": "{{estado_curso}}"
+                }
+              ]
+            }
+          },
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "pm.test('Status code is 200', function () {",
+                  "  pm.response.to.have.status(200);",
+                  "});"
+                ]
+              }
+            }
+          ],
+          "response": []
+        },
+        {
+          "name": "Prioritarios por provincia y municipio",
+          "request": {
+            "method": "GET",
+            "header": [
+              {
+                "key": "Authorization",
+                "value": "Api-Key {{apiKey}}",
+                "type": "text"
+              }
+            ],
+            "url": {
+              "raw": "{{baseUrl}}{{apiPrefix}}/vat/cursos/prioritarios/?provincia_id={{provincia_id}}&municipio_id={{municipio_id}}",
+              "host": [
+                "{{baseUrl}}{{apiPrefix}}"
+              ],
+              "path": [
+                "vat",
+                "cursos",
+                "prioritarios",
+                ""
+              ],
+              "query": [
+                {
+                  "key": "provincia_id",
+                  "value": "{{provincia_id}}"
+                },
+                {
+                  "key": "municipio_id",
+                  "value": "{{municipio_id}}"
+                }
+              ]
+            }
+          },
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "pm.test('Status code is 200', function () {",
+                  "  pm.response.to.have.status(200);",
+                  "});"
+                ]
+              }
+            }
+          ],
+          "response": []
+        },
+        {
+          "name": "Prioritarios por modalidad y programa",
+          "request": {
+            "method": "GET",
+            "header": [
+              {
+                "key": "Authorization",
+                "value": "Api-Key {{apiKey}}",
+                "type": "text"
+              }
+            ],
+            "url": {
+              "raw": "{{baseUrl}}{{apiPrefix}}/vat/cursos/prioritarios/?modalidad_id={{modalidad_id}}&programa_id={{programa_id}}",
+              "host": [
+                "{{baseUrl}}{{apiPrefix}}"
+              ],
+              "path": [
+                "vat",
+                "cursos",
+                "prioritarios",
+                ""
+              ],
+              "query": [
+                {
+                  "key": "modalidad_id",
+                  "value": "{{modalidad_id}}"
+                },
+                {
+                  "key": "programa_id",
+                  "value": "{{programa_id}}"
+                }
+              ]
+            }
+          },
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "pm.test('Status code is 200', function () {",
+                  "  pm.response.to.have.status(200);",
+                  "});"
+                ]
+              }
+            }
+          ],
+          "response": []
+        }
+      ]
+    }
+  ]
+}

--- a/postman/VAT - Planes Centros Cursos Comisiones.postman_collection.json
+++ b/postman/VAT - Planes Centros Cursos Comisiones.postman_collection.json
@@ -39,6 +39,10 @@
       "value": ""
     },
     {
+      "key": "curso_busqueda",
+      "value": "admin"
+    },
+    {
       "key": "sector_id",
       "value": ""
     }
@@ -648,6 +652,106 @@
                   "});",
                   "const body = pm.response.json();",
                   "const rows = Array.isArray(body) ? body : (body.results || []);",
+                  "if (rows.length && rows[0].id) {",
+                  "  pm.collectionVariables.set('curso_id', String(rows[0].id));",
+                  "}"
+                ]
+              }
+            }
+          ],
+          "response": []
+        },
+        {
+          "name": "Buscar cursos por texto",
+          "request": {
+            "method": "GET",
+            "header": [
+              {
+                "key": "Authorization",
+                "value": "Api-Key {{apiKey}}",
+                "type": "text"
+              }
+            ],
+            "url": {
+              "raw": "{{baseUrl}}{{apiPrefix}}/vat/cursos/buscar/?q={{curso_busqueda}}",
+              "host": [
+                "{{baseUrl}}{{apiPrefix}}"
+              ],
+              "path": [
+                "vat",
+                "cursos",
+                "buscar",
+                ""
+              ],
+              "query": [
+                {
+                  "key": "q",
+                  "value": "{{curso_busqueda}}"
+                }
+              ]
+            }
+          },
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "pm.test('Status code is 200', function () {",
+                  "  pm.response.to.have.status(200);",
+                  "});",
+                  "const body = pm.response.json();",
+                  "const rows = Array.isArray(body) ? body : (body.results || []);",
+                  "pm.test('La respuesta contiene resultados paginados', function () {",
+                  "  pm.expect(Array.isArray(rows)).to.eql(true);",
+                  "});",
+                  "if (rows.length && rows[0].id) {",
+                  "  pm.collectionVariables.set('curso_id', String(rows[0].id));",
+                  "}"
+                ]
+              }
+            }
+          ],
+          "response": []
+        },
+        {
+          "name": "Listar cursos prioritarios",
+          "request": {
+            "method": "GET",
+            "header": [
+              {
+                "key": "Authorization",
+                "value": "Api-Key {{apiKey}}",
+                "type": "text"
+              }
+            ],
+            "url": {
+              "raw": "{{baseUrl}}{{apiPrefix}}/vat/cursos/prioritarios/",
+              "host": [
+                "{{baseUrl}}{{apiPrefix}}"
+              ],
+              "path": [
+                "vat",
+                "cursos",
+                "prioritarios",
+                ""
+              ]
+            }
+          },
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "pm.test('Status code is 200', function () {",
+                  "  pm.response.to.have.status(200);",
+                  "});",
+                  "const body = pm.response.json();",
+                  "const rows = Array.isArray(body) ? body : (body.results || []);",
+                  "pm.test('La respuesta contiene resultados paginados', function () {",
+                  "  pm.expect(Array.isArray(rows)).to.eql(true);",
+                  "});",
                   "if (rows.length && rows[0].id) {",
                   "  pm.collectionVariables.set('curso_id', String(rows[0].id));",
                   "}"


### PR DESCRIPTION
- Implemented a new endpoint `GET /api/vat/cursos/buscar/?q=<texto>` for searching courses by name, study plan, and reference title, requiring a minimum of 3 characters.
- Added a boolean field `prioritario` to the `Curso` model to mark courses as priority.
- Created a new endpoint `GET /api/vat/cursos/prioritarios/` to list only priority courses with enriched payload.
- Updated serializers to include the new `prioritario` field and enrich responses for both search and priority endpoints.
- Added automated tests to validate the functionality of the new search and prioritization features.
- Enhanced Postman collections with examples for the new endpoints and updated Swagger documentation.

# Información de la Tarea
Vincular el #ISSUE

### **Resumen de la Solución:** 
-

### **Información Adicional:**
-

# Descripción de los Cambios

### **Cambios:**
-

# Cómo Testear los Cambios

### **Pruebas Automáticas:**
-

### **Prubeas Manuales:**
-

# Metadata para documentación automática

- Contexto funcional:
- Tipo de cambio:
- Área principal:
- Resumen para changelog:
- Impacto usuario:
- Riesgos / rollback:

# Capturas de Pantalla
