### PR TITLE
fix(celiaquia): integrar PRs 1580, 1584 y 1587

### DIFF
--- a/celiaquia/models.py
+++ b/celiaquia/models.py
@@ -280,21 +280,11 @@ class ExpedienteCiudadano(SoftDeleteModelMixin, models.Model):
     def _recompute_archivos_ok(self):
         """Calcula archivos_ok basado en documentos requeridos."""
         # Usar nuevo sistema si está disponible
-        if hasattr(self, "documentos"):
-            try:
-                tipos_requeridos = TipoDocumento.objects.filter(
-                    requerido=True, activo=True
-                ).count()
-                documentos_cargados = self.documentos.filter(
-                    tipo_documento__requerido=True, tipo_documento__activo=True
-                ).count()
-                self.archivos_ok = documentos_cargados >= tipos_requeridos
-            except:
-                # Fallback al sistema anterior
-                self.archivos_ok = bool(self.archivo2 and self.archivo3)
-        else:
-            # Sistema anterior
-            self.archivos_ok = bool(self.archivo2 and self.archivo3)
+        from .services.legajo_service import (  # pylint: disable=import-outside-toplevel
+            LegajoService,
+        )
+
+        self.archivos_ok = LegajoService.tiene_archivos_requeridos(self)
 
     def save(self, *args, **kwargs):
         self._recompute_archivos_ok()
@@ -360,19 +350,21 @@ class ExpedienteCiudadano(SoftDeleteModelMixin, models.Model):
     @property
     def documentos_completos(self):
         """Verifica si tiene todos los documentos requeridos."""
-        tipos_requeridos = TipoDocumento.objects.filter(
-            requerido=True, activo=True
-        ).count()
-        documentos_cargados = self.documentos.filter(
-            tipo_documento__requerido=True, tipo_documento__activo=True
-        ).count()
-        return tipos_requeridos == documentos_cargados
+        from .services.legajo_service import (  # pylint: disable=import-outside-toplevel
+            LegajoService,
+        )
+
+        return LegajoService.tiene_archivos_requeridos(self)
 
     def documentos_faltantes(self):
         """Lista los tipos de documentos faltantes."""
-        tipos_requeridos = TipoDocumento.objects.filter(requerido=True, activo=True)
-        tipos_cargados = self.documentos.values_list("tipo_documento_id", flat=True)
-        return tipos_requeridos.exclude(id__in=tipos_cargados)
+        from .services.legajo_service import (  # pylint: disable=import-outside-toplevel
+            LegajoService,
+        )
+
+        campos_faltantes = LegajoService.campos_archivos_faltantes(self)
+        archivos_requeridos = LegajoService.get_archivos_requeridos_por_legajo(self)
+        return [archivos_requeridos[campo] for campo in campos_faltantes]
 
 
 class AsignacionTecnico(SoftDeleteModelMixin, models.Model):

--- a/celiaquia/services/expediente_service/impl.py
+++ b/celiaquia/services/expediente_service/impl.py
@@ -90,14 +90,23 @@ class ExpedienteService:
                 f"El expediente no está en estado EN_ESPERA. Estado actual: {expediente.estado.nombre}"
             )
 
-        for leg in expediente.expediente_ciudadanos.all():
+        legajos_qs = expediente.expediente_ciudadanos
+        if hasattr(legajos_qs, "select_related"):
+            legajos_qs = legajos_qs.select_related("ciudadano")
+
+        responsables_ids = LegajoService.obtener_ids_responsables_expediente(
+            expediente, legajos_qs
+        )
+        for leg in legajos_qs.all():
             if hasattr(leg, "archivos_ok"):
-                leg.archivos_ok = bool(leg.archivo2 and leg.archivo3)
+                leg.archivos_ok = LegajoService.tiene_archivos_requeridos(
+                    leg, responsables_ids
+                )
                 leg.save(update_fields=["archivos_ok"])
 
         if not LegajoService.all_legajos_loaded(expediente):
             raise ValidationError(
-                "Debes subir un archivo para cada legajo antes de confirmar."
+                "Debes subir toda la documentacion obligatoria de cada legajo antes de confirmar."
             )
 
         _set_estado(expediente, "CONFIRMACION_DE_ENVIO", usuario)

--- a/celiaquia/services/importacion_service/impl.py
+++ b/celiaquia/services/importacion_service/impl.py
@@ -2578,4 +2578,3 @@ class ImportacionService:
                 extra={"expediente_id": expediente.id, "archivo": archivo_excel.name},
             )
             raise
-

--- a/celiaquia/services/legajo_service/__init__.py
+++ b/celiaquia/services/legajo_service/__init__.py
@@ -2,6 +2,9 @@
 
 import sys as _sys
 
+from .impl import LegajoService
 from . import impl as _impl
+
+__all__ = ["LegajoService"]
 
 _sys.modules[__name__] = _impl

