### PR TITLE
chore(ci): autoformatear PRs internos en lint

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -10,6 +10,13 @@ on:
             - main
             - development
 
+permissions:
+    contents: read
+
+concurrency:
+    group: lint-${{ github.event.pull_request.number || github.ref }}
+    cancel-in-progress: true
+
 jobs:
     setup:
         runs-on: ubuntu-latest
@@ -31,9 +38,109 @@ jobs:
                   pip install black==24.8.0 djlint pylint
               id: install-dependencies
 
-    encoding_check:
+    autofix:
         runs-on: ubuntu-latest
         needs: setup
+        permissions:
+            contents: write
+        steps:
+            - name: Checkout PR head branch
+              if: github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository
+              uses: actions/checkout@v4.1.7
+              with:
+                  fetch-depth: 0
+                  ref: ${{ github.event.pull_request.head.ref }}
+
+            - name: Skip autofix outside internal pull requests
+              if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name != github.repository
+              run: echo "Autofix solo habilitado para pull requests del mismo repositorio."
+
+            - name: Set up Python
+              if: github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository
+              uses: actions/setup-python@v5.2.0
+              with:
+                  python-version: ${{ needs.setup.outputs.python-version }}
+
+            - name: Install autofix dependencies
+              if: github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository
+              run: |
+                  python -m pip install --upgrade pip
+                  pip install black==24.8.0 djlint==1.34.2
+
+            - name: Detect changed Python files
+              id: detect-changed-python
+              if: github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository
+              run: echo "files=$(python scripts/ci/pr_lint_tools.py changed-files --kind python)" >> "$GITHUB_OUTPUT"
+
+            - name: Detect changed templates
+              id: detect-changed-templates
+              if: github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository
+              run: echo "files=$(python scripts/ci/pr_lint_tools.py changed-files --kind templates)" >> "$GITHUB_OUTPUT"
+
+            - name: Run Black autofix
+              if: github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository && steps.detect-changed-python.outputs.files != '[]'
+              run: |
+                  python - <<'PY'
+                  import json
+                  import os
+                  import subprocess
+
+                  files = json.loads(os.environ["PYTHON_FILES_JSON"])
+                  print("Running black on", len(files), "Python file(s)")
+                  subprocess.run(
+                      ["black", "--config", "pyproject.toml", *files],
+                      check=True,
+                  )
+                  PY
+              env:
+                  PYTHON_FILES_JSON: ${{ steps.detect-changed-python.outputs.files }}
+
+            - name: Run DJLint autofix
+              if: github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository && steps.detect-changed-templates.outputs.files != '[]'
+              run: |
+                  python - <<'PY'
+                  import json
+                  import os
+                  import subprocess
+
+                  templates = json.loads(os.environ["TEMPLATE_FILES_JSON"])
+                  print("Running djlint --reformat on", len(templates), "template file(s)")
+                  subprocess.run(
+                      [
+                          "djlint",
+                          *templates,
+                          "--reformat",
+                          "--configuration=.djlintrc",
+                      ],
+                      check=True,
+                  )
+                  PY
+              env:
+                  TEMPLATE_FILES_JSON: ${{ steps.detect-changed-templates.outputs.files }}
+
+            - name: Normalize mojibake in changed text files
+              if: github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository
+              run: python scripts/ci/pr_lint_tools.py fix-encoding
+
+            - name: Commit and push autofix
+              if: github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository
+              run: |
+                  if git diff --quiet; then
+                      echo "No hubo cambios automaticos para commitear."
+                      exit 0
+                  fi
+
+                  git config user.name "github-actions[bot]"
+                  git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+                  git add -A
+                  git commit -m "chore(ci): autoformatear PR"
+                  git push origin HEAD:${{ github.event.pull_request.head.ref }}
+
+    encoding_check:
+        runs-on: ubuntu-latest
+        needs:
+            - setup
+            - autofix
         steps:
             - name: Checkout code
               uses: actions/checkout@v4.1.7
