### PR TITLE
fix(celiaquia): modificar cantidad y tipo - logs renaper

### DIFF
--- a/celiaquia/views/validacion_renaper.py
+++ b/celiaquia/views/validacion_renaper.py
@@ -1,3 +1,4 @@
+import json
 import logging
 import time
 from django.conf import settings
@@ -17,11 +18,44 @@ logger = logging.getLogger(__name__)
 ROLE_COORDINADOR_CELIAQUIA_PERMISSION = "auth.role_coordinadorceliaquia"
 ROLE_TECNICO_CELIAQUIA_PERMISSION = "auth.role_tecnicoceliaquia"
 
+RENAPER_TRANSIENT_ERROR_TYPES = {
+    "timeout",
+    "remote_error",
+    "auth_error",
+    "invalid_response",
+    "unexpected_error",
+}
+RENAPER_REMOTE_UNAVAILABLE_MESSAGE = (
+    "No pudimos validar con RENAPER en este momento. "
+    "Por favor, intentá nuevamente en unos minutos."
+)
+RENAPER_INVALID_RESPONSE_MESSAGE = (
+    "RENAPER devolvió una respuesta inválida y no pudimos completar la validación. "
+    "Intentá nuevamente más tarde."
+)
+RENAPER_NO_MATCH_MESSAGE = (
+    "RENAPER no pudo validar los datos ingresados. "
+    "Verificá el DNI y el sexo registrados."
+)
+
 
 def _truncate(value, length=500):
     if isinstance(value, str) and len(value) > length:
         return f"{value[:length]}…"
     return value
+
+
+def _build_raw_response_excerpt(raw_response):
+    if raw_response in (None, ""):
+        return None
+
+    if isinstance(raw_response, (dict, list, tuple)):
+        try:
+            raw_response = json.dumps(raw_response, ensure_ascii=True)
+        except (TypeError, ValueError):
+            raw_response = str(raw_response)
+
+    return _truncate(str(raw_response))
 
 
 def _build_log_data(
@@ -131,16 +165,63 @@ def _get_renaper_retry_config():
     return max_retries, backoff_seconds
 
 
+def _es_error_reintentable(error_type):
+    return error_type in RENAPER_TRANSIENT_ERROR_TYPES
+
+
+def _enriquecer_resultado_renaper(resultado, retry_attempt, max_retries):
+    resultado_normalizado = dict(resultado or {})
+    if not resultado_normalizado.get("success", False):
+        resultado_normalizado.setdefault("error", "Error desconocido al consultar Renaper")
+        resultado_normalizado.setdefault("error_type", "unexpected_error")
+
+    resultado_normalizado["retry_attempt"] = retry_attempt
+    resultado_normalizado["max_retries"] = max_retries
+    return resultado_normalizado
+
+
+def _build_error_log_data(log_data, resultado_renaper, stage="response"):
+    return {
+        **log_data,
+        "stage": stage,
+        "error": resultado_renaper.get("error"),
+        "error_type": resultado_renaper.get("error_type"),
+        "retry_attempt": resultado_renaper.get("retry_attempt"),
+        "max_retries": resultado_renaper.get("max_retries"),
+        "raw_response_excerpt": _build_raw_response_excerpt(
+            resultado_renaper.get("raw_response")
+        ),
+    }
+
+
+def _get_error_message(resultado_renaper):
+    error_type = resultado_renaper.get("error_type")
+
+    if error_type == "fallecido" or resultado_renaper.get("fallecido"):
+        return "La persona figura como fallecida en Renaper"
+    if error_type == "invalid_response":
+        return RENAPER_INVALID_RESPONSE_MESSAGE
+    if error_type == "no_match":
+        return RENAPER_NO_MATCH_MESSAGE
+    return RENAPER_REMOTE_UNAVAILABLE_MESSAGE
+
+
 def _consultar_datos_renaper_con_reintentos(documento_consulta, sexo_renaper):
     max_retries, backoff_seconds = _get_renaper_retry_config()
     ultimo_resultado = None
 
     for intento in range(1, max_retries + 1):
-        ultimo_resultado = consultar_datos_renaper(documento_consulta, sexo_renaper)
+        ultimo_resultado = _enriquecer_resultado_renaper(
+            consultar_datos_renaper(documento_consulta, sexo_renaper),
+            retry_attempt=intento,
+            max_retries=max_retries,
+        )
         if ultimo_resultado.get("success"):
             return ultimo_resultado
 
-        if intento >= max_retries:
+        if intento >= max_retries or not _es_error_reintentable(
+            ultimo_resultado.get("error_type")
+        ):
             break
 
         logger.warning(
@@ -152,6 +233,10 @@ def _consultar_datos_renaper_con_reintentos(documento_consulta, sexo_renaper):
                     "retry_attempt": intento + 1,
                     "max_retries": max_retries,
                     "error": ultimo_resultado.get("error"),
+                    "error_type": ultimo_resultado.get("error_type"),
+                    "raw_response_excerpt": _build_raw_response_excerpt(
+                        ultimo_resultado.get("raw_response")
+                    ),
                 }
             },
         )
@@ -159,10 +244,15 @@ def _consultar_datos_renaper_con_reintentos(documento_consulta, sexo_renaper):
         if backoff_seconds > 0:
             time.sleep(backoff_seconds * (2 ** (intento - 1)))
 
-    return ultimo_resultado or {
-        "success": False,
-        "error": "Error desconocido al consultar Renaper",
-    }
+    return ultimo_resultado or _enriquecer_resultado_renaper(
+        {
+            "success": False,
+            "error": "Error desconocido al consultar Renaper",
+            "error_type": "unexpected_error",
+        },
+        retry_attempt=max_retries,
+        max_retries=max_retries,
+    )
 
 
 def _formatear_fecha_renaper(fecha_renaper):
@@ -236,20 +326,21 @@ def _log_respuesta_renaper(log_data, resultado_renaper):
     }
 
     if not success:
