### PR TITLE
docs(ia): reducir contexto raiz y normalizar worktrees externos

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,82 +1,19 @@
 # Instrucciones para GitHub Copilot (SISOC)
 
-Estas instrucciones están alineadas con `AGENTS.md` y la documentación en `docs/ia/`.
+Fuente de verdad:
+- `AGENTS.md`
 
-## Fuente de verdad (obligatorio)
-
-Copilot debe priorizar, en este orden:
-
-1. `AGENTS.md` (reglas principales)
+Arranque minimo:
+1. `AGENTS.md`
 2. `docs/indice.md`
-3. `docs/ia/CONTEXT_HYGIENE.md`
-4. `docs/ia/STYLE_GUIDE.md`
-5. `docs/ia/ARCHITECTURE.md`
-6. `docs/ia/TESTING.md`
-7. `docs/ia/SECURITY_AI.md` / `docs/ia/ERRORS_LOGGING.md` si aplica
+3. archivo objetivo + tests
+4. una guia relevante de `docs/ia/`
 
-Si `AGENTS.md` no fue cargado automáticamente por el entorno, usar estas instrucciones como fallback mínimo y evitar cambios grandes de arquitectura/refactor hasta tener contexto.
+Principios:
+- minimo contexto suficiente,
+- diffs chicos,
+- sin inventar contratos ni permisos,
+- validacion puntual antes de checks amplios,
+- documentacion en `docs/` para cambios importantes.
 
-## Resumen del stack real
-
-- Backend: `Python 3.11`, `Django 4.2`, `Django REST Framework`
-- DB: `MySQL` (tests pueden usar `SQLite` en memoria)
-- Frontend: templates Django + HTML/CSS/JS + Bootstrap
-- Infra local/CI: Docker Compose + GitHub Actions
-- Asincronía: **no se usa Celery** actualmente
-
-## Patrones críticos del repo (no asumir otra cosa)
-
-- La lógica de negocio va preferentemente en `services/`.
-- Coexisten vistas Django (web) y DRF (`api_views.py` / viewsets); validar patrón por app.
-- Hay logging custom en `config/settings.py` y `core/utils.py` (handlers/formatters propios).
-- No imponer `ruff`, `mypy`, `eslint`, `prettier` como checks obligatorios (no hay config formal activa para esos checks).
-
-## Reglas mínimas no negociables (fallback)
-
-- No inventar APIs, modelos, campos, serializers, endpoints ni permisos.
-- Hacer cambios mínimos (`small diffs`) y revisables.
-- No mezclar feature + refactor + formateo masivo.
-- Mantener compatibilidad hacia atrás por defecto.
-- No tocar configs de tooling/CI/settings sin pedido explícito.
-- Agregar tests mínimos en features nuevas y regresión en bugfixes cuando sea viable.
-- No loggear secretos, tokens ni PII.
-- Respetar permisos/autenticación existentes.
-- Leer documentación relevante en `docs/` antes de proponer cambios.
-- Documentar cambios/decisiones importantes en `docs/` dentro de subcarpeta temática (crearla si no existe).
-- Podés proponer mejoras cercanas, pero no implementarlas fuera de alcance sin aprobación.
-
-## Higiene de contexto (muy importante)
-
-- Cargar primero el mínimo contexto suficiente y expandir solo si hace falta.
-- Empezar por el archivo objetivo + tests del módulo + guías `docs/ia/*` relevantes.
-- Evitar explorar apps no relacionadas o hacer limpieza oportunista.
-- Si el repo está con cambios locales del usuario, no revertirlos ni asumir que son errores.
-
-Ver: `docs/ia/CONTEXT_HYGIENE.md`.
-
-## Comandos frecuentes (alineados al repo)
-
-```bash
-docker compose up
-docker compose exec django pytest -n auto
-docker compose exec django pytest -m smoke
-black .
-djlint . --configuration=.djlintrc --reformat
-pylint **/*.py --rcfile=.pylintrc
-```
-
-## Calidad esperada de cambios
-
-- Código profesional, simple y mantenible.
-- Priorizar claridad sobre soluciones complejas.
-- Reutilizar patrones existentes del módulo.
-- Si falta información, explicitar supuestos.
-- Si cambia comportamiento observable, actualizar docs relevantes.
-
-## Entrega recomendada (cuando Copilot genere cambios asistidos)
-
-- Qué cambió
-- Archivos tocados
-- Validación ejecutada (si se corrió)
-- Supuestos
-- Mejoras cercanas detectadas (opcional)
+Si falta `AGENTS.md`, usar este archivo como fallback corto y evitar cambios grandes hasta tener contexto.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,419 +1,162 @@
 # AGENTS.md
 