@@ -45,105 +152,14 @@ jobs:
               with:
                   python-version: ${{ needs.setup.outputs.python-version }}
 
-            - name: Detect mojibake in changed text files
-              run: |
-                  python - <<'PY'
-                  import json
-                  import os
-                  import subprocess
-                  from pathlib import Path
-
-                  EXCLUDED_DIRS = {
-                      ".git",
-                      ".venv",
-                      "__pycache__",
-                      "node_modules",
-                      "staticfiles",
-                      "media",
-                  }
-                  EXCLUDED_SUFFIXES = {
-                      ".png", ".jpg", ".jpeg", ".gif", ".svg", ".ico", ".webp",
-                      ".woff", ".woff2", ".ttf", ".eot", ".pdf", ".zip",
-                      ".sqlite3", ".pyc", ".pyo",
-                  }
-                  EXCLUDED_FILENAMES = {
-                      "package-lock.json",
-                      "poetry.lock",
-                  }
-                  PATTERNS = (
-                      "\u00c3\u00a1", "\u00c3\u00a9", "\u00c3\u00ad",
-                      "\u00c3\u00b3", "\u00c3\u00ba", "\u00c3\u00b1",
-                      "\u00c3\u0081", "\u00c3\u0089", "\u00c3\u008d",
-                      "\u00c3\u0093", "\u00c3\u009a", "\u00c3\u0091",
-                      "\u00c2\u00bf", "\u00c2\u00a1", "\u00c2\u00b0",
-                      "\u00e2\u20ac\u2122", "\u00e2\u20ac\u0153",
-                      "\u00e2\u20ac\u009d", "\u00e2\u20ac\u201c",
-                      "\u00e2\u20ac\u201d",
-                  )
-
-                  event_name = os.environ["GITHUB_EVENT_NAME"]
-                  event_path = os.environ["GITHUB_EVENT_PATH"]
-                  with open(event_path, encoding="utf-8") as fh:
-                      event = json.load(fh)
-
-                  if event_name == "pull_request":
-                      base_sha = event["pull_request"]["base"]["sha"]
-                      head_sha = event["pull_request"]["head"]["sha"]
-                  elif event_name == "push":
-                      base_sha = event["before"]
-                      head_sha = event["after"]
-                  else:
-                      raise SystemExit(f"Unsupported event: {event_name}")
-
-                  changed_output = subprocess.check_output(
-                      ["git", "diff", "--name-only", base_sha, head_sha],
-                      text=True,
-                  )
-                  changed_files = [
-                      Path(item.strip())
-                      for item in changed_output.splitlines()
-                      if item.strip()
-                  ]
-
-                  if not changed_files:
-                      print("No changed files to scan for mojibake.")
-                      raise SystemExit(0)
-
-                  findings = []
-                  for path in changed_files:
-                      if not path.is_file():
-                          continue
-                      if any(part in EXCLUDED_DIRS for part in path.parts):
-                          continue
-                      if path.name in EXCLUDED_FILENAMES:
-                          continue
-                      if path.suffix.lower() in EXCLUDED_SUFFIXES:
-                          continue
-
-                      try:
-                          text = path.read_text(encoding="utf-8")
-                      except UnicodeDecodeError:
-                          continue
-
-                      for line_number, line in enumerate(text.splitlines(), start=1):
-                          matches = [pattern for pattern in PATTERNS if pattern in line]
-                          if matches:
-                              findings.append(
-                                  f"{path}:{line_number}: suspicious patterns {matches} -> {line.strip()}"
-                              )
-
-                  if findings:
-                      print("Possible mojibake sequences detected:")
-                      for finding in findings:
-                          print(finding)
-                      raise SystemExit(1)
-
-                  print("No typical mojibake patterns were found in changed text files.")
-                  PY
+            - name: Validate encoding on changed text files
+              run: python scripts/ci/pr_lint_tools.py check-encoding
 
     black:
         runs-on: ubuntu-latest
-        needs: setup
+        needs:
+            - setup
+            - autofix
         steps:
             - name: Checkout code
               uses: actions/checkout@v4.1.7
