### PR TITLE
fix(release): saneamiento predeploy development-main

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -106,14 +106,22 @@ LOG_FALLBACK_DIR="/tmp/sisoc-logs"
 # =============================================================================
 # Si EMAIL_BACKEND queda vacio, SISOC usa backend de consola (no envía, solo loggea).
 # Resend SMTP recomendado:
-- EMAIL_BACKEND="django.core.mail.backends.smtp.EmailBackend"
-- EMAIL_HOST="smtp.resend.com"
-- EMAIL_PORT=587
-- EMAIL_HOST_USER="resend"
-- EMAIL_HOST_PASSWORD="<RESEND_API_KEY>"
-- EMAIL_USE_TLS=true
-- EMAIL_USE_SSL=false
-- DEFAULT_FROM_EMAIL="no-reply@sisoc.secretarianaf.gob.ar"
+# - EMAIL_BACKEND="django.core.mail.backends.smtp.EmailBackend"
+# - EMAIL_HOST="smtp.resend.com"
+# - EMAIL_PORT=587
+# - EMAIL_HOST_USER="resend"
+# - EMAIL_HOST_PASSWORD="<RESEND_API_KEY>"
+# - EMAIL_USE_TLS=true
+# - EMAIL_USE_SSL=false
+# - DEFAULT_FROM_EMAIL="no-reply@sisoc.secretarianaf.gob.ar"
+EMAIL_BACKEND=""
+EMAIL_HOST="localhost"
+EMAIL_PORT=587
+EMAIL_HOST_USER=""
+EMAIL_HOST_PASSWORD=""
+EMAIL_USE_TLS=true
+EMAIL_USE_SSL=false
+DEFAULT_FROM_EMAIL="no-reply@sisoc.local"
 EMAIL_TIMEOUT=10
 PASSWORD_RESET_TIMEOUT=3600
 INITIAL_PASSWORD_MAX_AGE_HOURS=336

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@
 - Correcciones en VAT para edición de cursos/comisiones y compatibilidad de vouchers/fixtures de CI, evitando regresiones recientes en centros, cursos e inscripciones.
 - Ajustes de merge y compatibilidad en Ciudadanos para priorizar registros `ESTANDAR` en lookups por DNI y evitar asociaciones erróneas en Celiaquía y Comedores.
 - Correcciones de infraestructura y CI para que la resolución de dependencias y los jobs de lint no fallen por pins incompatibles o entradas vacías.
+- Se corrigió `.env.example` para que el bootstrap/Compose mantengan defaults locales válidos y los ejemplos SMTP de Resend queden como comentarios, evitando `.env` inválidos en el pre-deploy.
 
 <!-- AUTO-GENERATED RELEASE END: 2026-04-16 -->
 

--- a/acompanamientos/migrations/0007_hitos_cleanup_comedor.py
+++ b/acompanamientos/migrations/0007_hitos_cleanup_comedor.py
@@ -5,7 +5,8 @@ Pasos:
 1. Borra los Hitos huérfanos (sin acompanamiento vinculado).
    El equipo confirmó que se puede perder esa data (894 registros vacíos + 11
    con datos reales sin admisión asociada — ver tk1273).