-Guía principal para IAs (Codex/Claude/GPT) que trabajen en este repositorio.
-
-Objetivo: reducir variabilidad entre IAs y PRs, producir cambios chicos y revisables, y mantener consistencia técnica con el stack real de SISOC.
-
-## Alcance
-
-Aplica a:
-- Bugfixes puntuales.
-- Features chicas y medianas.
-- Refactors seguros (sin cambio funcional).
-- Features grandes (por fases).
-
-No reemplaza documentación funcional o técnica profunda. Para detalle, usar `docs/` y las guías en `docs/ia/`.
-
-## Política Spec-as-Source (obligatoria)
-
-Para trabajar en SISOC con asistentes, la documentación en `docs/` es fuente de verdad operacional:
-
-- Antes de proponer o implementar cambios, es obligatorio leer `docs/indice.md`, `docs/ia/` y la documentación del dominio afectado.
-- Cada cambio y cada decisión importante debe quedar documentada en `docs/` dentro de la subcarpeta que corresponda al dominio/tema.
-- No se busca depender de herramientas específicas de spec-driven development: la fuente de verdad son archivos Markdown versionados en el repo.
-- Convención recomendada (no exclusiva):
-  - `docs/registro/cambios/YYYY-MM-DD-<tema>.md`
-  - `docs/registro/decisiones/YYYY-MM-DD-<tema>.md`
-- Si la subcarpeta necesaria no existe, debe crearse dentro de `docs/`.
-
-## Stack real del repo (resumen)
-
-- Backend: `Python 3.11`, `Django 4.2`, `Django REST Framework`.
-- Base de datos: `MySQL` (tests pueden usar `SQLite` en memoria según settings).
-- Frontend: templates Django + HTML/CSS/JS + Bootstrap.
-- API schema/docs: `drf-spectacular`.
-- Infra local/CI: `Docker Compose`, GitHub Actions.
-- Asincronía actual: **no se usa Celery**. Hay jobs/tareas vía comandos, hilos y procesos del propio stack Django cuando aplica.
-
-## Tooling real detectado (obligatorio respetar)
-
-- Formato Python: `black` (config en `pyproject.toml`).
-- Lint Python: `pylint` (config en `.pylintrc`, con `pylint_django`). Tomar `.pylintrc` como contrato real: primero ajustar el código para cumplir la regla y dejar `ignore`/`disable` como último recurso, local y justificado.
-- Templates: `djlint` (config en `.djlintrc`).
-- Tests: `pytest`, `pytest-django`, `pytest-xdist`.
-- CI: `.github/workflows/lint.yml` y `.github/workflows/tests.yml`.
-
-No imponer como obligatorio si no fue pedido: `ruff`, `mypy`, `eslint`, `prettier` (no hay configuración formal activa para estos checks en el repo).
-
-## Disciplina de formato y lint para IAs (obligatoria)
-
-- Escribir Python compatible con `black` desde el inicio. La referencia operativa es `line-length = 88`; no usar el `max-line-length = 150` de `pylint` como excusa para dejar líneas largas evitables.
-- Preferir construcciones que `black` resuelve bien: paréntesis implícitos, literales multilínea y llamadas partidas por argumentos. Evitar alinear manualmente, columnas “bonitas” o wraps ad hoc que después `black` desarma.
-- Mantener imports en bloques consistentes: standard library, terceros y código local. No reordenar imports no relacionados fuera del archivo tocado.
-- Escribir nombres, firmas y variables alineados con `.pylintrc`: `snake_case` para funciones/variables, `PascalCase` para clases y helpers privados con prefijo `_` cuando aplique.
-- Cuando `pylint` marque una violación, intentar resolverla con mejores prácticas antes que con una supresión: simplificar funciones, extraer helpers, ajustar nombres, mover lógica al boundary correcto o hacer más explícito el código.
-- Evitar `# pylint: disable=...`, `# pylint: skip-file`, `ignore-paths` nuevos o ampliaciones de `ignore` como atajo. Si una supresión es inevitable por una falsa positiva o por dinámica del framework, limitarla al menor scope posible y documentar la razón.
-- En templates, escribir HTML/Django template tags pensando en `djlint`: indentación de 4 espacios, tags anidados legibles y sin compactar bloques en una sola línea si el formatter los va a expandir.
-- Validar primero sobre archivos modificados para reducir fricción y ruido. Escalar a checks más amplios solo si el impacto del cambio lo justifica o el pedido lo exige.
-
-## Patrones críticos del repo (leer antes de proponer cambios)
-
-- La lógica de negocio va preferentemente en `services/` (no en views/templates).
-- Coexisten vistas Django (web) y DRF (`api_views.py` / viewsets). Verificar el patrón real de cada app antes de implementar.
-- El proyecto ya tiene logging custom configurado en `config/settings.py` y utilidades en `core/utils.py` (no inventar un esquema paralelo).
-- No asumir Celery/colas/workers: actualmente no se usa Celery.
-
-## Comandos principales (copy-paste)
-
-```bash
-# Levantar entorno local
-
-docker compose up
-# alternativa usada en docs históricas
-
-docker-compose up
-
-# Tests
-
-docker compose exec django pytest -n auto
-docker compose exec django pytest -m smoke
-
-# Formato / lint
-
-black .
-black --check . --config pyproject.toml
-black path/al/archivo.py --config pyproject.toml
-djlint . --configuration=.djlintrc --reformat
-djlint . --check --configuration=.djlintrc
-djlint templates/ruta.html --reformat --configuration=.djlintrc
-pylint **/*.py --rcfile=.pylintrc
-pylint app/archivo.py --rcfile=.pylintrc
-```
-
-## Reglas de comportamiento para IAs (obligatorias)
-
-## 1) Buscar antes de escribir
-
-- No inventar APIs, funciones, clases, modelos, campos, serializers, endpoints ni permisos.
-- Buscar referencias reales en el repo antes de proponer o escribir código.
-- Reutilizar patrones existentes del módulo/app que se toca.
-- No asumir Celery/colas workers si no está explícitamente pedido (actualmente no se usa Celery en el repo).
-
-## 2) Cambios mínimos y revisables
-
-- Hacer `small diffs`: modificar solo lo necesario para cumplir el pedido.
-- No mezclar en un mismo cambio: feature + refactor + formateo masivo.
-- No hacer refactors amplios no solicitados.
-- No tocar archivos no relacionados “porque estaban cerca” salvo justificación clara.
-
-## 3) Compatibilidad hacia atrás por defecto
-
-- Mantener compatibilidad hacia atrás salvo pedido explícito.
-- Si hay una ruptura necesaria, explicitarla antes y documentar impacto.
-
-## 4) Supuestos explícitos
-
-- Si falta información, avanzar con supuestos razonables y declararlos explícitamente.
-- Los supuestos deben quedar en el mensaje de entrega y/o PR/commit message sugerido.
-
-## 5) Respetar tooling y configuración
-
-- No modificar configuraciones de `black`, `pylint`, `djlint`, `pytest`, CI o settings de entorno sin pedido explícito.
-- No reordenar/importar/formatear todo el repo para “dejarlo prolijo”.
-
-## 6) Calidad de código esperada
-
-- Escribir código profesional, simple, eficiente y mantenible.
-- Priorizar claridad sobre cleverness.
-- Mantener nombres y estructura coherentes con el módulo existente.
-
-## 7) Idioma y naming (regla del equipo)
-
-- Documentación, comentarios y mensajes al usuario: en español.
-- Variables y nombres técnicos generales: preferentemente en inglés (`request_data`, `cache_key`).
-- Nombres de dominio del sistema: conservar en español cuando ya forman parte del modelo/flujo (`comedor`, `admisión`, `relevamiento`, `monto_prestacion`).
-- No traducir nombres de modelos/campos/URLs existentes.
-
-## 8) Testing mínimo obligatorio
-
-- Toda funcionalidad nueva debe incluir testing mínimo.
-- Todo bugfix debe incluir test de regresión cuando sea viable.
-- Si no se agrega test, explicar por qué.
-
-## 9) Documentación y ejemplos
-
-- Si cambia comportamiento observable, actualizar docs relevantes.
-- Incluir ejemplo mínimo de uso cuando el cambio agrega interfaz nueva (endpoint, helper, comando, flujo).
-
-## 10) Seguridad y datos
-
-- No hardcodear secretos.
-- No loggear credenciales, tokens ni PII.
-- Respetar permisos/autenticación existentes.
-
-## 11) Disciplina de documentación (spec-as-source)
-
-- Es obligatorio leer documentación vigente en `docs/` antes de implementar.
-- Es obligatorio registrar en `docs/` (subcarpeta temática) cada cambio o decisión importante del trabajo realizado.
-- Si una tarea no requiere registro, se debe explicitar por qué en la entrega.
-
-## Flujo de trabajo por tamaño de cambio
-
-## Tamaño S (bugfix / feature chica)
-
-- Cambiar solo archivos directamente implicados.
-- Agregar test puntual (service/view/api).
-- Validar con checks enfocados.
-- Entregar diff corto y explicación concreta.
-
-## Tamaño M (refactor seguro / feature mediana)
-
-- Dividir en pasos internos (sin PRs gigantes).
-- Mantener comportamiento actual y cubrir regresiones.
-- Separar refactor de comportamiento si es posible.
-- Documentar riesgos y supuestos.
-
-## Tamaño L (feature grande)
-
-- Trabajar por fases incrementales.
-- Definir interfaces/boundaries antes de expandir implementación.
-- Incluir pruebas por fase y actualización de docs.
-- Evitar “big bang changes”.
-
-## Regla de mejoras cercanas (nueva)
-
-La IA puede detectar mejoras cercanas al área tocada (por ejemplo: test faltante, validación débil, logging insuficiente, naming inconsistente, bug probable).
-
-Reglas:
-- Puede proponerlas.
-- No debe implementarlas fuera de alcance sin aprobación explícita.
-- Si son indispensables para que el cambio solicitado funcione correctamente, puede incluirlas, pero debe explicarlo.
-
-Formato sugerido en la entrega:
-
-```md
-## Mejoras cercanas detectadas (opcional)
-- [Impacto alto | costo bajo] Falta test de regresión en `app/tests/...` para X.
-- [Impacto medio | costo bajo] Validar `request.GET['...']` para evitar 500 en Y.
-```
-
-## Definition of Done (cambios hechos por IA)
-
-Antes de cerrar una tarea, la IA debe verificar (o declarar por qué no pudo):
-
-- Código implementado con diffs pequeños y coherentes con el alcance.
-- Formato/lint/test ejecutados (o justificación si no se ejecutaron).
-- Tests mínimos agregados cuando aplica.
-- Test de regresión agregado en bugfix cuando aplica.
-- Documentación actualizada si cambió comportamiento.
-- Registro de cambios/decisiones importantes en `docs/<subcarpeta>/...` (o justificación explícita si no aplica).
-- Supuestos y límites explicitados.
-- Riesgos o follow-ups listados (si existen).
-
-## Estructura de entrega recomendada (respuesta de la IA)
-
-- Qué cambió.
-- Archivos tocados.
-- Validación ejecutada (tests/lint/format).
-- Supuestos.
-- Documento spec-as-source creado/actualizado en `docs/<subcarpeta>/...` (si aplica).
-- Mejoras cercanas detectadas (opcional).
-
-## Índice de guías especializadas (`docs/ia/`)
-
-- `docs/ia/CONTRIBUTING_AI.md` - proceso de pedidos, PRs, commits, checks.
-- `docs/ia/STYLE_GUIDE.md` - estilo de código y convenciones.
-- `docs/ia/ARCHITECTURE.md` - organización del sistema y boundaries.
-- `docs/ia/CONTEXT_HYGIENE.md` - higiene de contexto para asistentes locales (qué leer primero y qué evitar cargar).
-- `docs/ia/TESTING.md` - estrategia de tests.
-- `docs/ia/SECURITY_AI.md` - seguridad para cambios asistidos por IA.
-- `docs/ia/ERRORS_LOGGING.md` - manejo de errores, excepciones y logs.
-
-## How to ask the AI (plantillas cortas)
-
-Usar estas plantillas para pedidos más consistentes. Adaptar paths y nombres reales del módulo.
-
-## 1) Feature pequeña
-
-```md
-Quiero una feature chica en `[app]/[archivo]`.
-
-Contexto:
-- [qué flujo resuelve]
-- [restricción de negocio]
-
-Alcance:
-- Cambiar solo [archivos o módulo]
-- No refactorizar otras áreas
-
-Criterio de aceptación:
-- [comportamiento esperado]
-- [caso borde importante]
-
-Checks a correr:
-- `docker compose exec django pytest -n auto [opcional: ruta específica]`
-
-Podés proponer mejoras cercanas: sí/no
-```
-
-## 2) Bugfix
-
-```md
-Necesito un bugfix en `[path]`.
-
-Bug actual:
-- [qué pasa]
-- [qué debería pasar]
-- [pasos para reproducir si aplica]
-
-Alcance:
-- Fix mínimo, sin refactor masivo
-- Mantener compatibilidad hacia atrás
-
-Criterio de aceptación:
-- [resultado esperado]
-- Agregar test de regresión
-
-Checks a correr:
-- `docker compose exec django pytest -n auto [ruta de tests]`
-
-Podés proponer mejoras cercanas: sí/no
-```
-
-## 3) Refactor seguro
-
-```md
-Quiero un refactor seguro (sin cambiar comportamiento) en `[path]`.
+Guia principal para IAs (Codex, Claude, Copilot, GPT) que trabajen en SISOC.
 
 Objetivo:
-- [legibilidad / duplicación / extraer helper / ordenar responsabilidades]
+- bajar variabilidad entre asistentes,
+- mantener diffs chicos y revisables,
+- reducir costo de contexto sin perder calidad,
+- respetar el stack y los patrones reales del repo.
 
-Restricciones:
-- No cambiar contratos públicos
-- No mezclar feature nueva
-- Diff revisable
+## Reglas duras
 
-Criterio de aceptación:
-- Tests existentes siguen pasando
-- Si agregás tests, que sean puntuales
+### 1. Aislamiento estricto de tareas
 
-Checks a correr:
-- `pylint **/*.py --rcfile=.pylintrc` (si impacta varias rutas)
-- `docker compose exec django pytest -n auto [ruta]`
-```
+Toda tarea no trivial debe correr en:
+- una branch dedicada,
+- un worktree dedicado,
+- un path fuera del checkout principal.
 
-## 4) Agregar endpoint (Django/DRF)
+Reglas:
+- Nunca trabajar directo sobre `development`, `main` ni el checkout compartido.
+- Nunca reutilizar un worktree viejo para una tarea nueva.
+- Nunca reutilizar la branch de una tarea para otra distinta.
+- Nunca editar archivos fuera del worktree asignado.
+- El path recomendado es `../worktrees/<slug>` respecto del repo principal.
 
-```md
-Quiero agregar un endpoint en `[app]`.
+Ejemplo:
+- branch: `task/fix-login-redirect`
+- worktree: `C:/Users/Juanito/Desktop/Repos-Codex/worktrees/fix-login-redirect`
 
-Tipo:
-- Django view / DRF endpoint
+### 2. Setup obligatorio antes de implementar
 
-Entrada/salida esperada:
-- Request: [params/body]
-- Response: [status + payload]
+Antes de editar:
+1. `git fetch origin --prune`
+2. Crear la branch desde `origin/development` actualizado o desde `development` ya sincronizado con remoto.
+3. Crear el worktree dedicado fuera del repo principal.
+4. Verificar branch actual, path actual y `git status`.
 
-Restricciones:
-- Respetar permisos/auth existentes
-- Reutilizar services/serializers si ya hay patrón
-- Agregar tests de permisos y caso feliz
+Si el entorno no esta aislado, no implementar hasta corregirlo.
 
-Criterio de aceptación:
-- [caso feliz]
-- [caso inválido]
-- [caso sin permiso]
+### 3. Politica de lectura: minimo contexto suficiente
 
-Podés proponer mejoras cercanas: sí/no
-```
+No cargar contexto amplio por defecto.
 
-## 5) Agregar componente/página (templates/JS)
+Lectura inicial obligatoria:
+1. `AGENTS.md`
+2. `docs/indice.md`
+3. archivo(s) objetivo
+4. tests del modulo o flujo afectado, si existen
+5. una sola guia de `docs/ia/` elegida segun la tarea
 
-```md
-Quiero agregar una página/componente en templates Django.
+Expandir solo si la evidencia lo requiere:
+- otra guia de `docs/ia/`,
+- documentacion del dominio afectado,
+- callers, servicios, serializers, templates o settings relacionados.
 
-Contexto:
-- App/módulo: [app]
-- Pantalla actual relacionada: [path]
+Casos en los que la documentacion del dominio pasa a ser obligatoria:
+- cambia comportamiento observable,
+- hay reglas funcionales o permisos del negocio,
+- el modulo tiene contratos implicitos que no quedan claros en el codigo.
 
-Alcance:
-- Reutilizar includes/parciales existentes si aplica
-- Evitar lógica de negocio en template
-- Mantener estilo visual actual
+Usar `docs/ia/CONTEXT_HYGIENE.md` como matriz de carga minima.
 
-Criterio de aceptación:
-- Render correcto
-- Permisos correctos
-- Tests mínimos si hay lógica en view/API asociada
+### 4. Spec-as-source
 
-Checks a correr:
-- `djlint . --check --configuration=.djlintrc`
-```
+`docs/` es la fuente de verdad operativa del repo.
 
-## 6) Agregar migración
+Reglas:
+- Toda decision o cambio importante debe quedar documentado en `docs/`.
+- Si el cambio es trivial y no hace falta registro, explicitarlo en la entrega.
+- Convencion recomendada:
+  - `docs/registro/cambios/YYYY-MM-DD-<tema>.md`
+  - `docs/registro/decisiones/YYYY-MM-DD-<tema>.md`
 
-```md
-Necesito agregar una migración para `[app]`.
+## THINK antes de tocar codigo
 
-Cambio de modelo:
-- [campo/índice/restricción]
+Antes de implementar, dejar claro en pocas lineas:
+- problema real,
+- solucion recomendada mas simple,
+- archivos o capas a tocar,
+- como se va a validar,
+- ambiguedades o supuestos relevantes.
 
-Restricciones:
-- Mantener compatibilidad de datos si aplica
-- Evitar migraciones peligrosas sin explicar impacto
-- Si hay data migration, que sea clara y reversible cuando sea viable
+Reglas por tipo de tarea:
+- feature o cambio de comportamiento: hacer un THINK corto antes de editar,
+- bug o fallo de tests: investigar causa raiz antes del fix,
+- review: priorizar hallazgos, evidencia y severidad.
 
-Criterio de aceptación:
-- Migración consistente con el cambio
-- Tests o validación mínima del comportamiento nuevo
+## Implementacion
 
-Podés proponer mejoras cercanas: sí/no
-```
+- Hacer cambios pequenos y enfocados.
+- No mezclar feature, refactor amplio y formateo masivo.
+- Reutilizar patrones existentes del modulo.
+- No inventar APIs, modelos, campos, serializers, endpoints ni permisos.
+- Mantener compatibilidad hacia atras salvo pedido explicito.
+- Si hace falta un supuesto, declararlo.
 
-## 7) Agregar test
+Patrones criticos del repo:
+- la logica de negocio vive preferentemente en `services/`,
+- coexisten Django views y DRF,
+- hay logging custom en `config/settings.py` y `core/utils.py`,
+- no se usa Celery actualmente.
 
-```md
-Quiero agregar tests para `[path o feature]`.
+## Tooling real del repo
 
-Objetivo del test:
-- [regresión / permisos / validación / status code / rollback]
+- Python: `black`
+- Lint Python: `pylint` + `pylint_django`
+- Templates: `djlint`
+- Tests: `pytest`, `pytest-django`, `pytest-xdist`
 
-Alcance:
-- Usar pytest + fixtures existentes
-- Mockear integraciones externas si aplica
-- No reescribir tests no relacionados
+No imponer como obligatorios si no fueron pedidos:
+- `ruff`
+- `mypy`
+- `eslint`
+- `prettier`
 
-Criterio de aceptación:
-- Cubre [casos]
-- Falla sin el fix (si es regresión)
+## Validacion minima
 
-Comando sugerido:
-- `docker compose exec django pytest -n auto [ruta de test]`
-```
+- Toda feature nueva debe incluir testing minimo.
+- Todo bugfix debe incluir test de regresion cuando sea viable.
+- Correr primero checks puntuales sobre archivos o tests tocados.
+- Escalar a checks amplios solo si el cambio lo requiere o fue pedido.
 
-## Ejemplos rápidos (buen pedido)
+## Review antes de cerrar
 
-## Ejemplo A - bugfix
+Verificar:
+- la branch contiene solo cambios de la tarea,
+- no se toco nada fuera del worktree asignado,
+- no se metieron refactors o formateos no pedidos,
+- los cambios relevantes quedaron documentados si aplica,
+- el commit y el push se hicieron sobre la misma branch aislada.
 
-```md
-Corregí un 500 en `core/views.py` cuando `page` no es numérica en `load_organizaciones`.
-Fix mínimo, sin refactor.
-Agregá test de regresión en `core/tests/`.
-Podés proponer mejoras cercanas, pero no implementarlas sin avisar.
-```
+Si no hay cambios de archivo, no hacer commits vacios.
 
-## Ejemplo B - feature chica
+## Entrega / handoff
 
-```md
-Agregá un filtro opcional por estado en el endpoint de comunicados de `comunicados/api_views.py`.
-Reutilizá serializer actual si alcanza.
-Incluí tests de caso feliz y parámetro inválido.
-Mantener compatibilidad hacia atrás.
-```
+La entrega debe incluir:
+- que cambio,
+- decision principal,
+- supuestos,
+- validacion ejecutada,
+- como probarlo manualmente,
+- que deberia entender el usuario de este cambio,
+- resumen de aislamiento:
+  - branch usada,
+  - worktree usado,
+  - confirmacion de que solo hubo cambios relevantes,
+  - confirmacion de commit y push en esa branch.
 
-## Ver también
+Si la tarea es no trivial, cerrar con 3 preguntas cortas de control.
 
-- `README.md`
-- `docs/indice.md`
-- `docs/contexto/arquitectura.md`
-- `docs/contexto/dominio.md`
+## Guias de referencia
+
+Leer solo las que apliquen:
+- `docs/ia/CONTEXT_HYGIENE.md`
+- `docs/ia/CONTRIBUTING_AI.md`
+- `docs/ia/STYLE_GUIDE.md`
+- `docs/ia/ARCHITECTURE.md`
+- `docs/ia/TESTING.md`
+- `docs/ia/SECURITY_AI.md`
+- `docs/ia/ERRORS_LOGGING.md`
+- `docs/registro/README.md`

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,109 +1,19 @@
 # CLAUDE.md
 
-Instrucciones específicas para Claude en este repo.
+Instrucciones especificas para Claude en SISOC.
 
-Fuente de verdad: `AGENTS.md`.
+Fuente de verdad:
+- `AGENTS.md`
 
-## Hard gate de lectura (importante)
-
-Antes de implementar cambios, Claude debe:
-
-1. Leer `AGENTS.md`.
-2. Tomarlo como regla principal.
-3. Leer `docs/indice.md` y luego complementar con `docs/ia/*` según la tarea.
-4. Leer la documentación funcional/técnica del dominio afectado dentro de `docs/`.
-5. Registrar cambios o decisiones importantes en `docs/` dentro de la subcarpeta que corresponda (crearla si no existe).
-
-Si el entorno no cargó `AGENTS.md` automáticamente, Claude debe abrirlo manualmente.
-Si no puede leer `AGENTS.md`, debe:
-- declararlo explícitamente,
-- aplicar el fallback de este archivo,
-- evitar decisiones amplias de arquitectura o refactors grandes hasta tener contexto.
-
-## Orden de lectura recomendado
-
+Arranque minimo:
 1. `AGENTS.md`
 2. `docs/indice.md`
-3. `docs/ia/CONTEXT_HYGIENE.md`
-4. `docs/ia/STYLE_GUIDE.md`
-5. `docs/ia/ARCHITECTURE.md`
-6. `docs/ia/TESTING.md`
-7. `docs/registro/README.md`
-8. `docs/ia/SECURITY_AI.md` / `docs/ia/ERRORS_LOGGING.md` si el cambio toca auth, datos o logs
+3. archivo objetivo + tests
+4. una guia relevante de `docs/ia/`
+5. ampliar solo con evidencia
 
-## Fallback mínimo (si `AGENTS.md` no está disponible)
-
-Reglas críticas a aplicar igual:
-
-- No inventar contratos, modelos, campos, endpoints ni permisos.
-- Mantener diffs pequeños y revisables.
-- No mezclar feature + refactor + formateo masivo.
-- Compatibilidad hacia atrás por defecto.
-- No modificar tooling/CI/settings sin pedido explícito.
-- Agregar tests mínimos (y regresión en bugfixes cuando sea viable).
-- No exponer secretos/PII en logs/tests/ejemplos.
-- Leer documentación relevante en `docs/` antes de proponer cambios.
-- Documentar decisiones/cambios importantes en `docs/<subcarpeta>/...` sin herramientas específicas obligatorias.
-- Proponer mejoras cercanas solo como propuesta, sin implementación fuera de alcance sin aprobación.
-- No asumir Celery/colas/workers: **actualmente no se usa Celery**.
-
-Si falta información clave, explicitar supuestos concretos y limitar el alcance.
-
-## Cómo trabajar bien en SISOC (Claude)
-
-## 1) Confirmar contexto antes de proponer cambios
-
-- Revisar el código real del módulo (views, models, services, tests).
-- Buscar patrones existentes en la app antes de crear uno nuevo.
-- Si falta información, explicitar supuestos concretos.
-- No asumir infraestructura async tipo Celery; validar patrón real del repo primero.
-- Aplicar higiene de contexto: empezar con el mínimo set de archivos y expandir según evidencia (`docs/ia/CONTEXT_HYGIENE.md`).
-- Podés usar `bash scripts/ai/preflight.sh <tipo> [path]` como preflight local opcional.
-
-## 2) Mantener cambios pequeños y revisables
-
-- Preferir diffs enfocados.
-- Evitar refactors amplios no solicitados.
-- No mezclar limpieza masiva con cambios funcionales.
-
-## 3) Estructura de entrega esperada
-
-Responder con:
-- Qué cambió.
-- Archivos tocados.
-- Validación ejecutada (tests/lint/format).
-- Supuestos y límites.
-- Riesgos o impactos.
-- Registro en `docs/<subcarpeta>/...` para cambios/decisiones importantes (o justificación si no aplica).
-- `Mejoras cercanas detectadas (opcional)`.
-
-## 4) Seguridad y PII
-
-- No hardcodear secretos.
-- No exponer tokens/credenciales/PII en logs, tests o ejemplos.
-- Respetar permisos y autenticación existentes.
-
-## 5) Mejoras cercanas (solo propuesta)
-
-Claude puede señalar mejoras cercanas al código tocado (tests faltantes, validación, logging, manejo de errores), pero no debe implementarlas fuera de alcance sin aprobación explícita.
-
-## Checklist de cierre (Claude)
-
-- Revisé `AGENTS.md` y docs de `docs/ia/` relevantes.
-- Si no pude leer `AGENTS.md`, lo declaré y apliqué fallback mínimo.
-- Mantuve higiene de contexto (sin explorar/cambiar archivos fuera de alcance).
-- No inventé contratos ni estructuras inexistentes.
-- Mantuve compatibilidad hacia atrás por defecto.
-- Agregué tests mínimos o expliqué la limitación.
-- Registré cambios/decisiones importantes en `docs/` (subcarpeta temática) o expliqué por qué no aplicaba.
-- Declaré supuestos explícitos.
-- Reporté mejoras cercanas sin generar scope creep.
-
-## Ejemplo de pedido (Claude)
-
-```md
-Refactor seguro en `core/views.py` para extraer validación repetida de filtros favoritos.
-Sin cambiar comportamiento.
-Agregá tests si detectás huecos críticos.
-Si ves mejoras cercanas, listalas pero no las implementes sin aprobación.
-```
+Reglas cortas:
+- no inventar modelos, endpoints ni permisos,
+- mantener cambios pequenos y revisables,
+- respetar `docs/ia/CONTEXT_HYGIENE.md`,
+- documentar cambios o decisiones importantes en `docs/`.

--- a/CODEX.md
+++ b/CODEX.md
@@ -1,142 +1,24 @@
 # CODEX.md
 
-Instrucciones específicas para Codex en este repo.
+Instrucciones especificas para Codex en SISOC.
 
-Fuente de verdad: `AGENTS.md`.
+Fuente de verdad:
+- `AGENTS.md`
 
-## Hard gate de lectura (importante)
-
-Antes de implementar cambios, Codex debe:
-
+Arranque minimo:
 1. Leer `AGENTS.md`.
-2. Aplicar sus reglas como prioridad.
-3. Leer `docs/indice.md` y luego `docs/ia/*` según el tipo de tarea.
-4. Leer la documentación funcional/técnica del dominio afectado dentro de `docs/`.
-5. Registrar cambios o decisiones importantes en `docs/` dentro de la subcarpeta que corresponda (crearla si no existe).
+2. Leer `docs/indice.md`.
+3. Leer archivo objetivo + tests del modulo.
+4. Elegir una sola guia de `docs/ia/` segun la tarea.
+5. Expandir solo si hace falta.
 
-Si la integración no cargó automáticamente `AGENTS.md`, Codex debe abrirlo manualmente.
-Si no puede acceder a `AGENTS.md`, debe:
-- declararlo explícitamente en la respuesta,
-- usar el bloque de fallback de este archivo,
-- evitar cambios grandes o de alto riesgo hasta tener contexto.
+Usar:
+- `docs/ia/CONTEXT_HYGIENE.md` para decidir que abrir,
+- `scripts/ai/preflight.sh <tipo> [path]` para un resumen corto del contexto.
 
-## Orden de lectura recomendado
-
-1. `AGENTS.md`
-2. `docs/indice.md`
-3. `docs/ia/CONTEXT_HYGIENE.md`
-4. `docs/ia/STYLE_GUIDE.md`
-5. `docs/ia/ARCHITECTURE.md`
-6. `docs/ia/TESTING.md`
-7. `docs/registro/README.md`
-8. Archivos concretos del módulo a modificar y docs del dominio afectado
-
-## Fallback mínimo (si `AGENTS.md` no está disponible)
-
-Aplicar estas reglas como no negociables:
-
-- No inventar APIs, modelos, campos, serializers, endpoints ni permisos.
-- Hacer cambios mínimos (`small diffs`) y no mezclar feature + refactor + formateo masivo.
-- Mantener compatibilidad hacia atrás por defecto.
-- No tocar configs de tooling/CI/settings sin pedido explícito.
-- Agregar tests mínimos en features nuevas y regresión en bugfixes cuando sea viable.
-- No loggear secretos/PII y respetar permisos existentes.
-- Leer documentación relevante en `docs/` antes de proponer cambios.
-- Documentar decisiones/cambios importantes en `docs/<subcarpeta>/...` sin depender de herramientas específicas.
-- Podés proponer mejoras cercanas, pero no implementarlas fuera de alcance sin aprobación.
-- No asumir Celery/workers/colas: **actualmente no se usa Celery** en este repo.
-
-Si falta contexto crítico, frenar expansión de alcance y pedir/explicitar supuestos.
-
-## Forma de trabajo esperada (Codex)
-
-## 1) Explorar contexto rápido sin romper alcance
-
-- Buscar implementaciones similares antes de editar.
-- Revisar tests existentes del módulo para copiar patrón.
-- Confirmar permisos, serializers, forms y services reales.
-- Evitar suposiciones sobre modelos/campos sin verificar.
-- Aplicar higiene de contexto: cargar primero archivos mínimos relevantes y expandir solo si hace falta (ver `docs/ia/CONTEXT_HYGIENE.md`).
-- Podés usar `bash scripts/ai/preflight.sh <tipo> [path]` como preflight local opcional.
-
-## 2) Decidir diff mínimo
-
-Antes de editar, definir:
-- cuál es el comportamiento a cambiar,
-- cuál es el archivo responsable,
-- cuál es el test mínimo que lo cubre.
-- cuál es el check mínimo de formato/lint que confirma que el archivo nuevo sigue `black`, `pylint` y/o `djlint`.
-
-Si el cambio requiere tocar muchos archivos, explicar por qué.
-
-## 2.1) Escribir compatible con el tooling del repo
-
-- Python: escribir `black-first`. Tomar `88` caracteres como referencia práctica y usar paréntesis implícitos antes que continuaciones manuales.
-- `pylint`: respetar naming y estructura definidos en `.pylintrc`; no introducir variables ambiguas, imports fuera de orden ni argumentos innecesarios “porque después se arreglan”.
-- Templates: escribir bloques y tags para que `djlint` necesite ajustes mínimos. Evitar HTML/Django comprimido en una sola línea cuando hay condicionales, loops o atributos largos.
-- Antes de correr checks globales, ejecutar validaciones acotadas sobre los archivos editados siempre que el cambio lo permita.
-
-## 3) Reportar cambios de forma útil
-
-Al entregar, incluir:
-- archivos tocados,
-- comportamiento nuevo/corregido,
-- validación ejecutada,
-- supuestos,
-- riesgos,
-- registro en `docs/<subcarpeta>/...` para cambios/decisiones importantes (o motivo si no aplica),
-- mejoras cercanas detectadas (opcional).
-
-## 4) Tareas grandes: trabajar por fases
-
-Para refactors/features grandes:
-- dividir en fases incrementales,
-- mantener el sistema funcional entre fases,
-- separar cambios estructurales de cambios funcionales cuando sea posible,
-- proponer el plan antes de expandir alcance.
-
-## 5) Mejoras cercanas sin scope creep
-
-Codex puede detectar mejoras cercanas, pero:
-- no las implementa fuera de alcance sin aprobación,
-- las reporta separadas,
-- indica impacto y costo estimado.
-
-Formato sugerido:
-
-```md
-## Mejoras cercanas detectadas (opcional)
-- [Impacto alto | costo bajo] ...
-```
-
-## Heurísticas útiles para este repo
-
-- Lógica de negocio suele vivir en `services/`.
-- Views Django y DRF coexisten; validar patrón por app.
-- Tests usan `pytest`, fixtures y `monkeypatch` con frecuencia.
-- Templates usan `djlint`; evitar meter lógica compleja en HTML.
-- Logging y errores tienen patrones ya implementados en `config/settings.py` y `core/utils.py`.
-- No asumir Celery para tareas async; revisar `management/commands`, servicios o hilos existentes antes de proponer colas/workers.
-
-## Checklist de cierre (Codex)
-
-- Leí `AGENTS.md` y guías relevantes de `docs/ia/`.
-- Si no pude leer `AGENTS.md`, lo declaré y apliqué fallback mínimo.
-- Respeté higiene de contexto (sin abrir/cambiar archivos innecesarios).
-- No inventé APIs/campos/modelos.
-- Mantuve diff chico y enfocado.
-- No toqué configs de tooling/CI sin pedido.
-- Escribí código/templates ya alineados con `black`, `pylint` y `djlint`, evitando depender de un formateo correctivo masivo.
-- Agregué tests mínimos o expliqué por qué no.
-- Registré cambios/decisiones importantes en `docs/` (subcarpeta temática) o expliqué por qué no aplicaba.
-- Declaré supuestos y riesgos.
-- Reporté mejoras cercanas solo como propuesta.
-
-## Ejemplo de pedido (Codex)
-
-```md
-Corregí el manejo de errores en `core/services/image_service.py` cuando la ruta es inválida.
-Fix mínimo + test de regresión.
-No refactorices el módulo completo.
-Podés proponer mejoras cercanas sin implementarlas.
-```
+Fallback si `AGENTS.md` no esta disponible:
+- no inventar contratos ni permisos,
+- mantener diffs chicos,
+- no mezclar feature con refactor amplio,
+- agregar tests minimos cuando aplique,
+- documentar cambios importantes en `docs/`.

--- a/LLM.md
+++ b/LLM.md
@@ -1,64 +1,16 @@
 # LLM.md
 
-Entrada rápida para cualquier IA que trabaje en SISOC.
+Entrada rapida para cualquier IA que trabaje en SISOC.
 
-## Fuente de verdad
+Leer primero:
+1. `AGENTS.md`
+2. `docs/indice.md`
+3. archivo objetivo + tests
+4. una guia relevante de `docs/ia/`
 
-Leer primero `AGENTS.md`.
-
-## Reglas críticas (resumen)
-
-- Buscar referencias reales en el repo antes de escribir código.
-- Leer `docs/indice.md`, `docs/ia/*` y docs del dominio afectado antes de implementar.
-- No inventar APIs, modelos, campos ni endpoints.
-- Hacer cambios mínimos (`small diffs`) y revisables.
-- Mantener compatibilidad hacia atrás salvo pedido.
-- No tocar configs de lint/format/test/CI sin pedido.
-- Agregar tests mínimos en features nuevas.
-- Agregar test de regresión en bugfixes cuando sea viable.
-- Explicitar supuestos si falta información.
-- Respetar seguridad/permisos y no loggear secretos/PII.
-- Documentar cada cambio o decisión importante en `docs/` dentro de una subcarpeta temática (crearla si no existe).
-- Podés proponer mejoras cercanas, pero no implementarlas fuera de alcance sin aprobación.
-
-## Comandos principales
-
-```bash
-docker compose up
-docker compose exec django pytest -n auto
-docker compose exec django pytest -m smoke
-black .
-djlint . --configuration=.djlintrc --reformat
-pylint **/*.py --rcfile=.pylintrc
-```
-
-## Guías detalladas
-
-- `docs/ia/CONTEXT_HYGIENE.md`
-- `docs/ia/CONTRIBUTING_AI.md`
-- `docs/ia/STYLE_GUIDE.md`
-- `docs/ia/ARCHITECTURE.md`
-- `docs/ia/TESTING.md`
-- `docs/ia/SECURITY_AI.md`
-- `docs/ia/ERRORS_LOGGING.md`
-- `docs/registro/README.md`
-
-## Mini-template de prompt correcto
-
-```md
-Necesito [bugfix/feature/refactor] en `[path]`.
-Alcance: [qué tocar] / [qué no tocar].
-Criterio de aceptación: [resultado esperado].
-Checks: [tests/lint].
-Podés proponer mejoras cercanas: sí/no.
-```
-
-## Mejores prácticas de entrega
-
-Incluir siempre:
-- qué cambió,
-- archivos tocados,
-- validación ejecutada,
-- supuestos,
-- documento de `docs/<subcarpeta>/...` creado/actualizado (si aplica),
-- mejoras cercanas detectadas (opcional).
+Principios:
+- minimo contexto suficiente,
+- diff chico,
+- sin inventar contratos,
+- tests minimos cuando aplique,
+- documentacion en `docs/` para cambios importantes.

--- a/docs/agentes/guia.md
+++ b/docs/agentes/guia.md
@@ -1,11 +1,9 @@
-# Guía para asistentes (IA)
+# Guia para asistentes (IA)
 
 - Fuente de verdad: `AGENTS.md`.
-- Lectura obligatoria antes de implementar: `docs/indice.md`, `docs/ia/*` y documentación del dominio afectado dentro de `docs/`.
-- Registro obligatorio de trabajo importante: documentar cada cambio o decisión importante en `docs/` usando la subcarpeta temática que corresponda (crearla si no existe). En caso de existir documentacion escrita del codigo que se esta modificando, actualizar la documentacion
-- Automatización complementaria: los PRs generan documentación automática en `docs/registro/prs/` y `docs/contexto/features/`; los PRs a `main` además regeneran `CHANGELOG.md` desde `docs/registro/releases/pending/`.
-- Enfoque: spec-as-source con archivos Markdown del repo (sin depender de herramientas específicas).
-- Commits generados por IA: mensaje en español y patrón obligatorio `<type>(<scope>): <subject>` (detalle y plantilla en `docs/ia/CONTRIBUTING_AI.md`).
-- Comandos base: `docker-compose up` levanta servicios; `docker compose exec django pytest -n auto` corre tests; para trabajo diario conviene empezar por `black path/al/archivo.py --config pyproject.toml`, `pylint app/archivo.py --rcfile=.pylintrc` y `djlint templates/ruta.html --reformat --configuration=.djlintrc`, dejando `black .`, `pylint **/*.py --rcfile=.pylintrc` y `djlint . --configuration=.djlintrc --reformat` para validaciones amplias. Si `pylint` marca algo, primero arreglar el código y solo usar `ignore` o `disable` como último recurso, local y justificado. Evidencia: `pyproject.toml`, `.pylintrc`, `.djlintrc` y `AGENTS.md`.
-- Buenas prácticas de código: agregar docstrings descriptivas; mantener estructura por app; pruebas en `tests/`. Evidencia: AGENTS.md:10-13.
-- Setup: copiar `.env.example` a `.env`; agregar ejemplos/scripts de datos en `docker/mysql`. Evidencia: AGENTS.md:15-17.
+- Arranque minimo: `AGENTS.md`, `docs/indice.md`, archivo objetivo, tests y una sola guia relevante de `docs/ia/`.
+- Expandir contexto solo si la evidencia lo requiere.
+- Registrar cambios o decisiones importantes en `docs/`.
+- Commits de IA: mensaje en espanol con patron `<type>(<scope>): <subject>`.
+- Validar primero sobre archivos y tests tocados.
+- Crear worktrees de tarea fuera del checkout principal, en `../worktrees/<slug>`.

--- a/docs/ia/CONTEXT_HYGIENE.md
+++ b/docs/ia/CONTEXT_HYGIENE.md
@@ -1,203 +1,131 @@
 # CONTEXT_HYGIENE.md
 
-Guía de higiene de contexto para asistentes locales (Codex/Claude/Copilot) en SISOC.
+Guia de higiene de contexto para asistentes en SISOC.
 
-Objetivo: reducir errores por contexto insuficiente o exceso de contexto (scope creep, cambios innecesarios, supuestos falsos).
-
-Fuente de verdad general: `../../AGENTS.md`.
+Fuente de verdad:
+- `../../AGENTS.md`
 
 ## Regla principal
 
-Cargar primero el **mínimo contexto suficiente** para resolver la tarea y expandir solo cuando la evidencia lo requiera.
-Además, para trabajo con IA en SISOC, es obligatorio leer `docs/indice.md` y documentación del dominio afectado en `docs/`.
+Cargar primero el minimo contexto suficiente y expandir solo cuando haya evidencia concreta de que falta contexto.
 
 Evitar:
-- abrir módulos enteros sin necesidad,
-- leer demasiados archivos “por si acaso”,
-- tocar archivos no relacionados por limpieza oportunista.
+- abrir modulos enteros por si acaso,
+- leer varias guias largas al inicio,
+- recorrer apps no relacionadas,
+- hacer limpieza oportunista fuera del alcance.
 
-## Helpers locales disponibles (opcional, recomendados)
+## Lectura inicial obligatoria
 
-- `scripts/ai/preflight.sh`: resume estado del repo, recordatorios críticos y contexto mínimo sugerido por tipo de tarea.
-- `.vscode/tasks.json`: tareas para preflight, pytest, black, djlint y pylint en Docker.
+Para cualquier tarea:
+1. `AGENTS.md`
+2. `docs/indice.md`
+3. archivo(s) objetivo
+4. tests del modulo o flujo afectado, si existen
+5. una sola guia de `docs/ia/` elegida por tipo de tarea
 
-Ejemplos:
+## Elegir una sola guia inicial
+
+- bugfix o feature web/API: `docs/ia/TESTING.md`
+- cambio de estructura o boundaries: `docs/ia/ARCHITECTURE.md`
+- cambio de estilo o templates: `docs/ia/STYLE_GUIDE.md`
+- auth, permisos, datos sensibles, uploads: `docs/ia/SECURITY_AI.md`
+- errores, fallbacks o logging: `docs/ia/ERRORS_LOGGING.md`
+
+## Cuando ampliar
+
+Ampliar contexto si aparece alguna de estas senales:
+- no esta claro donde vive la logica,
+- hay side effects no visibles,
+- aparecen permisos o reglas de negocio,
+- los tests muestran contratos implicitos,
+- el cambio toca comportamiento observable.
+
+En esos casos, leer solo lo siguiente que destraba:
+- una segunda guia de `docs/ia/`,
+- documentacion del dominio afectado,
+- callers, serializers, forms, templates o settings relacionados.
+
+## Matriz minima por tarea
+
+### Bugfix en view Django
+
+Inicial:
+- `AGENTS.md`
+- view afectada
+- tests del modulo
+- `docs/ia/TESTING.md`
+
+Expandir si hace falta:
+- services llamados por la view
+- template principal
+- `docs/ia/ERRORS_LOGGING.md`
+
+### Bugfix o feature DRF
+
+Inicial:
+- `AGENTS.md`
+- `api_views.py` y serializer relacionado
+- tests API
+- `docs/ia/TESTING.md`
+
+Expandir si hace falta:
+- `docs/ia/ARCHITECTURE.md`
+- permisos o auth
+- docs funcionales del dominio
+
+### Cambio en services
+
+Inicial:
+- `AGENTS.md`
+- service afectado
+- tests del flujo
+- `docs/ia/STYLE_GUIDE.md`
+
+Expandir si hace falta:
+- callers directos
+- models o querysets implicados
+- `docs/ia/ERRORS_LOGGING.md`
+
+### Template + view
+
+Inicial:
+- `AGENTS.md`
+- view que renderiza
+- template principal
+- tests de la view
+
+Expandir si hace falta:
+- parciales directos
+- form o service asociado
+- `docs/ia/SECURITY_AI.md` si entra input
+
+### Migracion o modelo
+
+Inicial:
+- `AGENTS.md`
+- modelo afectado
+- migraciones cercanas
+- tests del flujo
+- `docs/ia/ARCHITECTURE.md`
+
+Expandir si hace falta:
+- services o views dependientes
+- docs de seguridad o dominio
+
+## Worktrees y cambios locales
+
+- Nunca trabajar sobre el checkout principal.
+- Crear worktrees de tarea fuera del repo principal, en `../worktrees/<slug>`.
+- No revertir cambios del usuario.
+- Si aparece conflicto con trabajo ajeno, explicitarlo antes de seguir.
+
+## Helper recomendado
+
+`scripts/ai/preflight.sh` resume el arranque minimo segun el tipo de tarea:
 
 ```bash
 bash scripts/ai/preflight.sh general
 bash scripts/ai/preflight.sh bugfix-view core/views.py
 bash scripts/ai/preflight.sh feature-api comunicados/api_views.py
 ```
-
-## Patrones críticos del repo (recordatorio rápido)
-
-- La lógica de negocio va preferentemente en `services/`.
-- Coexisten Django web views y DRF (`api_views.py` / viewsets). Verificar patrón real por app.
-- Hay logging custom en `config/settings.py` + `core/utils.py` (handlers/formatters propios).
-- No se usa Celery actualmente (no asumir workers/colas).
-- Tests usan `pytest`; pueden correr con SQLite en memoria según `config/settings.py`.
-
-## Secuencia recomendada de lectura (mínima)
-
-## Siempre (primeros archivos)
-
-1. `AGENTS.md`
-2. `docs/indice.md`
-3. `docs/ia/STYLE_GUIDE.md`
-4. `docs/ia/ARCHITECTURE.md`
-5. `docs/ia/TESTING.md` (si la tarea cambia comportamiento)
-6. Archivos concretos del módulo involucrado + documentación del dominio afectado en `docs/`
-
-## Ampliar solo si aplica
-
-- `docs/ia/SECURITY_AI.md`: auth, permisos, datos sensibles, redirects, uploads.
-- `docs/ia/ERRORS_LOGGING.md`: cambios de errores/logs/fallbacks.
-- `config/settings.py`: si el cambio depende de settings, logging, auth, cache, tests.
-- Tests del módulo: siempre que haya cambio funcional.
-
-## Matriz de carga mínima por tipo de tarea
-
-## Bugfix en view Django
-
-Cargar primero:
-- `AGENTS.md`
-- view afectada (`views.py` o archivo específico)
-- tests del módulo (si existen)
-- `docs/ia/TESTING.md`
-
-Expandir solo si hace falta:
-- `services/` llamados por esa view
-- `forms.py`
-- `templates/` relacionados
-- `docs/ia/ERRORS_LOGGING.md` si toca manejo de errores
-
-## Bugfix/feature en endpoint DRF
-
-Cargar primero:
-- `AGENTS.md`
-- `api_views.py` / `serializers.py` / `api_serializers.py` del módulo
-- tests API del módulo
-- `docs/ia/ARCHITECTURE.md`
-- `docs/ia/TESTING.md`
-
-Expandir solo si hace falta:
-- `services/` usados por el endpoint
-- permisos/auth (`core/api_auth.py`, permissions locales)
-- `docs/ia/SECURITY_AI.md` y `docs/ia/ERRORS_LOGGING.md`
-
-## Cambio de lógica de negocio
-
-Cargar primero:
-- `AGENTS.md`
-- service afectado (`services/`)
-- tests del service/flujo
-- `docs/ia/STYLE_GUIDE.md`
-- `docs/ia/TESTING.md`
-
-Expandir solo si hace falta:
-- views/callers del service
-- modelos/managers/querysets implicados
-- logging/errors docs si se tocan fallbacks
-
-## Cambio en templates + view
-
-Cargar primero:
-- `AGENTS.md`
-- view que renderiza
-- template principal y parciales directos
-- tests de view (si existen)
-
-Expandir solo si hace falta:
-- forms/serializers/services asociados
-- `docs/ia/STYLE_GUIDE.md` (templates + responsabilidades)
-- `docs/ia/SECURITY_AI.md` (si hay input/redirect/upload)
-
-## Migración / modelo
-
-Cargar primero:
-- `AGENTS.md`
-- modelo(s) afectados
-- migraciones recientes de esa app (solo cercanas)
-- tests del flujo afectado
-- `docs/ia/ARCHITECTURE.md` + `docs/ia/TESTING.md`
-
-Expandir solo si hace falta:
-- services/views que dependan del campo
-- docs de seguridad si el cambio involucra PII/permisos
-
-## Cambio en logging / manejo de errores
-
-Cargar primero:
-- `AGENTS.md`
-- archivo afectado
-- `docs/ia/ERRORS_LOGGING.md`
-- `config/settings.py` y/o `core/utils.py` (si toca logging custom)
-
-Expandir solo si hace falta:
-- callsites y tests de integración del flujo
-
-## Señales de que te falta contexto (expandir)
-
-Expandir contexto cuando aparezca alguna señal:
-- No está claro dónde vive la lógica (view vs service vs serializer).
-- Hay side effects no visibles (signals, cache, integraciones).
-- El cambio impacta permisos/auth y no viste dónde se aplican.
-- Hay tests fallando por contrato implícito no documentado.
-- El módulo usa patrones distintos a los asumidos.
-
-## Señales de exceso de contexto (frenar)
-
-Frenar y volver al alcance cuando:
-- empezás a abrir apps no relacionadas,
-- querés “aprovechar” para limpiar código no solicitado,
-- estás leyendo demasiados archivos sin relación directa con el bug/feature,
-- el diff crece por refactor oportunista.
-
-## Protocolo de repo con cambios locales (dirty worktree)
-
-En uso local, es común que el repo tenga cambios del usuario.
-
-Reglas:
-- No asumir que los cambios no propios son errores.
-- No revertir cambios del usuario.
-- Trabajar solo sobre archivos del alcance.
-- Si hay conflicto con el trabajo del usuario, explicitarlo antes de seguir.
-
-## Qué NO asumir en SISOC (lista corta)
-
-- Que todo endpoint usa DRF (coexiste con Django web views).
-- Que toda lógica está en models (hay mucha lógica en `services/`).
-- Que existe Celery (no se usa actualmente).
-- Que `ruff/mypy/eslint/prettier` son checks obligatorios (no config formal activa).
-- Que el logging es estándar sin customizaciones (hay handlers/formatters propios).
-
-## Reglas de expansión incremental (prácticas)
-
-- Expandir de adentro hacia afuera: archivo afectado -> tests -> callers -> dependencias.
-- Antes de tocar más archivos, justificar por qué son necesarios.
-- Si el alcance cambia, declararlo explícitamente.
-- Si detectás mejoras cercanas, listarlas como propuesta; no ejecutarlas fuera de alcance sin aprobación.
-- Registrar cambios/decisiones importantes en `docs/` dentro de subcarpeta temática para mantener trazabilidad spec-as-source.
-
-## Ejemplos concretos
-
-## Ejemplo A - bugfix en `core/views.py`
-
-Contexto inicial suficiente:
-- `AGENTS.md`
-- `core/views.py`
-- `core/tests/` relacionados
-- `docs/ia/TESTING.md`
-
-No hace falta abrir de entrada:
-- `config/settings.py`
-- otras apps (`admisiones/`, `comedores/`) si el bug está aislado en `core`
-
-## Ejemplo B - ajuste de logging en service
-
-Contexto inicial suficiente:
-- `AGENTS.md`
-- service afectado
-- `docs/ia/ERRORS_LOGGING.md`
-- `config/settings.py` (logging custom)
-- `core/utils.py` (formatters/handlers)

--- a/docs/ia/CONTRIBUTING_AI.md
+++ b/docs/ia/CONTRIBUTING_AI.md
@@ -1,256 +1,70 @@
 # CONTRIBUTING_AI.md
 
-Proceso recomendado para trabajar con IA en este repo (pedido, implementación, validación y PR).
+Proceso recomendado para trabajar con IA en SISOC.
 
-Fuente de verdad general: `../../AGENTS.md`.
+Fuente de verdad:
+- `../../AGENTS.md`
 
-## Objetivo
+## Brief recomendado
 
-Estandarizar cómo se piden y revisan cambios hechos por IA para mantener:
-- diffs pequeños,
-- PRs revisables,
-- menos regresiones,
-- menor variabilidad entre asistentes.
+Todo pedido deberia incluir:
+- contexto,
+- objetivo,
+- alcance,
+- restricciones,
+- criterio de aceptacion,
+- validacion esperada,
+- si se permiten mejoras cercanas.
 
-## Política spec-as-source (obligatoria)
+## Lectura minima antes de implementar
 
-- Antes de implementar, leer `docs/indice.md`, `docs/ia/*` y documentación de `docs/` del dominio afectado.
-- Cada cambio y decisión importante debe registrarse en Markdown dentro de `docs/` usando la subcarpeta que corresponda al dominio/tema.
-- Si la subcarpeta no existe, debe crearse.
-- Convención sugerida (no obligatoria): `docs/registro/cambios/` y `docs/registro/decisiones/`.
-- El objetivo es trabajar en modo spec-as-source sin depender de herramientas específicas.
+No hace falta leer `docs/ia/*` completo.
 
-## Cómo pedir cambios a la IA (brief operativo)
+Base obligatoria:
+1. `AGENTS.md`
+2. `docs/indice.md`
+3. archivo objetivo
+4. tests del modulo
+5. una sola guia relevante de `docs/ia/`
 
-Todo pedido debería incluir:
-- Contexto: qué módulo/flujo toca.
-- Objetivo: qué problema resuelve.
-- Alcance: qué se puede tocar y qué no.
-- Restricciones: compatibilidad, performance, permisos, UX, etc.
-- Criterio de aceptación: casos esperados.
-- Validación esperada: tests/checks.
-- Si se permite o no proponer mejoras cercanas.
+Ampliar solo si el cambio lo exige.
 
-## Template corto para pedir cambios
+## Flujo sugerido
 
-```md
-Necesito [bugfix/feature/refactor] en `[path o app]`.
+1. Explorar el codigo real del modulo.
+2. Delimitar el diff minimo.
+3. Implementar alineado al patron existente.
+4. Validar primero con checks puntuales.
+5. Documentar cambios importantes en `docs/` si aplica.
+6. Entregar con resumen, validacion, supuestos y riesgos.
 
-Contexto:
-- ...
+## Reglas de PR y commits
 
-Alcance:
-- Tocar: ...
-- No tocar: ...
+- Una sola intencion principal por PR.
+- Mensaje de commit en espanol.
+- Primera linea con patron `<type>(<scope>): <subject>`.
 
-Criterio de aceptación:
-- ...
+Tipos frecuentes:
+- `fix`
+- `feat`
+- `refactor`
+- `test`
+- `docs`
+- `chore`
 
-Checks:
-- ...
+## Validacion recomendada
 
-Podés proponer mejoras cercanas: sí/no
-```
+Secuencia corta:
+1. formateo o lint de archivos editados,
+2. tests del modulo o flujo afectado,
+3. checks mas amplios solo si hace falta.
 
-## Proceso sugerido de implementación (con IA)
+## Spec-as-source
 
-## 1) Explorar
+Registrar en `docs/`:
+- cambios funcionales visibles,
+- decisiones de diseno,
+- cambios de seguridad o permisos,
+- trade-offs relevantes.
 
-- Revisar código real del módulo (`views`, `models`, `services`, `tests`).
-- Buscar implementaciones similares.
-- Confirmar contratos existentes antes de escribir.
-- Revisar documentación vigente en `docs/` para el dominio afectado.
-
-## 2) Delimitar alcance
-
-- Definir el cambio mínimo viable.
-- Identificar el test mínimo necesario.
-- Separar refactor de comportamiento cuando sea posible.
-
-## 3) Implementar
-
-- Reutilizar patrones existentes de la app.
-- Mantener compatibilidad hacia atrás por defecto.
-- Evitar cambios masivos no solicitados.
-
-## 4) Validar
-
-- Ejecutar checks puntuales primero (tests del módulo afectado).
-- Ejecutar formato/lint sobre archivos tocados antes de probar comandos globales.
-- Ejecutar checks más amplios si el impacto lo requiere.
-- Si no se pudo validar, dejarlo explícito.
-- Si `pylint` marca algo, el orden correcto es corregir el código, volver a correr `pylint` sobre el archivo tocado y recién después evaluar una excepción documentada. No usar `ignore` ni `disable` como atajo para cerrar el cambio.
-
-Secuencia recomendada para reducir fricción:
-
-1. Formatear o chequear solo archivos editados (`black path.py`, `djlint template.html --reformat`, `pylint app/archivo.py`).
-2. Correr tests puntuales del módulo o flujo afectado.
-3. Escalar a checks globales solo si el cambio toca superficies compartidas, varios archivos o fue pedido explícitamente.
-
-## 5) Entregar
-
-- Resumen de cambios.
-- Archivos tocados.
-- Validación ejecutada.
-- Supuestos.
-- Riesgos.
-- Registro spec-as-source en `docs/<subcarpeta>/...` (si aplica).
-- Mejoras cercanas detectadas (opcional).
-
-## PRs pequeños y revisables (regla)
-
-Preferir PRs con una sola intención principal:
-- `fix`: corrige bug.
-- `feat`: agrega capacidad.
-- `refactor`: mejora estructura sin cambiar comportamiento.
-- `test`: agrega/mejora pruebas.
-- `docs`: documentación.
-- `chore`: tareas de mantenimiento acotadas.
-
-Evitar PRs que mezclen:
-- refactor + feature + formateo global,
-- cambios funcionales en múltiples dominios sin relación,
-- limpieza masiva sin criterio de aceptación claro.
-
-## Convenciones de commits (obligatorias)
-
-Reglas obligatorias para commits hechos por IA:
-- Mensaje en español.
-- Primera línea obligatoria con patrón: `<type>(<scope>): <subject>`.
-- Usar `scope` semántico y concreto (app, módulo o área real afectada).
-
-Plantilla:
-
-```text
-Obligatorio:
-<type>(<scope>): <subject>
-
-Opcional:
-<why> (por qué se hace; contexto del problema)
-<what> (qué cambió; bullets si aplica)
-<how>  (cómo se resolvió; opcional, sólo si aporta)
-
-<impact> (impacto / migraciones / flags / backwards-compat)
-<tests>  (cómo se probó)
-
-<refs>   (Refs #123 / Closes #123)
-<breaking> (BREAKING CHANGE: ...)
-```
-
-Ejemplos:
-
-```text
-fix(core): corregir 500 al parsear page en load_organizaciones
-
-why: el endpoint devolvía 500 ante valores no numéricos en `page`.
-what:
-- valida `page` antes de convertirla a entero
-- responde 400 con mensaje de error controlado
-tests:
-- docker compose exec django pytest -n auto core/tests/test_views.py
-refs: Refs #123
-```
-
-```text
-feat(comunicados): agregar filtro opcional por estado en API
-
-what:
-- agrega parámetro `estado` en query params
-- mantiene comportamiento previo cuando no se envía
-impact: sin migraciones; backward compatible
-tests:
-- docker compose exec django pytest -n auto comunicados/tests/
-```
-
-## Supuestos explícitos (obligatorio si faltan datos)
-
-Si la IA avanza con supuestos, deben quedar documentados.
-
-Ejemplo:
-
-```md
-Supuestos:
-- Se mantiene el serializer actual porque el payload no cambia.
-- Se usa permiso existente `IsAuthenticated` por compatibilidad.
-```
-
-## Riesgos y rollback (cuando aplica)
-
-En cambios con más impacto (M/L), documentar:
-- Riesgo principal (compatibilidad, migración, performance, permisos).
-- Cómo revertir (archivo/commit/migración).
-- Qué monitorear después del merge.
-
-## Mejoras cercanas detectadas por IA (opcional)
-
-La IA puede proponer mejoras cercanas al cambio solicitado, pero no debe implementarlas fuera de alcance sin aprobación.
-
-Formato recomendado para PR/comentario:
-
-```md
-## Mejoras cercanas detectadas (opcional)
-- [Impacto alto | costo bajo] Agregar test de permiso faltante en `...`.
-- [Impacto medio | costo bajo] Reemplazar manejo genérico de excepción por `logger.exception(...)` en `...`.
-```
-
-## Checklist pre-PR (IA + dev)
-
-- Cambio cumple el alcance pedido.
-- Diff pequeño y revisable.
-- No se tocaron configs de tooling/CI sin pedido.
-- Tests mínimos agregados cuando aplica.
-- Test de regresión agregado en bugfix cuando aplica.
-- Lint/formato ejecutado si corresponde.
-- Docs actualizadas si cambia comportamiento.
-- Decisiones/cambios importantes registrados en `docs/` (subcarpeta temática) o justificación de excepción.
-- Supuestos y riesgos documentados.
-
-## Comandos locales y referencia a CI
-
-### Local (frecuentes)
-
-```bash
-docker compose up
-docker compose exec django pytest -n auto
-docker compose exec django pytest -m smoke
-black .
-black path/al/archivo.py --config pyproject.toml
-djlint . --configuration=.djlintrc --reformat
-djlint templates/ruta.html --reformat --configuration=.djlintrc
-pylint **/*.py --rcfile=.pylintrc
-pylint app/archivo.py --rcfile=.pylintrc
-```
-
-### Reglas operativas para escribir con menos fricción
-
-- Python nuevo o modificado debe escribirse ya compatible con `black`; evitar “después lo formateo”.
-- `pylint` se usa contra la configuración real del repo. No introducir patrones que generen warnings obvios y después compensarlos con cambios de formato.
-- Tratar las advertencias de `pylint` como señales de diseño o legibilidad: primero intentar resolver la causa raíz con mejores prácticas y dejar las supresiones como último recurso, localizadas y justificadas.
-- En templates, preferir estructura clara para que `djlint` haga ajustes mínimos y no rehaga bloques completos.
-- Evitar ejecutar `black .`, `djlint .` o `pylint **/*.py` como primer paso si el cambio está acotado a uno o pocos archivos.
-
-### CI (referencia)
-
-- Lint/formato: `.github/workflows/lint.yml`
-- Tests/smoke: `.github/workflows/tests.yml`
-
-CI usa `docker compose` y ejecuta smoke + tests automáticos.
-
-## Ejemplos concretos
-
-## Ejemplo A - Bugfix pequeño (buen pedido)
-
-```md
-Fix mínimo en `core/views.py` para evitar 500 cuando `page` no es numérica en `load_organizaciones`.
-No refactorizar otras vistas.
-Agregar test de regresión en `core/tests/`.
-Podés proponer mejoras cercanas: sí.
-```
-
-## Ejemplo B - Refactor seguro (buen pedido)
-
-```md
-Refactor seguro en `core/services/favorite_filters.py` para reducir duplicación en validaciones.
-Sin cambiar payload ni contratos públicos.
-Si detectás un bug cercano, reportalo como mejora opcional, no lo implementes sin aprobación.
-```
+Si no aplica, explicitarlo en la entrega.

--- a/docs/operacion/codex_desktop.md
+++ b/docs/operacion/codex_desktop.md
@@ -11,7 +11,16 @@ Dejar un flujo repetible para que Codex Desktop pueda trabajar en este repo sin 
 
 ## Flujo recomendado
 
-Desde la raiz del repo o del worktree:
+Crear cada tarea en un worktree externo al checkout principal.
+
+Esquema recomendado:
+
+```text
+repo principal: C:/Users/Juanito/Desktop/Repos-Codex/SISOC
+worktree tarea: C:/Users/Juanito/Desktop/Repos-Codex/worktrees/<slug>
+```
+
+Desde la raiz del worktree:
 
 ```powershell
 powershell -ExecutionPolicy Bypass -File scripts/ai/codex_bootstrap.ps1
@@ -72,3 +81,4 @@ El repo expone `.codex/environments/environment.toml` para que Codex Desktop ten
 - El camino principal es Docker-first porque el repo ya usa Docker Compose como entorno real.
 - El fallback local con `.venv` es degradado: sirve para salir del paso cuando Docker no esta disponible, pero no reemplaza el entorno oficial del proyecto.
 - Si un worktree nuevo no tiene `.env`, el bootstrap lo resuelve sin depender del checkout principal.
+- No crear worktrees nuevos dentro de `SISOC/.worktrees`; ese layout queda obsoleto.

--- a/docs/registro/README.md
+++ b/docs/registro/README.md
@@ -1,36 +1,37 @@
 # Spec-as-Source en SISOC
 
-Este directorio define una convención recomendada para documentación operativa que acompaña el desarrollo asistido por IA.
-
-Objetivo:
-- mantener una fuente de verdad versionada en el repo,
-- reducir decisiones implícitas,
-- facilitar revisión, auditoría y continuidad entre agentes/personas.
+Este directorio define la convencion para documentacion operativa y de cambios.
 
 ## Reglas obligatorias
 
-1. Antes de implementar, leer `docs/indice.md`, `docs/ia/*` y la documentación del dominio afectado.
-2. Registrar cada cambio o decisión importante en Markdown dentro de `docs/`, en la subcarpeta temática que corresponda.
-3. No depender de herramientas específicas para spec-driven development; la práctica se resuelve con documentación en `docs/`.
+1. Antes de implementar, leer `AGENTS.md`, `docs/indice.md` y solo el contexto minimo necesario para la tarea.
+2. Registrar en `docs/` cada cambio o decision importante.
+3. No depender de herramientas externas de spec-driven development; la fuente de verdad vive en Markdown dentro del repo.
 
-## Convención sugerida
+## Carga minima recomendada
 
-- `docs/registro/cambios/`: registro de cambios importantes realizados.
-- `docs/registro/decisiones/`: registro de decisiones importantes (ADR livianas).
+Inicio:
+- `AGENTS.md`
+- `docs/indice.md`
+- archivo objetivo
+- tests del modulo
+- una guia relevante de `docs/ia/`
 
-También se pueden crear subcarpetas por dominio fuera de `docs/registro/` (por ejemplo `docs/users/`, `docs/celiaquia/`, `docs/core/`) cuando convenga.
+Ampliar solo si el cambio toca reglas funcionales, permisos, seguridad o comportamiento observable.
 
-## Convención de nombres
+## Convencion sugerida
 
-- `YYYY-MM-DD-<tema>.md` (kebab-case, claro y corto).
+- `docs/registro/cambios/`
+- `docs/registro/decisiones/`
+- `YYYY-MM-DD-<tema>.md`
 
-## Cuándo registrar
+## Cuando registrar
 
-- Cambios funcionales con impacto visible.
-- Decisiones de diseño o arquitectura.
-- Cambios de seguridad, permisos o datos sensibles.
-- Trade-offs relevantes para mantenimiento futuro.
+- cambios funcionales visibles,
+- decisiones de arquitectura o diseno,
+- cambios de seguridad, permisos o datos sensibles,
+- trade-offs relevantes para mantenimiento.
 
-## Cuándo puede no aplicar
+## Cuando puede no aplicar
 
-En cambios triviales sin impacto funcional (por ejemplo typo menor o ajuste no observable), se puede omitir el archivo, pero debe quedar justificado en la entrega/PR.
+Si el cambio es trivial y sin impacto funcional, se puede omitir el archivo, pero debe quedar justificado en la entrega.

--- a/docs/registro/cambios/2026-04-13-reduccion-contexto-raiz-y-worktrees-externos.md
+++ b/docs/registro/cambios/2026-04-13-reduccion-contexto-raiz-y-worktrees-externos.md
@@ -1,0 +1,35 @@
+# Reduccion de contexto raiz y normalizacion de worktrees externos
+
+Fecha: 2026-04-13
+
+## Que cambio
+
+- `AGENTS.md` se compacto para dejar una sola fuente de verdad corta.
+- `CODEX.md`, `CLAUDE.md`, `LLM.md` y `.github/copilot-instructions.md` pasaron a ser adaptadores minimos en vez de duplicar reglas.
+- La politica de lectura obligatoria cambio a "minimo contexto suficiente":
+  - `AGENTS.md`
+  - `docs/indice.md`
+  - archivo objetivo
+  - tests del modulo
+  - una sola guia relevante de `docs/ia/`
+- `docs/ia/CONTEXT_HYGIENE.md`, `docs/ia/CONTRIBUTING_AI.md`, `docs/agentes/guia.md`, `docs/registro/README.md`, `docs/operacion/codex_desktop.md` y `scripts/ai/preflight.sh` quedaron alineados a ese flujo.
+
+## Politica vigente
+
+- No se lee `docs/ia/*` completo por defecto.
+- Se amplia contexto solo con evidencia concreta.
+- Los worktrees nuevos deben vivir fuera del checkout principal, en `C:/Users/Juanito/Desktop/Repos-Codex/worktrees/<slug>`.
+- `SISOC/.worktrees` queda obsoleto y no debe volver a usarse.
+
+## Cambio operativo aplicado
+
+- Se movieron los worktrees registrados dentro de `SISOC/.worktrees` al directorio externo `C:/Users/Juanito/Desktop/Repos-Codex/worktrees/`.
+- El contenido remanente de esa carpeta se movio a `C:/Users/Juanito/Desktop/Repos-Codex/worktrees/legacy-dot-worktrees/`.
+- Se elimino `SISOC/.worktrees` una vez vacio.
+
+## Impacto esperado
+
+- Menor costo fijo de tokens por turno.
+- Menos ruido al explorar el repo.
+- Menor riesgo de scope creep por lectura excesiva.
+- Flujo de aislamiento consistente entre tareas nuevas y tareas existentes.

--- a/scripts/ai/preflight.sh
+++ b/scripts/ai/preflight.sh
@@ -30,79 +30,75 @@ else
   git status --short
 fi
 
-print_header "Fuentes de verdad para IA"
-echo "- AGENTS.md (principal)"
-echo "- CODEX.md / CLAUDE.md (hard gate + fallback por herramienta)"
-echo "- docs/ia/CONTEXT_HYGIENE.md (qué leer primero / qué evitar cargar)"
-echo "- docs/ia/STYLE_GUIDE.md"
-echo "- docs/ia/ARCHITECTURE.md"
+print_header "Lectura inicial recomendada"
+echo "- AGENTS.md"
+echo "- docs/indice.md"
+echo "- archivo objetivo + tests del modulo"
+echo "- docs/ia/CONTEXT_HYGIENE.md"
+echo "- una sola guia de docs/ia segun la tarea"
 
 echo
-print_header "Recordatorios críticos del repo"
-echo "- Lógica de negocio preferentemente en services/"
-echo "- Coexisten Django views y DRF (verificar patrón real por app)"
+print_header "Recordatorios criticos del repo"
+echo "- Logica de negocio preferentemente en services/"
+echo "- Coexisten Django views y DRF"
 echo "- Logging custom en config/settings.py + core/utils.py"
 echo "- No se usa Celery actualmente"
-echo "- Tests: pytest (pueden usar SQLite en memoria en tests según settings)"
+echo "- Crear worktrees de tarea fuera del repo principal"
 
-print_header "Comandos útiles"
+print_header "Comandos utiles"
 cat <<'CMDS'
 docker compose up
 docker compose exec django pytest -n auto
 docker compose exec django pytest -m smoke
-black .
+black . --config pyproject.toml
 djlint . --configuration=.djlintrc --reformat
 pylint **/*.py --rcfile=.pylintrc
 CMDS
 