@@ -158,7 +174,35 @@ jobs:
                   python -m pip install --upgrade pip
                   pip install black==24.8.0
 
-            - name: Run Black
+            - name: Detect changed Python files
+              id: detect-changed-python
+              if: github.event_name == 'pull_request'
+              run: echo "files=$(python scripts/ci/pr_lint_tools.py changed-files --kind python)" >> "$GITHUB_OUTPUT"
+
+            - name: Run Black on changed Python files
+              if: github.event_name == 'pull_request' && steps.detect-changed-python.outputs.files != '[]'
+              run: |
+                  python - <<'PY'
+                  import json
+                  import os
+                  import subprocess
+
+                  files = json.loads(os.environ["PYTHON_FILES_JSON"])
+                  print("Checking black on", len(files), "Python file(s)")
+                  subprocess.run(
+                      ["black", "--check", "--config", "pyproject.toml", *files],
+                      check=True,
+                  )
+                  PY
+              env:
+                  PYTHON_FILES_JSON: ${{ steps.detect-changed-python.outputs.files }}
+
+            - name: Skip Black when PR has no Python changes
+              if: github.event_name == 'pull_request' && steps.detect-changed-python.outputs.files == '[]'
+              run: echo "No changed Python files detected in this pull request."
+
+            - name: Run Black on repository
+              if: github.event_name == 'push'
               run: black --check . --config pyproject.toml
 
             - name: Upload Black report
@@ -171,7 +215,9 @@ jobs:
 
     djlint:
         runs-on: ubuntu-latest
-        needs: setup
+        needs:
+            - setup
+            - autofix
         steps:
             - name: Checkout code
               uses: actions/checkout@v4.1.7
@@ -190,48 +236,7 @@ jobs:
 
             - name: Detect changed templates
               id: detect-changed-templates
-              run: |
-                  python - <<'PY'
-                  import json
-                  import os
-                  import subprocess
-                  from pathlib import Path
-
-                  TEMPLATE_SUFFIXES = {".html", ".htm", ".djhtml", ".jinja", ".j2"}
-
-                  event_name = os.environ["GITHUB_EVENT_NAME"]
-                  with open(os.environ["GITHUB_EVENT_PATH"], encoding="utf-8") as fh:
-                      event = json.load(fh)
-
-                  if event_name == "pull_request":
-                      base_sha = event["pull_request"]["base"]["sha"]
-                      head_sha = event["pull_request"]["head"]["sha"]
-                  elif event_name == "push":
-                      base_sha = event["before"]
-                      head_sha = event["after"]
-                  else:
-                      raise SystemExit(f"Unsupported event: {event_name}")
-
-                  changed_output = subprocess.check_output(
-                      ["git", "diff", "--name-only", base_sha, head_sha],
-                      text=True,
-                  )
-                  changed_templates = []
-                  for raw_path in changed_output.splitlines():
-                      path = Path(raw_path.strip())
-                      if path.suffix.lower() in TEMPLATE_SUFFIXES:
-                          changed_templates.append(str(path))
-
-                  with open(os.environ["GITHUB_OUTPUT"], "a", encoding="utf-8") as fh:
-                      fh.write(f"templates={json.dumps(changed_templates)}\n")
-
-                  if changed_templates:
-                      print("Templates to lint:")
-                      for template in changed_templates:
-                          print(template)
-                  else:
-                      print("No changed templates detected.")
-                  PY
+              run: echo "templates=$(python scripts/ci/pr_lint_tools.py changed-files --kind templates)" >> "$GITHUB_OUTPUT"
 
             - name: Run DJLint
               if: steps.detect-changed-templates.outputs.templates != '[]'
@@ -255,7 +260,9 @@ jobs:
 
     pylint:
         runs-on: ubuntu-latest
-        needs: setup
+        needs:
+            - setup
+            - autofix
         steps:
             - name: Checkout code
               uses: actions/checkout@v4.1.7