-2. Hace el campo acompanamiento NOT NULL.
+2. Conserva el campo acompanamiento nullable para permitir `SET_NULL` durante
+   la transición y reflejar el estado real del modelo.
 3. Elimina el campo comedor de Hitos.
 """
 
@@ -30,12 +31,13 @@ class Migration(migrations.Migration):
     ]
 
     operations = [
-        # 1. Borrar huérfanos antes de poner NOT NULL
+        # 1. Borrar huérfanos antes de remover `comedor`
         migrations.RunPython(
             borrar_hitos_huerfanos,
             revertir_hitos_huerfanos,
         ),
-        # 2. acompanamiento pasa a NOT NULL
+        # 2. acompanamiento se mantiene nullable; la operación documenta el
+        #    schema final y evita drift entre migración y modelo.
         migrations.AlterField(
             model_name="hitos",
             name="acompanamiento",

--- a/dashboard/tests.py
+++ b/dashboard/tests.py
@@ -1,5 +1,3 @@
-from pathlib import Path
-
 from dashboard.models import Tablero
 
 

--- a/docs/operacion/comandos_administracion.md
+++ b/docs/operacion/comandos_administracion.md
@@ -5,9 +5,6 @@
 - `generate_webp_images`: genera WebP para ImageFields con opciones de filtro, calidad y estadísticas. Evidencia: core/management/commands/generate_webp_images.py:1-111.
 - `debug_queries`: ejecuta depuración de queries para vistas (todas o Ciudadanos). Evidencia: core/management/commands/debug_queries.py:1-33.
 - `run_benchmarks`: ejecuta benchmarks reproducibles en una DB efímera, serializa resultados JSON y compara contra baseline versionado; soporta `--rebuild-baseline`. Evidencia: core/management/commands/run_benchmarks.py:1-176.
-- `load_fixtures`: carga fixtures en modo upsert (no borra) con opcion `--force` o `--overwrite` para reaplicar datos existentes. Evidencia: `core/management/commands/load_fixtures.py`.
-- `generate_webp_images`: genera WebP para ImageFields con opciones de filtro, calidad y estadisticas. Evidencia: `core/management/commands/generate_webp_images.py`.
-- `debug_queries`: ejecuta depuracion de queries para vistas (todas o Ciudadanos). Evidencia: `core/management/commands/debug_queries.py`.
 
 ## Users
 - `create_groups`: crea grupos predeterminados y sincroniza permisos bootstrap segun la semilla declarativa de IAM (`users/bootstrap/groups_seed.py`). Evidencia: `users/management/commands/create_groups.py`.

--- a/docs/registro/cambios/2026-04-16-analisis-predeploy-main.md
+++ b/docs/registro/cambios/2026-04-16-analisis-predeploy-main.md
@@ -34,3 +34,4 @@
 ## Resultado
 
 - Recomendación actual: **NO-GO** hasta completar validación en entorno Linux/Docker con WeasyPrint disponible, confirmar el tratamiento de datos borrados en `acompanamientos`, y ejecutar/planificar el backfill de identidad con backup y ventana operativa.
+- Saneamiento posterior al análisis: se corrigió `.env.example`, se alineó la release note preliminar con la fecha real del corte y se cerraron observaciones puntuales de review para el release train.

--- a/docs/registro/prs/PR-1564.md
+++ b/docs/registro/prs/PR-1564.md
@@ -28,7 +28,7 @@
 - `docs/contexto/features/pr-1564-update-main-2026-04-16.md`
 - `docs/registro/cambios/2026-04-16-analisis-predeploy-main.md`
 - `docs/registro/prs/PR-1564.md`
-- `docs/registro/releases/pending/2026-04-22-pr-1564.md`
+- `docs/registro/releases/pending/2026-04-16-pr-1564.md`
 
 ## Validación declarada
 
@@ -48,7 +48,7 @@
 - `docs/contexto/features/pr-1564-update-main-2026-04-16.md`
 - `docs/registro/cambios/2026-04-16-analisis-predeploy-main.md`
 - `docs/registro/prs/PR-1564.md`
-- `docs/registro/releases/pending/2026-04-22-pr-1564.md`
+- `docs/registro/releases/pending/2026-04-16-pr-1564.md`
 
 ## Notas para continuidad
 

--- a/docs/registro/releases/pending/2026-04-16-pr-1564.md
+++ b/docs/registro/releases/pending/2026-04-16-pr-1564.md
@@ -1,6 +1,6 @@
 ---
 pr: 1564
-release_date: 2026-04-22
+release_date: 2026-04-16
 category: Actualizaciones
 area: release
 title: Update main 2026.04.16
@@ -10,7 +10,7 @@ source_url: https://github.com/dsocial118/SISOC/pull/1564
 ---
 # Release note preliminar PR #1564
 
-- Fecha objetivo de release: 2026-04-22
+- Fecha objetivo de release: 2026-04-16
 - Categoría: Actualizaciones
 - Área: release
 - Título del PR: Update main 2026.04.16

--- a/tests/test_settings_env_parsing.py
+++ b/tests/test_settings_env_parsing.py
@@ -4,6 +4,7 @@ from uuid import uuid4
 
 
 SETTINGS_PATH = Path(__file__).resolve().parents[1] / "config" / "settings.py"
+ENV_EXAMPLE_PATH = Path(__file__).resolve().parents[1] / ".env.example"
 
 
 def _load_settings_module():
@@ -111,3 +112,27 @@ def test_settings_qa_mantiene_runtime_no_productivo(monkeypatch):
     assert module.GESTIONAR_INTEGRATION_ENABLED is False
     assert module.SECURE_SSL_REDIRECT is False
     assert module.SENTRY_REPLAY_ENABLED is False
+
+
+def test_env_example_declares_valid_email_assignments():
+    content = ENV_EXAMPLE_PATH.read_text(encoding="utf-8")
+    active_lines = {
+        line.strip()
+        for line in content.splitlines()
+        if line.strip() and not line.lstrip().startswith("#")
+    }
+    required_lines = {
+        'EMAIL_BACKEND=""',
+        'EMAIL_HOST="localhost"',
+        "EMAIL_PORT=587",
+        'EMAIL_HOST_USER=""',
+        'EMAIL_HOST_PASSWORD=""',
+        "EMAIL_USE_TLS=true",
+        "EMAIL_USE_SSL=false",
+        'DEFAULT_FROM_EMAIL="no-reply@sisoc.local"',
+    }
+
+    for line in required_lines:
+        assert line in active_lines
+
+    assert all(not line.startswith("- ") for line in active_lines)


### PR DESCRIPTION
## Qué se corrigió
- se restauró `.env.example` para que el bootstrap y `docker compose` generen una `.env` válida, dejando la configuración SMTP de Resend como ejemplo comentado y conservando defaults locales seguros
- se alineó la release note preliminar del corte `2026-04-16` con su nombre de archivo, `release_date` y referencias cruzadas en la documentación del PR
- se limpiaron observaciones puntuales del review previo: import sin uso en `dashboard/tests.py`, duplicados en `docs/operacion/comandos_administracion.md` y comentario engañoso en `acompanamientos/migrations/0007_hitos_cleanup_comedor.py`
- se actualizó `CHANGELOG.md` y el registro spec-as-source del análisis predeploy para reflejar este saneamiento

## Pruebas ejecutadas
- `uv run --python 3.11 --with-requirements requirements.txt pytest tests/test_settings_env_parsing.py::test_env_example_declares_valid_email_assignments -q`
  - OK (`1 passed`)
- `uv run --python 3.11 --with-requirements requirements.txt python -m black --check tests/test_settings_env_parsing.py dashboard/tests.py acompanamientos/migrations/0007_hitos_cleanup_comedor.py`
  - OK
- `uv run --python 3.11 --with-requirements requirements.txt python -m py_compile acompanamientos/migrations/0007_hitos_cleanup_comedor.py`
  - OK
- `powershell -ExecutionPolicy Bypass -File scripts/ai/codex_doctor.ps1`
  - OK para `.env`/Compose; el host sigue sin `pytest` global instalado

## Riesgos remanentes
- la migración `acompanamientos/0007_hitos_cleanup_comedor.py` sigue implicando borrado irreversible documentado y requiere validación operativa antes del deploy
- el modelo de identidad en `ciudadanos` sigue requiriendo backfill coordinado con backup y ventana operativa
- el bootstrap Docker-first ahora supera el parseo de `.env`, pero en esta máquina el arranque completo quedó frenado por el puerto local `3000` ya ocupado; no es un cambio del repo