--- a/celiaquia/services/legajo_service/impl.py
+++ b/celiaquia/services/legajo_service/impl.py
@@ -19,6 +19,14 @@ from celiaquia.services.familia_service import (
 logger = logging.getLogger("django")
 
 
+def _iter_legajos(qs):
+    if hasattr(qs, "iterator"):
+        return qs.iterator()
+    if hasattr(qs, "all"):
+        return iter(qs.all())
+    return iter(qs)
+
+
 @lru_cache(maxsize=1)
 def _estado_archivo_cargado_id():
     try:
@@ -34,15 +42,66 @@ def _set_estado_archivo_cargado(obj, update_fields):
         update_fields.append("estado")
 
 
-def _recalc_archivos_ok(obj, update_fields):
+def _recalc_archivos_ok(obj, update_fields, responsables_ids=None):
     if hasattr(obj, "archivos_ok"):
-        val = bool(obj.archivo2 and obj.archivo3)
+        val = LegajoService.tiene_archivos_requeridos(obj, responsables_ids)
         if obj.archivos_ok != val:
             obj.archivos_ok = val
             update_fields.append("archivos_ok")
 
 
 class LegajoService:
+    @staticmethod
+    def obtener_ids_responsables_expediente(expediente, qs=None):
+        if qs is None:
+            qs = expediente.expediente_ciudadanos
+
+        ciudadanos_ids = []
+        if hasattr(qs, "values_list"):
+            try:
+                ciudadanos_ids = list(qs.values_list("ciudadano_id", flat=True))
+            except Exception:
+                ciudadanos_ids = []
+        if not ciudadanos_ids and (hasattr(qs, "iterator") or hasattr(qs, "all")):
+            ciudadanos_ids = [
+                getattr(legajo, "ciudadano_id", None)
+                for legajo in _iter_legajos(qs)
+                if getattr(legajo, "ciudadano_id", None) is not None
+            ]
+
+        if not ciudadanos_ids:
+            return set()
+
+        try:
+            return FamiliaService.obtener_ids_responsables(ciudadanos_ids)
+        except Exception as exc:
+            logger.warning(
+                "No se pudo determinar responsables en expediente %s: %s",
+                getattr(expediente, "id", None),
+                exc,
+            )
+            return set()
+
+    @staticmethod
+    def campos_archivos_faltantes(legajo, responsables_ids=None):
+        if not hasattr(legajo, "ciudadano") and not hasattr(legajo, "ciudadano_id"):
+            return [
+                campo
+                for campo in ("archivo2", "archivo3")
+                if not getattr(legajo, campo, None)
+            ]
+
+        archivos_requeridos = LegajoService.get_archivos_requeridos_por_legajo(
+            legajo, responsables_ids
+        )
+        return [
+            campo for campo in archivos_requeridos if not getattr(legajo, campo, None)
+        ]
+
+    @staticmethod
+    def tiene_archivos_requeridos(legajo, responsables_ids=None):
+        return not LegajoService.campos_archivos_faltantes(legajo, responsables_ids)
+
     @staticmethod
     def listar_legajos(expediente):
         return expediente.expediente_ciudadanos.select_related(
@@ -189,12 +248,24 @@ class LegajoService:
     @staticmethod
     def all_legajos_loaded(expediente) -> bool:
         qs = expediente.expediente_ciudadanos
-        if hasattr(ExpedienteCiudadano, "archivos_ok"):
-            return not qs.filter(archivos_ok=False).exists()
-        return (
-            not qs.filter(archivo2__isnull=True).exists()
-            and not qs.filter(archivo3__isnull=True).exists()
+        if hasattr(qs, "select_related"):
+            qs = qs.select_related("ciudadano")
+
+        if not hasattr(qs, "iterator") and not hasattr(qs, "all"):
+            if hasattr(ExpedienteCiudadano, "archivos_ok") and hasattr(qs, "filter"):
+                return not qs.filter(archivos_ok=False).exists()
+            return (
+                not qs.filter(archivo2__isnull=True).exists()
+                and not qs.filter(archivo3__isnull=True).exists()
+            )
+
+        responsables_ids = LegajoService.obtener_ids_responsables_expediente(
+            expediente, qs
         )
+        for legajo in _iter_legajos(qs):
+            if not LegajoService.tiene_archivos_requeridos(legajo, responsables_ids):
+                return False
+        return True
 
     @staticmethod
     def faltantes_archivos(
@@ -208,43 +279,31 @@ class LegajoService:
         if friendly_names is None:
             friendly_names = {}
 
-        qs = expediente.expediente_ciudadanos.select_related(
-            "ciudadano", "estado"
-        ).only(
-            "id",
-            "archivo1",
-            "archivo2",
-            "archivo3",
-            "revision_tecnico",
-            "estado_id",
-            "ciudadano__documento",
-            "ciudadano__nombre",
-            "ciudadano__apellido",
-        )
-        if hasattr(ExpedienteCiudadano, "archivos_ok"):
-            qs = qs.filter(archivos_ok=False)
+        qs = expediente.expediente_ciudadanos
+        if hasattr(qs, "select_related"):
+            qs = qs.select_related("ciudadano", "estado")
+        if hasattr(qs, "only"):
+            qs = qs.only(
+                "id",
+                "archivo1",
+                "archivo2",
+                "archivo3",
+                "revision_tecnico",
+                "estado_id",
+                "rol",
+                "ciudadano__documento",
+                "ciudadano__nombre",
+                "ciudadano__apellido",
+                "ciudadano__fecha_nacimiento",
+            )
 
-        ciudadanos_ids = list(qs.values_list("ciudadano_id", flat=True))
-        responsables_ids = set()
-        if ciudadanos_ids:
-            try:
-                responsables_ids = FamiliaService.obtener_ids_responsables(
-                    ciudadanos_ids
-                )
-            except Exception as exc:
-                logger.warning(
-                    "No se pudo determinar responsables en expediente %s: %s",
-                    expediente.id,
-                    exc,
-                )
+        responsables_ids = LegajoService.obtener_ids_responsables_expediente(
+            expediente, qs
+        )
 
         faltantes = []
-        for leg in qs.iterator():
-            miss = []
-            if not leg.archivo2:
-                miss.append("archivo2")
-            if not leg.archivo3:
-                miss.append("archivo3")
+        for leg in _iter_legajos(qs):
+            miss = LegajoService.campos_archivos_faltantes(leg, responsables_ids)
 
             if miss:
                 es_responsable = LegajoService._es_responsable(
@@ -297,8 +356,11 @@ class LegajoService:
             rol_legajo == ExpedienteCiudadano.ROLE_BENEFICIARIO_Y_RESPONSABLE
         )
 
-        es_responsable = LegajoService._es_responsable(
-            legajo.ciudadano, responsables_ids
+        ciudadano = getattr(legajo, "ciudadano", getattr(legajo, "ciudadano_id", None))
+        es_responsable = (
+            LegajoService._es_responsable(ciudadano, responsables_ids)
+            if ciudadano is not None
+            else False
         )
 
         # Caso especial: Doble rol (beneficiario Y responsable)

--- a/celiaquia/services/legajo_service/impl.py
+++ b/celiaquia/services/legajo_service/impl.py
@@ -1,5 +1,5 @@
 import logging
-from datetime import date
+from datetime import date, datetime
 from functools import lru_cache
 from django.db import transaction
 from django.core.exceptions import ValidationError
@@ -48,6 +48,19 @@ def _recalc_archivos_ok(obj, update_fields, responsables_ids=None):
         if obj.archivos_ok != val:
             obj.archivos_ok = val
             update_fields.append("archivos_ok")
+
+
+def _normalizar_fecha_nacimiento(valor):
+    if isinstance(valor, datetime):
+        return valor.date()
+    if isinstance(valor, date):
+        return valor
+    if isinstance(valor, str):
+        try:
+            return date.fromisoformat(valor)
+        except ValueError:
+            return None
+    return None
 
 
 class LegajoService:
@@ -383,15 +396,15 @@ class LegajoService:
         # Calcular edad para beneficiarios
         # Por defecto asumir mayor de edad si no hay fecha_nacimiento
         es_menor = False
-        if (
-            hasattr(legajo.ciudadano, "fecha_nacimiento")
-            and legajo.ciudadano.fecha_nacimiento
-        ):
+        fecha_nacimiento = _normalizar_fecha_nacimiento(
+            getattr(legajo.ciudadano, "fecha_nacimiento", None)
+        )
+        if fecha_nacimiento:
             today = date.today()
-            edad = today.year - legajo.ciudadano.fecha_nacimiento.year
-            if today.month < legajo.ciudadano.fecha_nacimiento.month or (
-                today.month == legajo.ciudadano.fecha_nacimiento.month
-                and today.day < legajo.ciudadano.fecha_nacimiento.day
+            edad = today.year - fecha_nacimiento.year
+            if today.month < fecha_nacimiento.month or (
+                today.month == fecha_nacimiento.month
+                and today.day < fecha_nacimiento.day
             ):
                 edad -= 1
             es_menor = edad < 18
@@ -399,7 +412,7 @@ class LegajoService:
                 "Legajo %s - DNI: %s, Fecha nacimiento: %s, Edad calculada: %s, Es menor: %s",
                 legajo.pk,
                 legajo.ciudadano.documento,
-                legajo.ciudadano.fecha_nacimiento,
+                fecha_nacimiento,
                 edad,
                 es_menor,
             )

--- a/celiaquia/templates/celiaquia/expediente_detail.html
+++ b/celiaquia/templates/celiaquia/expediente_detail.html
@@ -1139,6 +1139,7 @@
                                                     <input type="text"
                                                            class="form-control{% if 'apellido_responsable' in registro.invalid_fields %} field-error-soft{% endif %}"
                                                            name="apellido_responsable"
+                                                           {% if registro.responsable_requerido %}aria-label="Apellido Responsable *"{% endif %}
                                                            value="{{ registro.datos_raw.apellido_responsable|default:'' }}"
                                                            {% if 'apellido_responsable' in registro.invalid_fields %}aria-invalid="true"{% endif %}
                                                            {% if registro.responsable_requerido %}required{% endif %} />

--- a/celiaquia/templates/celiaquia/expediente_detail.html
+++ b/celiaquia/templates/celiaquia/expediente_detail.html
@@ -676,9 +676,7 @@
                                 <div class="col-lg-4 col-md-7">
                                     {% if is_prov %}
                                         {% if leg.observacion_tecnica_texto %}
-                                            <div class="small muted">
-                                                {{ leg.observacion_tecnica_titulo|default:"Observación técnica" }}:
-                                            </div>
+                                            <div class="small muted">{{ leg.observacion_tecnica_titulo|default:"Observación técnica" }}:</div>
                                             <div class="mt-1">
                                                 <div class="p-2 rounded"
                                                      style="background:rgba(255,255,255,.04);
@@ -687,18 +685,18 @@
                                                 </div>
                                             </div>
                                         {% else %}
-                                        <div class="small muted">Observación (subsanación):</div>
-                                        <div class="mt-1">
-                                            {% if leg.subsanacion_motivo %}
-                                                <div class="p-2 rounded"
-                                                     style="background:rgba(255,255,255,.04);
-                                                            border:1px solid rgba(255,255,255,.08)">
-                                                    <span class="d-block text-break">{{ leg.subsanacion_motivo }}</span>
-                                                </div>
-                                            {% else %}
-                                                <span class="muted">-</span>
-                                            {% endif %}
-                                        </div>
+                                            <div class="small muted">Observación (subsanación):</div>
+                                            <div class="mt-1">
+                                                {% if leg.subsanacion_motivo %}
+                                                    <div class="p-2 rounded"
+                                                         style="background:rgba(255,255,255,.04);
+                                                                border:1px solid rgba(255,255,255,.08)">
+                                                        <span class="d-block text-break">{{ leg.subsanacion_motivo }}</span>
+                                                    </div>
+                                                {% else %}
+                                                    <span class="muted">-</span>
+                                                {% endif %}
+                                            </div>
                                         {% endif %}
                                         {% if leg.subsanacion_renaper_comentario %}
                                             <div class="small muted mt-2">Respuesta provincia:</div>
@@ -890,7 +888,7 @@
                               maxlength="500"></textarea>
                 </div>
                 <small class="text-muted d-block">
-                    El legajo quedarÃ¡ en estado <strong>RECHAZADO</strong> y la provincia verÃ¡ esta observaciÃ³n.
+                    El legajo quedará en estado <strong>RECHAZADO</strong> y la provincia verá esta observación.
                 </small>
             </div>
             <div class="modal-footer">
@@ -1134,7 +1132,10 @@
                                             </h6>
                                             <div class="row g-2">
                                                 <div class="col-md-4">
-                                                    <label class="form-label">Apellido Responsable{% if registro.responsable_requerido %} *{% endif %}</label>
+                                                    <label class="form-label">
+                                                        Apellido Responsable
+                                                        {% if registro.responsable_requerido %}*{% endif %}
+                                                    </label>
                                                     <input type="text"
                                                            class="form-control{% if 'apellido_responsable' in registro.invalid_fields %} field-error-soft{% endif %}"
                                                            name="apellido_responsable"
@@ -1143,7 +1144,10 @@
                                                            {% if registro.responsable_requerido %}required{% endif %} />
                                                 </div>
                                                 <div class="col-md-4">
-                                                    <label class="form-label">Nombre Responsable{% if registro.responsable_requerido %} *{% endif %}</label>
+                                                    <label class="form-label">
+                                                        Nombre Responsable
+                                                        {% if registro.responsable_requerido %}*{% endif %}
+                                                    </label>
                                                     <input type="text"
                                                            class="form-control{% if 'nombre_responsable' in registro.invalid_fields %} field-error-soft{% endif %}"
                                                            name="nombre_responsable"
@@ -1152,7 +1156,10 @@
                                                            {% if registro.responsable_requerido %}required{% endif %} />
                                                 </div>
                                                 <div class="col-md-4">
-                                                    <label class="form-label">CUIT/Documento Responsable{% if registro.responsable_requerido %} *{% endif %}</label>
+                                                    <label class="form-label">
+                                                        CUIT/Documento Responsable
+                                                        {% if registro.responsable_requerido %}*{% endif %}
+                                                    </label>
                                                     <input type="text"
                                                            class="form-control{% if 'documento_responsable' in registro.invalid_fields %} field-error-soft{% endif %}"
                                                            name="documento_responsable"
@@ -1161,7 +1168,10 @@
                                                            {% if registro.responsable_requerido %}required{% endif %} />
                                                 </div>
                                                 <div class="col-md-4">
-                                                    <label class="form-label">Fecha Nac. Responsable{% if registro.responsable_requerido %} *{% endif %}</label>
+                                                    <label class="form-label">
+                                                        Fecha Nac. Responsable
+                                                        {% if registro.responsable_requerido %}*{% endif %}
+                                                    </label>
                                                     <input type="text"
                                                            class="form-control{% if 'fecha_nacimiento_responsable' in registro.invalid_fields %} field-error-soft{% endif %}"
                                                            name="fecha_nacimiento_responsable"
@@ -1171,7 +1181,10 @@
                                                            {% if registro.responsable_requerido %}required{% endif %} />
                                                 </div>
                                                 <div class="col-md-4">
-                                                    <label class="form-label">Sexo Responsable{% if registro.responsable_requerido %} *{% endif %}</label>
+                                                    <label class="form-label">
+                                                        Sexo Responsable
+                                                        {% if registro.responsable_requerido %}*{% endif %}
+                                                    </label>
                                                     <select class="form-select{% if 'sexo_responsable' in registro.invalid_fields %} field-error-soft{% endif %}"
                                                             name="sexo_responsable"
                                                             {% if 'sexo_responsable' in registro.invalid_fields %}aria-invalid="true"{% endif %}
@@ -1202,7 +1215,10 @@
                                                            {% if 'email_responsable' in registro.invalid_fields %}aria-invalid="true"{% endif %} />
                                                 </div>
                                                 <div class="col-md-6">
-                                                    <label class="form-label">Domicilio Responsable{% if registro.responsable_requerido %} *{% endif %}</label>
+                                                    <label class="form-label">
+                                                        Domicilio Responsable
+                                                        {% if registro.responsable_requerido %}*{% endif %}
+                                                    </label>
                                                     <input type="text"
                                                            class="form-control{% if 'domicilio_responsable' in registro.invalid_fields %} field-error-soft{% endif %}"
                                                            name="domicilio_responsable"
@@ -1211,7 +1227,10 @@
                                                            {% if registro.responsable_requerido %}required{% endif %} />
                                                 </div>
                                                 <div class="col-md-6">
-                                                    <label class="form-label">Localidad Responsable{% if registro.responsable_requerido %} *{% endif %}</label>
+                                                    <label class="form-label">
+                                                        Localidad Responsable
+                                                        {% if registro.responsable_requerido %}*{% endif %}
+                                                    </label>
                                                     <select class="form-select{% if 'localidad_responsable' in registro.invalid_fields %} field-error-soft{% endif %}"
                                                             name="localidad_responsable"
                                                             {% if 'localidad_responsable' in registro.invalid_fields %}aria-invalid="true"{% endif %}
@@ -1946,5 +1965,3 @@
     <script src="{% static 'custom/js/pagination_fix.js' %}"></script>
     <script src="{% static 'custom/js/legajo_comentarios.js' %}"></script>
 {% endblock %}
-
-

--- a/celiaquia/templates/celiaquia/expediente_detail.html
+++ b/celiaquia/templates/celiaquia/expediente_detail.html
@@ -626,9 +626,12 @@
                                                                         Subsanar
                                                                     </button>
                                                                     <button type="button"
-                                                                            class="btn {% if estado == 'RECHAZADO' %}btn-danger active{% else %}btn-outline-danger{% endif %} btn-revision"
+                                                                            class="btn {% if estado == 'RECHAZADO' %}btn-danger active{% else %}btn-outline-danger{% endif %} btn-rechazar"
                                                                             data-legajo-id="{{ leg.pk }}"
-                                                                            data-accion="RECHAZAR">Rechazar</button>
+                                                                            data-bs-toggle="modal"
+                                                                            data-bs-target="#modalRechazar">
+                                                                        Rechazar
+                                                                    </button>
                                                                 </div>
                                                             {% endwith %}
                                                         </div>
@@ -672,6 +675,18 @@
                                 <!-- Col 2: Observaciones -->
                                 <div class="col-lg-4 col-md-7">
                                     {% if is_prov %}
+                                        {% if leg.observacion_tecnica_texto %}
+                                            <div class="small muted">
+                                                {{ leg.observacion_tecnica_titulo|default:"Observación técnica" }}:
+                                            </div>
+                                            <div class="mt-1">
+                                                <div class="p-2 rounded"
+                                                     style="background:rgba(255,255,255,.04);
+                                                            border:1px solid rgba(255,255,255,.08)">
+                                                    <span class="d-block text-break">{{ leg.observacion_tecnica_texto }}</span>
+                                                </div>
+                                            </div>
+                                        {% else %}
                                         <div class="small muted">Observación (subsanación):</div>
                                         <div class="mt-1">
                                             {% if leg.subsanacion_motivo %}
@@ -684,6 +699,7 @@
                                                 <span class="muted">-</span>
                                             {% endif %}
                                         </div>
+                                        {% endif %}
                                         {% if leg.subsanacion_renaper_comentario %}
                                             <div class="small muted mt-2">Respuesta provincia:</div>
                                             <div class="mt-1">
@@ -808,9 +824,10 @@
                                                             data-bs-toggle="modal"
                                                             data-bs-target="#modalSubsanar">Subsanar</button>
                                                     <button type="button"
-                                                            class="btn {% if estado == 'RECHAZADO' %}btn-danger active{% else %}btn-outline-danger{% endif %} btn-revision"
+                                                            class="btn {% if estado == 'RECHAZADO' %}btn-danger active{% else %}btn-outline-danger{% endif %} btn-rechazar"
                                                             data-legajo-id="{{ leg.pk }}"
-                                                            data-accion="RECHAZAR">Rechazar</button>
+                                                            data-bs-toggle="modal"
+                                                            data-bs-target="#modalRechazar">Rechazar</button>
                                                 </div>
                                             {% endwith %}
                                         </div>
@@ -844,6 +861,46 @@
 </div>
 
 <!-- Registros Erróneos -->
+<!-- Modal: rechazar legajo -->
+<div class="modal fade"
+     id="modalRechazar"
+     tabindex="-1"
+     aria-labelledby="modalRechazarLabel"
+     aria-hidden="true">
+    <div class="modal-dialog">
+        <form class="modal-content" id="form-rechazar" method="post">
+            {% csrf_token %}
+            <div class="modal-header">
+                <h5 class="modal-title" id="modalRechazarLabel">Motivo del Rechazo</h5>
+                <button type="button"
+                        class="btn-close"
+                        data-bs-dismiss="modal"
+                        aria-label="Cerrar"></button>
+            </div>
+            <div class="modal-body">
+                <input type="hidden" name="accion" value="RECHAZAR" />
+                <input type="hidden" id="rechazar-legajo-id" name="legajo_id" value="" />
+                <div class="mb-2">
+                    <label for="rechazar-motivo" class="form-label">Motivo del Rechazo *</label>
+                    <textarea id="rechazar-motivo"
+                              name="motivo"
+                              class="form-control"
+                              rows="3"
+                              required
+                              maxlength="500"></textarea>
+                </div>
+                <small class="text-muted d-block">
+                    El legajo quedarÃ¡ en estado <strong>RECHAZADO</strong> y la provincia verÃ¡ esta observaciÃ³n.
+                </small>
+            </div>
+            <div class="modal-footer">
+                <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Cancelar</button>
+                <button type="submit" class="btn btn-danger" id="btn-confirm-rechazar">Confirmar</button>
+            </div>
+        </form>
+    </div>
+</div>
+
 {% if registros_erroneos %}
     <div class="p-3 rounded shadow mb-4 registros-erroneos-section"
          style="background-color: #1c2a3a;

--- a/celiaquia/tests/test_expediente_detail.py
+++ b/celiaquia/tests/test_expediente_detail.py
@@ -11,8 +11,12 @@ from celiaquia.models import (
     EstadoLegajo,
     Expediente,
     ExpedienteCiudadano,
+    HistorialValidacionTecnica,
+    RevisionTecnico,
 )
+from core.models import Provincia
 from ciudadanos.models import Ciudadano, GrupoFamiliar
+from users.models import Profile
 
 
 @pytest.mark.django_db
@@ -130,3 +134,54 @@ def test_expediente_detail_ordena_grupo_familiar_independiente_del_orden_de_carg
     assert response.status_code == 200
     legajos_ids = [item.pk for item in response.context["legajos_enriquecidos"]]
     assert legajos_ids == [legajo_abuelo.pk, legajo_padre.pk, legajo_hijo.pk]
+
+
+@pytest.mark.django_db
+def test_expediente_detail_expone_motivo_rechazo_para_provincia(client):
+    provincia = Provincia.objects.create(nombre="Buenos Aires")
+    user = User.objects.create_user(username="prov_rechazo", password="pass")
+    permission = Permission.objects.get(
+        content_type__app_label="celiaquia",
+        codename="view_expediente",
+    )
+    user.user_permissions.add(permission)
+    profile, _ = Profile.objects.get_or_create(user=user)
+    profile.es_usuario_provincial = True
+    profile.provincia = provincia
+    profile.save()
+
+    estado_expediente = EstadoExpediente.objects.create(nombre="EN_ESPERA")
+    estado_legajo = EstadoLegajo.objects.create(nombre="DOCUMENTO_PENDIENTE_3")
+    expediente = Expediente.objects.create(
+        usuario_provincia=user,
+        estado=estado_expediente,
+    )
+    ciudadano = Ciudadano.objects.create(
+        apellido="Perez",
+        nombre="Lucia",
+        fecha_nacimiento=date(2005, 5, 1),
+        documento=33444555,
+    )
+    legajo = ExpedienteCiudadano.objects.create(
+        expediente=expediente,
+        ciudadano=ciudadano,
+        estado=estado_legajo,
+        revision_tecnico=RevisionTecnico.RECHAZADO,
+    )
+    HistorialValidacionTecnica.objects.create(
+        legajo=legajo,
+        estado_anterior=RevisionTecnico.PENDIENTE,
+        estado_nuevo=RevisionTecnico.RECHAZADO,
+        usuario=user,
+        motivo="Documento ilegible",
+    )
+
+    client.force_login(user)
+    response = client.get(reverse("expediente_detail", args=[expediente.pk]))
+
+    assert response.status_code == 200
+    legajo_ctx = response.context["legajos_enriquecidos"][0]
+    assert legajo_ctx.observacion_tecnica_titulo == "Motivo del Rechazo"
+    assert legajo_ctx.observacion_tecnica_texto == "Documento ilegible"
+    assert "Motivo del Rechazo" in response.content.decode()
+    assert "Documento ilegible" in response.content.decode()

--- a/celiaquia/tests/test_legajo_editar.py
+++ b/celiaquia/tests/test_legajo_editar.py
@@ -84,7 +84,9 @@ def test_legajo_editar_convierte_altura_y_telefono_vacios_en_none(client):
 
 
 @pytest.mark.django_db
-def test_legajo_editar_get_devuelve_nacionalidad_actual_y_municipio_desde_localidad(client):
+def test_legajo_editar_get_devuelve_nacionalidad_actual_y_municipio_desde_localidad(
+    client,
+):
     user = User.objects.create_superuser(
         username="tecnico_get",
         email="tecnico_get@example.com",
@@ -130,7 +132,9 @@ def test_legajo_editar_get_devuelve_nacionalidad_actual_y_municipio_desde_locali
 
 
 @pytest.mark.django_db
-def test_legajo_editar_actualiza_nacionalidad_elegida_y_municipio_desde_localidad(client):
+def test_legajo_editar_actualiza_nacionalidad_elegida_y_municipio_desde_localidad(
+    client,
+):
     user = User.objects.create_superuser(
         username="tecnico_defaults",
         email="tecnico_defaults@example.com",

--- a/celiaquia/tests/test_registros_erroneos_obligatorios.py
+++ b/celiaquia/tests/test_registros_erroneos_obligatorios.py
@@ -325,7 +325,7 @@ def test_detalle_expediente_muestra_nacionalidad_editable_y_autocompleta_municip
     content = response.content.decode()
     form_pattern = (
         rf'<form[^>]+class="form-editar-error"[^>]+data-registro-id="{registro.pk}"'
-        rf'.*?</form>'
+        rf".*?</form>"
     )
     form_match = re.search(form_pattern, content, flags=re.DOTALL)
 
@@ -343,11 +343,14 @@ def test_detalle_expediente_muestra_nacionalidad_editable_y_autocompleta_municip
     )
     assert nacionalidad_select is not None
     assert municipio_select is not None
-    assert re.search(
-        rf'option value="{argentina.pk}"\s+selected',
-        nacionalidad_select.group(0),
-        flags=re.DOTALL,
-    ) is None
+    assert (
+        re.search(
+            rf'option value="{argentina.pk}"\s+selected',
+            nacionalidad_select.group(0),
+            flags=re.DOTALL,
+        )
+        is None
+    )
     assert re.search(
         rf'option value="{municipio.pk}"\s+selected',
         municipio_select.group(0),
@@ -414,7 +417,7 @@ def test_detalle_expediente_no_autoselecciona_nacionalidad_invalida_o_vacia(clie
     for registro in (registro_invalido, registro_vacio):
         form_pattern = (
             rf'<form[^>]+class="form-editar-error"[^>]+data-registro-id="{registro.pk}"'
-            rf'.*?</form>'
+            rf".*?</form>"
         )
         form_match = re.search(form_pattern, content, flags=re.DOTALL)
         assert form_match is not None
@@ -425,11 +428,14 @@ def test_detalle_expediente_no_autoselecciona_nacionalidad_invalida_o_vacia(clie
             flags=re.DOTALL,
         )
         assert nacionalidad_select is not None
-        assert re.search(
-            rf'option value="{argentina.pk}"\s+selected',
-            nacionalidad_select.group(0),
-            flags=re.DOTALL,
-        ) is None
+        assert (
+            re.search(
+                rf'option value="{argentina.pk}"\s+selected',
+                nacionalidad_select.group(0),
+                flags=re.DOTALL,
+            )
+            is None
+        )
 
 
 @pytest.mark.django_db
@@ -712,7 +718,9 @@ def test_actualizar_registro_erroneo_permite_mayor_con_responsable_incompleto(cl
 
 
 @pytest.mark.django_db
-def test_actualizar_registro_erroneo_conserva_nacionalidad_elegida_y_corrige_municipio_por_localidad(client):
+def test_actualizar_registro_erroneo_conserva_nacionalidad_elegida_y_corrige_municipio_por_localidad(
+    client,
+):
     user, provincia = _crear_usuario_provincial("prov_update_defaults")
     user.is_superuser = True
     user.save(update_fields=["is_superuser"])

--- a/celiaquia/tests/test_validation_errors.py
+++ b/celiaquia/tests/test_validation_errors.py
@@ -38,11 +38,6 @@ def test_confirm_envio_validation_error_returns_validation_message():
         {"pk": 1, "usuario_provincia": object(), "estado": dummy_estado},
     )()
 
-    dummy_qs = MagicMock()
-    dummy_qs.select_related.return_value = dummy_qs
-    dummy_qs.filter.return_value = dummy_qs
-    dummy_qs.exists.return_value = False
-
     dummy_err_qs = MagicMock()
     dummy_err_qs.filter.return_value = dummy_err_qs
     dummy_err_qs.exists.return_value = False
@@ -51,8 +46,11 @@ def test_confirm_envio_validation_error_returns_validation_message():
         patch(
             "celiaquia.views.confirm_envio.get_object_or_404", return_value=dummy_exp
         ),
-        patch("celiaquia.views.confirm_envio.ExpedienteCiudadano.objects", dummy_qs),
         patch("celiaquia.views.confirm_envio.RegistroErroneo.objects", dummy_err_qs),
+        patch(
+            "celiaquia.views.confirm_envio.LegajoService.faltantes_archivos",
+            return_value=[],
+        ),
         patch(
             "celiaquia.views.confirm_envio.ExpedienteService.confirmar_envio",
             side_effect=ValidationError("err"),
@@ -62,6 +60,56 @@ def test_confirm_envio_validation_error_returns_validation_message():
 
     assert response.status_code == 400
     assert json.loads(response.content) == {"success": False, "error": "err"}
+
+
+def test_confirm_envio_rechaza_faltantes_dinamicos_por_tipo_de_ciudadano():
+    request = factory.post("/expediente/1/confirm/")
+    request.user = DummyUser()
+    request._dont_enforce_csrf_checks = True
+
+    dummy_estado = type("Estado", (), {"nombre": "EN_ESPERA"})()
+    dummy_exp = type(
+        "Exp",
+        (),
+        {"pk": 1, "usuario_provincia": object(), "estado": dummy_estado},
+    )()
+
+    dummy_err_qs = MagicMock()
+    dummy_err_qs.filter.return_value = dummy_err_qs
+    dummy_err_qs.exists.return_value = False
+
+    faltantes = [
+        {
+            "legajo_id": 7,
+            "apellido": "Perez",
+            "nombre": "Ana",
+            "documento": "123",
+            "faltan_nombres": ["Biopsia / Constancia medica"],
+        }
+    ]
+
+    with (
+        patch(
+            "celiaquia.views.confirm_envio.get_object_or_404", return_value=dummy_exp
+        ),
+        patch("celiaquia.views.confirm_envio.RegistroErroneo.objects", dummy_err_qs),
+        patch(
+            "celiaquia.views.confirm_envio.LegajoService.faltantes_archivos",
+            return_value=faltantes,
+        ),
+        patch("celiaquia.views.confirm_envio._is_ajax", return_value=True),
+        patch(
+            "celiaquia.views.confirm_envio.ExpedienteService.confirmar_envio"
+        ) as confirm,
+    ):
+        response = ExpedienteConfirmView.as_view()(request, pk=1)
+
+    payload = json.loads(response.content)
+    assert response.status_code == 400
+    assert payload["success"] is False
+    assert payload["faltantes_ids"] == [7]
+    assert "documentacion obligatoria" in payload["error"]
+    confirm.assert_not_called()
 
 
 def test_configurar_cupo_validation_error_returns_generic_message():

--- a/celiaquia/views/confirm_envio.py
+++ b/celiaquia/views/confirm_envio.py
@@ -3,16 +3,16 @@
 
 import logging
 
-from django.contrib import messages  # ✅ import correcto
-from django.views import View
-from django.http import JsonResponse, HttpResponseNotAllowed
-from django.shortcuts import get_object_or_404, redirect
-from django.core.exceptions import ValidationError
+from django.contrib import messages
 from django.contrib.auth.mixins import LoginRequiredMixin
-from django.db.models import Q
+from django.core.exceptions import ValidationError
+from django.http import HttpResponseNotAllowed, JsonResponse
+from django.shortcuts import get_object_or_404, redirect
+from django.views import View
 
-from celiaquia.models import Expediente, ExpedienteCiudadano, RegistroErroneo
+from celiaquia.models import Expediente, RegistroErroneo
 from celiaquia.services.expediente_service import ExpedienteService
+from celiaquia.services.legajo_service import LegajoService
 from celiaquia.views.expediente import _is_ajax
 
 logger = logging.getLogger("django")
@@ -20,14 +20,13 @@ logger = logging.getLogger("django")
 
 class ExpedienteConfirmView(LoginRequiredMixin, View):
     """
-    POST: confirma el envío del expediente (provincia). Responde JSON.
+    POST: confirma el envio del expediente (provincia). Responde JSON.
     - Si faltan archivos => 400 con mensaje (o messages.error si no es AJAX).
     - Si no tiene permisos => 403 con mensaje.
     - Nunca 404 por reglas de negocio.
     """
 
     def post(self, request, pk: int):
-        # 1) Traer el expediente por PK (sin filtrar por usuario para evitar 404 falsos)
         expediente = get_object_or_404(
             Expediente.objects.select_related(
                 "usuario_provincia", "usuario_provincia__profile"
@@ -35,13 +34,12 @@ class ExpedienteConfirmView(LoginRequiredMixin, View):
             pk=pk,
         )
 
-        # 2) Chequeo de permisos: dueño, misma provincia o staff
         user = request.user
         same_owner = user == expediente.usuario_provincia
 
-        def _prov_id(u):
+        def _prov_id(usuario):
             try:
-                return getattr(getattr(u, "profile", None), "provincia_id", None)
+                return getattr(getattr(usuario, "profile", None), "provincia_id", None)
             except Exception:
                 return None
 
@@ -55,105 +53,97 @@ class ExpedienteConfirmView(LoginRequiredMixin, View):
             msg = "No tiene permisos para confirmar este expediente."
             return JsonResponse({"success": False, "error": msg}, status=403)
 
-        # 3) Validación de negocio: estado correcto
         if expediente.estado.nombre != "EN_ESPERA":
             msg = (
-                "El expediente no está en estado EN_ESPERA. "
+                "El expediente no esta en estado EN_ESPERA. "
                 f"Estado actual: {expediente.estado.nombre}"
             )
-            logger.info("Validación en confirmar envío falló: %s", msg)
+            logger.info("Validacion en confirmar envio fallo: %s", msg)
             if _is_ajax(request):
                 return JsonResponse({"success": False, "error": msg}, status=400)
             messages.error(request, msg)
             return redirect("expediente_detail", pk=expediente.pk)
 
-        # 4) Validación de negocio: no hay registros erróneos pendientes
         registros_erroneos = RegistroErroneo.objects.filter(
             expediente=expediente, procesado=False
         )
         if registros_erroneos.exists():
             msg = (
-                "No se puede confirmar el envío: hay "
+                "No se puede confirmar el envio: hay "
                 f"{registros_erroneos.count()} registros con errores pendientes."
             )
-            logger.info("Validación en confirmar envío falló: %s", msg)
+            logger.info("Validacion en confirmar envio fallo: %s", msg)
             if _is_ajax(request):
                 return JsonResponse({"success": False, "error": msg}, status=400)
             messages.error(request, msg)
             return redirect("expediente_detail", pk=expediente.pk)
 
-        # 5) Validación de negocio: todos los legajos con los 2 archivos requeridos
-        faltantes_qs = (
-            ExpedienteCiudadano.objects.select_related("ciudadano")
-            .filter(expediente_id=expediente.pk)
-            .filter(
-                Q(archivo2__isnull=True)
-                | Q(archivo2="")
-                | Q(archivo3__isnull=True)
-                | Q(archivo3="")
-            )
-        )
-
-        if faltantes_qs.exists():
+        faltantes = LegajoService.faltantes_archivos(expediente, limit=10)
+        if faltantes:
             ejemplos = [
-                f"{l.ciudadano.apellido}, {l.ciudadano.nombre} (DNI {l.ciudadano.documento})"
-                for l in faltantes_qs[:10]
+                (
+                    f"{item['apellido']}, {item['nombre']} (DNI {item['documento']})"
+                    f" - faltan: {', '.join(item['faltan_nombres'])}"
+                )
+                for item in faltantes
             ]
             msg = (
-                "No podés confirmar el envío: hay legajos sin los 2 archivos requeridos. "
+                "No podes confirmar el envio: hay legajos sin toda la documentacion "
+                "obligatoria segun su tipo de ciudadano. "
                 + (
                     "Ejemplos: "
                     + "; ".join(ejemplos)
-                    + (" …" if faltantes_qs.count() > 10 else "")
+                    + (" ..." if len(faltantes) >= 10 else "")
                 )
             )
-            logger.info("Validación en confirmar envío falló: %s", msg)
+            logger.info("Validacion en confirmar envio fallo: %s", msg)
 
             if _is_ajax(request):
                 return JsonResponse(
                     {
                         "success": False,
                         "error": msg,
-                        "faltantes_ids": list(
-                            faltantes_qs.values_list("id", flat=True)
-                        ),
+                        "faltantes_ids": [item["legajo_id"] for item in faltantes],
                     },
                     status=400,
                 )
             messages.error(request, msg)
             return redirect("expediente_detail", pk=expediente.pk)
 
-        # 6) Transición de estado / lógica de confirmación
         try:
             result = ExpedienteService.confirmar_envio(expediente, request.user)
             logger.info(
-                "Confirmación de envío OK. Expediente %s por %s",
+                "Confirmacion de envio OK. Expediente %s por %s",
                 expediente.pk,
                 request.user.username,
             )
             return JsonResponse(
                 {
                     "success": True,
-                    "message": "Expediente enviado a Subsecretaría.",
+                    "message": "Expediente enviado a Subsecretaria.",
                     "estado": expediente.estado.display_name(),
                     "datos": result,
                 }
             )
-        except ValidationError as e:
-            logger.warning("Validación en confirmar envío falló: %s", e, exc_info=True)
-            if getattr(e, "messages", None):
-                error_msg = "; ".join(str(m) for m in e.messages if m)
-            elif getattr(e, "message", None):
-                error_msg = str(e.message)
+        except ValidationError as exc:
+            logger.warning(
+                "Validacion en confirmar envio fallo: %s", exc, exc_info=True
+            )
+            if getattr(exc, "messages", None):
+                error_msg = "; ".join(
+                    str(message) for message in exc.messages if message
+                )
+            elif getattr(exc, "message", None):
+                error_msg = str(exc.message)
             else:
-                error_msg = str(e)
+                error_msg = str(exc)
             return JsonResponse({"success": False, "error": error_msg}, status=400)
-        except Exception as e:
-            logger.error("Error inesperado al confirmar envío: %s", e, exc_info=True)
+        except Exception as exc:
+            logger.error("Error inesperado al confirmar envio: %s", exc, exc_info=True)
             return JsonResponse(
                 {
                     "success": False,
-                    "error": "No se pudo confirmar el envío. Revisa los datos e intenta de nuevo.",
+                    "error": "No se pudo confirmar el envio. Revisa los datos e intenta de nuevo.",
                 },
                 status=500,
             )

--- a/celiaquia/views/expediente.py
+++ b/celiaquia/views/expediente.py
@@ -943,9 +943,7 @@ class ExpedienteDetailView(DetailView):
         ):
             tecnicos = _tecnicos_queryset().order_by("last_name", "first_name")
 
-        faltan_archivos = expediente.expediente_ciudadanos.filter(
-            Q(archivo2__isnull=True) | Q(archivo3__isnull=True)
-        ).exists()
+        faltan_archivos = bool(faltantes_list)
 
         # Cupo: usar propiedad expediente.provincia (puede ser None)
         cupo = None

--- a/celiaquia/views/expediente.py
+++ b/celiaquia/views/expediente.py
@@ -776,6 +776,18 @@ class ExpedienteDetailView(DetailView):
 
         legajos_enriquecidos = []
         legajos_list = list(q.all())
+        historial_tecnico = (
+            HistorialValidacionTecnica.objects.filter(
+                legajo_id__in=[legajo.pk for legajo in legajos_list]
+            )
+            .exclude(Q(motivo__isnull=True) | Q(motivo=""))
+            .order_by("legajo_id", "-creado_en")
+        )
+        observaciones_tecnicas_por_legajo = {}
+        for historial_item in historial_tecnico:
+            observaciones_tecnicas_por_legajo.setdefault(
+                historial_item.legajo_id, historial_item
+            )
         legajos_por_ciudadano = {}
         ciudadanos_ids = [leg.ciudadano_id for leg in legajos_list]
         responsables_ids = set()
@@ -836,6 +848,19 @@ class ExpedienteDetailView(DetailView):
                     legajo, responsables_ids
                 )
             )
+            legajo.observacion_tecnica_titulo = None
+            legajo.observacion_tecnica_texto = None
+
+            observacion_tecnica = observaciones_tecnicas_por_legajo.get(legajo.pk)
+            if observacion_tecnica:
+                if observacion_tecnica.estado_nuevo == RevisionTecnico.RECHAZADO:
+                    legajo.observacion_tecnica_titulo = "Motivo del Rechazo"
+                else:
+                    legajo.observacion_tecnica_titulo = "Observación (subsanación)"
+                legajo.observacion_tecnica_texto = observacion_tecnica.motivo
+            elif legajo.subsanacion_motivo:
+                legajo.observacion_tecnica_titulo = "Observación (subsanación)"
+                legajo.observacion_tecnica_texto = legajo.subsanacion_motivo
 
             if (
                 legajo.es_responsable
@@ -1474,7 +1499,15 @@ class RevisarLegajoView(View):
                 }
             )
 
+        motivo = (request.POST.get("motivo") or "").strip()
+
         if accion == "RECHAZAR":
+            if not motivo:
+                return JsonResponse(
+                    {"success": False, "error": "Debe indicar un motivo de rechazo."},
+                    status=400,
+                )
+
             estado_anterior = leg.revision_tecnico
             leg.revision_tecnico = "RECHAZADO"
             # Marcar RENAPER como rechazado también
@@ -1495,7 +1528,7 @@ class RevisarLegajoView(View):
                 estado_anterior=estado_anterior,
                 estado_nuevo="RECHAZADO",
                 usuario=user,
-                motivo=None,
+                motivo=motivo[:500],
             )
 
             return JsonResponse(
@@ -1570,7 +1603,6 @@ class RevisarLegajoView(View):
                 )
 
         # SUBSANAR
-        motivo = (request.POST.get("motivo") or "").strip()
         tipo_subsanacion = (request.POST.get("tipo_subsanacion") or "").strip()
         if not motivo:
             return JsonResponse(

--- a/celiaquia/views/expediente.py
+++ b/celiaquia/views/expediente.py
@@ -20,7 +20,7 @@ from django.core.exceptions import ValidationError, PermissionDenied, ObjectDoes
 from django.conf import settings
 from django.utils.decorators import method_decorator
 from django.contrib.auth.models import User
-from django.db.models import Q, Count
+from django.db.models import Q, Count, OuterRef, Subquery
 from django.core.paginator import Paginator
 from iam.services import user_has_permission_code
 
@@ -776,12 +776,15 @@ class ExpedienteDetailView(DetailView):
 
         legajos_enriquecidos = []
         legajos_list = list(q.all())
-        historial_tecnico = (
-            HistorialValidacionTecnica.objects.filter(
-                legajo_id__in=[legajo.pk for legajo in legajos_list]
-            )
+        ultimo_historial_tecnico_con_motivo = (
+            HistorialValidacionTecnica.objects.filter(legajo_id=OuterRef("legajo_id"))
             .exclude(Q(motivo__isnull=True) | Q(motivo=""))
-            .order_by("legajo_id", "-creado_en")
+            .order_by("-creado_en", "-pk")
+            .values("pk")[:1]
+        )
+        historial_tecnico = HistorialValidacionTecnica.objects.filter(
+            legajo_id__in=[legajo.pk for legajo in legajos_list],
+            pk=Subquery(ultimo_historial_tecnico_con_motivo),
         )
         observaciones_tecnicas_por_legajo = {}
         for historial_item in historial_tecnico:

--- a/celiaquia/views/validacion_renaper.py
+++ b/celiaquia/views/validacion_renaper.py
@@ -172,7 +172,9 @@ def _es_error_reintentable(error_type):
 def _enriquecer_resultado_renaper(resultado, retry_attempt, max_retries):
     resultado_normalizado = dict(resultado or {})
     if not resultado_normalizado.get("success", False):
-        resultado_normalizado.setdefault("error", "Error desconocido al consultar Renaper")
+        resultado_normalizado.setdefault(
+            "error", "Error desconocido al consultar Renaper"
+        )
         resultado_normalizado.setdefault("error_type", "unexpected_error")
 
     resultado_normalizado["retry_attempt"] = retry_attempt

--- a/celiaquia/views/validacion_renaper.py
+++ b/celiaquia/views/validacion_renaper.py
@@ -1,3 +1,4 @@
+import json
 import logging
 import time
 from django.conf import settings
@@ -17,11 +18,44 @@ logger = logging.getLogger(__name__)
 ROLE_COORDINADOR_CELIAQUIA_PERMISSION = "auth.role_coordinadorceliaquia"
 ROLE_TECNICO_CELIAQUIA_PERMISSION = "auth.role_tecnicoceliaquia"
 
+RENAPER_TRANSIENT_ERROR_TYPES = {
+    "timeout",
+    "remote_error",
+    "auth_error",
+    "invalid_response",
+    "unexpected_error",
+}
+RENAPER_REMOTE_UNAVAILABLE_MESSAGE = (
+    "No pudimos validar con RENAPER en este momento. "
+    "Por favor, intentá nuevamente en unos minutos."
+)
+RENAPER_INVALID_RESPONSE_MESSAGE = (
+    "RENAPER devolvió una respuesta inválida y no pudimos completar la validación. "
+    "Intentá nuevamente más tarde."
+)
+RENAPER_NO_MATCH_MESSAGE = (
+    "RENAPER no pudo validar los datos ingresados. "
+    "Verificá el DNI y el sexo registrados."
+)
+
 
 def _truncate(value, length=500):
     if isinstance(value, str) and len(value) > length:
         return f"{value[:length]}…"
     return value
+
+
+def _build_raw_response_excerpt(raw_response):
+    if raw_response in (None, ""):
+        return None
+
+    if isinstance(raw_response, (dict, list, tuple)):
+        try:
+            raw_response = json.dumps(raw_response, ensure_ascii=True)
+        except (TypeError, ValueError):
+            raw_response = str(raw_response)
+
+    return _truncate(str(raw_response))
 
 
 def _build_log_data(
@@ -131,16 +165,63 @@ def _get_renaper_retry_config():
     return max_retries, backoff_seconds
 
 
+def _es_error_reintentable(error_type):
+    return error_type in RENAPER_TRANSIENT_ERROR_TYPES
+
+
+def _enriquecer_resultado_renaper(resultado, retry_attempt, max_retries):
+    resultado_normalizado = dict(resultado or {})
+    if not resultado_normalizado.get("success", False):
+        resultado_normalizado.setdefault("error", "Error desconocido al consultar Renaper")
+        resultado_normalizado.setdefault("error_type", "unexpected_error")
+
+    resultado_normalizado["retry_attempt"] = retry_attempt
+    resultado_normalizado["max_retries"] = max_retries
+    return resultado_normalizado
+
+
+def _build_error_log_data(log_data, resultado_renaper, stage="response"):
+    return {
+        **log_data,
+        "stage": stage,
+        "error": resultado_renaper.get("error"),
+        "error_type": resultado_renaper.get("error_type"),
+        "retry_attempt": resultado_renaper.get("retry_attempt"),
+        "max_retries": resultado_renaper.get("max_retries"),
+        "raw_response_excerpt": _build_raw_response_excerpt(
+            resultado_renaper.get("raw_response")
+        ),
+    }
+
+
+def _get_error_message(resultado_renaper):
+    error_type = resultado_renaper.get("error_type")
+
+    if error_type == "fallecido" or resultado_renaper.get("fallecido"):
+        return "La persona figura como fallecida en Renaper"
+    if error_type == "invalid_response":
+        return RENAPER_INVALID_RESPONSE_MESSAGE
+    if error_type == "no_match":
+        return RENAPER_NO_MATCH_MESSAGE
+    return RENAPER_REMOTE_UNAVAILABLE_MESSAGE
+
+
 def _consultar_datos_renaper_con_reintentos(documento_consulta, sexo_renaper):
     max_retries, backoff_seconds = _get_renaper_retry_config()
     ultimo_resultado = None
 
     for intento in range(1, max_retries + 1):
-        ultimo_resultado = consultar_datos_renaper(documento_consulta, sexo_renaper)
+        ultimo_resultado = _enriquecer_resultado_renaper(
+            consultar_datos_renaper(documento_consulta, sexo_renaper),
+            retry_attempt=intento,
+            max_retries=max_retries,
+        )
         if ultimo_resultado.get("success"):
             return ultimo_resultado
 
-        if intento >= max_retries:
+        if intento >= max_retries or not _es_error_reintentable(
+            ultimo_resultado.get("error_type")
+        ):
             break
 
         logger.warning(
@@ -152,6 +233,10 @@ def _consultar_datos_renaper_con_reintentos(documento_consulta, sexo_renaper):
                     "retry_attempt": intento + 1,
                     "max_retries": max_retries,
                     "error": ultimo_resultado.get("error"),
+                    "error_type": ultimo_resultado.get("error_type"),
+                    "raw_response_excerpt": _build_raw_response_excerpt(
+                        ultimo_resultado.get("raw_response")
+                    ),
                 }
             },
         )
@@ -159,10 +244,15 @@ def _consultar_datos_renaper_con_reintentos(documento_consulta, sexo_renaper):
         if backoff_seconds > 0:
             time.sleep(backoff_seconds * (2 ** (intento - 1)))
 
-    return ultimo_resultado or {
-        "success": False,
-        "error": "Error desconocido al consultar Renaper",
-    }
+    return ultimo_resultado or _enriquecer_resultado_renaper(
+        {
+            "success": False,
+            "error": "Error desconocido al consultar Renaper",
+            "error_type": "unexpected_error",
+        },
+        retry_attempt=max_retries,
+        max_retries=max_retries,
+    )
 
 
 def _formatear_fecha_renaper(fecha_renaper):
@@ -236,20 +326,21 @@ def _log_respuesta_renaper(log_data, resultado_renaper):
     }
 
     if not success:
-        response_summary["error"] = resultado_renaper.get("error")
-        response_summary["raw_response_excerpt"] = _truncate(
-            resultado_renaper.get("raw_response", "Sin respuesta")
-        )
-        logger.warning(
-            "renaper.validation.response_error",
-            extra={
-                "data": {
-                    **log_data,
-                    "stage": "response",
-                    "response": response_summary,
-                }
-            },
-        )
+        error_type = resultado_renaper.get("error_type")
+        log_extra = {"data": _build_error_log_data(log_data, resultado_renaper)}
+
+        if error_type == "no_match":
+            logger.info("renaper.validation.no_match", extra=log_extra)
+        elif error_type in {"timeout", "remote_error"}:
+            logger.warning("renaper.validation.remote_unavailable", extra=log_extra)
+        elif error_type == "auth_error":
+            logger.error("renaper.validation.remote_unavailable", extra=log_extra)
+        elif error_type == "invalid_response":
+            logger.error("renaper.validation.invalid_response", extra=log_extra)
+        elif error_type == "fallecido":
+            logger.info("renaper.validation.fallecido", extra=log_extra)
+        else:
+            logger.error("renaper.validation.response_error", extra=log_extra)
         return
 
     response_summary["data_keys"] = sorted(
@@ -553,47 +644,18 @@ class ValidacionRenaperView(View):
             fallecido = resultado_renaper.get("fallecido")
 
             if fallecido:
-                logger.warning(
-                    "renaper.validation.fallecido",
-                    extra={
-                        "data": {
-                            **log_data,
-                            "stage": "response",
-                            "fallecido": True,
-                        }
-                    },
-                )
                 return JsonResponse(
                     {
                         "success": False,
-                        "error": "La persona figura como fallecida en Renaper",
+                        "error": _get_error_message(resultado_renaper),
                     }
                 )
 
             if not success:
-                error_msg = resultado_renaper.get(
-                    "error", "Error desconocido al consultar Renaper"
-                )
-                raw_response = resultado_renaper.get(
-                    "raw_response", "Sin respuesta raw"
-                )
-
-                logger.error(
-                    "renaper.validation.remote_error",
-                    extra={
-                        "data": {
-                            **log_data,
-                            "stage": "response",
-                            "error": error_msg,
-                            "raw_response_excerpt": _truncate(raw_response),
-                        }
-                    },
-                )
-
                 return JsonResponse(
                     {
                         "success": False,
-                        "error": "Ocurrió un error El Cuit o el Sexo no coincide con esos datos.",
+                        "error": _get_error_message(resultado_renaper),
                     }
                 )
 

--- a/centrodefamilia/services/consulta_renaper/impl.py
+++ b/centrodefamilia/services/consulta_renaper/impl.py
@@ -15,6 +15,31 @@ LOGIN_URL = f"{API_BASE}/auth/login"
 CONSULTA_URL = f"{API_BASE}/consultarenaper"
 
 
+class RenaperServiceError(RuntimeError):
+    def __init__(self, message, error_type, raw_response=None):
+        super().__init__(message)
+        self.error_type = error_type
+        self.raw_response = raw_response
+
+
+def _safe_response_payload(response):
+    if response is None:
+        return None
+
+    try:
+        return response.json()
+    except ValueError:
+        return getattr(response, "text", None)
+
+
+def _build_error_result(message, error_type, raw_response=None, **extra):
+    result = {"success": False, "error": message, "error_type": error_type}
+    if raw_response is not None:
+        result["raw_response"] = raw_response
+    result.update(extra)
+    return result
+
+
 class APIClient:
     def __init__(self):
         self.username = settings.RENAPER_API_USERNAME
@@ -37,14 +62,46 @@ class APIClient:
                 timeout=10,
             )
             response.raise_for_status()
-        except Exception as exc:
-            logger.error(f"Error en login RENAPER: {str(exc)}")
-            raise RuntimeError(
-                f"No se pudo conectar al servicio de login: {str(exc)}"
+        except requests.Timeout as exc:
+            raise RenaperServiceError(
+                "RENAPER no respondio a tiempo durante la autenticacion.",
+                "timeout",
+            ) from exc
+        except requests.HTTPError as exc:
+            status_code = getattr(exc.response, "status_code", None)
+            error_type = "auth_error" if status_code in {401, 403} else "remote_error"
+            message = (
+                "RENAPER rechazo la autenticacion."
+                if error_type == "auth_error"
+                else "RENAPER devolvio un error durante la autenticacion."
+            )
+            raise RenaperServiceError(
+                message,
+                error_type,
+                raw_response=_safe_response_payload(exc.response),
+            ) from exc
+        except requests.RequestException as exc:
+            raise RenaperServiceError(
+                f"No se pudo conectar al servicio de login de RENAPER: {str(exc)}",
+                "remote_error",
             ) from exc
 
-        data = response.json()
-        token = data.get("token")
+        try:
+            data = response.json()
+        except ValueError as exc:
+            raise RenaperServiceError(
+                "RENAPER devolvio una respuesta invalida durante la autenticacion.",
+                "invalid_response",
+                raw_response=getattr(response, "text", None),
+            ) from exc
+
+        token = data.get("token") if isinstance(data, dict) else None
+        if not token:
+            raise RenaperServiceError(
+                "RENAPER no devolvio un token de autenticacion.",
+                "invalid_response",
+                raw_response=data,
+            )
 
         # Cache por 50 minutos
         cache.set("renaper_token", {"token": token}, 3000)
@@ -53,9 +110,10 @@ class APIClient:
     def consultar_ciudadano(self, dni, sexo):
         try:
             token = self.get_token()
-        except RuntimeError as exc:
-            logger.error(f"Error al obtener token: {str(exc)}")
-            return {"success": False, "error": f"Error al obtener token: {str(exc)}"}
+        except RenaperServiceError as exc:
+            return _build_error_result(
+                str(exc), exc.error_type, raw_response=exc.raw_response
+            )
 
         headers = {"Authorization": f"Bearer {token}"}
         params = {"dni": dni, "sexo": sexo.upper()}
@@ -65,30 +123,58 @@ class APIClient:
                 CONSULTA_URL, headers=headers, params=params, timeout=10
             )
             response.raise_for_status()
-        except Exception as exc:
-            logger.error(f"Error consulta RENAPER DNI {dni}: {str(exc)}")
-            return {
-                "success": False,
-                "error": f"Error inesperado: {str(exc)}",
-            }
+        except requests.Timeout:
+            return _build_error_result(
+                "RENAPER no respondio a tiempo durante la consulta.", "timeout"
+            )
+        except requests.HTTPError as exc:
+            status_code = getattr(exc.response, "status_code", None)
+            error_type = "auth_error" if status_code in {401, 403} else "remote_error"
+            message = (
+                "RENAPER rechazo la autenticacion de la consulta."
+                if error_type == "auth_error"
+                else "RENAPER devolvio un error durante la consulta."
+            )
+            return _build_error_result(
+                message,
+                error_type,
+                raw_response=_safe_response_payload(exc.response),
+            )
+        except requests.RequestException as exc:
+            return _build_error_result(
+                f"No se pudo consultar RENAPER: {str(exc)}", "remote_error"
+            )
 
         try:
             data = response.json()
-        except Exception as exc:
-            logger.error(f"Error decodificar JSON RENAPER DNI {dni}: {str(exc)}")
-            return {
-                "success": False,
-                "error": f"No se pudo decodificar JSON: {str(exc)}",
-            }
+        except ValueError as exc:
+            return _build_error_result(
+                f"No se pudo decodificar JSON de RENAPER: {str(exc)}",
+                "invalid_response",
+                raw_response=getattr(response, "text", None),
+            )
+
+        if not isinstance(data, dict):
+            return _build_error_result(
+                "RENAPER devolvio una estructura de respuesta invalida.",
+                "invalid_response",
+                raw_response=data,
+            )
 
         if not data.get("isSuccess", False):
-            return {
-                "success": False,
-                "error": "No se encontró coincidencia.",
-                "raw_response": data,
-            }
+            return _build_error_result(
+                "No se encontro coincidencia.", "no_match", raw_response=data
+            )
 
-        return {"success": True, "data": data["result"]}
+        result = data.get("result")
+        if not isinstance(result, dict):
+            return _build_error_result(
+                "RENAPER devolvio una respuesta invalida.",
+                "invalid_response",
+                raw_response=data,
+            )
+
+        return {"success": True, "data": result}
 
 
 def normalizar(texto):
@@ -109,16 +195,27 @@ def consultar_datos_renaper(dni, sexo):
         response = client.consultar_ciudadano(dni, sexo)
 
         if not response["success"]:
-            return {
-                "success": False,
-                "error": response.get("error", "Error desconocido"),
-                "raw_response": response.get("raw_response"),
-            }
+            return _build_error_result(
+                response.get("error", "Error desconocido al consultar RENAPER"),
+                response.get("error_type", "unexpected_error"),
+                raw_response=response.get("raw_response"),
+            )
 
         datos = response["data"]
+        if not isinstance(datos, dict):
+            return _build_error_result(
+                "RENAPER devolvio un payload invalido del ciudadano.",
+                "invalid_response",
+                raw_response=datos,
+            )
 
         if datos.get("mensaf") == "FALLECIDO":
-            return {"success": False, "error": "El ciudadano se encuentra fallecido."}
+            return _build_error_result(
+                "El ciudadano se encuentra fallecido.",
+                "fallecido",
+                raw_response=datos,
+                fallecido=True,
+            )
 
         sexo_map = {"F": "Femenino", "M": "Masculino", "X": "X"}
         sexo_texto = sexo_map.get(sexo)
@@ -127,8 +224,7 @@ def consultar_datos_renaper(dni, sexo):
             sexo_obj = Sexo.objects.filter(sexo=sexo_texto).first()
             sexo_pk = sexo_obj.pk if sexo_obj else None
 
-        # Solo datos básicos de RENAPER, sin mapeo de ubicación
-
+        # Solo datos basicos de RENAPER, sin mapeo de ubicacion
         # Mapeo optimizado de datos
         def safe_int(value):
             try:
@@ -150,7 +246,7 @@ def consultar_datos_renaper(dni, sexo):
             "sexo": sexo_pk,
             "tipo_documento": Ciudadano.DOCUMENTO_DNI,
             "fecha_nacimiento": datos.get("fechaNacimiento"),
-            # Datos de ubicación sin mapear (se seleccionarán manualmente)
+            # Datos de ubicacion sin mapear (se seleccionaran manualmente)
             "provincia_api": datos.get("provincia", ""),
             "municipio_api": datos.get("municipio", ""),
             "localidad_api": datos.get("ciudad", ""),
@@ -171,7 +267,7 @@ def consultar_datos_renaper(dni, sexo):
         return {"success": True, "data": datos_mapeados, "datos_api": datos}
     except Exception as exc:
         logger.exception(f"Error inesperado consultando RENAPER: {str(exc)}")
-        return {
-            "success": False,
-            "error": f"Error inesperado al consultar RENAPER: {str(exc)}",
-        }
+        return _build_error_result(
+            f"Error inesperado al consultar RENAPER: {str(exc)}",
+            "unexpected_error",
+        )

--- a/ciudadanos/migrations/0028_merge_0026_0027.py
+++ b/ciudadanos/migrations/0028_merge_0026_0027.py
@@ -1,0 +1,14 @@
+from django.db import migrations
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        (
+            "ciudadanos",
+            "0026_merge_0023_optimize_listado_ciudadanos_indexes_0025_alter_ciudadano_fecha_nacimiento_nullable",
+        ),
+        ("ciudadanos", "0027_alter_ciudadano_telefono_longitud"),
+    ]
+
+    operations = []

--- a/docs/registro/cambios/2026-04-17-celiaquia-renaper-clasificacion-errores-y-logs.md
+++ b/docs/registro/cambios/2026-04-17-celiaquia-renaper-clasificacion-errores-y-logs.md
@@ -1,0 +1,167 @@
+# Celiaquia: clasificacion de errores, retries y logs de validacion RENAPER
+
+Fecha: 2026-04-17
+
+## Contexto
+El endpoint `celiaquia/expedientes/{pk}/legajos/{legajo_id}/validar-renaper` estaba mezclando errores transitorios de RENAPER con errores funcionales de datos del ciudadano.
+
+Eso generaba tres problemas principales:
+
+- mensajes funcionales incorrectos o demasiado genericos para el usuario,
+- retries sobre casos no reintentables como `no_match`,
+- logs ruidosos o duplicados, donde un mismo caso podia verse como `response_error` y tambien como error funcional.
+
+El objetivo del cambio fue separar explicitamente:
+
+- errores tecnicos o transitorios del servicio externo,
+- respuestas invalidas del proveedor,
+- errores funcionales de coincidencia de datos del ciudadano.
+
+## Decision principal
+Se consolidó un contrato de clasificacion por `error_type` en el servicio compartido de RENAPER y la vista de Celiaquia pasó a decidir retries, mensaje funcional y tipo de log a partir de esa clasificacion.
+
+Los tipos usados quedan:
+
+- `timeout`
+- `remote_error`
+- `auth_error`
+- `invalid_response`
+- `unexpected_error`
+- `no_match`
+- `fallecido`
+
+## Cambios realizados
+
+### 1. Servicio RENAPER
+Archivo: `centrodefamilia/services/consulta_renaper/impl.py`
+
+- Se agregó `RenaperServiceError` para clasificar fallas de login/autenticacion/integracion.
+- `consultar_ciudadano()` ahora devuelve resultados con `error_type` explicito para:
+  - timeout,
+  - auth error,
+  - remote error,
+  - invalid response,
+  - no match.
+- `consultar_datos_renaper()` propaga la clasificacion y agrega:
+  - `fallecido`,
+  - `unexpected_error`,
+  - `raw_response` cuando aporta contexto util.
+- Se restauraron comentarios previos validos del archivo.
+- No se incorporaron cambios de SSL local, `verify`, CA bundle, variables nuevas de entorno ni workarounds de certificados.
+
+### 2. Vista de validacion RENAPER
+Archivo: `celiaquia/views/validacion_renaper.py`
+
+- Se agregaron mensajes funcionales diferenciados:
+  - indisponibilidad remota/transitoria:
+    `No pudimos validar con RENAPER en este momento. Por favor, intentá nuevamente en unos minutos.`
+  - respuesta invalida:
+    `RENAPER devolvió una respuesta inválida y no pudimos completar la validación. Intentá nuevamente más tarde.`
+  - no coincidencia:
+    `RENAPER no pudo validar los datos ingresados. Verificá el DNI y el sexo registrados.`
+- La logica de retry quedó limitada a errores transitorios o tecnicos:
+  - `timeout`
+  - `remote_error`
+  - `auth_error`
+  - `invalid_response`
+  - `unexpected_error`
+- `no_match` deja de reintentarse.
+- `no_match` deja de disparar `renaper.validation.retrying_remote_query`.
+- Se consolidó el detalle util del log final de error con:
+  - `stage`
+  - `error`
+  - `error_type`
+  - `retry_attempt`
+  - `max_retries`
+  - `raw_response_excerpt`
+  - mas el contexto existente del legajo/ciudadano/usuario
+
+### 3. Logging operativo
+Archivo: `celiaquia/views/validacion_renaper.py`
+
+Se normalizaron los eventos:
+
+- `renaper.validation.no_match`
+  - severidad: `info`
+  - no duplica `renaper.validation.response_error`
+- `renaper.validation.remote_unavailable`
+  - severidad: `warning`
+  - para `timeout`, `remote_error`
+- `renaper.validation.remote_unavailable` con `auth_error`
+  - severidad: `error`
+- `renaper.validation.invalid_response`
+  - severidad: `error`
+- `renaper.validation.fallecido`
+  - severidad: `info`
+- `renaper.validation.response_error`
+  - queda solo para errores genericos o no clasificados especificamente
+
+## Archivos tocados
+- `celiaquia/views/validacion_renaper.py`
+- `centrodefamilia/services/consulta_renaper/impl.py`
+- `tests/test_validacion_renaper_view_unit.py`
+- `tests/test_consulta_renaper_unit.py`
+
+## Cobertura agregada o actualizada
+
+### Vista
+Archivo: `tests/test_validacion_renaper_view_unit.py`
+
+Se cubren estos casos:
+
+- `no_match` no reintenta
+- `no_match` no genera `retrying_remote_query`
+- `no_match` no duplica `response_error`
+- timeout reintenta y respeta backoff
+- error transitorio muestra mensaje funcional correcto
+- invalid response muestra mensaje funcional correcto
+- flujo exitoso sigue funcionando
+- `fallecido` sigue funcionando
+
+### Servicio
+Archivo: `tests/test_consulta_renaper_unit.py`
+
+Se cubren estos casos:
+
+- `no_match`
+- `timeout`
+- `auth_error`
+- `invalid_response`
+- propagacion de `remote_error`
+- clasificacion de `fallecido`
+- payload invalido del ciudadano
+
+## Validacion ejecutada
+
+### Pytest dentro del ambiente Docker de la app
+Comando:
+
+```bash
+docker compose run --rm django pytest tests/test_validacion_renaper_view_unit.py tests/test_consulta_renaper_unit.py
+```
+
+Resultado:
+
+```text
+25 passed in 2.44s
+```
+
+### Validacion de sintaxis
+Comando:
+
+```bash
+python -m py_compile \
+  BACKOFFICE/centrodefamilia/services/consulta_renaper/impl.py \
+  BACKOFFICE/celiaquia/views/validacion_renaper.py \
+  BACKOFFICE/tests/test_validacion_renaper_view_unit.py \
+  BACKOFFICE/tests/test_consulta_renaper_unit.py
+```
+
+Resultado: OK
+
+## Impacto esperado
+- El usuario recibe mensajes mas precisos y accionables segun el problema real.
+- Los retries dejan de ocurrir sobre errores funcionales del ciudadano.
+- Los logs quedan mas legibles para operacion y soporte.
+- `no_match` deja de verse como error tecnico del sistema.
+- Se preserva el comportamiento exitoso y el caso `fallecido`.

--- a/docs/registro/cambios/2026-04-20-celiaquia-rechazo-con-motivo.md
+++ b/docs/registro/cambios/2026-04-20-celiaquia-rechazo-con-motivo.md
@@ -1,0 +1,29 @@
+# 2026-04-20 - Celiaquia: rechazo tecnico con motivo visible para Provincia
+
+## Que cambio
+
+- En `celiaquia/expediente_detail` el boton `Rechazar` ahora abre un modal con el texto `Motivo del Rechazo` y un campo libre obligatorio.
+- `RevisarLegajoView` exige ese motivo para la accion `RECHAZAR` y lo guarda en `HistorialValidacionTecnica.motivo`.
+- El detalle del expediente ahora resuelve la ultima observacion tecnica con motivo por legajo y la expone a la vista para que Provincia vea tanto pedidos de subsanacion como rechazos con su observacion.
+
+## Decision clave
+
+- Se reutilizo el historial tecnico existente como fuente de verdad para el motivo del rechazo, en lugar de sobrecargar `subsanacion_motivo` con un significado nuevo.
+- Esto mantiene el cambio acotado, evita mezclar conceptos de negocio y preserva la trazabilidad por estado tecnico.
+
+## Archivos tocados
+
+- `celiaquia/views/expediente.py`
+- `celiaquia/templates/celiaquia/expediente_detail.html`
+- `static/custom/js/expediente_detail.js`
+- `tests/test_celiaquia_expediente_view_helpers_unit.py`
+- `celiaquia/tests/test_expediente_detail.py`
+
+## Validacion
+
+- `uv run --with-requirements requirements.txt pytest tests/test_celiaquia_expediente_view_helpers_unit.py -q`
+- `uv run --with black black --check celiaquia/views/expediente.py tests/test_celiaquia_expediente_view_helpers_unit.py celiaquia/tests/test_expediente_detail.py`
+
+## Limites / entorno
+
+- La corrida local de `celiaquia/tests/test_expediente_detail.py` queda bloqueada en este entorno Windows por una dependencia nativa faltante de `weasyprint` (`libgobject-2.0-0`) al cargar el arbol completo de URLs de Django.

--- a/docs/registro/cambios/2026-04-20-celiaquia-rechazo-con-motivo.md
+++ b/docs/registro/cambios/2026-04-20-celiaquia-rechazo-con-motivo.md
@@ -1,15 +1,15 @@
-# 2026-04-20 - Celiaquia: rechazo tecnico con motivo visible para Provincia
+# 2026-04-20 - Celiaquía: rechazo técnico con motivo visible para Provincia
 
-## Que cambio
+## Qué cambió
 
-- En `celiaquia/expediente_detail` el boton `Rechazar` ahora abre un modal con el texto `Motivo del Rechazo` y un campo libre obligatorio.
-- `RevisarLegajoView` exige ese motivo para la accion `RECHAZAR` y lo guarda en `HistorialValidacionTecnica.motivo`.
-- El detalle del expediente ahora resuelve la ultima observacion tecnica con motivo por legajo y la expone a la vista para que Provincia vea tanto pedidos de subsanacion como rechazos con su observacion.
+- En `celiaquia/expediente_detail` el botón `Rechazar` ahora abre un modal con el texto `Motivo del Rechazo` y un campo libre obligatorio.
+- `RevisarLegajoView` exige ese motivo para la acción `RECHAZAR` y lo guarda en `HistorialValidacionTecnica.motivo`.
+- El detalle del expediente ahora resuelve la última observación técnica con motivo por legajo y la expone a la vista para que Provincia vea tanto pedidos de subsanación como rechazos con su observación.
 
-## Decision clave
+## Decisión clave
 
-- Se reutilizo el historial tecnico existente como fuente de verdad para el motivo del rechazo, en lugar de sobrecargar `subsanacion_motivo` con un significado nuevo.
-- Esto mantiene el cambio acotado, evita mezclar conceptos de negocio y preserva la trazabilidad por estado tecnico.
+- Se reutilizó el historial técnico existente como fuente de verdad para el motivo del rechazo, en lugar de sobrecargar `subsanacion_motivo` con un significado nuevo.
+- Esto mantiene el cambio acotado, evita mezclar conceptos de negocio y preserva la trazabilidad por estado técnico.
 
 ## Archivos tocados
 
@@ -19,11 +19,11 @@
 - `tests/test_celiaquia_expediente_view_helpers_unit.py`
 - `celiaquia/tests/test_expediente_detail.py`
 
-## Validacion
+## Validación
 
 - `uv run --with-requirements requirements.txt pytest tests/test_celiaquia_expediente_view_helpers_unit.py -q`
 - `uv run --with black black --check celiaquia/views/expediente.py tests/test_celiaquia_expediente_view_helpers_unit.py celiaquia/tests/test_expediente_detail.py`
 
-## Limites / entorno
+## Límites / entorno
+- La corrida local de `celiaquia/tests/test_expediente_detail.py` queda bloqueada en este entorno Windows por una dependencia nativa faltante de `weasyprint` (`libgobject-2.0-0`) al cargar el árbol completo de URLs de Django.
 
-- La corrida local de `celiaquia/tests/test_expediente_detail.py` queda bloqueada en este entorno Windows por una dependencia nativa faltante de `weasyprint` (`libgobject-2.0-0`) al cargar el arbol completo de URLs de Django.

--- a/docs/registro/cambios/2026-04-20-fix-celiaquia-documentos-obligatorios-envio.md
+++ b/docs/registro/cambios/2026-04-20-fix-celiaquia-documentos-obligatorios-envio.md
@@ -1,0 +1,51 @@
+# Fix Celiaquia: documentos obligatorios para confirmar envio
+
+## Problema
+
+En Celiaquia, el flujo de confirmacion de envio del expediente seguia usando la validacion legacy de `archivo2` y `archivo3` para decidir si un legajo tenia la documentacion completa.
+
+Eso dejaba pasar un caso incorrecto:
+
+- `beneficiario_y_responsable` requiere `archivo1`, `archivo2` y `archivo3`
+- la confirmacion del expediente solo miraba `archivo2` y `archivo3`
+- una provincia podia avanzar con un legajo incompleto
+
+## Decision
+
+Se centralizo la regla de "documentacion completa" en `LegajoService`, reutilizando `get_archivos_requeridos_por_legajo(...)` como fuente de verdad para:
+
+- calcular faltantes por legajo
+- recalcular `archivos_ok`
+- validar si todos los legajos del expediente estan completos
+- bloquear la confirmacion del envio cuando falta al menos un documento obligatorio segun el tipo de ciudadano
+
+## Cambio implementado
+
+- `celiaquia/services/legajo_service/impl.py`
+  - agrega helpers para obtener faltantes reales por legajo
+  - deja de asumir que siempre alcanza con `archivo2` y `archivo3`
+- `celiaquia/services/expediente_service/impl.py`
+  - recalcula `archivos_ok` con la regla por tipo de ciudadano antes de confirmar envio
+- `celiaquia/views/confirm_envio.py`
+  - usa faltantes dinamicos para devolver error de negocio consistente
+- `celiaquia/views/expediente.py`
+  - alinea `faltan_archivos` con la misma regla centralizada
+- `celiaquia/models.py`
+  - evita que el `save()` del legajo vuelva a pisar `archivos_ok` con la regla vieja
+
+## Validacion
+
+Se ejecuto:
+
+```powershell
+$env:USE_SQLITE_FOR_TESTS='1'
+& 'C:\Users\Juanito\Desktop\Repos-Codex\worktrees\bulk-credentials-mail-fallback-user-email\.venv\Scripts\python.exe' -m pytest tests/test_legajo_service_unit.py tests/test_expediente_service_unit.py celiaquia/tests/test_validation_errors.py tests/test_celiaquia_expediente_view_helpers_unit.py -q
+```
+
+Resultado:
+
+- `47 passed`
+
+## Supuesto explicitado
+
+Se mantuvo como fuente de verdad el esquema actual basado en `archivo1`/`archivo2`/`archivo3` para este flujo de confirmacion. No se cambio el sistema normalizado de `DocumentoLegajo` ni otros flujos fuera del alcance del envio del expediente.

--- a/docs/registro/cambios/2026-04-20-fix-celiaquia-nomina-sintys-y-lint-integracion.md
+++ b/docs/registro/cambios/2026-04-20-fix-celiaquia-nomina-sintys-y-lint-integracion.md
@@ -1,0 +1,18 @@
+# Fix de integración Celiaquía: nómina SINTyS, registros erróneos y lint
+
+## Contexto
+
+La branch integradora de los PRs 1580, 1584 y 1587 seguía con fallas en tests de Celiaquía y en checks de lint del PR.
+
+## Qué se ajustó
+
+- Se normalizó `fecha_nacimiento` en `LegajoService` para tolerar valores `date`, `datetime` y strings ISO al calcular la edad de un legajo.
+- Se ajustó el template de detalle de expediente para que la marca textual `Apellido Responsable *` solo aparezca cuando el responsable es realmente obligatorio.
+- Se expuso explícitamente `LegajoService` desde `celiaquia.services.legajo_service` para que `pylint` resuelva correctamente el import usado por `celiaquia.models`.
+- Se aplicó `black` a los archivos del PR que todavía no estaban formateados y dejaban rojo el check global.
+
+## Validación
+
+- `docker compose run --build --rm --no-deps -T django sh -lc "black --check . --config pyproject.toml && pylint **/*.py --rcfile=.pylintrc"`
+- `docker compose run --build --rm --no-deps -T django sh -lc "djlint celiaquia/templates/celiaquia/expediente_detail.html --check --configuration=.djlintrc && pytest celiaquia/tests/test_nomina_sintys_export.py celiaquia/tests/test_registros_erroneos_obligatorios.py -q"`
+- `docker compose run --build --rm --no-deps -T django pytest tests/test_legajo_service_unit.py tests/test_expediente_service_unit.py celiaquia/tests/test_validation_errors.py tests/test_celiaquia_expediente_view_helpers_unit.py celiaquia/tests/test_expediente_detail.py celiaquia/tests/test_nomina_sintys_export.py celiaquia/tests/test_registros_erroneos_obligatorios.py -q`

--- a/docs/registro/cambios/2026-04-20-fix-ciudadanos-merge-migration.md
+++ b/docs/registro/cambios/2026-04-20-fix-ciudadanos-merge-migration.md
@@ -1,0 +1,18 @@
+# 2026-04-20 - Ciudadanos: merge migration para destrabar CI
+
+## Qué cambió
+
+- Se agregó `ciudadanos/migrations/0028_merge_0026_0027.py`.
+- La nueva migración unifica las dos hojas activas del grafo de `ciudadanos`:
+  - `0026_merge_0023_optimize_listado_ciudadanos_indexes_0025_alter_ciudadano_fecha_nacimiento_nullable`
+  - `0027_alter_ciudadano_telefono_longitud`
+
+## Decisión clave
+
+- Se eligió una merge migration vacía en lugar de reescribir dependencias de migraciones ya publicadas.
+- Esto preserva el historial existente y resuelve el conflicto que estaba rompiendo `makemigrations --check` y la inicialización de la base de tests MySQL.
+
+## Validación
+
+- `docker compose exec -T django python manage.py makemigrations --check --dry-run`
+- `docker compose exec -T django pytest -m mysql_compat -q`

--- a/static/custom/js/expediente_detail.js
+++ b/static/custom/js/expediente_detail.js
@@ -496,6 +496,93 @@ document.addEventListener('DOMContentLoaded', () => {
   }
 
 
+  /* ===== MODAL RECHAZAR (técnico) ===== */
+  const modalRechazar = document.getElementById('modalRechazar');
+  if (modalRechazar) {
+    modalRechazar.addEventListener('show.bs.modal', function (event) {
+      const trigger = event.relatedTarget;
+      const legajoId = trigger?.getAttribute('data-legajo-id') || '';
+      modalRechazar.querySelector('#rechazar-legajo-id').value = legajoId;
+      const ta = modalRechazar.querySelector('#rechazar-motivo');
+      if (ta) ta.value = '';
+    });
+
+    const formRechazar = document.getElementById('form-rechazar');
+    formRechazar.addEventListener('submit', async (e) => {
+      e.preventDefault();
+
+      const legajoId = modalRechazar.querySelector('#rechazar-legajo-id').value;
+      const motivo = (modalRechazar.querySelector('#rechazar-motivo').value || '').trim();
+      const btn = document.getElementById('btn-confirm-rechazar');
+      const original = btn.innerHTML;
+
+      if (!legajoId) {
+        showAlert('danger', 'No se pudo identificar el legajo.');
+        return;
+      }
+      if (!motivo) {
+        showAlert('warning', 'Indicá el motivo del rechazo.');
+        return;
+      }
+
+      if (!window.REVISAR_URL_TEMPLATE) {
+        showAlert('danger', 'No se configuró la URL de revisión de legajos.');
+        return;
+      }
+      const url = window.REVISAR_URL_TEMPLATE.replace('{id}', legajoId);
+
+      btn.disabled = true;
+      btn.innerHTML = '<span class="spinner-border spinner-border-sm" role="status"></span> Guardando…';
+
+      try {
+        const fd = new FormData();
+        fd.append('accion', 'RECHAZAR');
+        fd.append('motivo', motivo);
+
+        const resp = await fetch(url, {
+          method: 'POST',
+          body: fd,
+          credentials: 'same-origin',
+          headers: {
+            'X-CSRFToken': getCsrfToken(),
+            'X-Requested-With': 'XMLHttpRequest',
+            'Accept': 'application/json'
+          }
+        });
+
+        const ct = resp.headers.get('Content-Type') || '';
+        let data = {};
+        if (ct.includes('application/json')) {
+          data = await resp.json();
+        } else {
+          const text = await resp.text();
+          if (!resp.ok) throw new Error(text || `HTTP ${resp.status}`);
+          data = { success: true, message: text, estado: 'RECHAZADO' };
+        }
+
+        if (!resp.ok || data.success === false) {
+          const msg = data.error || data.message || `HTTP ${resp.status}`;
+          throw new Error(msg);
+        }
+
+        showAlert('success', data.message || `Legajo ${legajoId}: quedó rechazado.`);
+        setTimeout(() => {
+          const modal = bootstrap.Modal.getInstance(modalRechazar);
+          modal.hide();
+          window.location.reload();
+        }, 800);
+
+      } catch (err) {
+        console.error('Rechazar legajo:', err);
+        showAlert('danger', 'No se pudo registrar el rechazo. ', err.message);
+      } finally {
+        btn.disabled = false;
+        btn.innerHTML = original;
+      }
+    });
+  }
+
+
   /* ===== CRUCE CUIT (Nuevo/Reprocesar) ===== */
   const modalCruce = document.getElementById('modalCruceCuit');
   if (modalCruce) {
@@ -649,16 +736,14 @@ document.addEventListener('DOMContentLoaded', () => {
     }
 
     function toggleActive(btnAprobar, btnRechazar, estado) {
-      [btnAprobar, btnRechazar].forEach(b => {
-        if (!b) return;
-        b.classList.remove('active');
-        b.classList.remove('btn-success', 'btn-danger');
-        b.classList.add('btn-outline-success');
-        if (b && b.dataset.accion === 'RECHAZAR') {
-          b.classList.remove('btn-outline-success');
-          b.classList.add('btn-outline-danger');
-        }
-      });
+      if (btnAprobar) {
+        btnAprobar.classList.remove('active', 'btn-success', 'btn-danger', 'btn-outline-danger');
+        btnAprobar.classList.add('btn-outline-success');
+      }
+      if (btnRechazar) {
+        btnRechazar.classList.remove('active', 'btn-success', 'btn-danger', 'btn-outline-success');
+        btnRechazar.classList.add('btn-outline-danger');
+      }
 
       if (estado === 'APROBADO' && btnAprobar) {
         btnAprobar.classList.add('active');
@@ -689,7 +774,7 @@ document.addEventListener('DOMContentLoaded', () => {
 
         const container = btn.closest('.legajo-item') || document;
         const btnAprobar = container.querySelector(`.btn-revision[data-legajo-id="${legajoId}"][data-accion="APROBAR"]`);
-        const btnRechazar = container.querySelector(`.btn-revision[data-legajo-id="${legajoId}"][data-accion="RECHAZAR"]`);
+        const btnRechazar = container.querySelector(`.btn-rechazar[data-legajo-id="${legajoId}"]`);
 
         setLoading(btn, true);
 

--- a/static/custom/js/expediente_detail.js
+++ b/static/custom/js/expediente_detail.js
@@ -1403,7 +1403,6 @@ document.addEventListener('DOMContentLoaded', () => {
 
 
 });
-
   /* ===== CONFIRMAR SUBSANACIÓN INDIVIDUAL ===== */
   const botonesConfirmarSubsanacion = document.querySelectorAll('.btn-confirmar-subsanacion-individual');
   botonesConfirmarSubsanacion.forEach(btn => {
@@ -1850,3 +1849,4 @@ document.addEventListener('DOMContentLoaded', function() {
         });
     }
 });
+

--- a/tests/test_celiaquia_expediente_view_helpers_unit.py
+++ b/tests/test_celiaquia_expediente_view_helpers_unit.py
@@ -598,14 +598,24 @@ def test_revisar_legajo_invalid_and_eliminar_paths(mocker):
     no_motivo = view.post(no_motivo_req, pk=1, legajo_id=3)
     assert no_motivo.status_code == 400
 
+    no_motivo_rechazo_req = SimpleNamespace(
+        user=_user_stub(user_id=1, tec=True), POST={"accion": "RECHAZAR", "motivo": ""}
+    )
+    no_motivo_rechazo = view.post(no_motivo_rechazo_req, pk=1, legajo_id=3)
+    assert no_motivo_rechazo.status_code == 400
+
     liberar = mocker.patch("celiaquia.views.expediente.CupoService.liberar_slot")
-    mocker.patch("celiaquia.views.expediente.HistorialValidacionTecnica.objects.create")
+    historial_create = mocker.patch(
+        "celiaquia.views.expediente.HistorialValidacionTecnica.objects.create"
+    )
     rechazar_req = SimpleNamespace(
-        user=_user_stub(user_id=1, tec=True), POST={"accion": "RECHAZAR"}
+        user=_user_stub(user_id=1, tec=True),
+        POST={"accion": "RECHAZAR", "motivo": "Documento ilegible"},
     )
     rechazar = view.post(rechazar_req, pk=1, legajo_id=3)
     assert rechazar.status_code == 200
     assert liberar.called
+    assert historial_create.call_args.kwargs["motivo"] == "Documento ilegible"
 
     mocker.patch("celiaquia.views.expediente._is_admin", return_value=True)
     eliminar_req = SimpleNamespace(

--- a/tests/test_consulta_renaper_unit.py
+++ b/tests/test_consulta_renaper_unit.py
@@ -32,7 +32,9 @@ def test_api_client_no_log_error_when_no_match(mocker):
     client = module.APIClient()
     client.session = session
     mocker.patch.object(client, "get_token", return_value="token")
-    log_error = mocker.patch("centrodefamilia.services.consulta_renaper.impl.logger.error")
+    log_error = mocker.patch(
+        "centrodefamilia.services.consulta_renaper.impl.logger.error"
+    )
 
     out = client.consultar_ciudadano("13163071", "M")
 
@@ -60,7 +62,9 @@ def test_api_client_clasifica_timeout_en_consulta(mocker):
 
 def test_api_client_clasifica_auth_error_en_consulta(mocker):
     session = mocker.Mock()
-    session.get.return_value = _HTTPErrorResponse({"detail": "unauthorized"}, status_code=401)
+    session.get.return_value = _HTTPErrorResponse(
+        {"detail": "unauthorized"}, status_code=401
+    )
 
     client = module.APIClient()
     client.session = session
@@ -75,7 +79,9 @@ def test_api_client_clasifica_auth_error_en_consulta(mocker):
 
 def test_api_client_clasifica_invalid_response_en_consulta(mocker):
     session = mocker.Mock()
-    session.get.return_value = _ResponseMock(ValueError("bad json"), text="<html>broken</html>")
+    session.get.return_value = _ResponseMock(
+        ValueError("bad json"), text="<html>broken</html>"
+    )
 
     client = module.APIClient()
     client.session = session
@@ -96,7 +102,9 @@ def test_consultar_datos_renaper_propagates_error_type(mocker):
         "error_type": "remote_error",
         "raw_response": {"detail": "boom"},
     }
-    mocker.patch("centrodefamilia.services.consulta_renaper.impl.APIClient", return_value=client)
+    mocker.patch(
+        "centrodefamilia.services.consulta_renaper.impl.APIClient", return_value=client
+    )
 
     out = module.consultar_datos_renaper("13163071", "M")
 
@@ -111,7 +119,9 @@ def test_consultar_datos_renaper_detecta_fallecido(mocker):
         "success": True,
         "data": {"mensaf": "FALLECIDO"},
     }
-    mocker.patch("centrodefamilia.services.consulta_renaper.impl.APIClient", return_value=client)
+    mocker.patch(
+        "centrodefamilia.services.consulta_renaper.impl.APIClient", return_value=client
+    )
 
     out = module.consultar_datos_renaper("13163071", "M")
 
@@ -126,7 +136,9 @@ def test_consultar_datos_renaper_clasifica_payload_invalido(mocker):
         "success": True,
         "data": "payload roto",
     }
-    mocker.patch("centrodefamilia.services.consulta_renaper.impl.APIClient", return_value=client)
+    mocker.patch(
+        "centrodefamilia.services.consulta_renaper.impl.APIClient", return_value=client
+    )
 
     out = module.consultar_datos_renaper("13163071", "M")
 

--- a/tests/test_consulta_renaper_unit.py
+++ b/tests/test_consulta_renaper_unit.py
@@ -1,17 +1,28 @@
 """Tests unitarios para centrodefamilia.services.consulta_renaper.impl."""
 
+import requests
+
 import centrodefamilia.services.consulta_renaper as module
 
 
 class _ResponseMock:
-    def __init__(self, payload):
+    def __init__(self, payload=None, text="", status_code=200):
         self.payload = payload
+        self.text = text
+        self.status_code = status_code
 
     def raise_for_status(self):
         return None
 
     def json(self):
+        if isinstance(self.payload, Exception):
+            raise self.payload
         return self.payload
+
+
+class _HTTPErrorResponse(_ResponseMock):
+    def raise_for_status(self):
+        raise requests.HTTPError(response=self)
 
 
 def test_api_client_no_log_error_when_no_match(mocker):
@@ -21,12 +32,103 @@ def test_api_client_no_log_error_when_no_match(mocker):
     client = module.APIClient()
     client.session = session
     mocker.patch.object(client, "get_token", return_value="token")
-    log_error = mocker.patch(
-        "centrodefamilia.services.consulta_renaper.impl.logger.error"
-    )
+    log_error = mocker.patch("centrodefamilia.services.consulta_renaper.impl.logger.error")
 
     out = client.consultar_ciudadano("13163071", "M")
 
     assert out["success"] is False
-    assert out["error"] == "No se encontró coincidencia."
+    assert out["error_type"] == "no_match"
     log_error.assert_not_called()
+
+
+def test_api_client_clasifica_timeout_en_consulta(mocker):
+    session = mocker.Mock()
+    session.get.side_effect = requests.Timeout()
+
+    client = module.APIClient()
+    client.session = session
+    mocker.patch.object(client, "get_token", return_value="token")
+
+    out = client.consultar_ciudadano("13163071", "M")
+
+    assert out == {
+        "success": False,
+        "error": "RENAPER no respondio a tiempo durante la consulta.",
+        "error_type": "timeout",
+    }
+
+
+def test_api_client_clasifica_auth_error_en_consulta(mocker):
+    session = mocker.Mock()
+    session.get.return_value = _HTTPErrorResponse({"detail": "unauthorized"}, status_code=401)
+
+    client = module.APIClient()
+    client.session = session
+    mocker.patch.object(client, "get_token", return_value="token")
+
+    out = client.consultar_ciudadano("13163071", "M")
+
+    assert out["success"] is False
+    assert out["error_type"] == "auth_error"
+    assert out["raw_response"] == {"detail": "unauthorized"}
+
+
+def test_api_client_clasifica_invalid_response_en_consulta(mocker):
+    session = mocker.Mock()
+    session.get.return_value = _ResponseMock(ValueError("bad json"), text="<html>broken</html>")
+
+    client = module.APIClient()
+    client.session = session
+    mocker.patch.object(client, "get_token", return_value="token")
+
+    out = client.consultar_ciudadano("13163071", "M")
+
+    assert out["success"] is False
+    assert out["error_type"] == "invalid_response"
+    assert out["raw_response"] == "<html>broken</html>"
+
+
+def test_consultar_datos_renaper_propagates_error_type(mocker):
+    client = mocker.Mock()
+    client.consultar_ciudadano.return_value = {
+        "success": False,
+        "error": "upstream unavailable",
+        "error_type": "remote_error",
+        "raw_response": {"detail": "boom"},
+    }
+    mocker.patch("centrodefamilia.services.consulta_renaper.impl.APIClient", return_value=client)
+
+    out = module.consultar_datos_renaper("13163071", "M")
+
+    assert out["success"] is False
+    assert out["error_type"] == "remote_error"
+    assert out["raw_response"] == {"detail": "boom"}
+
+
+def test_consultar_datos_renaper_detecta_fallecido(mocker):
+    client = mocker.Mock()
+    client.consultar_ciudadano.return_value = {
+        "success": True,
+        "data": {"mensaf": "FALLECIDO"},
+    }
+    mocker.patch("centrodefamilia.services.consulta_renaper.impl.APIClient", return_value=client)
+
+    out = module.consultar_datos_renaper("13163071", "M")
+
+    assert out["success"] is False
+    assert out["error_type"] == "fallecido"
+    assert out["fallecido"] is True
+
+
+def test_consultar_datos_renaper_clasifica_payload_invalido(mocker):
+    client = mocker.Mock()
+    client.consultar_ciudadano.return_value = {
+        "success": True,
+        "data": "payload roto",
+    }
+    mocker.patch("centrodefamilia.services.consulta_renaper.impl.APIClient", return_value=client)
+
+    out = module.consultar_datos_renaper("13163071", "M")
+
+    assert out["success"] is False
+    assert out["error_type"] == "invalid_response"

--- a/tests/test_expediente_service_unit.py
+++ b/tests/test_expediente_service_unit.py
@@ -86,6 +86,22 @@ class _LegajosQS:
     def count(self):
         return len(self._legs)
 
+    def select_related(self, *args, **kwargs):
+        return self
+
+    def values_list(self, *args, **kwargs):
+        return [leg.ciudadano_id for leg in self._legs]
+
+    def filter(self, **kwargs):
+        if kwargs == {"archivos_ok": False}:
+            return SimpleNamespace(
+                exists=lambda: any(not leg.archivos_ok for leg in self._legs)
+            )
+        raise AssertionError(f"Filtro no esperado: {kwargs}")
+
+    def iterator(self):
+        return iter(self._legs)
+
 
 def test_confirmar_envio_paths(mocker):
     exp_bad = SimpleNamespace(estado=SimpleNamespace(nombre="CREADO"))
@@ -120,6 +136,34 @@ def test_confirmar_envio_paths(mocker):
     out = module.ExpedienteService.confirmar_envio(exp, usuario="u")
     assert out == {"validos": 2, "errores": 0}
     assert set_estado.called
+
+
+def test_confirmar_envio_rechaza_doble_rol_sin_archivo1(mocker):
+    leg = SimpleNamespace(
+        pk=12,
+        rol="beneficiario_y_responsable",
+        archivo1=None,
+        archivo2=object(),
+        archivo3=object(),
+        archivos_ok=False,
+        ciudadano=SimpleNamespace(id=4, documento="400", fecha_nacimiento=None),
+        ciudadano_id=4,
+        save=mocker.Mock(),
+    )
+    exp = SimpleNamespace(
+        pk=13,
+        estado=SimpleNamespace(nombre="EN_ESPERA"),
+        expediente_ciudadanos=_LegajosQS([leg]),
+    )
+    mocker.patch(
+        "celiaquia.services.legajo_service.FamiliaService.obtener_ids_responsables",
+        return_value={4},
+    )
+
+    with pytest.raises(ValidationError):
+        module.ExpedienteService.confirmar_envio(exp, usuario="u")
+
+    assert leg.archivos_ok is False
 
 
 def test_asignar_tecnico_with_id_and_user(mocker):

--- a/tests/test_legajo_service_unit.py
+++ b/tests/test_legajo_service_unit.py
@@ -250,6 +250,52 @@ def test_archivos_requeridos_respeta_flag_es_doble_rol():
     assert out["archivo3"] == "Certificacion de ANSES"
 
 
+def test_faltantes_archivos_incluye_archivo1_para_doble_rol(mocker):
+    class Leg:
+        def __init__(self):
+            self.id = 15
+            self.pk = 15
+            self.archivo1 = None
+            self.archivo2 = object()
+            self.archivo3 = object()
+            self.rol = module.ExpedienteCiudadano.ROLE_BENEFICIARIO_Y_RESPONSABLE
+            self.ciudadano = SimpleNamespace(
+                id=3, documento="300", nombre="Ana", apellido="Perez"
+            )
+            self.ciudadano_id = 3
+            self.estado = SimpleNamespace(nombre="E")
+            self.revision_tecnico = "R"
+            self.archivos_ok = True
+
+    class Qs:
+        def select_related(self, *args, **kwargs):
+            return self
+
+        def only(self, *args, **kwargs):
+            return self
+
+        def filter(self, *args, **kwargs):
+            return self
+
+        def values_list(self, *args, **kwargs):
+            return [3]
+
+        def iterator(self):
+            return iter([Leg()])
+
+    exp = SimpleNamespace(id=2, expediente_ciudadanos=Qs())
+    mocker.patch(
+        "celiaquia.services.legajo_service.FamiliaService.obtener_ids_responsables",
+        return_value={3},
+    )
+
+    out = module.LegajoService.faltantes_archivos(exp)
+
+    assert len(out) == 1
+    assert out[0]["faltan"] == ["archivo1"]
+    assert out[0]["faltan_nombres"] == ["Biopsia / Constancia medica"]
+
+
 def test_actualizar_subsanacion_warning_and_estado_cache_missing(mocker):
     class Missing(Exception):
         pass

--- a/tests/test_pr_lint_tools_unit.py
+++ b/tests/test_pr_lint_tools_unit.py
@@ -22,7 +22,9 @@ def test_get_changed_files_usa_api_del_pr_si_falta_el_rango_git(monkeypatch):
     monkeypatch.setattr(
         pr_lint_tools,
         "read_event_payload",
-        lambda: {"pull_request": {"url": "https://api.github.test/repos/org/repo/pulls/1"}},
+        lambda: {
+            "pull_request": {"url": "https://api.github.test/repos/org/repo/pulls/1"}
+        },
     )
 
     def fake_run_git_command(*args, check=True):
@@ -38,7 +40,10 @@ def test_get_changed_files_usa_api_del_pr_si_falta_el_rango_git(monkeypatch):
         pr_lint_tools,
         "_fetch_github_json",
         lambda url: (
-            [{"filename": "scripts/ci/pr_lint_tools.py"}, {"filename": "VAT/serializers.py"}]
+            [
+                {"filename": "scripts/ci/pr_lint_tools.py"},
+                {"filename": "VAT/serializers.py"},
+            ]
             if "page=1" in url
             else []
         ),
@@ -59,7 +64,9 @@ def test_get_changed_files_usa_fallback_si_falta_el_base_sha(monkeypatch):
         "get_diff_range",
         lambda: ("base-sha", "head-sha"),
     )
-    monkeypatch.setattr(pr_lint_tools, "get_pull_request_changed_files_from_api", lambda: [])
+    monkeypatch.setattr(
+        pr_lint_tools, "get_pull_request_changed_files_from_api", lambda: []
+    )
 
     def fake_run_git_command(*args, check=True):
         if args in (

--- a/tests/test_validacion_renaper_view_unit.py
+++ b/tests/test_validacion_renaper_view_unit.py
@@ -201,7 +201,9 @@ def test_consultar_renaper_guard_clauses(mocker):
     resp_bad_doc = view._consultar_renaper(
         SimpleNamespace(user=_User(superuser=True)), pk=1, legajo_id=1
     )
-    assert "DNI v" in json.loads(resp_bad_doc.content)["error"]
+    assert json.loads(resp_bad_doc.content)["error"].startswith(
+        "No se pudo extraer DNI válido"
+    )
 
 
 def test_consultar_renaper_fallecido_y_exito(mocker):

--- a/tests/test_validacion_renaper_view_unit.py
+++ b/tests/test_validacion_renaper_view_unit.py
@@ -72,13 +72,25 @@ class _Legajo:
         self.saved_fields = update_fields
 
 
+def _crear_ciudadano_base(sexo="Masculino"):
+    return SimpleNamespace(
+        documento="20123456780",
+        sexo=SimpleNamespace(sexo=sexo) if sexo else None,
+        nombre="ana",
+        apellido="perez",
+        fecha_nacimiento=None,
+        calle="mitre",
+        altura=10,
+        piso_departamento="1a",
+        ciudad="la plata",
+        provincia=None,
+        codigo_postal=1900,
+    )
+
+
 @pytest.mark.parametrize(
     "value,length,expected",
-    [
-        ("abc", 10, "abc"),
-        ("a" * 8, 5, "aaaaa…"),
-        (123, 5, 123),
-    ],
+    [("abc", 10, "abc"), ("a" * 8, 5, "aaaaa…"), (123, 5, 123)],
 )
 def test_helpers_truncate(value, length, expected):
     assert module._truncate(value, length) == expected
@@ -123,14 +135,12 @@ def test_guardar_validacion_estado_paths(mocker):
     invalid = view._guardar_validacion_estado(
         req, pk=1, legajo_id=2, validacion_estado="9"
     )
-    body_invalid = json.loads(invalid.content)
-    assert body_invalid["success"] is False
+    assert json.loads(invalid.content)["success"] is False
 
     subsanar = view._guardar_validacion_estado(
         req, pk=1, legajo_id=2, validacion_estado="3"
     )
-    body_subsanar = json.loads(subsanar.content)
-    assert body_subsanar["success"] is True
+    assert json.loads(subsanar.content)["success"] is True
     assert legajo.revision_tecnico == "SUBSANAR"
     assert "subsanacion_motivo" in legajo.saved_fields
 
@@ -146,10 +156,7 @@ def test_consultar_renaper_guard_clauses(mocker):
     view = module.ValidacionRenaperView()
     tecnico = _User(groups=_Groups({"TecnicoCeliaquia"}))
 
-    # técnico no asignado
-    legajo_no_asig = _Legajo(
-        ciudadano=SimpleNamespace(documento="12345678"), assigned=False
-    )
+    legajo_no_asig = _Legajo(ciudadano=SimpleNamespace(documento="12345678"), assigned=False)
     mocker.patch(
         "celiaquia.views.validacion_renaper.get_object_or_404",
         return_value=legajo_no_asig,
@@ -159,7 +166,6 @@ def test_consultar_renaper_guard_clauses(mocker):
     )
     assert resp_forbidden.status_code == 403
 
-    # ciudadano inexistente
     legajo_sin_ciudadano = _Legajo(ciudadano=None, assigned=True)
     mocker.patch(
         "celiaquia.views.validacion_renaper.get_object_or_404",
@@ -170,21 +176,22 @@ def test_consultar_renaper_guard_clauses(mocker):
     )
     assert json.loads(resp_no_cit.content)["success"] is False
 
-    # documento inválido
-    citizen = SimpleNamespace(
-        documento="abc",
-        sexo=SimpleNamespace(sexo="Masculino"),
-        nombre="ana",
-        apellido="perez",
-        fecha_nacimiento=None,
-        calle="",
-        altura=None,
-        piso_departamento="",
-        ciudad="",
-        provincia=None,
-        codigo_postal=None,
+    legajo_bad_doc = _Legajo(
+        ciudadano=SimpleNamespace(
+            documento="abc",
+            sexo=SimpleNamespace(sexo="Masculino"),
+            nombre="ana",
+            apellido="perez",
+            fecha_nacimiento=None,
+            calle="",
+            altura=None,
+            piso_departamento="",
+            ciudad="",
+            provincia=None,
+            codigo_postal=None,
+        ),
+        assigned=True,
     )
-    legajo_bad_doc = _Legajo(ciudadano=citizen, assigned=True)
     mocker.patch(
         "celiaquia.views.validacion_renaper.get_object_or_404",
         return_value=legajo_bad_doc,
@@ -192,55 +199,37 @@ def test_consultar_renaper_guard_clauses(mocker):
     resp_bad_doc = view._consultar_renaper(
         SimpleNamespace(user=_User(superuser=True)), pk=1, legajo_id=1
     )
-    assert "DNI válido" in json.loads(resp_bad_doc.content)["error"]
+    assert "DNI v" in json.loads(resp_bad_doc.content)["error"]
 
 
-def test_consultar_renaper_remote_error_fallecido_and_success(mocker):
+def test_consultar_renaper_fallecido_y_exito(mocker):
     view = module.ValidacionRenaperView()
-    base_ciudadano = dict(
-        documento="20123456780",
-        sexo=SimpleNamespace(sexo="Masculino"),
-        nombre="ana",
-        apellido="perez",
-        fecha_nacimiento=None,
-        calle="mitre",
-        altura=10,
-        piso_departamento="1a",
-        ciudad="la plata",
-        provincia=None,
-        codigo_postal=1900,
-    )
 
-    # Fallecido
-    legajo_fall = _Legajo(ciudadano=SimpleNamespace(**base_ciudadano))
+    legajo_fall = _Legajo(ciudadano=_crear_ciudadano_base())
     mocker.patch(
         "celiaquia.views.validacion_renaper.get_object_or_404", return_value=legajo_fall
     )
     mocker.patch(
         "celiaquia.views.validacion_renaper.consultar_datos_renaper",
-        return_value={"success": True, "fallecido": True, "data": {}},
+        return_value={
+            "success": False,
+            "fallecido": True,
+            "error": "El ciudadano se encuentra fallecido.",
+            "error_type": "fallecido",
+            "raw_response": {"mensaf": "FALLECIDO"},
+        },
     )
+    info = mocker.patch.object(module.logger, "info")
+
     r1 = view._consultar_renaper(
         SimpleNamespace(user=_User(superuser=True)), pk=1, legajo_id=1
     )
+
     assert "fallecida" in json.loads(r1.content)["error"]
+    info_messages = [call.args[0] for call in info.call_args_list]
+    assert "renaper.validation.fallecido" in info_messages
 
-    # Error remoto
-    legajo_err = _Legajo(ciudadano=SimpleNamespace(**base_ciudadano))
-    mocker.patch(
-        "celiaquia.views.validacion_renaper.get_object_or_404", return_value=legajo_err
-    )
-    mocker.patch(
-        "celiaquia.views.validacion_renaper.consultar_datos_renaper",
-        return_value={"success": False, "error": "x", "raw_response": "raw"},
-    )
-    r2 = view._consultar_renaper(
-        SimpleNamespace(user=_User(superuser=True)), pk=1, legajo_id=1
-    )
-    assert "Cuit o el Sexo" in json.loads(r2.content)["error"]
-
-    # Éxito + mapeo provincia por id
-    legajo_ok = _Legajo(ciudadano=SimpleNamespace(**base_ciudadano))
+    legajo_ok = _Legajo(ciudadano=_crear_ciudadano_base())
     mocker.patch(
         "celiaquia.views.validacion_renaper.get_object_or_404", return_value=legajo_ok
     )
@@ -267,12 +256,188 @@ def test_consultar_renaper_remote_error_fallecido_and_success(mocker):
         "core.models.Provincia.objects.get",
         return_value=SimpleNamespace(nombre="Buenos Aires"),
     )
-    r3 = view._consultar_renaper(
+
+    r2 = view._consultar_renaper(
         SimpleNamespace(user=_User(superuser=True)), pk=1, legajo_id=1
     )
-    body = json.loads(r3.content)
+    body = json.loads(r2.content)
     assert body["success"] is True
     assert body["datos_renaper"]["provincia"] == "Buenos Aires"
+
+
+def test_consultar_renaper_remote_error_muestra_mensaje_funcional(mocker):
+    view = module.ValidacionRenaperView()
+    legajo = _Legajo(ciudadano=_crear_ciudadano_base())
+    mocker.patch(
+        "celiaquia.views.validacion_renaper.get_object_or_404", return_value=legajo
+    )
+    mocker.patch(
+        "celiaquia.views.validacion_renaper.consultar_datos_renaper",
+        return_value={
+            "success": False,
+            "error": "temporarily unavailable",
+            "error_type": "remote_error",
+            "raw_response": {"message": "upstream down"},
+        },
+    )
+
+    response = view._consultar_renaper(
+        SimpleNamespace(user=_User(superuser=True)), pk=1, legajo_id=1
+    )
+
+    assert (
+        json.loads(response.content)["error"]
+        == module.RENAPER_REMOTE_UNAVAILABLE_MESSAGE
+    )
+
+
+def test_consultar_renaper_invalid_response_muestra_mensaje_y_log(mocker):
+    mocker.patch.object(module.settings, "RENAPER_VALIDACION_MAX_RETRIES", 1)
+    mocker.patch.object(module.settings, "RENAPER_VALIDACION_BACKOFF_SECONDS", 0)
+    view = module.ValidacionRenaperView()
+    legajo = _Legajo(ciudadano=_crear_ciudadano_base())
+    mocker.patch(
+        "celiaquia.views.validacion_renaper.get_object_or_404", return_value=legajo
+    )
+    mocker.patch(
+        "celiaquia.views.validacion_renaper.consultar_datos_renaper",
+        return_value={
+            "success": False,
+            "error": "payload invalido",
+            "error_type": "invalid_response",
+            "raw_response": {"broken": True},
+        },
+    )
+    error = mocker.patch.object(module.logger, "error")
+
+    response = view._consultar_renaper(
+        SimpleNamespace(user=_User(superuser=True)), pk=1, legajo_id=1
+    )
+    body = json.loads(response.content)
+
+    assert body["error"] == module.RENAPER_INVALID_RESPONSE_MESSAGE
+    assert error.call_args[0][0] == "renaper.validation.invalid_response"
+    log_data = error.call_args[1]["extra"]["data"]
+    assert log_data["stage"] == "response"
+    assert log_data["error_type"] == "invalid_response"
+    assert log_data["retry_attempt"] == 1
+    assert log_data["max_retries"] == 1
+    assert '"broken": true' in log_data["raw_response_excerpt"]
+
+
+def test_no_match_no_reintenta_ni_loguea_retry(mocker):
+    mocker.patch.object(module.settings, "RENAPER_VALIDACION_MAX_RETRIES", 3)
+    mocker.patch.object(module.settings, "RENAPER_VALIDACION_BACKOFF_SECONDS", 0.25)
+    consultar = mocker.patch(
+        "celiaquia.views.validacion_renaper.consultar_datos_renaper",
+        return_value={
+            "success": False,
+            "error": "No se encontro coincidencia.",
+            "error_type": "no_match",
+            "raw_response": {"isSuccess": False},
+        },
+    )
+    warning = mocker.patch.object(module.logger, "warning")
+    sleep = mocker.patch("celiaquia.views.validacion_renaper.time.sleep")
+
+    out = module._consultar_datos_renaper_con_reintentos("12345678", "M")
+
+    assert out["error_type"] == "no_match"
+    assert out["retry_attempt"] == 1
+    assert out["max_retries"] == 3
+    assert consultar.call_count == 1
+    sleep.assert_not_called()
+    assert not any(call.args[0] == "renaper.validation.retrying_remote_query" for call in warning.call_args_list)
+
+
+def test_no_match_loguea_solo_no_match_y_mensaje_funcional(mocker):
+    mocker.patch.object(module.settings, "RENAPER_VALIDACION_MAX_RETRIES", 1)
+    mocker.patch.object(module.settings, "RENAPER_VALIDACION_BACKOFF_SECONDS", 0)
+    view = module.ValidacionRenaperView()
+    legajo = _Legajo(ciudadano=_crear_ciudadano_base())
+    mocker.patch(
+        "celiaquia.views.validacion_renaper.get_object_or_404", return_value=legajo
+    )
+    mocker.patch(
+        "celiaquia.views.validacion_renaper.consultar_datos_renaper",
+        return_value={
+            "success": False,
+            "error": "No se encontro coincidencia.",
+            "error_type": "no_match",
+            "raw_response": {"isSuccess": False, "detalle": "mismatch"},
+        },
+    )
+    info = mocker.patch.object(module.logger, "info")
+    warning = mocker.patch.object(module.logger, "warning")
+    error = mocker.patch.object(module.logger, "error")
+
+    response = view._consultar_renaper(
+        SimpleNamespace(user=_User(superuser=True)), pk=1, legajo_id=1
+    )
+    body = json.loads(response.content)
+
+    assert body["error"] == module.RENAPER_NO_MATCH_MESSAGE
+    info_messages = [call.args[0] for call in info.call_args_list]
+    assert "renaper.validation.no_match" in info_messages
+    warning_messages = [call.args[0] for call in warning.call_args_list]
+    assert "renaper.validation.no_match" not in warning_messages
+    assert "renaper.validation.retrying_remote_query" not in warning_messages
+    error_messages = [call.args[0] for call in error.call_args_list]
+    assert "renaper.validation.response_error" not in error_messages
+    no_match_logs = [
+        call for call in info.call_args_list if call.args[0] == "renaper.validation.no_match"
+    ]
+    assert len(no_match_logs) == 1
+    log_data = no_match_logs[0].kwargs["extra"]["data"]
+    assert log_data["error_type"] == "no_match"
+    assert log_data["retry_attempt"] == 1
+    assert log_data["max_retries"] == 1
+    assert '"detalle": "mismatch"' in log_data["raw_response_excerpt"]
+
+
+def test_consultar_datos_renaper_con_reintentos_respeta_backoff_y_retry_log(mocker):
+    mocker.patch.object(module.settings, "RENAPER_VALIDACION_MAX_RETRIES", 3)
+    mocker.patch.object(module.settings, "RENAPER_VALIDACION_BACKOFF_SECONDS", 0.25)
+    consultar = mocker.patch(
+        "celiaquia.views.validacion_renaper.consultar_datos_renaper",
+        side_effect=[
+            {"success": False, "error": "timeout 1", "error_type": "timeout"},
+            {"success": False, "error": "timeout 2", "error_type": "timeout"},
+            {"success": True, "data": {"documento": "12345678"}},
+        ],
+    )
+    warning = mocker.patch.object(module.logger, "warning")
+    sleep = mocker.patch("celiaquia.views.validacion_renaper.time.sleep")
+
+    out = module._consultar_datos_renaper_con_reintentos("12345678", "M")
+
+    assert out["success"] is True
+    assert out["retry_attempt"] == 3
+    assert out["max_retries"] == 3
+    assert consultar.call_count == 3
+    assert sleep.call_count == 2
+    assert sleep.call_args_list[0].args == (0.25,)
+    assert sleep.call_args_list[1].args == (0.5,)
+    retry_logs = [call for call in warning.call_args_list if call.args[0] == "renaper.validation.retrying_remote_query"]
+    assert len(retry_logs) == 2
+    assert retry_logs[0].kwargs["extra"]["data"]["error_type"] == "timeout"
+
+
+def test_consultar_datos_renaper_con_reintentos_defaults_invalidos(mocker):
+    mocker.patch.object(module.settings, "RENAPER_VALIDACION_MAX_RETRIES", "abc")
+    mocker.patch.object(module.settings, "RENAPER_VALIDACION_BACKOFF_SECONDS", "x")
+    consultar = mocker.patch(
+        "celiaquia.views.validacion_renaper.consultar_datos_renaper",
+        return_value={"success": False, "error": "fail", "error_type": "remote_error"},
+    )
+    sleep = mocker.patch("celiaquia.views.validacion_renaper.time.sleep")
+
+    out = module._consultar_datos_renaper_con_reintentos("12345678", "F")
+
+    assert out["success"] is False
+    assert out["retry_attempt"] == 1
+    assert consultar.call_count == 1
+    sleep.assert_not_called()
 
 
 def test_formatear_datos_renaper_usa_provincia_api_cuando_no_hay_pk():
@@ -334,19 +499,8 @@ def test_post_routes_to_save_or_consulta(mocker):
 
 def test_consultar_renaper_sin_sexo_reintenta_y_reutiliza_respuesta(mocker):
     view = module.ValidacionRenaperView()
-    ciudadano = SimpleNamespace(
-        documento="12345678",
-        sexo=None,
-        nombre="ana",
-        apellido="perez",
-        fecha_nacimiento=None,
-        calle="mitre",
-        altura=10,
-        piso_departamento="1a",
-        ciudad="la plata",
-        provincia=None,
-        codigo_postal=1900,
-    )
+    ciudadano = _crear_ciudadano_base(sexo=None)
+    ciudadano.documento = "12345678"
     legajo = _Legajo(ciudadano=ciudadano, assigned=True)
     mocker.patch(
         "celiaquia.views.validacion_renaper.get_object_or_404",
@@ -355,7 +509,7 @@ def test_consultar_renaper_sin_sexo_reintenta_y_reutiliza_respuesta(mocker):
     consultar = mocker.patch(
         "celiaquia.views.validacion_renaper.consultar_datos_renaper",
         side_effect=[
-            {"success": False, "error": "mismatch"},
+            {"success": False, "error": "mismatch", "error_type": "no_match"},
             {
                 "success": True,
                 "fallecido": False,
@@ -385,41 +539,3 @@ def test_consultar_renaper_sin_sexo_reintenta_y_reutiliza_respuesta(mocker):
     assert consultar.call_count == 2
     assert consultar.call_args_list[0].args == ("12345678", "M")
     assert consultar.call_args_list[1].args == ("12345678", "F")
-
-
-def test_consultar_datos_renaper_con_reintentos_respeta_backoff(mocker):
-    mocker.patch.object(module.settings, "RENAPER_VALIDACION_MAX_RETRIES", 3)
-    mocker.patch.object(module.settings, "RENAPER_VALIDACION_BACKOFF_SECONDS", 0.25)
-    consultar = mocker.patch(
-        "celiaquia.views.validacion_renaper.consultar_datos_renaper",
-        side_effect=[
-            {"success": False, "error": "timeout"},
-            {"success": False, "error": "timeout"},
-            {"success": True, "data": {"documento": "12345678"}},
-        ],
-    )
-    sleep = mocker.patch("celiaquia.views.validacion_renaper.time.sleep")
-
-    out = module._consultar_datos_renaper_con_reintentos("12345678", "M")
-
-    assert out["success"] is True
-    assert consultar.call_count == 3
-    assert sleep.call_count == 2
-    assert sleep.call_args_list[0].args == (0.25,)
-    assert sleep.call_args_list[1].args == (0.5,)
-
-
-def test_consultar_datos_renaper_con_reintentos_defaults_invalidos(mocker):
-    mocker.patch.object(module.settings, "RENAPER_VALIDACION_MAX_RETRIES", "abc")
-    mocker.patch.object(module.settings, "RENAPER_VALIDACION_BACKOFF_SECONDS", "x")
-    consultar = mocker.patch(
-        "celiaquia.views.validacion_renaper.consultar_datos_renaper",
-        return_value={"success": False, "error": "fail"},
-    )
-    sleep = mocker.patch("celiaquia.views.validacion_renaper.time.sleep")
-
-    out = module._consultar_datos_renaper_con_reintentos("12345678", "F")
-
-    assert out["success"] is False
-    assert consultar.call_count == 1
-    sleep.assert_not_called()

--- a/tests/test_validacion_renaper_view_unit.py
+++ b/tests/test_validacion_renaper_view_unit.py
@@ -156,7 +156,9 @@ def test_consultar_renaper_guard_clauses(mocker):
     view = module.ValidacionRenaperView()
     tecnico = _User(groups=_Groups({"TecnicoCeliaquia"}))
 
-    legajo_no_asig = _Legajo(ciudadano=SimpleNamespace(documento="12345678"), assigned=False)
+    legajo_no_asig = _Legajo(
+        ciudadano=SimpleNamespace(documento="12345678"), assigned=False
+    )
     mocker.patch(
         "celiaquia.views.validacion_renaper.get_object_or_404",
         return_value=legajo_no_asig,
@@ -347,7 +349,10 @@ def test_no_match_no_reintenta_ni_loguea_retry(mocker):
     assert out["max_retries"] == 3
     assert consultar.call_count == 1
     sleep.assert_not_called()
-    assert not any(call.args[0] == "renaper.validation.retrying_remote_query" for call in warning.call_args_list)
+    assert not any(
+        call.args[0] == "renaper.validation.retrying_remote_query"
+        for call in warning.call_args_list
+    )
 
 
 def test_no_match_loguea_solo_no_match_y_mensaje_funcional(mocker):
@@ -385,7 +390,9 @@ def test_no_match_loguea_solo_no_match_y_mensaje_funcional(mocker):
     error_messages = [call.args[0] for call in error.call_args_list]
     assert "renaper.validation.response_error" not in error_messages
     no_match_logs = [
-        call for call in info.call_args_list if call.args[0] == "renaper.validation.no_match"
+        call
+        for call in info.call_args_list
+        if call.args[0] == "renaper.validation.no_match"
     ]
     assert len(no_match_logs) == 1
     log_data = no_match_logs[0].kwargs["extra"]["data"]
@@ -418,7 +425,11 @@ def test_consultar_datos_renaper_con_reintentos_respeta_backoff_y_retry_log(mock
     assert sleep.call_count == 2
     assert sleep.call_args_list[0].args == (0.25,)
     assert sleep.call_args_list[1].args == (0.5,)
-    retry_logs = [call for call in warning.call_args_list if call.args[0] == "renaper.validation.retrying_remote_query"]
+    retry_logs = [
+        call
+        for call in warning.call_args_list
+        if call.args[0] == "renaper.validation.retrying_remote_query"
+    ]
     assert len(retry_logs) == 2
     assert retry_logs[0].kwargs["extra"]["data"]["error_type"] == "timeout"
 


### PR DESCRIPTION
## Resumen
- integra los cambios de los PRs #1580, #1584 y #1587 sobre `development`
- corrige la integración para que quede consistente el flujo de Celiaquía
- incorpora ajustes mínimos para dejar la rama lista para CI

## Ajustes de integración
- normaliza strings con mojibake en el modal de rechazo y en el registro de cambios
- reduce la consulta de observaciones técnicas al último historial con motivo por legajo
- aplica formato pendiente en los tests de RENAPER para evitar que `black` autofixee el PR

## Validación local
- `docker compose run --build --rm --no-deps -T django pytest tests/test_consulta_renaper_unit.py tests/test_validacion_renaper_view_unit.py tests/test_legajo_service_unit.py tests/test_expediente_service_unit.py tests/test_celiaquia_expediente_view_helpers_unit.py celiaquia/tests/test_validation_errors.py celiaquia/tests/test_expediente_detail.py -q`
- `black --check` sobre los Python tocados
- `djlint --check` sobre `celiaquia/templates/celiaquia/expediente_detail.html`

Refs: #1580 #1584 #1587