-        response_summary["error"] = resultado_renaper.get("error")
-        response_summary["raw_response_excerpt"] = _truncate(
-            resultado_renaper.get("raw_response", "Sin respuesta")
-        )
-        logger.warning(
-            "renaper.validation.response_error",
-            extra={
-                "data": {
-                    **log_data,
-                    "stage": "response",
-                    "response": response_summary,
-                }
-            },
-        )
+        error_type = resultado_renaper.get("error_type")
+        log_extra = {"data": _build_error_log_data(log_data, resultado_renaper)}
+
+        if error_type == "no_match":
+            logger.info("renaper.validation.no_match", extra=log_extra)
+        elif error_type in {"timeout", "remote_error"}:
+            logger.warning("renaper.validation.remote_unavailable", extra=log_extra)
+        elif error_type == "auth_error":
+            logger.error("renaper.validation.remote_unavailable", extra=log_extra)
+        elif error_type == "invalid_response":
+            logger.error("renaper.validation.invalid_response", extra=log_extra)
+        elif error_type == "fallecido":
+            logger.info("renaper.validation.fallecido", extra=log_extra)
+        else:
+            logger.error("renaper.validation.response_error", extra=log_extra)
         return
 
     response_summary["data_keys"] = sorted(
@@ -553,47 +644,18 @@ class ValidacionRenaperView(View):
             fallecido = resultado_renaper.get("fallecido")
 
             if fallecido:
-                logger.warning(
-                    "renaper.validation.fallecido",
-                    extra={
-                        "data": {
-                            **log_data,
-                            "stage": "response",
-                            "fallecido": True,
-                        }
-                    },
-                )
                 return JsonResponse(
                     {
                         "success": False,
-                        "error": "La persona figura como fallecida en Renaper",
+                        "error": _get_error_message(resultado_renaper),
                     }
                 )
 
             if not success:
-                error_msg = resultado_renaper.get(
-                    "error", "Error desconocido al consultar Renaper"
-                )
-                raw_response = resultado_renaper.get(
-                    "raw_response", "Sin respuesta raw"
-                )
-
-                logger.error(
-                    "renaper.validation.remote_error",
-                    extra={
-                        "data": {
-                            **log_data,
-                            "stage": "response",
-                            "error": error_msg,
-                            "raw_response_excerpt": _truncate(raw_response),
-                        }
-                    },
-                )
-
                 return JsonResponse(
                     {
                         "success": False,
-                        "error": "Ocurrió un error El Cuit o el Sexo no coincide con esos datos.",
+                        "error": _get_error_message(resultado_renaper),
                     }
                 )
 

--- a/centrodefamilia/services/consulta_renaper/impl.py
+++ b/centrodefamilia/services/consulta_renaper/impl.py
@@ -15,6 +15,31 @@ LOGIN_URL = f"{API_BASE}/auth/login"
 CONSULTA_URL = f"{API_BASE}/consultarenaper"
 
 
+class RenaperServiceError(RuntimeError):
+    def __init__(self, message, error_type, raw_response=None):
+        super().__init__(message)
+        self.error_type = error_type
+        self.raw_response = raw_response
+
+
+def _safe_response_payload(response):
+    if response is None:
+        return None
+
+    try:
+        return response.json()
+    except ValueError:
+        return getattr(response, "text", None)
+
+
+def _build_error_result(message, error_type, raw_response=None, **extra):
+    result = {"success": False, "error": message, "error_type": error_type}
+    if raw_response is not None:
+        result["raw_response"] = raw_response
+    result.update(extra)
+    return result
+
+
 class APIClient:
     def __init__(self):
         self.username = settings.RENAPER_API_USERNAME
@@ -37,14 +62,46 @@ class APIClient:
                 timeout=10,
             )
             response.raise_for_status()
-        except Exception as exc:
-            logger.error(f"Error en login RENAPER: {str(exc)}")
-            raise RuntimeError(
-                f"No se pudo conectar al servicio de login: {str(exc)}"
+        except requests.Timeout as exc:
+            raise RenaperServiceError(
+                "RENAPER no respondio a tiempo durante la autenticacion.",
+                "timeout",
+            ) from exc
+        except requests.HTTPError as exc:
+            status_code = getattr(exc.response, "status_code", None)
+            error_type = "auth_error" if status_code in {401, 403} else "remote_error"
+            message = (
+                "RENAPER rechazo la autenticacion."
+                if error_type == "auth_error"
+                else "RENAPER devolvio un error durante la autenticacion."
+            )
+            raise RenaperServiceError(
+                message,
+                error_type,
+                raw_response=_safe_response_payload(exc.response),
+            ) from exc
+        except requests.RequestException as exc:
+            raise RenaperServiceError(
+                f"No se pudo conectar al servicio de login de RENAPER: {str(exc)}",
+                "remote_error",
             ) from exc
 
-        data = response.json()
-        token = data.get("token")
+        try:
+            data = response.json()
+        except ValueError as exc:
+            raise RenaperServiceError(
+                "RENAPER devolvio una respuesta invalida durante la autenticacion.",
+                "invalid_response",
+                raw_response=getattr(response, "text", None),
+            ) from exc
+
+        token = data.get("token") if isinstance(data, dict) else None
+        if not token:
+            raise RenaperServiceError(
+                "RENAPER no devolvio un token de autenticacion.",
+                "invalid_response",
+                raw_response=data,
+            )
 
         # Cache por 50 minutos
         cache.set("renaper_token", {"token": token}, 3000)
@@ -53,9 +110,10 @@ class APIClient:
     def consultar_ciudadano(self, dni, sexo):
         try:
             token = self.get_token()
-        except RuntimeError as exc:
-            logger.error(f"Error al obtener token: {str(exc)}")
-            return {"success": False, "error": f"Error al obtener token: {str(exc)}"}
+        except RenaperServiceError as exc:
+            return _build_error_result(
+                str(exc), exc.error_type, raw_response=exc.raw_response
+            )
 
         headers = {"Authorization": f"Bearer {token}"}
         params = {"dni": dni, "sexo": sexo.upper()}
@@ -65,30 +123,58 @@ class APIClient:
                 CONSULTA_URL, headers=headers, params=params, timeout=10
             )
             response.raise_for_status()
