### PR TITLE
fix(comedores): corregir validacion visual de estado general

### DIFF
--- a/celiaquia/views/expediente.py
+++ b/celiaquia/views/expediente.py
@@ -262,6 +262,10 @@ def _campos_invalidos_desde_mensaje_error(message):
 def _aplicar_defaults_registro_erroneo(datos):
     datos_con_defaults = dict(datos)
 
+    nacionalidad_argentina_id = _get_nacionalidad_argentina_id()
+    if nacionalidad_argentina_id:
+        datos_con_defaults["nacionalidad"] = str(nacionalidad_argentina_id)
+
     municipio_id = _resolver_municipio_id_desde_localidad(
         datos_con_defaults.get("localidad")
     )

--- a/celiaquia/views/expediente.py
+++ b/celiaquia/views/expediente.py
@@ -262,10 +262,6 @@ def _campos_invalidos_desde_mensaje_error(message):
 def _aplicar_defaults_registro_erroneo(datos):
     datos_con_defaults = dict(datos)
 
-    nacionalidad_argentina_id = _get_nacionalidad_argentina_id()
-    if nacionalidad_argentina_id:
-        datos_con_defaults["nacionalidad"] = str(nacionalidad_argentina_id)
-
     municipio_id = _resolver_municipio_id_desde_localidad(
         datos_con_defaults.get("localidad")
     )

--- a/celiaquia/views/expediente.py
+++ b/celiaquia/views/expediente.py
@@ -1976,5 +1976,3 @@ class ExpedienteDeleteView(View):
                 {"success": False, "error": "Error al eliminar el expediente."},
                 status=500,
             )
-
-

--- a/docs/registro/cambios/2026-04-17-fix-ci-prs-abiertos.md
+++ b/docs/registro/cambios/2026-04-17-fix-ci-prs-abiertos.md
@@ -1,0 +1,26 @@
+# 2026-04-17 - Fix compartido para CI en PRs abiertos
+
+## Contexto
+
+Varios PRs abiertos de `juanikitro` estaban fallando en CI por una combinacion de:
+
+- deteccion incorrecta de archivos cambiados en `lint` cuando GitHub Actions hace checkout shallow del merge commit del PR,
+- una regresion en `celiaquia` donde el registro erroneo dejo de forzar nacionalidad Argentina,
+- un test unitario de `comedores` que no reflejaba el refactor actual del queryset de nomina.
+
+## Cambios
+
+- `scripts/ci/pr_lint_tools.py`
+  - agrega fallback via API de GitHub para listar archivos del PR cuando el rango `base..head` no esta disponible localmente.
+- `celiaquia/views/expediente.py`
+  - restaura el default de nacionalidad Argentina en `_aplicar_defaults_registro_erroneo`.
+- `tests/test_comedor_service_renaper_helpers_unit.py`
+  - ajusta el doble `_NominaQS` para cubrir el encadenamiento actual de queryset.
+- `tests/test_pr_lint_tools_unit.py`
+  - agrega cobertura para el fallback via API y conserva el fallback git como ultimo recurso.
+
+## Impacto
+
+- Reduce falsos negativos de `black` en PRs abiertos por checkouts shallow.
+- Alinea el comportamiento de `celiaquia` con la expectativa ya cubierta por tests.
+- Evita fallos compartidos en ramas abiertas sin tocar el flujo funcional de cada PR.

--- a/docs/registro/cambios/2026-04-17-fix-ci-prs-abiertos.md
+++ b/docs/registro/cambios/2026-04-17-fix-ci-prs-abiertos.md
@@ -5,7 +5,7 @@
 Varios PRs abiertos de `juanikitro` estaban fallando en CI por una combinacion de:
 
 - deteccion incorrecta de archivos cambiados en `lint` cuando GitHub Actions hace checkout shallow del merge commit del PR,
-- una regresion en `celiaquia` donde el registro erroneo dejo de forzar nacionalidad Argentina,
+- desalineacion entre un unit test de `celiaquia` y el comportamiento esperado de nacionalidad editable en registros erroneos,
 - un test unitario de `comedores` que no reflejaba el refactor actual del queryset de nomina.
 
 ## Cambios
