### PR TITLE
fix(requirements): alinear pins de runtime incompatibles

### DIFF
--- a/docs/registro/cambios/2026-04-16-fix-cffi-cryptography-resolver.md
+++ b/docs/registro/cambios/2026-04-16-fix-cffi-cryptography-resolver.md
@@ -1,0 +1,37 @@
+# Fix de resolucion de dependencias de runtime
+
+## Contexto
+
+El build de la imagen `docker/django/Dockerfile` fallo durante `pip install -r requirements.txt`
+porque `requirements/base.txt` tenia dos upgrades parciales de dependencias:
+
+- `cryptography==46.0.5`
+- `cffi==1.17.0`
+- `weasyprint==68.0`
+- `tinycss2==1.4.0`
+
+Desde `cryptography 46.0.5`, el paquete requiere `cffi>=2.0.0` en CPython 3.9+.
+Ademas, `weasyprint 68.0` requiere `tinycss2>=1.5.0`.
+
+## Cambio aplicado
+
+- Se actualizo `cffi` de `1.17.0` a `2.0.0` en `requirements/base.txt`.
+- Se actualizo `tinycss2` de `1.4.0` a `1.5.0` en `requirements/base.txt`.
+- No se modificaron otras dependencias ni el Dockerfile.
+
+## Decision
+
+Se eligio el cambio minimo compatible con los upgrades ya presentes de `cryptography` y
+`weasyprint`, para restaurar la resolucion de `pip` sin introducir un refresh mas amplio
+del stack.
+
+## Validacion
+
+Se reprodujeron los conflictos en `python:3.11.9-bullseye` con:
+
+```bash
+python -m pip install --dry-run -r requirements.txt
+```
+
+Luego del cambio, el build de `docker/django/Dockerfile` avanzo con el set de dependencias
+alineado usando la misma imagen base.

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -6,7 +6,7 @@ astroid==3.2.4
 botocore==1.35.29
 Brotli==1.2.0
 certifi==2024.7.4
-cffi==1.17.0
+cffi==2.0.0
 chardet==5.2.0
 charset-normalizer==3.3.2
 click==8.1.7
@@ -78,7 +78,7 @@ six==1.16.0
 sqlparse==0.5.4
 svglib==1.5.1
 tablib==3.6.1
-tinycss2==1.4.0
+tinycss2==1.5.0
 tinyhtml5==2.0.0
 tomli==2.0.1
 tomlkit==0.13.2


### PR DESCRIPTION
why: dependabot actualizo cryptography y weasyprint sin ajustar sus dependencias fijadas, lo que rompia la instalacion en Docker.

what:
- sube cffi a 2.0.0 para compatibilidad con cryptography 46.0.5
- sube tinycss2 a 1.5.0 para compatibilidad con weasyprint 68.0
- registra la correccion en docs/registro/cambios

tests:
- docker build -f docker/django/Dockerfile -t sisoc-cffi-cryptography-test .

# Información de la Tarea
Vincular el #ISSUE

### **Resumen de la Solución:** 
-

### **Información Adicional:**
-

# Descripción de los Cambios

### **Cambios:**
-

# Cómo Testear los Cambios

### **Pruebas Automáticas:**
-

### **Prubeas Manuales:**
-

# Metadata para documentación automática

- Contexto funcional:
- Tipo de cambio:
- Área principal:
- Resumen para changelog:
- Impacto usuario:
- Riesgos / rollback:

# Capturas de Pantalla