-print_header "Contexto mínimo sugerido (por tipo)"
+print_header "Contexto minimo sugerido (por tipo)"
 case "$TASK_KIND" in
   bugfix-view)
     echo "- AGENTS.md"
-    echo "- docs/ia/CONTEXT_HYGIENE.md"
+    echo "- docs/indice.md"
     echo "- view afectada"
-    echo "- tests del módulo"
+    echo "- tests del modulo"
     echo "- docs/ia/TESTING.md"
     ;;
   bugfix-api|feature-api)
     echo "- AGENTS.md"
-    echo "- docs/ia/CONTEXT_HYGIENE.md"
-    echo "- api_views.py / serializers*.py del módulo"
-    echo "- tests API del módulo"
-    echo "- docs/ia/ARCHITECTURE.md"
+    echo "- docs/indice.md"
+    echo "- api_views.py / serializers*.py del modulo"
+    echo "- tests API del modulo"
     echo "- docs/ia/TESTING.md"
-    echo "- docs/ia/SECURITY_AI.md (si toca permisos/auth)"
+    echo "- docs/ia/ARCHITECTURE.md si el boundary no esta claro"
     ;;
   feature-service|refactor-service)
     echo "- AGENTS.md"
-    echo "- docs/ia/CONTEXT_HYGIENE.md"
+    echo "- docs/indice.md"
     echo "- service afectado"
     echo "- tests del flujo"
     echo "- docs/ia/STYLE_GUIDE.md"
