### PR TITLE
fix(celiaquia): exigir todos los documentos al confirmar envio

### DIFF
--- a/celiaquia/models.py
+++ b/celiaquia/models.py
@@ -280,21 +280,11 @@ class ExpedienteCiudadano(SoftDeleteModelMixin, models.Model):
     def _recompute_archivos_ok(self):
         """Calcula archivos_ok basado en documentos requeridos."""
         # Usar nuevo sistema si está disponible
-        if hasattr(self, "documentos"):
-            try:
-                tipos_requeridos = TipoDocumento.objects.filter(
-                    requerido=True, activo=True
-                ).count()
-                documentos_cargados = self.documentos.filter(
-                    tipo_documento__requerido=True, tipo_documento__activo=True
-                ).count()
-                self.archivos_ok = documentos_cargados >= tipos_requeridos
-            except:
-                # Fallback al sistema anterior
-                self.archivos_ok = bool(self.archivo2 and self.archivo3)
-        else:
-            # Sistema anterior
-            self.archivos_ok = bool(self.archivo2 and self.archivo3)
+        from .services.legajo_service import (  # pylint: disable=import-outside-toplevel
+            LegajoService,
+        )
+
+        self.archivos_ok = LegajoService.tiene_archivos_requeridos(self)
 
     def save(self, *args, **kwargs):
         self._recompute_archivos_ok()
@@ -360,19 +350,21 @@ class ExpedienteCiudadano(SoftDeleteModelMixin, models.Model):
     @property
     def documentos_completos(self):
         """Verifica si tiene todos los documentos requeridos."""
-        tipos_requeridos = TipoDocumento.objects.filter(
-            requerido=True, activo=True
-        ).count()
-        documentos_cargados = self.documentos.filter(
-            tipo_documento__requerido=True, tipo_documento__activo=True
-        ).count()
-        return tipos_requeridos == documentos_cargados
+        from .services.legajo_service import (  # pylint: disable=import-outside-toplevel
+            LegajoService,
+        )
+
+        return LegajoService.tiene_archivos_requeridos(self)
 
     def documentos_faltantes(self):
         """Lista los tipos de documentos faltantes."""
-        tipos_requeridos = TipoDocumento.objects.filter(requerido=True, activo=True)
-        tipos_cargados = self.documentos.values_list("tipo_documento_id", flat=True)
-        return tipos_requeridos.exclude(id__in=tipos_cargados)
+        from .services.legajo_service import (  # pylint: disable=import-outside-toplevel
+            LegajoService,
+        )
+
+        campos_faltantes = LegajoService.campos_archivos_faltantes(self)
+        archivos_requeridos = LegajoService.get_archivos_requeridos_por_legajo(self)
+        return [archivos_requeridos[campo] for campo in campos_faltantes]
 
 
 class AsignacionTecnico(SoftDeleteModelMixin, models.Model):

--- a/celiaquia/services/expediente_service/impl.py
+++ b/celiaquia/services/expediente_service/impl.py
@@ -90,14 +90,23 @@ class ExpedienteService:
                 f"El expediente no está en estado EN_ESPERA. Estado actual: {expediente.estado.nombre}"
             )
 
-        for leg in expediente.expediente_ciudadanos.all():
+        legajos_qs = expediente.expediente_ciudadanos
+        if hasattr(legajos_qs, "select_related"):
+            legajos_qs = legajos_qs.select_related("ciudadano")
+
+        responsables_ids = LegajoService.obtener_ids_responsables_expediente(
+            expediente, legajos_qs
+        )
+        for leg in legajos_qs.all():
             if hasattr(leg, "archivos_ok"):
-                leg.archivos_ok = bool(leg.archivo2 and leg.archivo3)
+                leg.archivos_ok = LegajoService.tiene_archivos_requeridos(
+                    leg, responsables_ids
+                )
                 leg.save(update_fields=["archivos_ok"])
 
         if not LegajoService.all_legajos_loaded(expediente):
             raise ValidationError(
-                "Debes subir un archivo para cada legajo antes de confirmar."
+                "Debes subir toda la documentacion obligatoria de cada legajo antes de confirmar."
             )
 
         _set_estado(expediente, "CONFIRMACION_DE_ENVIO", usuario)

