### PR TITLE
fix(release): sanear predeploy development-main 2026-04-23

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -106,15 +106,23 @@ LOG_FALLBACK_DIR="/tmp/sisoc-logs"
 # =============================================================================
 # Si EMAIL_BACKEND queda vacio, SISOC usa backend de consola (no envía, solo loggea).
 # Resend SMTP recomendado:
-- EMAIL_BACKEND="django.core.mail.backends.smtp.EmailBackend"
-- EMAIL_HOST="smtp.resend.com"
-- EMAIL_PORT=587
-- EMAIL_HOST_USER="resend"
-- EMAIL_HOST_PASSWORD="<RESEND_API_KEY>"
-- EMAIL_USE_TLS=true
-- EMAIL_USE_SSL=false
-- DEFAULT_FROM_EMAIL="no-reply@sisoc.secretarianaf.gob.ar"
+# - EMAIL_BACKEND="django.core.mail.backends.smtp.EmailBackend"
+# - EMAIL_HOST="smtp.resend.com"
+# - EMAIL_PORT=587
+# - EMAIL_HOST_USER="resend"
+# - EMAIL_HOST_PASSWORD="<RESEND_API_KEY>"
+# - EMAIL_USE_TLS=true
+# - EMAIL_USE_SSL=false
+# - DEFAULT_FROM_EMAIL="SISOC <onboarding@resend.dev>"
+EMAIL_BACKEND=""
+EMAIL_HOST="localhost"
+EMAIL_PORT=587
+EMAIL_HOST_USER=""
+EMAIL_HOST_PASSWORD=""
+EMAIL_USE_TLS=true
+EMAIL_USE_SSL=false
 EMAIL_TIMEOUT=10
+DEFAULT_FROM_EMAIL="no-reply@sisoc.local"
 PASSWORD_RESET_TIMEOUT=3600
 INITIAL_PASSWORD_MAX_AGE_HOURS=336
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,27 +1,27 @@
-<!-- AUTO-GENERATED RELEASE START: 2026-04-16 -->
-# Versión SISOC 16.04.2026
+<!-- AUTO-GENERATED RELEASE START: 2026-04-23 -->
+# Versión SISOC 23.04.2026
 
 ## Nuevas Funcionalidades
 
 - Nuevo modelo de identidad de Ciudadanos con identificador interno, cola de revisión manual, comando `backfill_identidad` y filtros/badges para tratar DNIs duplicados, sin DNI y registros no validados por RENAPER.
 - Nuevo flujo de Acompañamientos por admisión, con entidad propia, migración de hitos/prestaciones/información relevante y detalle web asociado para sostener seguimiento más consistente.
-- Sistema reproducible de benchmarks con `python manage.py run_benchmarks`, baseline versionado y métricas de tiempo/queries para monitorear regresiones en listados críticos.
+- Nuevos flujos operativos en CDI, Relevamientos y Core: formulario detallado de nómina/intervenciones con trazabilidad de creación, asignación de territorial desde pendientes y comandos para benchmarks/exportes técnicos reproducibles.
 
 ## Actualizaciones
 
-- Evolución de VAT en centros y cursos: edición preservando `activo`, filtro `Código` alineado al CUE vigente, detalle de cursos con filtrado de comisiones por selección explícita y tabla de comisiones mostrando 25 registros por defecto.
-- Ajustes fuertes en Celiaquía para importación y reproceso: nacionalidad por país normalizado, responsable obligatorio solo para menores, comparación RENAPER priorizando localidad y UI más clara en registros erróneos.
-- Optimización transversal de listados pesados en Ciudadanos y Organizaciones mediante paginación sin `COUNT(*)`, nuevos índices y pruebas unitarias para sostener búsquedas y navegación en grandes volúmenes.
-- Mejoras operativas del repo: memoria de contexto reutilizable para agentes, correcciones de workflows/lint y alineación de dependencias de runtime (`cffi`/`tinycss2`) para estabilizar builds.
+- Evolución de VAT en centros, cursos y comisiones: edición preservando `activo`, filtro `Código` alineado al CUE vigente, exportación de nómina de preinscriptos, filtrado explícito de comisiones y refresco visual con tema global de `select2`.
+- Ajustes fuertes en Celiaquía y Admisiones: nacionalidad por país normalizado, responsable obligatorio solo para menores, comparación RENAPER priorizando localidad, buscador de localidades más estable y mejoras documentales/técnicas en la carga de expedientes.
+- Optimización transversal de listados pesados en Ciudadanos, Organizaciones y Comedores mediante paginación sin `COUNT(*)`, nuevos índices, reordenamiento de nóminas activas y sincronización de estado operativo para soft-delete.
+- Mejoras operativas del repo: memoria de contexto reutilizable para agentes, endurecimiento de CI/lint, actualización de documentación IAM/infraestructura y saneamiento del bootstrap de worktrees nuevas.
 
 ## Corrección de Errores
 