-    echo "- docs/ia/TESTING.md"
     ;;
   logging|errores)
     echo "- AGENTS.md"
-    echo "- docs/ia/CONTEXT_HYGIENE.md"
+    echo "- docs/indice.md"
     echo "- archivo afectado"
     echo "- docs/ia/ERRORS_LOGGING.md"
-    echo "- config/settings.py (logging custom)"
-    echo "- core/utils.py"
+    echo "- config/settings.py / core/utils.py si aplica"
     ;;
   migration|modelo)
     echo "- AGENTS.md"
-    echo "- docs/ia/CONTEXT_HYGIENE.md"
+    echo "- docs/indice.md"
     echo "- modelo(s)"
-    echo "- migraciones recientes de la app"
+    echo "- migraciones cercanas"
     echo "- tests relacionados"
     echo "- docs/ia/ARCHITECTURE.md"
-    echo "- docs/ia/TESTING.md"
     ;;
   *)
     echo "- AGENTS.md"
-    echo "- docs/ia/CONTEXT_HYGIENE.md"
+    echo "- docs/indice.md"
     echo "- archivo(s) objetivo"
-    echo "- tests del módulo"
+    echo "- tests del modulo"
     echo "- docs/ia/STYLE_GUIDE.md"
     ;;
 esac


### PR DESCRIPTION
why: el repo repetia instrucciones y mantenia worktrees dentro del checkout principal, lo que sumaba ruido y costo fijo de contexto.

what:\n- compacta AGENTS y adaptadores de herramienta\n- cambia la lectura obligatoria a minimo contexto suficiente\n- alinea guias operativas y preflight\n- registra el cambio en docs/registro

impact: sin cambios funcionales de producto; los worktrees internos se movieron al directorio externo estandar

tests: git diff --check y verificacion de git worktree list sin entradas en SISOC/.worktrees

# Información de la Tarea
Vincular el #ISSUE

### **Resumen de la Solución:** 
-

### **Información Adicional:**
-

# Descripción de los Cambios

### **Cambios:**
-

# Cómo Testear los Cambios

### **Pruebas Automáticas:**
-

### **Prubeas Manuales:**
-

# Metadata para documentación automática

- Contexto funcional:
- Tipo de cambio:
- Área principal:
- Resumen para changelog:
- Impacto usuario:
- Riesgos / rollback:

# Capturas de Pantalla