-        except Exception as exc:
-            logger.error(f"Error consulta RENAPER DNI {dni}: {str(exc)}")
-            return {
-                "success": False,
-                "error": f"Error inesperado: {str(exc)}",
-            }
+        except requests.Timeout:
+            return _build_error_result(
+                "RENAPER no respondio a tiempo durante la consulta.", "timeout"
+            )
+        except requests.HTTPError as exc:
+            status_code = getattr(exc.response, "status_code", None)
+            error_type = "auth_error" if status_code in {401, 403} else "remote_error"
+            message = (
+                "RENAPER rechazo la autenticacion de la consulta."
+                if error_type == "auth_error"
+                else "RENAPER devolvio un error durante la consulta."
+            )
+            return _build_error_result(
+                message,
+                error_type,
+                raw_response=_safe_response_payload(exc.response),
+            )
+        except requests.RequestException as exc:
+            return _build_error_result(
+                f"No se pudo consultar RENAPER: {str(exc)}", "remote_error"
+            )
 
         try:
             data = response.json()
-        except Exception as exc:
-            logger.error(f"Error decodificar JSON RENAPER DNI {dni}: {str(exc)}")
-            return {
-                "success": False,
-                "error": f"No se pudo decodificar JSON: {str(exc)}",
-            }
+        except ValueError as exc:
+            return _build_error_result(
+                f"No se pudo decodificar JSON de RENAPER: {str(exc)}",
+                "invalid_response",
+                raw_response=getattr(response, "text", None),
+            )
+
+        if not isinstance(data, dict):
+            return _build_error_result(
+                "RENAPER devolvio una estructura de respuesta invalida.",
+                "invalid_response",
+                raw_response=data,
+            )
 
         if not data.get("isSuccess", False):
-            return {
-                "success": False,
-                "error": "No se encontró coincidencia.",
-                "raw_response": data,
-            }
+            return _build_error_result(
+                "No se encontro coincidencia.", "no_match", raw_response=data
+            )
 
-        return {"success": True, "data": data["result"]}
+        result = data.get("result")
+        if not isinstance(result, dict):
+            return _build_error_result(
+                "RENAPER devolvio una respuesta invalida.",
+                "invalid_response",
+                raw_response=data,
+            )
+
+        return {"success": True, "data": result}
 
 
 def normalizar(texto):
@@ -109,16 +195,27 @@ def consultar_datos_renaper(dni, sexo):
         response = client.consultar_ciudadano(dni, sexo)
 
         if not response["success"]:
-            return {
-                "success": False,
-                "error": response.get("error", "Error desconocido"),
-                "raw_response": response.get("raw_response"),
-            }
+            return _build_error_result(
+                response.get("error", "Error desconocido al consultar RENAPER"),
+                response.get("error_type", "unexpected_error"),
+                raw_response=response.get("raw_response"),
+            )
 
         datos = response["data"]
+        if not isinstance(datos, dict):
+            return _build_error_result(
+                "RENAPER devolvio un payload invalido del ciudadano.",
+                "invalid_response",
+                raw_response=datos,
+            )
 
         if datos.get("mensaf") == "FALLECIDO":
-            return {"success": False, "error": "El ciudadano se encuentra fallecido."}
+            return _build_error_result(
+                "El ciudadano se encuentra fallecido.",
+                "fallecido",
+                raw_response=datos,
+                fallecido=True,
+            )
 
         sexo_map = {"F": "Femenino", "M": "Masculino", "X": "X"}
         sexo_texto = sexo_map.get(sexo)
@@ -127,8 +224,7 @@ def consultar_datos_renaper(dni, sexo):
             sexo_obj = Sexo.objects.filter(sexo=sexo_texto).first()
             sexo_pk = sexo_obj.pk if sexo_obj else None
 
-        # Solo datos básicos de RENAPER, sin mapeo de ubicación
-
+        # Solo datos basicos de RENAPER, sin mapeo de ubicacion
         # Mapeo optimizado de datos
         def safe_int(value):
             try:
@@ -150,7 +246,7 @@ def consultar_datos_renaper(dni, sexo):
             "sexo": sexo_pk,
             "tipo_documento": Ciudadano.DOCUMENTO_DNI,
             "fecha_nacimiento": datos.get("fechaNacimiento"),
-            # Datos de ubicación sin mapear (se seleccionarán manualmente)
+            # Datos de ubicacion sin mapear (se seleccionaran manualmente)
             "provincia_api": datos.get("provincia", ""),
             "municipio_api": datos.get("municipio", ""),
             "localidad_api": datos.get("ciudad", ""),
@@ -171,7 +267,7 @@ def consultar_datos_renaper(dni, sexo):
         return {"success": True, "data": datos_mapeados, "datos_api": datos}
     except Exception as exc:
         logger.exception(f"Error inesperado consultando RENAPER: {str(exc)}")
-        return {
-            "success": False,
-            "error": f"Error inesperado al consultar RENAPER: {str(exc)}",
-        }
+        return _build_error_result(
+            f"Error inesperado al consultar RENAPER: {str(exc)}",
+            "unexpected_error",
+        )