-- Corrección de duplicados visibles en nómina de Comedores, con revalidación transaccional al alta para reducir carreras y priorizar un único registro por ciudadano.
-- Correcciones en VAT para edición de cursos/comisiones y compatibilidad de vouchers/fixtures de CI, evitando regresiones recientes en centros, cursos e inscripciones.
-- Ajustes de merge y compatibilidad en Ciudadanos para priorizar registros `ESTANDAR` en lookups por DNI y evitar asociaciones erróneas en Celiaquía y Comedores.
-- Correcciones de infraestructura y CI para que la resolución de dependencias y los jobs de lint no fallen por pins incompatibles o entradas vacías.
+- Corrección de duplicados visibles y orden inestable en nóminas de Comedores, con revalidación transaccional al alta para reducir carreras y priorizar un único registro por ciudadano.
+- Correcciones en VAT, Ciudadanos y Acompañamientos para resolver regresiones de edición, merges de migraciones y compatibilidad de vouchers/fixtures sin romper el flujo productivo reciente.
+- Ajustes en Celiaquía para rechazo con motivo, reprocesos RENAPER, exportación SINTyS y localización de datos inválidos sin perder trazabilidad para el usuario.
+- Corrección de infraestructura y release para que `.env.example`, la resolución de dependencias y los jobs de lint/bootstrap no fallen por configuraciones inválidas o entradas vacías.
 
-<!-- AUTO-GENERATED RELEASE END: 2026-04-16 -->
+<!-- AUTO-GENERATED RELEASE END: 2026-04-23 -->
 
 <!-- AUTO-GENERATED RELEASE START: 2026-04-09 -->
 # Versión SISOC 09.04.2026

--- a/docs/registro/cambios/2026-04-23-analisis-predeploy-main.md
+++ b/docs/registro/cambios/2026-04-23-analisis-predeploy-main.md
@@ -1,0 +1,49 @@
+# 2026-04-23 - Análisis pre-deploy development -> main
+
+## Contexto
+
+- Se actualizó el estado remoto del repo y se comparó `origin/main` contra `origin/development`.
+- El PR previo `#1567` (`development -> main`, 2026-04-16) ya estaba cerrado sin merge, por lo que este análisis toma como fuente de verdad el delta actual entre ramas.
+- El trabajo se hizo en la worktree aislada `C:\Users\Juanito\Desktop\Repos-Codex\worktrees\predeploy-development-main-20260423`, sobre la branch `task/predeploy-development-main-20260423`.
+
+## Alcance observado
+
+- Distancia entre ramas: `311` commits del lado `development` y `0` del lado `main` en `git rev-list --left-right --count origin/main...origin/development`.
+- Diff agregado: `267` archivos, `17696` inserciones y `1694` eliminaciones.
+- Módulos con mayor movimiento: `docs`, `tests`, `celiaquia`, `ciudadanos`, `VAT`, `centrodeinfancia`, `core`, `acompanamientos`, `comedores`, `admisiones` y `relevamientos`.
+
+## Riesgos bloqueantes
+
+- La release sigue incorporando la migración `acompanamientos/0007_hitos_cleanup_comedor.py`, que borra hitos huérfanos y exige tratamiento operativo/manual sobre datos reales antes de producción.
+- `ciudadanos` mantiene como requisito operativo el backfill `python manage.py backfill_identidad ...`, con backup y ventana coordinada antes de ejecutarlo en producción.
+- Se detectó un bug real en `.env.example`: el bloque de Resend dejaba líneas activas con prefijo `- `, lo que rompía `docker compose config` y el bootstrap de cualquier worktree nueva. Este saneamiento debe entrar en `development` antes de considerar GO.
+- No hay todavía evidencia concluyente de checks verdes para un PR nuevo `development -> main`; debe validarse sobre ese PR exacto.
+
+## Riesgos no bloqueantes
+
+- El corte mezcla funcionalidades, migraciones, performance, CI, documentación y tooling, con riesgo de interacción mayor que un deploy chico.
+- El entorno local no puede levantar Docker porque `dockerDesktopLinuxEngine` no está disponible en esta máquina; por eso la validación completa depende de GitHub Actions y de checks puntuales locales con `uv`.
+- El host local no tiene `pytest` global instalado, aunque sí fue posible correr regresiones focales con `uv run`.
+
+## Saneamiento aplicado
+
+- Se corrigió `.env.example` para dejar el ejemplo de Resend comentado y restaurar defaults válidos de email por defecto.
+- Se agregó una regresión en `tests/test_settings_env_parsing.py` para evitar que vuelvan a entrar asignaciones inválidas en la sección de email.
+- Se actualizó `CHANGELOG.md` para reflejar el corte completo que hoy viaja de `development` hacia `main` con fecha `2026-04-23`.
+
+## Validaciones ejecutadas
+
+- `powershell -ExecutionPolicy Bypass -File scripts/ai/codex_bootstrap.ps1`
+  - Falló primero por `.env.example` inválido; luego del fix quedó bloqueado únicamente por Docker Desktop apagado.
+- `uv run --python 3.11 --with-requirements requirements.txt pytest tests/test_settings_env_parsing.py::test_env_example_declares_valid_email_assignments -q`
+  - OK (`1 passed`)
+- `uv run --python 3.11 --with-requirements requirements.txt python -m black --check tests/test_settings_env_parsing.py`
+  - OK
+- `docker compose config -q`
+  - OK
+- `powershell -ExecutionPolicy Bypass -File scripts/ai/codex_doctor.ps1`
+  - OK para `.env` y `compose-config`; pendiente Docker engine en esta máquina
+
+## Resultado
+
+- Recomendación actual: **NO-GO** hasta que el PR de saneamiento a `development` entre, se revisen los riesgos de datos de `acompanamientos` y `ciudadanos`, y el PR exacto `development -> main` muestre checks concluyentes.

