### PR TITLE
fix(celiaquia): estabilizar labels de responsable en expediente

### DIFF
--- a/celiaquia/templates/celiaquia/expediente_detail.html
+++ b/celiaquia/templates/celiaquia/expediente_detail.html
@@ -1034,10 +1034,7 @@
                                             </h6>
                                             <div class="row g-2">
                                                 <div class="col-md-4">
-                                                    <label class="form-label">
-                                                        Apellido Responsable
-                                                        {% if registro.responsable_requerido %}*{% endif %}
-                                                    </label>
+                                                    <label class="form-label">Apellido Responsable{% if registro.responsable_requerido %} *{% endif %}</label>
                                                     <input type="text"
                                                            class="form-control"
                                                            name="apellido_responsable"
@@ -1045,10 +1042,7 @@
                                                            {% if registro.responsable_requerido %}required{% endif %} />
                                                 </div>
                                                 <div class="col-md-4">
-                                                    <label class="form-label">
-                                                        Nombre Responsable
-                                                        {% if registro.responsable_requerido %}*{% endif %}
-                                                    </label>
+                                                    <label class="form-label">Nombre Responsable{% if registro.responsable_requerido %} *{% endif %}</label>
                                                     <input type="text"
                                                            class="form-control"
                                                            name="nombre_responsable"
@@ -1056,10 +1050,7 @@
                                                            {% if registro.responsable_requerido %}required{% endif %} />
                                                 </div>
                                                 <div class="col-md-4">
-                                                    <label class="form-label">
-                                                        CUIT/Documento Responsable
-                                                        {% if registro.responsable_requerido %}*{% endif %}
-                                                    </label>
+                                                    <label class="form-label">CUIT/Documento Responsable{% if registro.responsable_requerido %} *{% endif %}</label>
                                                     <input type="text"
                                                            class="form-control"
                                                            name="documento_responsable"
@@ -1067,10 +1058,7 @@
                                                            {% if registro.responsable_requerido %}required{% endif %} />
                                                 </div>
                                                 <div class="col-md-4">
-                                                    <label class="form-label">
-                                                        Fecha Nac. Responsable
-                                                        {% if registro.responsable_requerido %}*{% endif %}
-                                                    </label>
+                                                    <label class="form-label">Fecha Nac. Responsable{% if registro.responsable_requerido %} *{% endif %}</label>
                                                     <input type="text"
                                                            class="form-control"
                                                            name="fecha_nacimiento_responsable"
@@ -1079,10 +1067,7 @@
                                                            {% if registro.responsable_requerido %}required{% endif %} />
                                                 </div>
                                                 <div class="col-md-4">
-                                                    <label class="form-label">
-                                                        Sexo Responsable
-                                                        {% if registro.responsable_requerido %}*{% endif %}
-                                                    </label>
+                                                    <label class="form-label">Sexo Responsable{% if registro.responsable_requerido %} *{% endif %}</label>
                                                     <select class="form-select"
                                                             name="sexo_responsable"
                                                             {% if registro.responsable_requerido %}required{% endif %}>
@@ -1110,10 +1095,7 @@
                                                            value="{{ registro.datos_raw.email_responsable|default:'' }}" />
                                                 </div>
                                                 <div class="col-md-6">
-                                                    <label class="form-label">
-                                                        Domicilio Responsable
-                                                        {% if registro.responsable_requerido %}*{% endif %}
-                                                    </label>
+                                                    <label class="form-label">Domicilio Responsable{% if registro.responsable_requerido %} *{% endif %}</label>
                                                     <input type="text"
                                                            class="form-control"
                                                            name="domicilio_responsable"
@@ -1121,10 +1103,7 @@
                                                            {% if registro.responsable_requerido %}required{% endif %} />
                                                 </div>
                                                 <div class="col-md-6">
-                                                    <label class="form-label">
-                                                        Localidad Responsable
-                                                        {% if registro.responsable_requerido %}*{% endif %}
-                                                    </label>
+                                                    <label class="form-label">Localidad Responsable{% if registro.responsable_requerido %} *{% endif %}</label>
                                                     <select class="form-select"
                                                             name="localidad_responsable"
                                                             {% if registro.responsable_requerido %}required{% endif %}>

--- a/docs/registro/cambios/2026-04-12-fix-pr1511-celiaquia-label-responsable.md
+++ b/docs/registro/cambios/2026-04-12-fix-pr1511-celiaquia-label-responsable.md
@@ -1,0 +1,17 @@
+# 2026-04-12 - Fix PR 1511 Celiaquia label responsable
+
+## Que se corrigio
+- Se estabilizo el render de las etiquetas del bloque `Responsable` en el detalle de expediente de Celiaquia.
+- Las labels con obligatoriedad condicional vuelven a renderizar el asterisco en la misma linea del texto, evitando falsos negativos en tests que validan el contenido HTML generado.
+
+## Causa raiz
+- Un cambio de formato en `celiaquia/templates/celiaquia/expediente_detail.html` partio labels como `Apellido Responsable *` en multiples lineas.
+- El formulario seguia mostrando los campos del responsable, pero el HTML ya no contenia la cadena exacta esperada por la regresion `test_detalle_expediente_muestra_campos_responsable_para_registros_erroneos`.
+
+## Impacto funcional
+- No cambia la logica de negocio ni la validacion de responsables.
+- Se recupera un HTML estable para el detalle de registros erroneos y se evita la regresion del test de render.
+
+## Validacion
+- No se pudo ejecutar `pytest` en este entorno porque Docker Desktop no estaba disponible y no hay interprete Python con dependencias del proyecto instalado en PATH.
+- Se verifico la causa raiz revisando el historial del template: el commit `c3c4968f9` (`format`) introdujo el label multilinea.


### PR DESCRIPTION
why: un cambio de formato dejo labels multilinea en el bloque de responsable y rompio la regresion que valida el HTML del detalle de expediente.

what:
- vuelve a renderizar en una sola linea las labels condicionales del responsable
- registra el ajuste en docs/registro/cambios

impact: sin cambios funcionales ni de validacion de negocio

tests: no ejecutados; Docker Desktop no estaba disponible y no hay Python del proyecto en PATH

# Información de la Tarea
Vincular el #ISSUE

### **Resumen de la Solución:** 
-

### **Información Adicional:**
-

# Descripción de los Cambios

### **Cambios:**
-

# Cómo Testear los Cambios

### **Pruebas Automáticas:**
-

### **Prubeas Manuales:**
-

# Metadata para documentación automática

- Contexto funcional:
- Tipo de cambio:
- Área principal:
- Resumen para changelog:
- Impacto usuario:
- Riesgos / rollback:

# Capturas de Pantalla