--- a/docs/registro/cambios/2026-04-13-ci-autofix-pr-format-encoding.md
+++ b/docs/registro/cambios/2026-04-13-ci-autofix-pr-format-encoding.md
@@ -1,0 +1,32 @@
+# Cambio: autofix de formato y encoding en PRs
+
+## Fecha
+
+- 2026-04-13
+
+## Alcance
+
+- `.github/workflows/lint.yml`
+- `scripts/ci/pr_lint_tools.py`
+
+## Resumen
+
+- Se agrego un job `autofix` al workflow de lint para PRs del mismo repositorio.
+- El job corrige automaticamente:
+  - formato Python con `black` sobre archivos `.py` cambiados en el PR
+  - formato de templates con `djlint --reformat` sobre templates cambiados
+  - secuencias tipicas de mojibake/encoding en archivos de texto modificados
+- Si el bot aplico cambios, hace commit y push directo a la branch origen del PR.
+- Despues del autofix, los jobs `encoding_check`, `black` y `djlint` vuelven a validar y fallan si aun queda algo no corregible automaticamente.
+
+## Decision operativa
+
+- El autofix solo corre en `pull_request` cuando la branch origen pertenece al mismo repositorio.
+- En forks o eventos `push`, el workflow se mantiene en modo validacion sin intentar escribir.
+- Se agrego `concurrency` para cancelar corridas viejas del mismo PR cuando el bot empuja un commit de autofix.
+
+## Impacto esperado
+
+- Menos fallas manuales por formato en PRs internos.
+- Menos idas y vueltas de revision por errores triviales de `black`, `djlint` o mojibake comun.
+- Si el problema no se puede corregir de forma segura, la CI sigue fallando para exigir intervencion humana.