--- a/docs/registro/cambios/2026-04-17-celiaquia-renaper-clasificacion-errores-y-logs.md
+++ b/docs/registro/cambios/2026-04-17-celiaquia-renaper-clasificacion-errores-y-logs.md
@@ -1,0 +1,167 @@
+# Celiaquia: clasificacion de errores, retries y logs de validacion RENAPER
+
+Fecha: 2026-04-17
+
+## Contexto
+El endpoint `celiaquia/expedientes/{pk}/legajos/{legajo_id}/validar-renaper` estaba mezclando errores transitorios de RENAPER con errores funcionales de datos del ciudadano.
+
+Eso generaba tres problemas principales:
+
+- mensajes funcionales incorrectos o demasiado genericos para el usuario,
+- retries sobre casos no reintentables como `no_match`,
+- logs ruidosos o duplicados, donde un mismo caso podia verse como `response_error` y tambien como error funcional.
+
+El objetivo del cambio fue separar explicitamente:
+
+- errores tecnicos o transitorios del servicio externo,
+- respuestas invalidas del proveedor,
+- errores funcionales de coincidencia de datos del ciudadano.
+
+## Decision principal
+Se consolidó un contrato de clasificacion por `error_type` en el servicio compartido de RENAPER y la vista de Celiaquia pasó a decidir retries, mensaje funcional y tipo de log a partir de esa clasificacion.
+
+Los tipos usados quedan:
+
+- `timeout`
+- `remote_error`
+- `auth_error`
+- `invalid_response`
+- `unexpected_error`
+- `no_match`
+- `fallecido`
+
+## Cambios realizados
+
+### 1. Servicio RENAPER
+Archivo: `centrodefamilia/services/consulta_renaper/impl.py`
+
+- Se agregó `RenaperServiceError` para clasificar fallas de login/autenticacion/integracion.
+- `consultar_ciudadano()` ahora devuelve resultados con `error_type` explicito para:
+  - timeout,
+  - auth error,
+  - remote error,
+  - invalid response,
+  - no match.
+- `consultar_datos_renaper()` propaga la clasificacion y agrega:
+  - `fallecido`,
+  - `unexpected_error`,
+  - `raw_response` cuando aporta contexto util.
+- Se restauraron comentarios previos validos del archivo.
+- No se incorporaron cambios de SSL local, `verify`, CA bundle, variables nuevas de entorno ni workarounds de certificados.
+
+### 2. Vista de validacion RENAPER
+Archivo: `celiaquia/views/validacion_renaper.py`
+
+- Se agregaron mensajes funcionales diferenciados:
+  - indisponibilidad remota/transitoria:
+    `No pudimos validar con RENAPER en este momento. Por favor, intentá nuevamente en unos minutos.`
+  - respuesta invalida:
+    `RENAPER devolvió una respuesta inválida y no pudimos completar la validación. Intentá nuevamente más tarde.`
+  - no coincidencia:
+    `RENAPER no pudo validar los datos ingresados. Verificá el DNI y el sexo registrados.`
+- La logica de retry quedó limitada a errores transitorios o tecnicos:
+  - `timeout`
+  - `remote_error`
+  - `auth_error`
+  - `invalid_response`
+  - `unexpected_error`
+- `no_match` deja de reintentarse.
+- `no_match` deja de disparar `renaper.validation.retrying_remote_query`.
+- Se consolidó el detalle util del log final de error con:
+  - `stage`
+  - `error`
+  - `error_type`
+  - `retry_attempt`
+  - `max_retries`
+  - `raw_response_excerpt`
+  - mas el contexto existente del legajo/ciudadano/usuario
+
+### 3. Logging operativo
+Archivo: `celiaquia/views/validacion_renaper.py`
+
+Se normalizaron los eventos:
+
+- `renaper.validation.no_match`
+  - severidad: `info`
+  - no duplica `renaper.validation.response_error`
+- `renaper.validation.remote_unavailable`
+  - severidad: `warning`
+  - para `timeout`, `remote_error`
+- `renaper.validation.remote_unavailable` con `auth_error`
+  - severidad: `error`
+- `renaper.validation.invalid_response`
+  - severidad: `error`
+- `renaper.validation.fallecido`
+  - severidad: `info`
+- `renaper.validation.response_error`
+  - queda solo para errores genericos o no clasificados especificamente
+
+## Archivos tocados
+- `celiaquia/views/validacion_renaper.py`
+- `centrodefamilia/services/consulta_renaper/impl.py`
+- `tests/test_validacion_renaper_view_unit.py`
+- `tests/test_consulta_renaper_unit.py`
+
+## Cobertura agregada o actualizada
+
+### Vista
+Archivo: `tests/test_validacion_renaper_view_unit.py`
+
+Se cubren estos casos:
+
+- `no_match` no reintenta
+- `no_match` no genera `retrying_remote_query`
+- `no_match` no duplica `response_error`
+- timeout reintenta y respeta backoff
+- error transitorio muestra mensaje funcional correcto
+- invalid response muestra mensaje funcional correcto
+- flujo exitoso sigue funcionando
+- `fallecido` sigue funcionando
+
+### Servicio
+Archivo: `tests/test_consulta_renaper_unit.py`
+
+Se cubren estos casos:
+
+- `no_match`
+- `timeout`
+- `auth_error`
+- `invalid_response`
+- propagacion de `remote_error`
+- clasificacion de `fallecido`
+- payload invalido del ciudadano
+
+## Validacion ejecutada
+
+### Pytest dentro del ambiente Docker de la app
+Comando:
+
+```bash
+docker compose run --rm django pytest tests/test_validacion_renaper_view_unit.py tests/test_consulta_renaper_unit.py
+```
+
+Resultado:
+
+```text
+25 passed in 2.44s
+```
+
+### Validacion de sintaxis
+Comando:
+
+```bash
+python -m py_compile \
+  BACKOFFICE/centrodefamilia/services/consulta_renaper/impl.py \
+  BACKOFFICE/celiaquia/views/validacion_renaper.py \
+  BACKOFFICE/tests/test_validacion_renaper_view_unit.py \
+  BACKOFFICE/tests/test_consulta_renaper_unit.py
+```
+
+Resultado: OK
+
+## Impacto esperado
+- El usuario recibe mensajes mas precisos y accionables segun el problema real.
+- Los retries dejan de ocurrir sobre errores funcionales del ciudadano.
+- Los logs quedan mas legibles para operacion y soporte.
+- `no_match` deja de verse como error tecnico del sistema.
+- Se preserva el comportamiento exitoso y el caso `fallecido`.

--- a/tests/test_consulta_renaper_unit.py
+++ b/tests/test_consulta_renaper_unit.py
@@ -1,17 +1,28 @@
 """Tests unitarios para centrodefamilia.services.consulta_renaper.impl."""
 
+import requests
+
 import centrodefamilia.services.consulta_renaper as module
 
 
 class _ResponseMock:
-    def __init__(self, payload):
+    def __init__(self, payload=None, text="", status_code=200):
         self.payload = payload
+        self.text = text
+        self.status_code = status_code
 
     def raise_for_status(self):
         return None
 
     def json(self):
+        if isinstance(self.payload, Exception):
+            raise self.payload
         return self.payload
+
+
+class _HTTPErrorResponse(_ResponseMock):
+    def raise_for_status(self):
+        raise requests.HTTPError(response=self)
 
 
 def test_api_client_no_log_error_when_no_match(mocker):