--- a/docs/registro/cambios/2026-04-23-analisis-predeploy-main.md
+++ b/docs/registro/cambios/2026-04-23-analisis-predeploy-main.md
@@ -31,6 +31,12 @@
 - Se agregó una regresión en `tests/test_settings_env_parsing.py` para evitar que vuelvan a entrar asignaciones inválidas en la sección de email.
 - Se actualizó `CHANGELOG.md` para reflejar el corte completo que hoy viaja de `development` hacia `main` con fecha `2026-04-23`.
 
+## Seguimiento de pytest
+
+- Los cuatro fallos observados en GitHub Actions no respondían a una regresión nueva de runtime sino a tests desalineados respecto de contratos ya mergeados en `development`.
+- `relevamientos`: `update_territorial()` ya había recuperado el contrato de validación estricta y el mensaje `"Debe seleccionar un territorial válido."`; dos asserts seguían matcheando la variante sin tilde.
+- `comedores/nomina`: desde `fix(comedores): ordenar bajas y contar asistentes activos` la vista usa `cantidad_activos` para la tarjeta de asistentes y el resumen agrega ese campo explícitamente; los mocks de tests seguían modelando el contrato previo.
+
 ## Validaciones ejecutadas
 
 - `powershell -ExecutionPolicy Bypass -File scripts/ai/codex_bootstrap.ps1`

--- a/docs/registro/releases/pending/2026-04-23-pr-1613.md
+++ b/docs/registro/releases/pending/2026-04-23-pr-1613.md
@@ -1,0 +1,19 @@
+---
+pr: 1613
+release_date: 2026-04-23
+category: Actualizaciones
+area: release
+title: Release: development -> main (2026-04-23)
+summary: Release 2026-04-23 con identidad de ciudadanos, acompañamientos por admisión, mejoras VAT/Celiaquía/CDI/Relevamientos y saneamiento operativo del bootstrap de release
+impact: Consolida el corte actual de development hacia main, dejando trazabilidad explícita sobre riesgos de datos y el saneamiento mínimo requerido para evaluar el merge a producción.
+source_url: https://github.com/dsocial118/SISOC/pull/1613
+---
+# Release note preliminar PR #1613
+
+- Fecha objetivo de release: 2026-04-23
+- Categoría: Actualizaciones
+- Área: release
+- Título del PR: Release: development -> main (2026-04-23)
+- Resumen: Release 2026-04-23 con identidad de ciudadanos, acompañamientos por admisión, mejoras VAT/Celiaquía/CDI/Relevamientos y saneamiento operativo del bootstrap de release
+- Impacto usuario: Consolida el corte actual de development hacia main, dejando trazabilidad explícita sobre riesgos de datos y el saneamiento mínimo requerido para evaluar el merge a producción.
+- Fuente: https://github.com/dsocial118/SISOC/pull/1613