--- a/scripts/ci/pr_lint_tools.py
+++ b/scripts/ci/pr_lint_tools.py
@@ -1,0 +1,283 @@
+"""Utilidades compartidas para lint/autofix en GitHub Actions."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import subprocess
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+
+EXCLUDED_DIRS = {
+    ".git",
+    ".venv",
+    "__pycache__",
+    "node_modules",
+    "staticfiles",
+    "media",
+}
+EXCLUDED_SUFFIXES = {
+    ".png",
+    ".jpg",
+    ".jpeg",
+    ".gif",
+    ".svg",
+    ".ico",
+    ".webp",
+    ".woff",
+    ".woff2",
+    ".ttf",
+    ".eot",
+    ".pdf",
+    ".zip",
+    ".sqlite3",
+    ".pyc",
+    ".pyo",
+}
+EXCLUDED_FILENAMES = {
+    "package-lock.json",
+    "poetry.lock",
+}
+TEMPLATE_SUFFIXES = {".html", ".htm", ".djhtml", ".jinja", ".j2"}
+PYTHON_SUFFIXES = {".py"}
+MOJIBAKE_REPLACEMENTS = {
+    "\u00c3\u00a1": "\u00e1",
+    "\u00c3\u00a9": "\u00e9",
+    "\u00c3\u00ad": "\u00ed",
+    "\u00c3\u00b3": "\u00f3",
+    "\u00c3\u00ba": "\u00fa",
+    "\u00c3\u00b1": "\u00f1",
+    "\u00c3\u0081": "\u00c1",
+    "\u00c3\u0089": "\u00c9",
+    "\u00c3\u008d": "\u00cd",
+    "\u00c3\u0093": "\u00d3",
+    "\u00c3\u009a": "\u00da",
+    "\u00c3\u0091": "\u00d1",
+    "\u00c2\u00bf": "\u00bf",
+    "\u00c2\u00a1": "\u00a1",
+    "\u00c2\u00b0": "\u00b0",
+    "\u00e2\u20ac\u2122": "\u2019",
+    "\u00e2\u20ac\u0153": "\u201c",
+    "\u00e2\u20ac\u009d": "\u201d",
+    "\u00e2\u20ac\u201c": "\u2013",
+    "\u00e2\u20ac\u201d": "\u2014",
+    "\u00e2\u20ac\u00a6": "\u2026",
+}
+
+
+def read_event_payload() -> dict:
+    """Carga el payload del evento actual de GitHub."""
+
+    event_path = os.environ.get("GITHUB_EVENT_PATH")
+    if not event_path:
+        raise RuntimeError("GITHUB_EVENT_PATH no esta definido.")
+    return json.loads(Path(event_path).read_text(encoding="utf-8"))
+
+
+def get_diff_range() -> tuple[str, str]:
+    """Devuelve el rango git relevante para el evento actual."""
+
+    event_name = os.environ.get("GITHUB_EVENT_NAME")
+    payload = read_event_payload()
+    if event_name == "pull_request":
+        return (
+            payload["pull_request"]["base"]["sha"],
+            payload["pull_request"]["head"]["sha"],
+        )
+    if event_name == "push":
+        return payload["before"], payload["after"]
+    raise RuntimeError(f"Evento no soportado: {event_name}")
+
+
+def get_changed_files() -> list[Path]:
+    """Lista archivos cambiados dentro del rango del evento."""
+
+    base_sha, head_sha = get_diff_range()
+    output = subprocess.check_output(
+        ["git", "diff", "--name-only", base_sha, head_sha],
+        cwd=REPO_ROOT,
+        text=True,
+    )
+    return [Path(item.strip()) for item in output.splitlines() if item.strip()]
+
+
+def is_excluded(path: Path) -> bool:
+    """Determina si un archivo debe quedar fuera de los chequeos de texto."""
+
+    return (
+        any(part in EXCLUDED_DIRS for part in path.parts)
+        or path.name in EXCLUDED_FILENAMES
+        or path.suffix.lower() in EXCLUDED_SUFFIXES
+    )
+
+
+def is_binary_content(data: bytes) -> bool:
+    """Heuristica simple para ignorar blobs binarios."""
+
+    return b"\x00" in data
+
+
+def list_changed_files(kind: str) -> int:
+    """Imprime como JSON los archivos cambiados relevantes para un tipo."""
+
+    suffixes = TEMPLATE_SUFFIXES if kind == "templates" else PYTHON_SUFFIXES
+    files = [
+        str(path)
+        for path in get_changed_files()
+        if path.suffix.lower() in suffixes and (REPO_ROOT / path).is_file()
+    ]
+    print(json.dumps(files))
+    return 0
+
+
+def collect_text_files() -> tuple[list[tuple[Path, Path, bytes]], list[str]]:
+    """Devuelve archivos de texto changed y archivos no UTF-8 que no se pueden tratar."""
+
+    text_files: list[tuple[Path, Path, bytes]] = []
+    undecodable: list[str] = []
+    for relative_path in get_changed_files():
+        absolute_path = REPO_ROOT / relative_path
+        if not absolute_path.is_file() or is_excluded(relative_path):
+            continue
+
+        data = absolute_path.read_bytes()
+        if is_binary_content(data):
+            continue
+
+        try:
+            data.decode("utf-8")
+        except UnicodeDecodeError as exc:
+            undecodable.append(
+                f"{relative_path}: archivo de texto no UTF-8, sin correccion segura ({exc})"
+            )
+            continue
+
+        text_files.append((relative_path, absolute_path, data))
+
+    return text_files, undecodable
+
+
+def find_patterns(text: str) -> list[str]:
+    """Busca secuencias de mojibake conocidas en un texto."""
+
+    return [pattern for pattern in MOJIBAKE_REPLACEMENTS if pattern in text]
+
+
+def format_findings(relative_path: Path, text: str) -> list[str]:
+    """Construye findings por linea para la salida de CI."""
+
+    findings: list[str] = []
+    for line_number, line in enumerate(text.splitlines(), start=1):
+        matches = [pattern for pattern in MOJIBAKE_REPLACEMENTS if pattern in line]
+        if matches:
+            findings.append(
+                f"{relative_path}:{line_number}: patrones sospechosos {matches} -> {line.strip()}"
+            )
+    return findings
+
+
+def normalize_text(text: str) -> tuple[str, int]:
+    """Aplica reemplazos seguros de mojibake y devuelve la cantidad de cambios."""
+
+    updated_text = text
+    replacements = 0
+    for source, target in MOJIBAKE_REPLACEMENTS.items():
+        count = updated_text.count(source)
+        if count:
+            updated_text = updated_text.replace(source, target)
+            replacements += count
+    return updated_text, replacements
+
+
+def check_encoding() -> int:
+    """Falla si quedan patrones de mojibake o archivos no UTF-8 en el diff."""
+
+    text_files, undecodable = collect_text_files()
+    findings = list(undecodable)
+    for relative_path, _, data in text_files:
+        text = data.decode("utf-8")
+        findings.extend(format_findings(relative_path, text))
+
+    if findings:
+        print("Problemas de encoding detectados:")
+        for finding in findings:
+            print(finding)
+        return 1
+
+    print("No se detectaron problemas de encoding corregibles en los archivos cambiados.")
+    return 0
+
+
+def fix_encoding() -> int:
+    """Normaliza mojibake segura en archivos changed y falla si queda algo sin resolver."""
+
+    text_files, undecodable = collect_text_files()
+    unresolved = list(undecodable)
+    updated_files: list[str] = []
+
+    for relative_path, absolute_path, data in text_files:
+        original_text = data.decode("utf-8")
+        normalized_text, replacements = normalize_text(original_text)
+        if replacements:
+            absolute_path.write_text(
+                normalized_text,
+                encoding="utf-8",
+                newline="",
+            )
+            updated_files.append(f"{relative_path}: {replacements} reemplazo(s)")
+        unresolved.extend(format_findings(relative_path, normalized_text))
+
+    if updated_files:
+        print("Archivos normalizados por encoding:")
+        for updated_file in updated_files:
+            print(updated_file)
+
+    if unresolved:
+        print("Persisten problemas de encoding que requieren correccion manual:")
+        for finding in unresolved:
+            print(finding)
+        return 1
+
+    print("Normalizacion de encoding completada sin problemas pendientes.")
+    return 0
+
+
+def build_parser() -> argparse.ArgumentParser:
+    """Construye el parser CLI del script."""
+
+    parser = argparse.ArgumentParser()
+    subparsers = parser.add_subparsers(dest="command", required=True)
+
+    changed_files_parser = subparsers.add_parser("changed-files")
+    changed_files_parser.add_argument(
+        "--kind",
+        choices=("python", "templates"),
+        required=True,
+    )
+
+    subparsers.add_parser("check-encoding")
+    subparsers.add_parser("fix-encoding")
+    return parser
+
+
+def main() -> int:
+    """Punto de entrada CLI."""
+
+    parser = build_parser()
+    args = parser.parse_args()
+
+    if args.command == "changed-files":
+        return list_changed_files(args.kind)
+    if args.command == "check-encoding":
+        return check_encoding()
+    if args.command == "fix-encoding":
+        return fix_encoding()
+    parser.error(f"Comando no soportado: {args.command}")
+    return 2
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
what:
- agrega job de autofix para black, djlint y mojibake en PRs internos
- reutiliza un helper de CI para detectar archivos cambiados y validar encoding
- mantiene validacion final y documenta el cambio operativo

tests:
- py -3 -m compileall scripts/ci/pr_lint_tools.py
- smoke import del helper y parseo YAML de .github/workflows/lint.yml

# Información de la Tarea
Vincular el #ISSUE

### **Resumen de la Solución:** 
-

### **Información Adicional:**
-

# Descripción de los Cambios

### **Cambios:**
-

# Cómo Testear los Cambios

### **Pruebas Automáticas:**
-

### **Prubeas Manuales:**
-

# Metadata para documentación automática

- Contexto funcional:
- Tipo de cambio:
- Área principal:
- Resumen para changelog:
- Impacto usuario:
- Riesgos / rollback:

# Capturas de Pantalla