@@ -21,12 +32,103 @@ def test_api_client_no_log_error_when_no_match(mocker):
     client = module.APIClient()
     client.session = session
     mocker.patch.object(client, "get_token", return_value="token")
-    log_error = mocker.patch(
-        "centrodefamilia.services.consulta_renaper.impl.logger.error"
-    )
+    log_error = mocker.patch("centrodefamilia.services.consulta_renaper.impl.logger.error")
 
     out = client.consultar_ciudadano("13163071", "M")
 
     assert out["success"] is False
-    assert out["error"] == "No se encontró coincidencia."
+    assert out["error_type"] == "no_match"
     log_error.assert_not_called()
+
+
+def test_api_client_clasifica_timeout_en_consulta(mocker):
+    session = mocker.Mock()
+    session.get.side_effect = requests.Timeout()
+
+    client = module.APIClient()
+    client.session = session
+    mocker.patch.object(client, "get_token", return_value="token")
+
+    out = client.consultar_ciudadano("13163071", "M")
+
+    assert out == {
+        "success": False,
+        "error": "RENAPER no respondio a tiempo durante la consulta.",
+        "error_type": "timeout",
+    }
+
+
+def test_api_client_clasifica_auth_error_en_consulta(mocker):
+    session = mocker.Mock()
+    session.get.return_value = _HTTPErrorResponse({"detail": "unauthorized"}, status_code=401)
+
+    client = module.APIClient()
+    client.session = session
+    mocker.patch.object(client, "get_token", return_value="token")
+
+    out = client.consultar_ciudadano("13163071", "M")
+
+    assert out["success"] is False
+    assert out["error_type"] == "auth_error"
+    assert out["raw_response"] == {"detail": "unauthorized"}
+
+
+def test_api_client_clasifica_invalid_response_en_consulta(mocker):
+    session = mocker.Mock()
+    session.get.return_value = _ResponseMock(ValueError("bad json"), text="<html>broken</html>")
+
+    client = module.APIClient()
+    client.session = session
+    mocker.patch.object(client, "get_token", return_value="token")
+
+    out = client.consultar_ciudadano("13163071", "M")
+
+    assert out["success"] is False
+    assert out["error_type"] == "invalid_response"
+    assert out["raw_response"] == "<html>broken</html>"
+
+
+def test_consultar_datos_renaper_propagates_error_type(mocker):
+    client = mocker.Mock()
+    client.consultar_ciudadano.return_value = {
+        "success": False,
+        "error": "upstream unavailable",
+        "error_type": "remote_error",
+        "raw_response": {"detail": "boom"},
+    }
+    mocker.patch("centrodefamilia.services.consulta_renaper.impl.APIClient", return_value=client)
+
+    out = module.consultar_datos_renaper("13163071", "M")
+
+    assert out["success"] is False
+    assert out["error_type"] == "remote_error"
+    assert out["raw_response"] == {"detail": "boom"}
+
+
+def test_consultar_datos_renaper_detecta_fallecido(mocker):
+    client = mocker.Mock()
+    client.consultar_ciudadano.return_value = {
+        "success": True,
+        "data": {"mensaf": "FALLECIDO"},
+    }
+    mocker.patch("centrodefamilia.services.consulta_renaper.impl.APIClient", return_value=client)
+
+    out = module.consultar_datos_renaper("13163071", "M")
+
+    assert out["success"] is False
+    assert out["error_type"] == "fallecido"
+    assert out["fallecido"] is True
+
+
+def test_consultar_datos_renaper_clasifica_payload_invalido(mocker):
+    client = mocker.Mock()
+    client.consultar_ciudadano.return_value = {
+        "success": True,
+        "data": "payload roto",
+    }
+    mocker.patch("centrodefamilia.services.consulta_renaper.impl.APIClient", return_value=client)
+
+    out = module.consultar_datos_renaper("13163071", "M")
+
+    assert out["success"] is False
+    assert out["error_type"] == "invalid_response"

--- a/tests/test_validacion_renaper_view_unit.py
+++ b/tests/test_validacion_renaper_view_unit.py
@@ -72,13 +72,25 @@ class _Legajo:
         self.saved_fields = update_fields
 
 
+def _crear_ciudadano_base(sexo="Masculino"):
+    return SimpleNamespace(
+        documento="20123456780",
+        sexo=SimpleNamespace(sexo=sexo) if sexo else None,
+        nombre="ana",
+        apellido="perez",
+        fecha_nacimiento=None,
+        calle="mitre",
+        altura=10,
+        piso_departamento="1a",
+        ciudad="la plata",
+        provincia=None,
+        codigo_postal=1900,
+    )
+
+
 @pytest.mark.parametrize(
     "value,length,expected",
-    [
-        ("abc", 10, "abc"),
-        ("a" * 8, 5, "aaaaa…"),
-        (123, 5, 123),
-    ],
+    [("abc", 10, "abc"), ("a" * 8, 5, "aaaaa…"), (123, 5, 123)],
 )
 def test_helpers_truncate(value, length, expected):
     assert module._truncate(value, length) == expected
@@ -123,14 +135,12 @@ def test_guardar_validacion_estado_paths(mocker):
     invalid = view._guardar_validacion_estado(
         req, pk=1, legajo_id=2, validacion_estado="9"
     )
-    body_invalid = json.loads(invalid.content)
-    assert body_invalid["success"] is False
+    assert json.loads(invalid.content)["success"] is False
 
     subsanar = view._guardar_validacion_estado(
         req, pk=1, legajo_id=2, validacion_estado="3"
     )
-    body_subsanar = json.loads(subsanar.content)
-    assert body_subsanar["success"] is True
+    assert json.loads(subsanar.content)["success"] is True
     assert legajo.revision_tecnico == "SUBSANAR"
     assert "subsanacion_motivo" in legajo.saved_fields
 
@@ -146,10 +156,7 @@ def test_consultar_renaper_guard_clauses(mocker):
     view = module.ValidacionRenaperView()
     tecnico = _User(groups=_Groups({"TecnicoCeliaquia"}))
 