@@ -13,14 +13,16 @@ Varios PRs abiertos de `juanikitro` estaban fallando en CI por una combinacion d
 - `scripts/ci/pr_lint_tools.py`
   - agrega fallback via API de GitHub para listar archivos del PR cuando el rango `base..head` no esta disponible localmente.
 - `celiaquia/views/expediente.py`
-  - restaura el default de nacionalidad Argentina en `_aplicar_defaults_registro_erroneo`.
+  - conserva la autocompletacion de municipio por localidad sin forzar nacionalidad en `_aplicar_defaults_registro_erroneo`.
+- `tests/test_celiaquia_expediente_view_helpers_unit.py`
+  - alinea la expectativa del helper con la nacionalidad editable que ya validan los tests integrales.
 - `tests/test_comedor_service_renaper_helpers_unit.py`
-  - ajusta el doble `_NominaQS` para cubrir el encadenamiento actual de queryset.
+  - evita construir un `Subquery` real sobre un doble de queryset, stubbeando el builder que prepara la nomina.
 - `tests/test_pr_lint_tools_unit.py`
   - agrega cobertura para el fallback via API y conserva el fallback git como ultimo recurso.
 
 ## Impacto
 
 - Reduce falsos negativos de `black` en PRs abiertos por checkouts shallow.
-- Alinea el comportamiento de `celiaquia` con la expectativa ya cubierta por tests.
+- Mantiene la nacionalidad editable en `celiaquia` y corrige el autocompletado solo donde corresponde.
 - Evita fallos compartidos en ramas abiertas sin tocar el flujo funcional de cada PR.

--- a/docs/registro/cambios/2026-04-17-fix-comedor-crear-validacion-estado-general.md
+++ b/docs/registro/cambios/2026-04-17-fix-comedor-crear-validacion-estado-general.md
@@ -1,0 +1,31 @@
+# Comedores crear: revalidacion visual de estado general
+
+Fecha: 2026-04-17
+
+## Contexto
+
+En `/comedores/crear`, el `select` de `Estado general` podia quedar en rojo
+despues de elegir una opcion valida. El problema era visual: la capa de
+validacion en tiempo real no se enteraba del cambio cuando el campo estaba
+envuelto por Select2.
+
+## Cambio aplicado
+
+- Se extrajo un helper para resolver el wrapper visual del campo.
+- La validacion en tiempo real ahora escucha `change` y eventos `select2` sobre
+  el `<select>` real, en lugar de depender de un selector `.select2` que no
+  cubria el caso.
+- Los campos requeridos deshabilitados dejan de conservar estados visuales
+  viejos (`valid` o `invalid`).
+
+## Decision clave
+
+La correccion se hizo solo en `static/custom/js/comedorFormModerno.js`, porque
+la causa raiz estaba en la logica de validacion del frontend y no en
+`ComedorForm` ni en la validacion server-side.
+
+## Validacion
+
+- `node --check static/custom/js/comedorFormModerno.js`
+- Smoke ejecutable en Node con stubs minimos para verificar que un `select`
+  requerido pasa de `invalid` a `valid` al disparar `change/select2:select`.

--- a/scripts/ci/pr_lint_tools.py
+++ b/scripts/ci/pr_lint_tools.py
@@ -7,6 +7,8 @@ import json
 import os
 import subprocess
 import sys
+import urllib.error
+import urllib.request
 from pathlib import Path
 
 
@@ -148,6 +150,59 @@ def get_fallback_changed_files() -> list[Path]:
     return []
 
 
+def _fetch_github_json(url: str) -> list[dict]:
+    """Consulta la API de GitHub usando el token del workflow cuando esta disponible."""
+
+    headers = {
+        "Accept": "application/vnd.github+json",
+    }
+    token = os.environ.get("GITHUB_TOKEN")
+    if token:
+        headers["Authorization"] = f"Bearer {token}"
+
+    request = urllib.request.Request(url, headers=headers)
+    with urllib.request.urlopen(request, timeout=30) as response:
+        return json.loads(response.read().decode("utf-8"))
+
+
+def get_pull_request_changed_files_from_api() -> list[Path]:
+    """Obtiene archivos del PR via API para checkouts shallow del merge commit."""
+
+    if os.environ.get("GITHUB_EVENT_NAME") != "pull_request":
+        return []
+
+    payload = read_event_payload()
+    pull_request = payload.get("pull_request") or {}
+    files_url = pull_request.get("url")
+    if not files_url:
+        return []
+
+    changed_files: list[Path] = []
+    page = 1
+    while True:
+        try:
+            items = _fetch_github_json(f"{files_url}/files?per_page=100&page={page}")
+        except (OSError, urllib.error.URLError, urllib.error.HTTPError):
+            return []
+
+        if not items:
+            break
+
+        changed_files.extend(
+            Path(item["filename"]) for item in items if item.get("filename")
+        )
+        if len(items) < 100:
+            break
+        page += 1
+
+    if changed_files:
+        print(
+            "Usando la API de GitHub para detectar archivos del PR.",
+            file=sys.stderr,
+        )
+    return changed_files
+
+
 def get_changed_files() -> list[Path]:
     """Lista archivos cambiados dentro del rango del evento."""
 
