### PR TITLE
fix(vat): quitar paginacion en api de localidades

### DIFF
--- a/VAT/api_views.py
+++ b/VAT/api_views.py
@@ -154,6 +154,7 @@ class LocalidadViewSet(viewsets.ReadOnlyModelViewSet):
     )
     serializer_class = LocalidadSerializer
     permission_classes = [HasAPIKey]
+    pagination_class = None
 
     def get_queryset(self):
         queryset = super().get_queryset()

--- a/VAT/tests.py
+++ b/VAT/tests.py
@@ -2161,6 +2161,27 @@ def test_api_vat_provincias_lista_sin_paginacion(vat_api_client):
 
 
 @pytest.mark.django_db
+def test_api_vat_localidades_lista_sin_paginacion(vat_api_client):
+    provincia = Provincia.objects.create(nombre="Provincia VAT")
+    municipio = Municipio.objects.create(nombre="Municipio VAT", provincia=provincia)
+    Localidad.objects.bulk_create(
+        [
+            Localidad(nombre=f"Localidad VAT {index:02d}", municipio=municipio)
+            for index in range(12)
+        ]
+    )
+
+    response = vat_api_client.get("/api/vat/localidades/")
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert isinstance(payload, list)
+    assert len(payload) == 12
+    assert payload[0]["nombre"] == "Localidad VAT 00"
+    assert payload[-1]["nombre"] == "Localidad VAT 11"
+
+
+@pytest.mark.django_db
 def test_api_vat_centros_lista_con_api_key(vat_api_client, vat_curso_base):
     centro, _, _ = vat_curso_base
 

--- a/docs/registro/cambios/2026-04-13-vat-localidades-sin-paginacion.md
+++ b/docs/registro/cambios/2026-04-13-vat-localidades-sin-paginacion.md
@@ -1,0 +1,16 @@
+# VAT localidades sin paginacion
+
+Fecha: 2026-04-13
+
+## Que cambio
+
+- El endpoint `GET /api/vat/localidades/` deja de usar la paginacion global de DRF.
+- La respuesta ahora devuelve una lista plana de localidades, ordenada por nombre.
+
+## Decision clave
+
+- Se desactivo la paginacion solo en `LocalidadViewSet` con `pagination_class = None` para no alterar el resto de los endpoints VAT ni la configuracion global de DRF.
+
+## Validacion prevista
+
+- Test de regresion en `VAT/tests.py` que verifica que el endpoint responde una lista JSON y no el envelope paginado (`count`, `results`).


### PR DESCRIPTION
why: el endpoint /api/vat/localidades/ necesitaba devolver el listado completo sin depender del envelope paginado.

what:
- desactiva la paginacion solo en LocalidadViewSet
- agrega test de regresion para validar respuesta no paginada
- registra el cambio en docs/registro/cambios

impact: no modifica la paginacion global ni otros endpoints VAT

tests: no se pudo ejecutar pytest en esta terminal porque no hay pytest disponible, Docker no esta activo y el .env autogenerado desde .env.example contiene lineas de ejemplo invalidas para Compose

# Información de la Tarea
Vincular el #ISSUE

### **Resumen de la Solución:** 
-

### **Información Adicional:**
-

# Descripción de los Cambios

### **Cambios:**
-

# Cómo Testear los Cambios

### **Pruebas Automáticas:**
-

### **Prubeas Manuales:**
-

# Metadata para documentación automática

- Contexto funcional:
- Tipo de cambio:
- Área principal:
- Resumen para changelog:
- Impacto usuario:
- Riesgos / rollback:

# Capturas de Pantalla