--- a/tests/test_comedor_service_renaper_helpers_unit.py
+++ b/tests/test_comedor_service_renaper_helpers_unit.py
@@ -836,12 +836,13 @@ def test_get_nomina_detail_calcula_resumen_y_porcentajes(mocker):
         "cantidad_nomina_x": 1,
         "espera": 2,
         "cantidad_total": 10,
+        "cantidad_activos": 8,
         "rango_ninos": 2,
         "rango_adolescentes": 1,
-        "rango_adultos": 3,
+        "rango_adultos": 2,
         "rango_adultos_mayores": 2,
         "rango_adulto_mayor_avanzado": 1,
-        "rango_total_activos": 9,
+        "rango_total_activos": 8,
     }
     nomina_qs = _NominaQS(resumen)
     mocker.patch(
@@ -859,12 +860,13 @@ def test_get_nomina_detail_calcula_resumen_y_porcentajes(mocker):
     assert out[0] is page_obj
     assert out[1:6] == (3, 4, 1, 2, 10)
     rangos = out[6]
-    assert rangos["total_activos"] == 9
-    assert rangos["pct_ninos"] == 22
-    assert rangos["pct_adolescentes"] == 11
-    assert rangos["pct_adultos"] == 33
-    assert rangos["pct_adultos_mayores"] == 22
-    assert rangos["pct_adulto_mayor_avanzado"] == 11
+    assert rangos["cantidad_activos"] == 8
+    assert rangos["total_activos"] == 8
+    assert rangos["pct_ninos"] == 25
+    assert rangos["pct_adolescentes"] == 12
+    assert rangos["pct_adultos"] == 25
+    assert rangos["pct_adultos_mayores"] == 25
+    assert rangos["pct_adulto_mayor_avanzado"] == 12
     assert any(call[0] == "aggregate" for call in nomina_qs.calls)
     paginator_mock.assert_called_once()
 

--- a/tests/test_nomina_views_unit.py
+++ b/tests/test_nomina_views_unit.py
@@ -47,7 +47,15 @@ def test_nomina_detail_context_data(mocker):
     )
     get_nomina_detail_mock = mocker.patch(
         "comedores.views.nomina.ComedorService.get_nomina_detail",
-        return_value=("page_obj", 1, 2, 3, 4, 10, {"ninos": 2, "adolescentes": 3}),
+        return_value=(
+            "page_obj",
+            1,
+            2,
+            3,
+            4,
+            10,
+            {"ninos": 2, "adolescentes": 3, "cantidad_activos": 6},
+        ),
     )
     mocker.patch(
         "comedores.views.nomina._get_admision_del_comedor_or_404",
@@ -62,7 +70,7 @@ def test_nomina_detail_context_data(mocker):
 
     ctx = view.get_context_data()
     assert ctx["object"] == "comedor"
-    assert ctx["cantidad_nomina"] == 10
+    assert ctx["cantidad_nomina"] == 6
     assert ctx["menores"] == 5
     assert ctx["dni_query"] == "1234"
     get_nomina_detail_mock.assert_called_once_with(77, 2, dni_query="1234")

--- a/tests/test_relevamientos_service_unit.py
+++ b/tests/test_relevamientos_service_unit.py
@@ -513,7 +513,7 @@ def test_populate_relevamiento_and_update_territorial_without_data(mocker):
     starter = mocker.patch("relevamientos.service.AsyncSendRelevamientoToGestionar")
     req = SimpleNamespace(POST={"relevamiento_id": "2", "territorial_editar": ""})
     with pytest.raises(
-        ValidationError, match="Debe seleccionar un territorial valido."
+        ValidationError, match="Debe seleccionar un territorial válido."
     ):
         module.RelevamientoService.update_territorial(req)
     assert rel2.estado == "Pendiente"
@@ -535,7 +535,7 @@ def test_update_territorial_rechaza_json_valido_no_objeto(mocker):
     req = SimpleNamespace(POST={"relevamiento_id": "3", "territorial_editar": "[]"})
 
     with pytest.raises(
-        ValidationError, match="Debe seleccionar un territorial valido."
+        ValidationError, match="Debe seleccionar un territorial válido."
     ):
         module.RelevamientoService.update_territorial(req)
 

--- a/tests/test_settings_env_parsing.py
+++ b/tests/test_settings_env_parsing.py
@@ -111,3 +111,31 @@ def test_settings_qa_mantiene_runtime_no_productivo(monkeypatch):
     assert module.GESTIONAR_INTEGRATION_ENABLED is False
     assert module.SECURE_SSL_REDIRECT is False
     assert module.SENTRY_REPLAY_ENABLED is False
+
+
+def test_env_example_declares_valid_email_assignments():
+    env_example_path = Path(__file__).resolve().parents[1] / ".env.example"
+    lines = env_example_path.read_text(encoding="utf-8").splitlines()
+
+    email_section_started = False
+    email_lines = []
+    for line in lines:
+        stripped = line.strip()
+        if stripped == "# EMAIL / PASSWORD RESET":
+            email_section_started = True
+            continue
+        if email_section_started and stripped == "# PWA WEB PUSH":
+            break
+        if email_section_started:
+            email_lines.append(stripped)
+
+    active_assignments = [
+        line for line in email_lines if line and not line.startswith("#")
+    ]
+
+    assert not any(line.startswith("- ") for line in active_assignments)
+    assert 'EMAIL_BACKEND=""' in active_assignments
+    assert 'EMAIL_HOST="localhost"' in active_assignments
+    assert 'EMAIL_HOST_USER=""' in active_assignments
+    assert 'EMAIL_HOST_PASSWORD=""' in active_assignments
+    assert 'DEFAULT_FROM_EMAIL="no-reply@sisoc.local"' in active_assignments


### PR DESCRIPTION
## Qué corrige
- restaura una `.env.example` válida para que el bootstrap de worktrees nuevas no rompa `docker compose config` por líneas activas inválidas en la sección de email
- agrega una regresión en `tests/test_settings_env_parsing.py` para evitar que vuelvan a entrar asignaciones inválidas en el bloque de Resend/email
- alinea cuatro regresiones de `pytest` que quedaron desfasadas respecto de contratos ya mergeados en `development`:
  - `relevamientos.update_territorial()` ya validaba con el mensaje exacto `"Debe seleccionar un territorial válido."`
  - `nomina` ya expone `cantidad_activos` en el resumen y la tarjeta principal usa asistentes activos, no el total bruto
- corrige el workflow `.github/workflows/pr-docs.yml` para que deje de intentar `git push` sobre ramas protegidas (`development`/`main`) y reporte el diff en el summary del job
- pre-genera en `development` los artefactos spec-as-source que el draft `#1613` esperaba (`docs/registro/prs/PR-1613.md`, `docs/contexto/features/pr-1613-*.md` y la pending release note con fecha objetivo `2026-04-29`)
- documenta el análisis pre-deploy vigente en `docs/registro/cambios/2026-04-23-analisis-predeploy-main.md` y el ajuste del workflow en `docs/registro/cambios/2026-04-23-fix-pr-docs-rama-protegida.md`

## Por qué es necesario antes de promover a `main`
- el corte actual `origin/development -> origin/main` ya no coincide con el release draft cerrado `#1567`
- el bug de `.env.example` afecta directamente el workflow documentado del repo para worktrees y bootstrap de release
- los cuatro fallos de `pytest` vistos en el draft `#1613` impedían tener una señal confiable del release, aunque no respondían a una regresión funcional nueva sino a tests desalineados
- el workflow `pr-docs` estaba rompiendo el draft `development -> main` por intentar violar la regla del repositorio `Changes must be made through a pull request`

## Pruebas ejecutadas
- `uv run --python 3.11 --with-requirements requirements.txt pytest tests/test_settings_env_parsing.py::test_env_example_declares_valid_email_assignments -q`
- `uv run --python 3.11 --with-requirements requirements.txt pytest tests/test_relevamientos_service_unit.py tests/test_comedor_service_renaper_helpers_unit.py tests/test_nomina_views_unit.py -q`
- `uv run --python 3.11 --with-requirements requirements.txt pytest tests/test_pr_doc_automation_unit.py -q`
- `uv run --python 3.11 --with-requirements requirements.txt python -m black --check tests/test_relevamientos_service_unit.py tests/test_comedor_service_renaper_helpers_unit.py tests/test_nomina_views_unit.py`
- `docker compose config -q`
- `powershell -ExecutionPolicy Bypass -File scripts/ai/codex_doctor.ps1`
- `uv run --python 3.11 --with-requirements requirements.txt pytest -q`
  - interrumpido por limitación local de Windows/WeasyPrint (`libgobject-2.0-0` faltante), distinta de los fallos de GitHub Actions que motivaron este ajuste

## Riesgos remanentes
- siguen vigentes los riesgos operativos del corte completo: cleanup destructivo en `acompanamientos`, backfill obligatorio en `ciudadanos` y la necesidad de validar el PR exacto `development -> main` con GitHub Actions
- en esta máquina no hay Docker engine activo, así que la señal concluyente del release completo queda delegada a los checks del PR final a `main`
- este PR no mergea por sí solo a producción: deja `development` lista para que el draft definitivo `development -> main` pueda evaluarse con el saneamiento aplicado