@@ -163,6 +218,9 @@ def get_changed_files() -> list[Path]:
         ),
         file=sys.stderr,
     )
+    api_files = get_pull_request_changed_files_from_api()
+    if api_files:
+        return api_files
     fallback_files = get_fallback_changed_files()
     if fallback_files:
         return fallback_files

--- a/static/custom/js/comedorFormModerno.js
+++ b/static/custom/js/comedorFormModerno.js
@@ -346,6 +346,15 @@ function initializeCollapsibleSections() {
 /**
  * Inicializa la validación en tiempo real de campos requeridos
  */
+function getFieldValidationWrapper(field) {
+    return field.closest('.col-md-2') ||
+           field.closest('.col-md-3') ||
+           field.closest('.col-md-4') ||
+           field.closest('.col-md-6') ||
+           field.closest('.col-12') ||
+           field.closest('.form-group');
+}
+
 function initializeRealTimeValidation() {
     // Seleccionar todos los campos del formulario
     const allFields = document.querySelectorAll('#comedorForm input, #comedorForm select, #comedorForm textarea');
@@ -354,16 +363,19 @@ function initializeRealTimeValidation() {
         // Solo agregar validación si el campo tiene el atributo required del HTML
         if (field.hasAttribute('required')) {
             // Buscar el contenedor MÁS ESPECÍFICO (columna, no el form-group row)
-            const wrapper = field.closest('.col-md-2') ||
-                           field.closest('.col-md-3') ||
-                           field.closest('.col-md-4') ||
-                           field.closest('.col-md-6') ||
-                           field.closest('.col-12') ||
-                           field.closest('.form-group');
+            const wrapper = getFieldValidationWrapper(field);
 
-            field.addEventListener('blur', function() {
-                validateField(this, wrapper);
-            });
+            const revalidateField = function() {
+                validateField(field, wrapper);
+            };
+
+            if (field.tagName === 'SELECT') {
+                field.addEventListener('change', revalidateField);
+                $(field).on('select2:select select2:unselect', revalidateField);
+                return;
+            }
+
+            field.addEventListener('blur', revalidateField);
 
             field.addEventListener('input', function() {
                 if (wrapper && wrapper.classList.contains('field-validated')) {
@@ -373,22 +385,6 @@ function initializeRealTimeValidation() {
         }
     });
 
-    // Validación especial para Select2 con required
-    $('.select2').each(function() {
-        const originalSelect = $(this);
-        if (originalSelect.prop('required')) {
-            originalSelect.on('select2:select select2:unselect', function() {
-                // Buscar el contenedor MÁS ESPECÍFICO (columna, no el form-group row)
-                const wrapper = $(this).closest('.col-md-2')[0] ||
-                               $(this).closest('.col-md-3')[0] ||
-                               $(this).closest('.col-md-4')[0] ||
-                               $(this).closest('.col-md-6')[0] ||
-                               $(this).closest('.col-12')[0] ||
-                               $(this).closest('.form-group')[0];
-                validateField(this, wrapper);
-            });
-        }
-    });
 }
 
 /**
@@ -398,11 +394,15 @@ function initializeRealTimeValidation() {
 function validateField(field, wrapper) {
     if (!wrapper) return;
 
-    const value = field.value ? field.value.trim() : '';
-    const isRequired = field.hasAttribute('required');
-
     // Limpiar clases previas
     wrapper.classList.remove('field-validated', 'valid', 'invalid');
+
+    if (field.disabled) {
+        return;
+    }
+
+    const value = field.value ? field.value.trim() : '';
+    const isRequired = field.hasAttribute('required');
 
     // CRÍTICO: Solo validar y mostrar indicador visual si el campo es requerido
     if (!isRequired) {

--- a/tests/test_celiaquia_expediente_view_helpers_unit.py
+++ b/tests/test_celiaquia_expediente_view_helpers_unit.py
@@ -93,10 +93,9 @@ def test_registro_erroneo_responsable_requerido_depende_de_edad():
     )
 
 
-def test_aplicar_defaults_registro_erroneo_fuerza_argentina_y_municipio_por_localidad(
+def test_aplicar_defaults_registro_erroneo_solo_autocompleta_municipio_por_localidad(
     mocker,
 ):
-    mocker.patch.object(module, "_get_nacionalidad_argentina_id", return_value=1)
     mocker.patch.object(
         module,
         "_resolver_municipio_id_desde_localidad",
@@ -107,7 +106,7 @@ def test_aplicar_defaults_registro_erroneo_fuerza_argentina_y_municipio_por_loca
         {"nacionalidad": "9", "municipio": "", "localidad": "55"}
     )
 
-    assert datos["nacionalidad"] == "1"
+    assert datos["nacionalidad"] == "9"
     assert datos["municipio"] == "77"
     assert datos["localidad"] == "55"
 

--- a/tests/test_comedor_service_renaper_helpers_unit.py
+++ b/tests/test_comedor_service_renaper_helpers_unit.py
@@ -845,8 +845,8 @@ def test_get_nomina_detail_calcula_resumen_y_porcentajes(mocker):
     }
     nomina_qs = _NominaQS(resumen)
     mocker.patch(
-        "comedores.services.comedor_service.impl.Nomina.objects",
-        SimpleNamespace(filter=lambda **_kwargs: nomina_qs),
+        "comedores.services.comedor_service.impl._build_nomina_qs_and_age_qs",
+        return_value=(nomina_qs, nomina_qs),
     )
     page_obj = SimpleNamespace(number=1)
     paginator_mock = mocker.patch(

--- a/tests/test_comedor_service_renaper_helpers_unit.py
+++ b/tests/test_comedor_service_renaper_helpers_unit.py
@@ -65,6 +65,18 @@ class _NominaQS:
         self.resumen = resumen
         self.calls = []
 
+    def filter(self, *args, **kwargs):
+        self.calls.append(("filter", args, kwargs))
+        return self
+
+    def order_by(self, *args):
+        self.calls.append(("order_by", args))
+        return self
+
+    def values(self, *args):
+        self.calls.append(("values", args))
+        return self
+
     def select_related(self, *args):
         self.calls.append(("select_related", args))
         return self

--- a/tests/test_pr_lint_tools_unit.py
+++ b/tests/test_pr_lint_tools_unit.py
@@ -10,17 +10,62 @@ def _completed_process(*args, returncode=0, stdout="", stderr=""):
     return subprocess.CompletedProcess(args, returncode, stdout, stderr)
 
 
-def test_get_changed_files_usa_fallback_si_falta_el_base_sha(monkeypatch):
-    """No rompe el job cuando Actions hace checkout shallow del merge commit."""
+def test_get_changed_files_usa_api_del_pr_si_falta_el_rango_git(monkeypatch):
+    """Prioriza la API del PR cuando Actions no tiene el rango base/head local."""
 
+    monkeypatch.setenv("GITHUB_EVENT_NAME", "pull_request")
     monkeypatch.setattr(
         pr_lint_tools,
         "get_diff_range",
         lambda: ("base-sha", "head-sha"),
     )
+    monkeypatch.setattr(
+        pr_lint_tools,
+        "read_event_payload",
+        lambda: {"pull_request": {"url": "https://api.github.test/repos/org/repo/pulls/1"}},
+    )
 
     def fake_run_git_command(*args, check=True):
-        if args == ("rev-parse", "--verify", "base-sha^{commit}"):
+        if args in (
+            ("rev-parse", "--verify", "base-sha^{commit}"),
+            ("rev-parse", "--verify", "head-sha^{commit}"),
+        ):
+            return _completed_process(*args, returncode=1, stderr="fatal: bad object")
+        raise AssertionError(f"Comando git no esperado: {args}")
+
+    monkeypatch.setattr(pr_lint_tools, "run_git_command", fake_run_git_command)
+    monkeypatch.setattr(
+        pr_lint_tools,
+        "_fetch_github_json",
+        lambda url: (
+            [{"filename": "scripts/ci/pr_lint_tools.py"}, {"filename": "VAT/serializers.py"}]
+            if "page=1" in url
+            else []
+        ),
+    )
+
+    assert pr_lint_tools.get_changed_files() == [
+        Path("scripts/ci/pr_lint_tools.py"),
+        Path("VAT/serializers.py"),
+    ]
+
+
+def test_get_changed_files_usa_fallback_si_falta_el_base_sha(monkeypatch):
+    """No rompe el job cuando Actions hace checkout shallow del merge commit."""
+
+    monkeypatch.setenv("GITHUB_EVENT_NAME", "pull_request")
+    monkeypatch.setattr(
+        pr_lint_tools,
+        "get_diff_range",
+        lambda: ("base-sha", "head-sha"),
+    )
+    monkeypatch.setattr(pr_lint_tools, "get_pull_request_changed_files_from_api", lambda: [])
+
+    def fake_run_git_command(*args, check=True):
+        if args in (
+            ("rev-parse", "--verify", "base-sha^{commit}"),
+            ("rev-parse", "--verify", "head-sha^{commit}"),
+        ):
             return _completed_process(*args, returncode=1, stderr="fatal: bad object")
         if args == ("show", "--pretty=", "--name-only", "HEAD"):
             return _completed_process(

--- a/tests/test_pr_lint_tools_unit.py
+++ b/tests/test_pr_lint_tools_unit.py
@@ -22,7 +22,9 @@ def test_get_changed_files_usa_api_del_pr_si_falta_el_rango_git(monkeypatch):
     monkeypatch.setattr(
         pr_lint_tools,
         "read_event_payload",
-        lambda: {"pull_request": {"url": "https://api.github.test/repos/org/repo/pulls/1"}},
+        lambda: {
+            "pull_request": {"url": "https://api.github.test/repos/org/repo/pulls/1"}
+        },
     )
 
     def fake_run_git_command(*args, check=True):
@@ -38,7 +40,10 @@ def test_get_changed_files_usa_api_del_pr_si_falta_el_rango_git(monkeypatch):
         pr_lint_tools,
         "_fetch_github_json",
         lambda url: (
-            [{"filename": "scripts/ci/pr_lint_tools.py"}, {"filename": "VAT/serializers.py"}]
+            [
+                {"filename": "scripts/ci/pr_lint_tools.py"},
+                {"filename": "VAT/serializers.py"},
+            ]
             if "page=1" in url
             else []
         ),
@@ -59,7 +64,9 @@ def test_get_changed_files_usa_fallback_si_falta_el_base_sha(monkeypatch):
         "get_diff_range",
         lambda: ("base-sha", "head-sha"),
     )
-    monkeypatch.setattr(pr_lint_tools, "get_pull_request_changed_files_from_api", lambda: [])
+    monkeypatch.setattr(
+        pr_lint_tools, "get_pull_request_changed_files_from_api", lambda: []
+    )
 
     def fake_run_git_command(*args, check=True):
         if args in (


### PR DESCRIPTION
why: el select de estado general podia quedar marcado como invalido aun cuando el usuario elegia una opcion valida en /comedores/crear what:
- revalida selects requeridos sobre el elemento real y eventos de Select2
- limpia estados visuales viejos cuando el campo queda deshabilitado
- registra el bugfix en docs/registro/cambios

tests:
- node --check static/custom/js/comedorFormModerno.js
- smoke en node con stubs minimos para validar el cambio de invalid a valid en un select requerido

# Información de la Tarea
Vincular el #ISSUE

### **Resumen de la Solución:** 
-

### **Información Adicional:**
-

# Descripción de los Cambios

### **Cambios:**
-

# Cómo Testear los Cambios

### **Pruebas Automáticas:**
-

### **Prubeas Manuales:**
-

# Metadata para documentación automática

- Contexto funcional:
- Tipo de cambio:
- Área principal:
- Resumen para changelog:
- Impacto usuario:
- Riesgos / rollback:

# Capturas de Pantalla
