### PR TITLE
fix(vat): quitar paginacion en endpoint de provincias

### DIFF
--- a/VAT/api_views.py
+++ b/VAT/api_views.py
@@ -130,6 +130,7 @@ class ProvinciaViewSet(viewsets.ReadOnlyModelViewSet):
     queryset = Provincia.objects.all().order_by("nombre")
     serializer_class = ProvinciaSerializer
     permission_classes = [HasAPIKey]
+    pagination_class = None
 
 
 @extend_schema(tags=["VAT - Ubicación"])

--- a/VAT/tests.py
+++ b/VAT/tests.py
@@ -2145,6 +2145,22 @@ def vat_curso_base(db, vat_geo_data):
 
 
 @pytest.mark.django_db
+def test_api_vat_provincias_lista_sin_paginacion(vat_api_client):
+    Provincia.objects.bulk_create(
+        [Provincia(nombre=f"Provincia VAT {index:02d}") for index in range(12)]
+    )
+
+    response = vat_api_client.get("/api/vat/provincias/")
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert isinstance(payload, list)
+    assert len(payload) == 12
+    assert payload[0]["nombre"] == "Provincia VAT 00"
+    assert payload[-1]["nombre"] == "Provincia VAT 11"
+
+
+@pytest.mark.django_db
 def test_api_vat_centros_lista_con_api_key(vat_api_client, vat_curso_base):
     centro, _, _ = vat_curso_base
 

--- a/docs/registro/cambios/2026-04-13-vat-provincias-sin-paginacion.md
+++ b/docs/registro/cambios/2026-04-13-vat-provincias-sin-paginacion.md
@@ -1,0 +1,16 @@
+# VAT provincias sin paginacion
+
+Fecha: 2026-04-13
+
+## Que cambio
+
+- El endpoint `GET /api/vat/provincias/` deja de usar la paginacion global de DRF.
+- La respuesta ahora devuelve una lista plana de provincias, ordenada por nombre.
+
+## Decision clave
+
+- Se desactivo la paginacion solo en `ProvinciaViewSet` con `pagination_class = None` para no alterar el resto de los endpoints VAT ni la configuracion global de DRF.
+
+## Validacion prevista
+
+- Test de regresion en `VAT/tests.py` que verifica que el endpoint responde una lista JSON y no el envelope paginado (`count`, `results`).


### PR DESCRIPTION
## Que cambia
- quita la paginacion solo en `GET /api/vat/provincias/`
- agrega test de regresion para verificar respuesta no paginada
- registra el cambio en `docs/registro/cambios/`

## Decision
- se usa `pagination_class = None` solo en `ProvinciaViewSet` para no afectar otros endpoints VAT ni la configuracion global de DRF

## Validacion
- no se pudo ejecutar `pytest` en esta terminal porque este entorno no tiene `pytest` ni Docker disponibles

## Notas
- rama origen: `task/vat-provincias-sin-paginacion`
- destino: `development`