-    # técnico no asignado
-    legajo_no_asig = _Legajo(
-        ciudadano=SimpleNamespace(documento="12345678"), assigned=False
-    )
+    legajo_no_asig = _Legajo(ciudadano=SimpleNamespace(documento="12345678"), assigned=False)
     mocker.patch(
         "celiaquia.views.validacion_renaper.get_object_or_404",
         return_value=legajo_no_asig,
@@ -159,7 +166,6 @@ def test_consultar_renaper_guard_clauses(mocker):
     )
     assert resp_forbidden.status_code == 403
 
-    # ciudadano inexistente
     legajo_sin_ciudadano = _Legajo(ciudadano=None, assigned=True)
     mocker.patch(
         "celiaquia.views.validacion_renaper.get_object_or_404",
@@ -170,21 +176,22 @@ def test_consultar_renaper_guard_clauses(mocker):
     )
     assert json.loads(resp_no_cit.content)["success"] is False
 
-    # documento inválido
-    citizen = SimpleNamespace(
-        documento="abc",
-        sexo=SimpleNamespace(sexo="Masculino"),
-        nombre="ana",
-        apellido="perez",
-        fecha_nacimiento=None,
-        calle="",
-        altura=None,
-        piso_departamento="",
-        ciudad="",
-        provincia=None,
-        codigo_postal=None,
+    legajo_bad_doc = _Legajo(
+        ciudadano=SimpleNamespace(
+            documento="abc",
+            sexo=SimpleNamespace(sexo="Masculino"),
+            nombre="ana",
+            apellido="perez",
+            fecha_nacimiento=None,
+            calle="",
+            altura=None,
+            piso_departamento="",
+            ciudad="",
+            provincia=None,
+            codigo_postal=None,
+        ),
+        assigned=True,
     )
-    legajo_bad_doc = _Legajo(ciudadano=citizen, assigned=True)
     mocker.patch(
         "celiaquia.views.validacion_renaper.get_object_or_404",
         return_value=legajo_bad_doc,
@@ -192,55 +199,37 @@ def test_consultar_renaper_guard_clauses(mocker):
     resp_bad_doc = view._consultar_renaper(
         SimpleNamespace(user=_User(superuser=True)), pk=1, legajo_id=1
     )
-    assert "DNI válido" in json.loads(resp_bad_doc.content)["error"]
+    assert "DNI v" in json.loads(resp_bad_doc.content)["error"]
 
 
-def test_consultar_renaper_remote_error_fallecido_and_success(mocker):
+def test_consultar_renaper_fallecido_y_exito(mocker):
     view = module.ValidacionRenaperView()
-    base_ciudadano = dict(
-        documento="20123456780",
-        sexo=SimpleNamespace(sexo="Masculino"),
-        nombre="ana",
-        apellido="perez",
-        fecha_nacimiento=None,
-        calle="mitre",
-        altura=10,
-        piso_departamento="1a",
-        ciudad="la plata",
-        provincia=None,
-        codigo_postal=1900,
-    )
 
-    # Fallecido
-    legajo_fall = _Legajo(ciudadano=SimpleNamespace(**base_ciudadano))
+    legajo_fall = _Legajo(ciudadano=_crear_ciudadano_base())
     mocker.patch(
         "celiaquia.views.validacion_renaper.get_object_or_404", return_value=legajo_fall
     )
     mocker.patch(
         "celiaquia.views.validacion_renaper.consultar_datos_renaper",
-        return_value={"success": True, "fallecido": True, "data": {}},
+        return_value={
+            "success": False,
+            "fallecido": True,
+            "error": "El ciudadano se encuentra fallecido.",
+            "error_type": "fallecido",
+            "raw_response": {"mensaf": "FALLECIDO"},
+        },
     )
+    info = mocker.patch.object(module.logger, "info")
+
     r1 = view._consultar_renaper(
         SimpleNamespace(user=_User(superuser=True)), pk=1, legajo_id=1
     )
+
     assert "fallecida" in json.loads(r1.content)["error"]
+    info_messages = [call.args[0] for call in info.call_args_list]
+    assert "renaper.validation.fallecido" in info_messages
 
-    # Error remoto
-    legajo_err = _Legajo(ciudadano=SimpleNamespace(**base_ciudadano))
-    mocker.patch(
-        "celiaquia.views.validacion_renaper.get_object_or_404", return_value=legajo_err
-    )
-    mocker.patch(
-        "celiaquia.views.validacion_renaper.consultar_datos_renaper",
-        return_value={"success": False, "error": "x", "raw_response": "raw"},
-    )
-    r2 = view._consultar_renaper(
-        SimpleNamespace(user=_User(superuser=True)), pk=1, legajo_id=1
-    )
-    assert "Cuit o el Sexo" in json.loads(r2.content)["error"]
-
-    # Éxito + mapeo provincia por id
-    legajo_ok = _Legajo(ciudadano=SimpleNamespace(**base_ciudadano))
+    legajo_ok = _Legajo(ciudadano=_crear_ciudadano_base())
     mocker.patch(
         "celiaquia.views.validacion_renaper.get_object_or_404", return_value=legajo_ok
     )
@@ -267,12 +256,188 @@ def test_consultar_renaper_remote_error_fallecido_and_success(mocker):
         "core.models.Provincia.objects.get",
         return_value=SimpleNamespace(nombre="Buenos Aires"),
     )
-    r3 = view._consultar_renaper(
+
+    r2 = view._consultar_renaper(
         SimpleNamespace(user=_User(superuser=True)), pk=1, legajo_id=1
     )
-    body = json.loads(r3.content)
+    body = json.loads(r2.content)
     assert body["success"] is True
     assert body["datos_renaper"]["provincia"] == "Buenos Aires"
+
+
+def test_consultar_renaper_remote_error_muestra_mensaje_funcional(mocker):
+    view = module.ValidacionRenaperView()
+    legajo = _Legajo(ciudadano=_crear_ciudadano_base())
+    mocker.patch(
+        "celiaquia.views.validacion_renaper.get_object_or_404", return_value=legajo
+    )
+    mocker.patch(
+        "celiaquia.views.validacion_renaper.consultar_datos_renaper",
+        return_value={
+            "success": False,
+            "error": "temporarily unavailable",
+            "error_type": "remote_error",
+            "raw_response": {"message": "upstream down"},
+        },
+    )
+
+    response = view._consultar_renaper(
+        SimpleNamespace(user=_User(superuser=True)), pk=1, legajo_id=1
+    )
+
+    assert (
+        json.loads(response.content)["error"]
+        == module.RENAPER_REMOTE_UNAVAILABLE_MESSAGE
+    )
+
+
+def test_consultar_renaper_invalid_response_muestra_mensaje_y_log(mocker):
+    mocker.patch.object(module.settings, "RENAPER_VALIDACION_MAX_RETRIES", 1)
+    mocker.patch.object(module.settings, "RENAPER_VALIDACION_BACKOFF_SECONDS", 0)
+    view = module.ValidacionRenaperView()
+    legajo = _Legajo(ciudadano=_crear_ciudadano_base())
+    mocker.patch(
+        "celiaquia.views.validacion_renaper.get_object_or_404", return_value=legajo
+    )
+    mocker.patch(
+        "celiaquia.views.validacion_renaper.consultar_datos_renaper",
+        return_value={
+            "success": False,
+            "error": "payload invalido",
+            "error_type": "invalid_response",
+            "raw_response": {"broken": True},
+        },
+    )
+    error = mocker.patch.object(module.logger, "error")
+
+    response = view._consultar_renaper(
+        SimpleNamespace(user=_User(superuser=True)), pk=1, legajo_id=1
+    )
+    body = json.loads(response.content)
+
+    assert body["error"] == module.RENAPER_INVALID_RESPONSE_MESSAGE
+    assert error.call_args[0][0] == "renaper.validation.invalid_response"
+    log_data = error.call_args[1]["extra"]["data"]
+    assert log_data["stage"] == "response"
+    assert log_data["error_type"] == "invalid_response"
+    assert log_data["retry_attempt"] == 1
+    assert log_data["max_retries"] == 1
+    assert '"broken": true' in log_data["raw_response_excerpt"]
+
+
+def test_no_match_no_reintenta_ni_loguea_retry(mocker):
+    mocker.patch.object(module.settings, "RENAPER_VALIDACION_MAX_RETRIES", 3)
+    mocker.patch.object(module.settings, "RENAPER_VALIDACION_BACKOFF_SECONDS", 0.25)
+    consultar = mocker.patch(
+        "celiaquia.views.validacion_renaper.consultar_datos_renaper",
+        return_value={
+            "success": False,
+            "error": "No se encontro coincidencia.",
+            "error_type": "no_match",
+            "raw_response": {"isSuccess": False},
+        },
+    )
+    warning = mocker.patch.object(module.logger, "warning")
+    sleep = mocker.patch("celiaquia.views.validacion_renaper.time.sleep")
+
+    out = module._consultar_datos_renaper_con_reintentos("12345678", "M")
+
+    assert out["error_type"] == "no_match"
+    assert out["retry_attempt"] == 1
+    assert out["max_retries"] == 3
+    assert consultar.call_count == 1
+    sleep.assert_not_called()
+    assert not any(call.args[0] == "renaper.validation.retrying_remote_query" for call in warning.call_args_list)
+
+
+def test_no_match_loguea_solo_no_match_y_mensaje_funcional(mocker):
+    mocker.patch.object(module.settings, "RENAPER_VALIDACION_MAX_RETRIES", 1)
+    mocker.patch.object(module.settings, "RENAPER_VALIDACION_BACKOFF_SECONDS", 0)
+    view = module.ValidacionRenaperView()
+    legajo = _Legajo(ciudadano=_crear_ciudadano_base())
+    mocker.patch(
+        "celiaquia.views.validacion_renaper.get_object_or_404", return_value=legajo
+    )
+    mocker.patch(
+        "celiaquia.views.validacion_renaper.consultar_datos_renaper",
+        return_value={
+            "success": False,
+            "error": "No se encontro coincidencia.",
+            "error_type": "no_match",
+            "raw_response": {"isSuccess": False, "detalle": "mismatch"},
+        },
+    )
+    info = mocker.patch.object(module.logger, "info")
+    warning = mocker.patch.object(module.logger, "warning")
+    error = mocker.patch.object(module.logger, "error")
+
+    response = view._consultar_renaper(
+        SimpleNamespace(user=_User(superuser=True)), pk=1, legajo_id=1
+    )
+    body = json.loads(response.content)
+
+    assert body["error"] == module.RENAPER_NO_MATCH_MESSAGE
+    info_messages = [call.args[0] for call in info.call_args_list]
+    assert "renaper.validation.no_match" in info_messages
+    warning_messages = [call.args[0] for call in warning.call_args_list]
+    assert "renaper.validation.no_match" not in warning_messages
+    assert "renaper.validation.retrying_remote_query" not in warning_messages
+    error_messages = [call.args[0] for call in error.call_args_list]
+    assert "renaper.validation.response_error" not in error_messages
+    no_match_logs = [
+        call for call in info.call_args_list if call.args[0] == "renaper.validation.no_match"
+    ]
+    assert len(no_match_logs) == 1
+    log_data = no_match_logs[0].kwargs["extra"]["data"]
+    assert log_data["error_type"] == "no_match"
+    assert log_data["retry_attempt"] == 1
+    assert log_data["max_retries"] == 1
+    assert '"detalle": "mismatch"' in log_data["raw_response_excerpt"]
+
+
+def test_consultar_datos_renaper_con_reintentos_respeta_backoff_y_retry_log(mocker):
+    mocker.patch.object(module.settings, "RENAPER_VALIDACION_MAX_RETRIES", 3)
+    mocker.patch.object(module.settings, "RENAPER_VALIDACION_BACKOFF_SECONDS", 0.25)
+    consultar = mocker.patch(
+        "celiaquia.views.validacion_renaper.consultar_datos_renaper",
+        side_effect=[
+            {"success": False, "error": "timeout 1", "error_type": "timeout"},
+            {"success": False, "error": "timeout 2", "error_type": "timeout"},
+            {"success": True, "data": {"documento": "12345678"}},
+        ],
+    )
+    warning = mocker.patch.object(module.logger, "warning")
+    sleep = mocker.patch("celiaquia.views.validacion_renaper.time.sleep")
+
+    out = module._consultar_datos_renaper_con_reintentos("12345678", "M")
+
+    assert out["success"] is True
+    assert out["retry_attempt"] == 3
+    assert out["max_retries"] == 3
+    assert consultar.call_count == 3
+    assert sleep.call_count == 2
+    assert sleep.call_args_list[0].args == (0.25,)
+    assert sleep.call_args_list[1].args == (0.5,)
+    retry_logs = [call for call in warning.call_args_list if call.args[0] == "renaper.validation.retrying_remote_query"]
+    assert len(retry_logs) == 2
+    assert retry_logs[0].kwargs["extra"]["data"]["error_type"] == "timeout"
+
+
+def test_consultar_datos_renaper_con_reintentos_defaults_invalidos(mocker):
+    mocker.patch.object(module.settings, "RENAPER_VALIDACION_MAX_RETRIES", "abc")
+    mocker.patch.object(module.settings, "RENAPER_VALIDACION_BACKOFF_SECONDS", "x")
+    consultar = mocker.patch(
+        "celiaquia.views.validacion_renaper.consultar_datos_renaper",
+        return_value={"success": False, "error": "fail", "error_type": "remote_error"},
+    )
+    sleep = mocker.patch("celiaquia.views.validacion_renaper.time.sleep")
+
+    out = module._consultar_datos_renaper_con_reintentos("12345678", "F")
+
+    assert out["success"] is False
+    assert out["retry_attempt"] == 1
+    assert consultar.call_count == 1
+    sleep.assert_not_called()
 
 
 def test_formatear_datos_renaper_usa_provincia_api_cuando_no_hay_pk():
@@ -334,19 +499,8 @@ def test_post_routes_to_save_or_consulta(mocker):
 
 def test_consultar_renaper_sin_sexo_reintenta_y_reutiliza_respuesta(mocker):
     view = module.ValidacionRenaperView()
-    ciudadano = SimpleNamespace(
-        documento="12345678",
-        sexo=None,
-        nombre="ana",
-        apellido="perez",
-        fecha_nacimiento=None,
-        calle="mitre",
-        altura=10,
-        piso_departamento="1a",
-        ciudad="la plata",
-        provincia=None,
-        codigo_postal=1900,
-    )
+    ciudadano = _crear_ciudadano_base(sexo=None)
+    ciudadano.documento = "12345678"
     legajo = _Legajo(ciudadano=ciudadano, assigned=True)
     mocker.patch(
         "celiaquia.views.validacion_renaper.get_object_or_404",
@@ -355,7 +509,7 @@ def test_consultar_renaper_sin_sexo_reintenta_y_reutiliza_respuesta(mocker):
     consultar = mocker.patch(
         "celiaquia.views.validacion_renaper.consultar_datos_renaper",
         side_effect=[
-            {"success": False, "error": "mismatch"},
+            {"success": False, "error": "mismatch", "error_type": "no_match"},
             {
                 "success": True,
                 "fallecido": False,
@@ -385,41 +539,3 @@ def test_consultar_renaper_sin_sexo_reintenta_y_reutiliza_respuesta(mocker):
     assert consultar.call_count == 2
     assert consultar.call_args_list[0].args == ("12345678", "M")
     assert consultar.call_args_list[1].args == ("12345678", "F")
-
-
-def test_consultar_datos_renaper_con_reintentos_respeta_backoff(mocker):
-    mocker.patch.object(module.settings, "RENAPER_VALIDACION_MAX_RETRIES", 3)
-    mocker.patch.object(module.settings, "RENAPER_VALIDACION_BACKOFF_SECONDS", 0.25)
-    consultar = mocker.patch(
-        "celiaquia.views.validacion_renaper.consultar_datos_renaper",
-        side_effect=[
-            {"success": False, "error": "timeout"},
-            {"success": False, "error": "timeout"},
-            {"success": True, "data": {"documento": "12345678"}},
-        ],
-    )
-    sleep = mocker.patch("celiaquia.views.validacion_renaper.time.sleep")
-
-    out = module._consultar_datos_renaper_con_reintentos("12345678", "M")
-
-    assert out["success"] is True
-    assert consultar.call_count == 3
-    assert sleep.call_count == 2
-    assert sleep.call_args_list[0].args == (0.25,)
-    assert sleep.call_args_list[1].args == (0.5,)
-
-
-def test_consultar_datos_renaper_con_reintentos_defaults_invalidos(mocker):
-    mocker.patch.object(module.settings, "RENAPER_VALIDACION_MAX_RETRIES", "abc")
-    mocker.patch.object(module.settings, "RENAPER_VALIDACION_BACKOFF_SECONDS", "x")
-    consultar = mocker.patch(
-        "celiaquia.views.validacion_renaper.consultar_datos_renaper",
-        return_value={"success": False, "error": "fail"},
-    )
-    sleep = mocker.patch("celiaquia.views.validacion_renaper.time.sleep")
-
-    out = module._consultar_datos_renaper_con_reintentos("12345678", "F")
-
-    assert out["success"] is False
-    assert consultar.call_count == 1
-    sleep.assert_not_called()


### PR DESCRIPTION
# Información de la Tarea
Vincular el #ISSUE
https://github.com/dsocial118/SISOC/issues/1560
### **Resumen de la Solución:** 
-Se consolidó un contrato de clasificacion por `error_type` en el servicio compartido de RENAPER y la vista de Celiaquia pasó a decidir retries, mensaje funcional y tipo de log a partir de esa clasificacion.

### **Información Adicional:**
-

# Descripción de los Cambios

### **Cambios:**
no_match -> info
fallecido -> info
timeout -> warning
remote_error -> warning
auth_error -> error
invalid_response -> error
unexpected_error -> error

# Cómo Testear los Cambios

### **Pruebas Automáticas:**
-

### **Prubeas Manuales:**
-

# Metadata para documentación automática

- Contexto funcional:
- Tipo de cambio:
- Área principal:
- Resumen para changelog:
- Impacto usuario:
- Riesgos / rollback:

# Capturas de Pantalla