--- a/celiaquia/services/legajo_service/impl.py
+++ b/celiaquia/services/legajo_service/impl.py
@@ -19,6 +19,14 @@ from celiaquia.services.familia_service import (
 logger = logging.getLogger("django")
 
 
+def _iter_legajos(qs):
+    if hasattr(qs, "iterator"):
+        return qs.iterator()
+    if hasattr(qs, "all"):
+        return iter(qs.all())
+    return iter(qs)
+
+
 @lru_cache(maxsize=1)
 def _estado_archivo_cargado_id():
     try:
@@ -34,15 +42,66 @@ def _set_estado_archivo_cargado(obj, update_fields):
         update_fields.append("estado")
 
 
-def _recalc_archivos_ok(obj, update_fields):
+def _recalc_archivos_ok(obj, update_fields, responsables_ids=None):
     if hasattr(obj, "archivos_ok"):
-        val = bool(obj.archivo2 and obj.archivo3)
+        val = LegajoService.tiene_archivos_requeridos(obj, responsables_ids)
         if obj.archivos_ok != val:
             obj.archivos_ok = val
             update_fields.append("archivos_ok")
 
 
 class LegajoService:
+    @staticmethod
+    def obtener_ids_responsables_expediente(expediente, qs=None):
+        if qs is None:
+            qs = expediente.expediente_ciudadanos
+
+        ciudadanos_ids = []
+        if hasattr(qs, "values_list"):
+            try:
+                ciudadanos_ids = list(qs.values_list("ciudadano_id", flat=True))
+            except Exception:
+                ciudadanos_ids = []
+        if not ciudadanos_ids and (hasattr(qs, "iterator") or hasattr(qs, "all")):
+            ciudadanos_ids = [
+                getattr(legajo, "ciudadano_id", None)
+                for legajo in _iter_legajos(qs)
+                if getattr(legajo, "ciudadano_id", None) is not None
+            ]
+
+        if not ciudadanos_ids:
+            return set()
+
+        try:
+            return FamiliaService.obtener_ids_responsables(ciudadanos_ids)
+        except Exception as exc:
+            logger.warning(
+                "No se pudo determinar responsables en expediente %s: %s",
+                getattr(expediente, "id", None),
+                exc,
+            )
+            return set()
+
+    @staticmethod
+    def campos_archivos_faltantes(legajo, responsables_ids=None):
+        if not hasattr(legajo, "ciudadano") and not hasattr(legajo, "ciudadano_id"):
+            return [
+                campo
+                for campo in ("archivo2", "archivo3")
+                if not getattr(legajo, campo, None)
+            ]
+
+        archivos_requeridos = LegajoService.get_archivos_requeridos_por_legajo(
+            legajo, responsables_ids
+        )
+        return [
+            campo for campo in archivos_requeridos if not getattr(legajo, campo, None)
+        ]
+
+    @staticmethod
+    def tiene_archivos_requeridos(legajo, responsables_ids=None):
+        return not LegajoService.campos_archivos_faltantes(legajo, responsables_ids)
+
     @staticmethod
     def listar_legajos(expediente):
         return expediente.expediente_ciudadanos.select_related(
@@ -189,12 +248,24 @@ class LegajoService:
     @staticmethod
     def all_legajos_loaded(expediente) -> bool:
         qs = expediente.expediente_ciudadanos
-        if hasattr(ExpedienteCiudadano, "archivos_ok"):
-            return not qs.filter(archivos_ok=False).exists()
-        return (
-            not qs.filter(archivo2__isnull=True).exists()
-            and not qs.filter(archivo3__isnull=True).exists()
+        if hasattr(qs, "select_related"):
+            qs = qs.select_related("ciudadano")
+
+        if not hasattr(qs, "iterator") and not hasattr(qs, "all"):
+            if hasattr(ExpedienteCiudadano, "archivos_ok") and hasattr(qs, "filter"):
+                return not qs.filter(archivos_ok=False).exists()
+            return (
+                not qs.filter(archivo2__isnull=True).exists()
+                and not qs.filter(archivo3__isnull=True).exists()
+            )
+
+        responsables_ids = LegajoService.obtener_ids_responsables_expediente(
+            expediente, qs
         )
+        for legajo in _iter_legajos(qs):
+            if not LegajoService.tiene_archivos_requeridos(legajo, responsables_ids):
+                return False
+        return True
 
     @staticmethod
     def faltantes_archivos(
@@ -208,43 +279,31 @@ class LegajoService:
         if friendly_names is None:
             friendly_names = {}
 
-        qs = expediente.expediente_ciudadanos.select_related(
-            "ciudadano", "estado"
-        ).only(
-            "id",
-            "archivo1",
-            "archivo2",
-            "archivo3",
-            "revision_tecnico",
-            "estado_id",
-            "ciudadano__documento",
-            "ciudadano__nombre",
-            "ciudadano__apellido",
-        )
-        if hasattr(ExpedienteCiudadano, "archivos_ok"):
-            qs = qs.filter(archivos_ok=False)
+        qs = expediente.expediente_ciudadanos
+        if hasattr(qs, "select_related"):
+            qs = qs.select_related("ciudadano", "estado")
+        if hasattr(qs, "only"):
+            qs = qs.only(
+                "id",
+                "archivo1",
+                "archivo2",
+                "archivo3",
+                "revision_tecnico",
+                "estado_id",
+                "rol",
+                "ciudadano__documento",
+                "ciudadano__nombre",
+                "ciudadano__apellido",
+                "ciudadano__fecha_nacimiento",
+            )
 
-        ciudadanos_ids = list(qs.values_list("ciudadano_id", flat=True))
-        responsables_ids = set()
-        if ciudadanos_ids:
-            try:
-                responsables_ids = FamiliaService.obtener_ids_responsables(
-                    ciudadanos_ids
-                )
-            except Exception as exc:
-                logger.warning(
-                    "No se pudo determinar responsables en expediente %s: %s",
-                    expediente.id,
-                    exc,
-                )
+        responsables_ids = LegajoService.obtener_ids_responsables_expediente(
+            expediente, qs
+        )
 
         faltantes = []
-        for leg in qs.iterator():
-            miss = []
-            if not leg.archivo2:
-                miss.append("archivo2")
-            if not leg.archivo3:
-                miss.append("archivo3")
+        for leg in _iter_legajos(qs):
+            miss = LegajoService.campos_archivos_faltantes(leg, responsables_ids)
 
             if miss:
                 es_responsable = LegajoService._es_responsable(
@@ -297,8 +356,11 @@ class LegajoService:
             rol_legajo == ExpedienteCiudadano.ROLE_BENEFICIARIO_Y_RESPONSABLE
         )
 
-        es_responsable = LegajoService._es_responsable(
-            legajo.ciudadano, responsables_ids
+        ciudadano = getattr(legajo, "ciudadano", getattr(legajo, "ciudadano_id", None))
+        es_responsable = (
+            LegajoService._es_responsable(ciudadano, responsables_ids)
+            if ciudadano is not None
+            else False
         )
 
         # Caso especial: Doble rol (beneficiario Y responsable)

--- a/celiaquia/tests/test_validation_errors.py
+++ b/celiaquia/tests/test_validation_errors.py
@@ -38,11 +38,6 @@ def test_confirm_envio_validation_error_returns_validation_message():
         {"pk": 1, "usuario_provincia": object(), "estado": dummy_estado},
     )()
 
-    dummy_qs = MagicMock()
-    dummy_qs.select_related.return_value = dummy_qs
-    dummy_qs.filter.return_value = dummy_qs
-    dummy_qs.exists.return_value = False
-
     dummy_err_qs = MagicMock()
     dummy_err_qs.filter.return_value = dummy_err_qs
     dummy_err_qs.exists.return_value = False
@@ -51,8 +46,11 @@ def test_confirm_envio_validation_error_returns_validation_message():
         patch(
             "celiaquia.views.confirm_envio.get_object_or_404", return_value=dummy_exp
         ),
-        patch("celiaquia.views.confirm_envio.ExpedienteCiudadano.objects", dummy_qs),
         patch("celiaquia.views.confirm_envio.RegistroErroneo.objects", dummy_err_qs),
+        patch(
+            "celiaquia.views.confirm_envio.LegajoService.faltantes_archivos",
+            return_value=[],
+        ),
         patch(
             "celiaquia.views.confirm_envio.ExpedienteService.confirmar_envio",
             side_effect=ValidationError("err"),
@@ -62,6 +60,56 @@ def test_confirm_envio_validation_error_returns_validation_message():
 
     assert response.status_code == 400
     assert json.loads(response.content) == {"success": False, "error": "err"}
+
+
+def test_confirm_envio_rechaza_faltantes_dinamicos_por_tipo_de_ciudadano():
+    request = factory.post("/expediente/1/confirm/")
+    request.user = DummyUser()
+    request._dont_enforce_csrf_checks = True
+
+    dummy_estado = type("Estado", (), {"nombre": "EN_ESPERA"})()
+    dummy_exp = type(
+        "Exp",
+        (),
+        {"pk": 1, "usuario_provincia": object(), "estado": dummy_estado},
+    )()
+
+    dummy_err_qs = MagicMock()
+    dummy_err_qs.filter.return_value = dummy_err_qs
+    dummy_err_qs.exists.return_value = False
+
+    faltantes = [
+        {
+            "legajo_id": 7,
+            "apellido": "Perez",
+            "nombre": "Ana",
+            "documento": "123",
+            "faltan_nombres": ["Biopsia / Constancia medica"],
+        }
+    ]
+
+    with (
+        patch(
+            "celiaquia.views.confirm_envio.get_object_or_404", return_value=dummy_exp
+        ),
+        patch("celiaquia.views.confirm_envio.RegistroErroneo.objects", dummy_err_qs),
+        patch(
+            "celiaquia.views.confirm_envio.LegajoService.faltantes_archivos",
+            return_value=faltantes,
+        ),
+        patch("celiaquia.views.confirm_envio._is_ajax", return_value=True),
+        patch(
+            "celiaquia.views.confirm_envio.ExpedienteService.confirmar_envio"
+        ) as confirm,
+    ):
+        response = ExpedienteConfirmView.as_view()(request, pk=1)
+
+    payload = json.loads(response.content)
+    assert response.status_code == 400
+    assert payload["success"] is False
+    assert payload["faltantes_ids"] == [7]
+    assert "documentacion obligatoria" in payload["error"]
+    confirm.assert_not_called()
 
 
 def test_configurar_cupo_validation_error_returns_generic_message():

--- a/celiaquia/views/confirm_envio.py
+++ b/celiaquia/views/confirm_envio.py
@@ -3,16 +3,16 @@
 
 import logging
 
-from django.contrib import messages  # ✅ import correcto
-from django.views import View
-from django.http import JsonResponse, HttpResponseNotAllowed
-from django.shortcuts import get_object_or_404, redirect
-from django.core.exceptions import ValidationError
+from django.contrib import messages
 from django.contrib.auth.mixins import LoginRequiredMixin
-from django.db.models import Q
+from django.core.exceptions import ValidationError
+from django.http import HttpResponseNotAllowed, JsonResponse
+from django.shortcuts import get_object_or_404, redirect
+from django.views import View
 
-from celiaquia.models import Expediente, ExpedienteCiudadano, RegistroErroneo
+from celiaquia.models import Expediente, RegistroErroneo
 from celiaquia.services.expediente_service import ExpedienteService
+from celiaquia.services.legajo_service import LegajoService
 from celiaquia.views.expediente import _is_ajax
 
 logger = logging.getLogger("django")
@@ -20,14 +20,13 @@ logger = logging.getLogger("django")
 
 class ExpedienteConfirmView(LoginRequiredMixin, View):
     """
-    POST: confirma el envío del expediente (provincia). Responde JSON.
+    POST: confirma el envio del expediente (provincia). Responde JSON.
     - Si faltan archivos => 400 con mensaje (o messages.error si no es AJAX).
     - Si no tiene permisos => 403 con mensaje.
     - Nunca 404 por reglas de negocio.
     """
 
     def post(self, request, pk: int):
-        # 1) Traer el expediente por PK (sin filtrar por usuario para evitar 404 falsos)
         expediente = get_object_or_404(
             Expediente.objects.select_related(
                 "usuario_provincia", "usuario_provincia__profile"
@@ -35,13 +34,12 @@ class ExpedienteConfirmView(LoginRequiredMixin, View):
             pk=pk,
         )
 
-        # 2) Chequeo de permisos: dueño, misma provincia o staff
         user = request.user
         same_owner = user == expediente.usuario_provincia
 
-        def _prov_id(u):
+        def _prov_id(usuario):
             try:
-                return getattr(getattr(u, "profile", None), "provincia_id", None)
+                return getattr(getattr(usuario, "profile", None), "provincia_id", None)
             except Exception:
                 return None
 
@@ -55,105 +53,97 @@ class ExpedienteConfirmView(LoginRequiredMixin, View):
             msg = "No tiene permisos para confirmar este expediente."
             return JsonResponse({"success": False, "error": msg}, status=403)
 
-        # 3) Validación de negocio: estado correcto
         if expediente.estado.nombre != "EN_ESPERA":
             msg = (
-                "El expediente no está en estado EN_ESPERA. "
+                "El expediente no esta en estado EN_ESPERA. "
                 f"Estado actual: {expediente.estado.nombre}"
             )
-            logger.info("Validación en confirmar envío falló: %s", msg)
+            logger.info("Validacion en confirmar envio fallo: %s", msg)
             if _is_ajax(request):
                 return JsonResponse({"success": False, "error": msg}, status=400)
             messages.error(request, msg)
             return redirect("expediente_detail", pk=expediente.pk)
 
-        # 4) Validación de negocio: no hay registros erróneos pendientes
         registros_erroneos = RegistroErroneo.objects.filter(
             expediente=expediente, procesado=False
         )
         if registros_erroneos.exists():
             msg = (
-                "No se puede confirmar el envío: hay "
+                "No se puede confirmar el envio: hay "
                 f"{registros_erroneos.count()} registros con errores pendientes."
             )
-            logger.info("Validación en confirmar envío falló: %s", msg)
+            logger.info("Validacion en confirmar envio fallo: %s", msg)
             if _is_ajax(request):
                 return JsonResponse({"success": False, "error": msg}, status=400)
             messages.error(request, msg)
             return redirect("expediente_detail", pk=expediente.pk)
 
-        # 5) Validación de negocio: todos los legajos con los 2 archivos requeridos
-        faltantes_qs = (
-            ExpedienteCiudadano.objects.select_related("ciudadano")
-            .filter(expediente_id=expediente.pk)
-            .filter(
-                Q(archivo2__isnull=True)
-                | Q(archivo2="")
-                | Q(archivo3__isnull=True)
-                | Q(archivo3="")
-            )
-        )
-
-        if faltantes_qs.exists():
+        faltantes = LegajoService.faltantes_archivos(expediente, limit=10)
+        if faltantes:
             ejemplos = [
-                f"{l.ciudadano.apellido}, {l.ciudadano.nombre} (DNI {l.ciudadano.documento})"
-                for l in faltantes_qs[:10]
+                (
+                    f"{item['apellido']}, {item['nombre']} (DNI {item['documento']})"
+                    f" - faltan: {', '.join(item['faltan_nombres'])}"
+                )
+                for item in faltantes
             ]
             msg = (
-                "No podés confirmar el envío: hay legajos sin los 2 archivos requeridos. "
+                "No podes confirmar el envio: hay legajos sin toda la documentacion "
+                "obligatoria segun su tipo de ciudadano. "
                 + (
                     "Ejemplos: "
                     + "; ".join(ejemplos)
-                    + (" …" if faltantes_qs.count() > 10 else "")
+                    + (" ..." if len(faltantes) >= 10 else "")
                 )
             )
-            logger.info("Validación en confirmar envío falló: %s", msg)
+            logger.info("Validacion en confirmar envio fallo: %s", msg)
 
             if _is_ajax(request):
                 return JsonResponse(
                     {
                         "success": False,
                         "error": msg,
-                        "faltantes_ids": list(
-                            faltantes_qs.values_list("id", flat=True)
-                        ),
+                        "faltantes_ids": [item["legajo_id"] for item in faltantes],
                     },
                     status=400,
                 )
             messages.error(request, msg)
             return redirect("expediente_detail", pk=expediente.pk)
 
-        # 6) Transición de estado / lógica de confirmación
         try:
             result = ExpedienteService.confirmar_envio(expediente, request.user)
             logger.info(
-                "Confirmación de envío OK. Expediente %s por %s",
+                "Confirmacion de envio OK. Expediente %s por %s",
                 expediente.pk,
                 request.user.username,
             )
             return JsonResponse(
                 {
                     "success": True,
-                    "message": "Expediente enviado a Subsecretaría.",
+                    "message": "Expediente enviado a Subsecretaria.",
                     "estado": expediente.estado.display_name(),
                     "datos": result,
                 }
             )
-        except ValidationError as e:
-            logger.warning("Validación en confirmar envío falló: %s", e, exc_info=True)
-            if getattr(e, "messages", None):
-                error_msg = "; ".join(str(m) for m in e.messages if m)
-            elif getattr(e, "message", None):
-                error_msg = str(e.message)
+        except ValidationError as exc:
+            logger.warning(
+                "Validacion en confirmar envio fallo: %s", exc, exc_info=True
+            )
+            if getattr(exc, "messages", None):
+                error_msg = "; ".join(
+                    str(message) for message in exc.messages if message
+                )
+            elif getattr(exc, "message", None):
+                error_msg = str(exc.message)
             else:
-                error_msg = str(e)
+                error_msg = str(exc)
             return JsonResponse({"success": False, "error": error_msg}, status=400)
-        except Exception as e:
-            logger.error("Error inesperado al confirmar envío: %s", e, exc_info=True)
+        except Exception as exc:
+            logger.error("Error inesperado al confirmar envio: %s", exc, exc_info=True)
             return JsonResponse(
                 {
                     "success": False,
-                    "error": "No se pudo confirmar el envío. Revisa los datos e intenta de nuevo.",
+                    "error": "No se pudo confirmar el envio. Revisa los datos e intenta de nuevo.",
                 },
                 status=500,
             )

--- a/celiaquia/views/expediente.py
+++ b/celiaquia/views/expediente.py
@@ -943,9 +943,7 @@ class ExpedienteDetailView(DetailView):
         ):
             tecnicos = _tecnicos_queryset().order_by("last_name", "first_name")
 
-        faltan_archivos = expediente.expediente_ciudadanos.filter(
-            Q(archivo2__isnull=True) | Q(archivo3__isnull=True)
-        ).exists()
+        faltan_archivos = bool(faltantes_list)
 
         # Cupo: usar propiedad expediente.provincia (puede ser None)
         cupo = None

--- a/docs/registro/cambios/2026-04-20-fix-celiaquia-documentos-obligatorios-envio.md
+++ b/docs/registro/cambios/2026-04-20-fix-celiaquia-documentos-obligatorios-envio.md
@@ -1,0 +1,51 @@
+# Fix Celiaquia: documentos obligatorios para confirmar envio
+
+## Problema
+
+En Celiaquia, el flujo de confirmacion de envio del expediente seguia usando la validacion legacy de `archivo2` y `archivo3` para decidir si un legajo tenia la documentacion completa.
+
+Eso dejaba pasar un caso incorrecto:
+
+- `beneficiario_y_responsable` requiere `archivo1`, `archivo2` y `archivo3`
+- la confirmacion del expediente solo miraba `archivo2` y `archivo3`
+- una provincia podia avanzar con un legajo incompleto
+
+## Decision
+
+Se centralizo la regla de "documentacion completa" en `LegajoService`, reutilizando `get_archivos_requeridos_por_legajo(...)` como fuente de verdad para:
+
+- calcular faltantes por legajo
+- recalcular `archivos_ok`
+- validar si todos los legajos del expediente estan completos
+- bloquear la confirmacion del envio cuando falta al menos un documento obligatorio segun el tipo de ciudadano
+
+## Cambio implementado
+
+- `celiaquia/services/legajo_service/impl.py`
+  - agrega helpers para obtener faltantes reales por legajo
+  - deja de asumir que siempre alcanza con `archivo2` y `archivo3`
+- `celiaquia/services/expediente_service/impl.py`
+  - recalcula `archivos_ok` con la regla por tipo de ciudadano antes de confirmar envio
+- `celiaquia/views/confirm_envio.py`
+  - usa faltantes dinamicos para devolver error de negocio consistente
+- `celiaquia/views/expediente.py`
+  - alinea `faltan_archivos` con la misma regla centralizada
+- `celiaquia/models.py`
+  - evita que el `save()` del legajo vuelva a pisar `archivos_ok` con la regla vieja
+
+## Validacion
+
+Se ejecuto:
+
+```powershell
+$env:USE_SQLITE_FOR_TESTS='1'
+& 'C:\Users\Juanito\Desktop\Repos-Codex\worktrees\bulk-credentials-mail-fallback-user-email\.venv\Scripts\python.exe' -m pytest tests/test_legajo_service_unit.py tests/test_expediente_service_unit.py celiaquia/tests/test_validation_errors.py tests/test_celiaquia_expediente_view_helpers_unit.py -q
+```
+
+Resultado:
+
+- `47 passed`
+
+## Supuesto explicitado
+
+Se mantuvo como fuente de verdad el esquema actual basado en `archivo1`/`archivo2`/`archivo3` para este flujo de confirmacion. No se cambio el sistema normalizado de `DocumentoLegajo` ni otros flujos fuera del alcance del envio del expediente.

--- a/tests/test_expediente_service_unit.py
+++ b/tests/test_expediente_service_unit.py
@@ -86,6 +86,22 @@ class _LegajosQS:
     def count(self):
         return len(self._legs)
 
+    def select_related(self, *args, **kwargs):
+        return self
+
+    def values_list(self, *args, **kwargs):
+        return [leg.ciudadano_id for leg in self._legs]
+
+    def filter(self, **kwargs):
+        if kwargs == {"archivos_ok": False}:
+            return SimpleNamespace(
+                exists=lambda: any(not leg.archivos_ok for leg in self._legs)
+            )
+        raise AssertionError(f"Filtro no esperado: {kwargs}")
+
+    def iterator(self):
+        return iter(self._legs)
+
 
 def test_confirmar_envio_paths(mocker):
     exp_bad = SimpleNamespace(estado=SimpleNamespace(nombre="CREADO"))
@@ -120,6 +136,34 @@ def test_confirmar_envio_paths(mocker):
     out = module.ExpedienteService.confirmar_envio(exp, usuario="u")
     assert out == {"validos": 2, "errores": 0}
     assert set_estado.called
+
+
+def test_confirmar_envio_rechaza_doble_rol_sin_archivo1(mocker):
+    leg = SimpleNamespace(
+        pk=12,
+        rol="beneficiario_y_responsable",
+        archivo1=None,
+        archivo2=object(),
+        archivo3=object(),
+        archivos_ok=False,
+        ciudadano=SimpleNamespace(id=4, documento="400", fecha_nacimiento=None),
+        ciudadano_id=4,
+        save=mocker.Mock(),
+    )
+    exp = SimpleNamespace(
+        pk=13,
+        estado=SimpleNamespace(nombre="EN_ESPERA"),
+        expediente_ciudadanos=_LegajosQS([leg]),
+    )
+    mocker.patch(
+        "celiaquia.services.legajo_service.FamiliaService.obtener_ids_responsables",
+        return_value={4},
+    )
+
+    with pytest.raises(ValidationError):
+        module.ExpedienteService.confirmar_envio(exp, usuario="u")
+
+    assert leg.archivos_ok is False
 
 
 def test_asignar_tecnico_with_id_and_user(mocker):

--- a/tests/test_legajo_service_unit.py
+++ b/tests/test_legajo_service_unit.py
@@ -250,6 +250,52 @@ def test_archivos_requeridos_respeta_flag_es_doble_rol():
     assert out["archivo3"] == "Certificacion de ANSES"
 
 
+def test_faltantes_archivos_incluye_archivo1_para_doble_rol(mocker):
+    class Leg:
+        def __init__(self):
+            self.id = 15
+            self.pk = 15
+            self.archivo1 = None
+            self.archivo2 = object()
+            self.archivo3 = object()
+            self.rol = module.ExpedienteCiudadano.ROLE_BENEFICIARIO_Y_RESPONSABLE
+            self.ciudadano = SimpleNamespace(
+                id=3, documento="300", nombre="Ana", apellido="Perez"
+            )
+            self.ciudadano_id = 3
+            self.estado = SimpleNamespace(nombre="E")
+            self.revision_tecnico = "R"
+            self.archivos_ok = True
+
+    class Qs:
+        def select_related(self, *args, **kwargs):
+            return self
+
+        def only(self, *args, **kwargs):
+            return self
+
+        def filter(self, *args, **kwargs):
+            return self
+
+        def values_list(self, *args, **kwargs):
+            return [3]
+
+        def iterator(self):
+            return iter([Leg()])
+
+    exp = SimpleNamespace(id=2, expediente_ciudadanos=Qs())
+    mocker.patch(
+        "celiaquia.services.legajo_service.FamiliaService.obtener_ids_responsables",
+        return_value={3},
+    )
+
+    out = module.LegajoService.faltantes_archivos(exp)
+
+    assert len(out) == 1
+    assert out[0]["faltan"] == ["archivo1"]
+    assert out[0]["faltan_nombres"] == ["Biopsia / Constancia medica"]
+
+
 def test_actualizar_subsanacion_warning_and_estado_cache_missing(mocker):
     class Missing(Exception):
         pass


### PR DESCRIPTION
why: la confirmacion del expediente seguia validando solo archivo2 y archivo3, por lo que un legajo beneficiario_y_responsable podia enviarse sin archivo1.

what:
- centraliza la regla de archivos requeridos por tipo de ciudadano en LegajoService
- recalcula archivos_ok con la regla correcta antes de confirmar envio
- bloquea la vista de confirmacion cuando faltan documentos obligatorios segun el rol
- agrega regresiones de servicios y vista

tests: USE_SQLITE_FOR_TESTS=1 pytest tests/test_legajo_service_unit.py tests/test_expediente_service_unit.py celiaquia/tests/test_validation_errors.py tests/test_celiaquia_expediente_view_helpers_unit.py -q

# Información de la Tarea
Vincular el #ISSUE

### **Resumen de la Solución:** 
-

### **Información Adicional:**
-

# Descripción de los Cambios

### **Cambios:**
-

# Cómo Testear los Cambios

### **Pruebas Automáticas:**
-

### **Prubeas Manuales:**
-

# Metadata para documentación automática

- Contexto funcional:
- Tipo de cambio:
- Área principal:
- Resumen para changelog:
- Impacto usuario:
- Riesgos / rollback:

# Capturas de Pantalla
