### PR TITLE
fix(vat): corregir fallback del formulario de ubicacion

### DIFF
--- a/VAT/templates/vat/institucion/ubicacion_form.html
+++ b/VAT/templates/vat/institucion/ubicacion_form.html
@@ -1,6 +1,5 @@
 {% extends "includes/main.html" %}
 {% load static %}
-{% url 'vat_institucion_ubicacion_list' as ubicacion_list_url %}
 
 {% block title %}
     {% if form.instance.id %}
@@ -16,7 +15,7 @@
         <div class="row mb-4">
             <div class="col-12">
                 <div class="d-flex align-items-center gap-2 mb-4">
-                    <a href="{% if return_url %}{{ return_url }}{% else %}{{ ubicacion_list_url }}{% endif %}"
+                    <a href="{% if return_url %}{{ return_url }}{% else %}{% url 'vat_institucion_ubicacion_list' %}{% endif %}"
                        class="btn btn-light"><i class="bi bi-arrow-left"></i></a>
                     <div>
                         <h1 class="h2 mb-0" style="color: #1f3a93;">
@@ -109,7 +108,7 @@
 
                             <hr class="my-4" />
                             <div class="d-flex gap-2 justify-content-end">
-                                <a href="{% if return_url %}{{ return_url }}{% else %}{{ ubicacion_list_url }}{% endif %}"
+                                <a href="{% if return_url %}{{ return_url }}{% else %}{% url 'vat_institucion_ubicacion_list' %}{% endif %}"
                                    class="btn btn-outline-secondary"><i class="bi bi-x-lg me-2"></i>Cancelar</a>
                                 <button type="submit" class="btn btn-primary">
                                     <i class="bi bi-check-lg me-2"></i>

--- a/VAT/tests.py
+++ b/VAT/tests.py
@@ -1333,6 +1333,63 @@ def test_centro_detail_muestra_boton_editar_para_referente_cfp(client, vat_geo_d
 
 @pytest.mark.django_db
 @override_settings(ROOT_URLCONF="config.urls")
+def test_institucion_ubicacion_update_renderiza_con_volver_al_detalle_del_centro(
+    client, vat_geo_data
+):
+    provincia, municipio, localidad = vat_geo_data
+    group, _ = Group.objects.get_or_create(name="CFP")
+    user = User.objects.create_superuser(
+        username="admin-ubicacion-update-get",
+        email="admin-ubicacion-update-get@vat.test",
+        password="test1234",
+    )
+    user.groups.add(group)
+    centro = Centro.objects.create(
+        nombre="Centro Ubicaciones GET",
+        codigo="CFP-UBI-GET",
+        provincia=provincia,
+        municipio=municipio,
+        localidad=localidad,
+        calle="8",
+        numero=456,
+        domicilio_actividad="Calle 8 N° 456",
+        telefono="221-4100000",
+        celular="221-5100000",
+        correo="centro-ubicaciones-get@vat.test",
+        nombre_referente="Luisa",
+        apellido_referente="Martinez",
+        telefono_referente="221-6100000",
+        correo_referente="luisa-get@vat.test",
+        referente=user,
+        tipo_gestion="Estatal",
+        clase_institucion="Formación Profesional",
+        situacion="Institución de ETP",
+        activo=True,
+    )
+    ubicacion = InstitucionUbicacion.objects.create(
+        centro=centro,
+        localidad=localidad,
+        rol_ubicacion="anexo",
+        nombre_ubicacion="Anexo Norte",
+        domicilio="Calle 8 N° 460",
+        es_principal=False,
+    )
+
+    client.force_login(user)
+    response = client.get(
+        reverse("vat_institucion_ubicacion_update", kwargs={"pk": ubicacion.pk})
+    )
+
+    return_url = reverse("vat_centro_detail", kwargs={"pk": centro.pk})
+    content = response.content.decode("utf-8")
+
+    assert response.status_code == 200
+    assert response.context["return_url"] == return_url
+    assert f'href="{return_url}"' in content
+
+
+@pytest.mark.django_db
+@override_settings(ROOT_URLCONF="config.urls")
 def test_institucion_ubicacion_update_redirige_al_detalle_del_centro(
     client, vat_geo_data
 ):

--- a/docs/registro/cambios/2026-04-12-vat-ubicacion-editar-return-url.md
+++ b/docs/registro/cambios/2026-04-12-vat-ubicacion-editar-return-url.md
@@ -1,0 +1,16 @@
+# Fix edición de ubicación VAT
+
+Fecha: 2026-04-12
+
+## Qué cambió
+
+- Se corrigió el template `vat/institucion/ubicacion_form.html` para que los botones de volver y cancelar usen `return_url` cuando la vista lo provee.
+- Si `return_url` no está presente, el template ahora resuelve el fallback directamente con `{% url 'vat_institucion_ubicacion_list' %}`.
+
+## Problema resuelto
+
+- La pantalla `/vat/institucion/ubicaciones/<pk>/editar/` podía fallar con `VariableDoesNotExist` al intentar renderizar `ubicacion_list_url` sin haberla definido.
+
+## Decisión
+
+- Se mantuvo la navegación especial de la edición hacia el detalle del centro y se eliminó la dependencia del template a una variable auxiliar implícita.


### PR DESCRIPTION
why: la edición de ubicaciones podía romper al renderizar un fallback de navegación no definido.

what:
- usa return_url con fallback directo al listado en el template
- agrega test de regresión del GET de edición
- registra el cambio en docs/registro/cambios

tests:
- py -3 -m black --check VAT/tests.py
- pytest no ejecutado: el host no tiene pytest y Docker Desktop no estaba levantado

# Información de la Tarea
Vincular el #ISSUE

### **Resumen de la Solución:** 
-

### **Información Adicional:**
-

# Descripción de los Cambios

### **Cambios:**
-

# Cómo Testear los Cambios

### **Pruebas Automáticas:**
-

### **Prubeas Manuales:**
-

# Metadata para documentación automática

- Contexto funcional:
- Tipo de cambio:
- Área principal:
- Resumen para changelog:
- Impacto usuario:
- Riesgos / rollback:

# Capturas de Pantalla
