### PR TITLE
fix(config): corregir origenes CSRF en homologacion local

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -5,6 +5,8 @@ DJANGO_DEBUG=True
 ENVIRONMENT=dev
 DJANGO_SECRET_KEY=""
 DJANGO_ALLOWED_HOSTS="localhost,127.0.0.1"
+# Opcional: origenes CSRF extra separados por coma (ej. http://localhost:8001,https://mi-dominio)
+DJANGO_CSRF_TRUSTED_ORIGINS=""
 
 # =============================================================================
 # BASE DE DATOS

--- a/.env.homologacion
+++ b/.env.homologacion
@@ -5,6 +5,8 @@ DJANGO_DEBUG=False
 ENVIRONMENT=homologacion
 DJANGO_SECRET_KEY=""  # WARNING: Generar y no commitear
 DJANGO_ALLOWED_HOSTS="homologacion.sisoc.example.gov.ar,localhost,127.0.0.1"
+# Opcional: si el acceso real usa otro origen, declararlo completo (scheme + host[:port])
+DJANGO_CSRF_TRUSTED_ORIGINS=""
 
 # =============================================================================
 # BASE DE DATOS (DB externa a Docker, homologacion real)

--- a/config/settings.py
+++ b/config/settings.py
@@ -4,6 +4,7 @@ import sys
 import logging
 import tempfile
 from pathlib import Path
+from urllib.parse import urlsplit
 from django.contrib.messages import constants as messages
 from django.utils.module_loading import import_string
 from dotenv import load_dotenv
@@ -46,6 +47,61 @@ def _to_origin(h: str) -> str:
     return h if h.startswith(("http://", "https://")) else f"{DEFAULT_SCHEME}://{h}"
 
 
+def _normalize_origin(value: str) -> str | None:
+    raw_value = (value or "").strip().rstrip("/")
+    if not raw_value:
+        return None
+
+    candidate = raw_value if "://" in raw_value else _to_origin(raw_value)
+    parsed = urlsplit(candidate)
+    if not parsed.scheme or not parsed.netloc:
+        return None
+
+    return f"{parsed.scheme}://{parsed.netloc}"
+
+
+def _extract_hostname(value: str) -> str:
+    candidate = (value or "").strip()
+    if not candidate:
+        return ""
+
+    parsed = urlsplit(candidate if "://" in candidate else f"http://{candidate}")
+    return (parsed.hostname or "").strip().lower()
+
+
+def _is_local_origin_host(host_value: str) -> bool:
+    return _extract_hostname(host_value) in {"localhost", "127.0.0.1", "::1"}
+
+
+def _build_csrf_trusted_origins() -> list[str]:
+    trusted_origins = []
+
+    def _append_origin(candidate: str) -> None:
+        normalized = _normalize_origin(candidate)
+        if normalized and normalized not in trusted_origins:
+            trusted_origins.append(normalized)
+
+    for allowed_host in ALLOWED_HOSTS:
+        _append_origin(allowed_host)
+
+        if _is_local_origin_host(allowed_host):
+            local_host = _extract_hostname(allowed_host)
+            _append_origin(f"http://{local_host}")
+            _append_origin(f"https://{local_host}")
+
+            local_port = os.getenv("DOCKER_DJANGO_PORT_FORWARD", "").strip()
+            if local_port:
+                _append_origin(f"http://{local_host}:{local_port}")
+                _append_origin(f"https://{local_host}:{local_port}")
+
+    _append_origin(os.getenv("DOMINIO", ""))
+
+    for raw_origin in os.getenv("DJANGO_CSRF_TRUSTED_ORIGINS", "").split(","):
+        _append_origin(raw_origin)
+
+    return trusted_origins
+
+
 def _safe_int_env(var_name: str, default: int) -> int:
     raw_value = os.getenv(var_name)
     if raw_value is None or raw_value.strip() == "":
@@ -79,7 +135,7 @@ def _safe_bool_env(var_name: str, default: bool) -> bool:
     return default
 
 
-CSRF_TRUSTED_ORIGINS = [_to_origin(h) for h in ALLOWED_HOSTS]
+CSRF_TRUSTED_ORIGINS = _build_csrf_trusted_origins()
 
 # Apps
 INSTALLED_APPS = [

--- a/docs/registro/cambios/2026-04-13-fix-login-csrf-homologacion-local.md
+++ b/docs/registro/cambios/2026-04-13-fix-login-csrf-homologacion-local.md
@@ -1,0 +1,31 @@
+# Fix CSRF en login de homologacion local
+
+Fecha: 2026-04-13
+
+## Que cambio
+
+- Se corrigio la construccion de `CSRF_TRUSTED_ORIGINS` en `config/settings.py`.
+- Ahora los origenes confiables para CSRF:
+  - siguen derivandose de `DJANGO_ALLOWED_HOSTS`,
+  - agregan `DOMINIO` cuando viene configurado con esquema real,
+  - aceptan overrides explicitos desde `DJANGO_CSRF_TRUSTED_ORIGINS`,
+  - y contemplan `localhost` / `127.0.0.1` con el puerto publicado por Docker (`DOCKER_DJANGO_PORT_FORWARD`).
+- Se agrego un test de regresion en `tests/test_settings_env_parsing.py` para cubrir el caso `ENVIRONMENT=homologacion` accedido por `http://localhost:8001`.
+
+## Decision principal
+
+No se toco el flujo de login ni el template. El problema estaba en configuracion: el entorno de homologacion arma origenes CSRF con perfil productivo (`https`) pero el compose local sigue exponiendo la app por `http://localhost:8001`.
+
+La correccion se hizo en `settings` para mantener el hardening de homologacion/produccion y, a la vez, permitir el arranque local del mismo perfil sin deshabilitar CSRF.
+
+## Impacto operativo
+
+- Homologacion real sigue aceptando su dominio HTTPS configurado.
+- Homologacion local deja de fallar en login por mismatch de `Origin`/`Referer` cuando se usa `localhost:8001`.
+- Si un entorno usa un origen adicional no cubierto por `DJANGO_ALLOWED_HOSTS` o `DOMINIO`, ahora puede declararlo en `DJANGO_CSRF_TRUSTED_ORIGINS`.
+
+## Validacion esperada
+
+- Acceder al login del entorno levantado con perfil homologacion desde `http://localhost:8001/`.
+- Enviar usuario y contrasena validos.
+- Verificar que ya no aparezca `403 Verificacion CSRF fallida. Peticion abortada`.

--- a/tests/test_settings_env_parsing.py
+++ b/tests/test_settings_env_parsing.py
@@ -87,6 +87,21 @@ def test_settings_homologacion_usa_perfil_similar_a_produccion(monkeypatch):
     )
 
 
+def test_settings_homologacion_agrega_origen_local_para_csrf(monkeypatch):
+    monkeypatch.setenv("ENVIRONMENT", "homologacion")
+    monkeypatch.setenv(
+        "DJANGO_ALLOWED_HOSTS",
+        "homologacion.sisoc.example.gov.ar,localhost,127.0.0.1",
+    )
+    monkeypatch.setenv("DOCKER_DJANGO_PORT_FORWARD", "8001")
+
+    module = _load_settings_module()
+
+    assert "https://homologacion.sisoc.example.gov.ar" in module.CSRF_TRUSTED_ORIGINS
+    assert "http://localhost:8001" in module.CSRF_TRUSTED_ORIGINS
+    assert "http://127.0.0.1:8001" in module.CSRF_TRUSTED_ORIGINS
+
+
 def test_settings_qa_mantiene_runtime_no_productivo(monkeypatch):
     monkeypatch.setenv("ENVIRONMENT", "qa")
 


### PR DESCRIPTION
why: el login web devolvia 403 CSRF al levantar el perfil de homologacion en localhost:8001 porque los origenes confiables se armaban solo con https y sin puerto local.

what:
- normaliza CSRF_TRUSTED_ORIGINS desde hosts, DOMINIO y un override explicito
- agrega origenes locales con DOCKER_DJANGO_PORT_FORWARD para localhost y 127.0.0.1
- documenta el ajuste y cubre la regresion con un test de settings

tests: no se pudieron ejecutar; el host no tiene Python disponible y Docker Desktop no esta levantado en esta sesion

# Información de la Tarea
Vincular el #ISSUE

### **Resumen de la Solución:** 
-

### **Información Adicional:**
-

# Descripción de los Cambios

### **Cambios:**
-

# Cómo Testear los Cambios

### **Pruebas Automáticas:**
-

### **Prubeas Manuales:**
-

# Metadata para documentación automática

- Contexto funcional:
- Tipo de cambio:
- Área principal:
- Resumen para changelog:
- Impacto usuario:
- Riesgos / rollback:

# Capturas de Pantalla
