### PR TITLE
fix(celiaquia):Modificar Logs, Validacion en editar y mensajes

### DIFF
--- a/admisiones/services/admisiones_service/impl.py
+++ b/admisiones/services/admisiones_service/impl.py
@@ -64,6 +64,8 @@ class AdmisionService:
         "if_informe_tecnico_cargado",
         "enviado_a_legales",
         "enviado_a_acompaniamiento",
+        "descartado",
+        "inactivada",
     )
     ESTADOS_BLOQUEO_AVANCE_DOCUMENTAL = (
         "documentacion_aprobada",

--- a/admisiones/views/web_views.py
+++ b/admisiones/views/web_views.py
@@ -498,23 +498,6 @@ def eliminar_archivo_admision(request, admision_id, documentacion_id):
                     "No se pueden eliminar documentos cuando el informe tecnico "
                     "esta finalizado o en etapas posteriores."
                 ),
-    estados_bloqueo_eliminacion = {
-        "informe_tecnico_finalizado",
-        "informe_tecnico_docx_editado",
-        "informe_tecnico_en_revision",
-        "informe_tecnico_en_subsanacion",
-        "informe_tecnico_aprobado",
-        "if_informe_tecnico_cargado",
-        "enviado_a_legales",
-        "enviado_a_acompaniamiento",
-        "descartado",
-        "inactivada",
-    }
-    if getattr(admision, "estado_admision", None) in estados_bloqueo_eliminacion:
-        return JsonResponse(
-            {
-                "success": False,
-                "error": "No se pueden eliminar documentos cuando el informe tecnico esta finalizado o en etapas posteriores.",
             },
             status=400,
         )

--- a/celiaquia/services/expediente_service/impl.py
+++ b/celiaquia/services/expediente_service/impl.py
@@ -30,14 +30,17 @@ def _set_estado(
     expediente.save(update_fields=update_fields)
 
     if observaciones and getattr(expediente, "pk", None):
-        (
+        historial_actual = (
             ExpedienteEstadoHistorial.objects.filter(
                 expediente=expediente,
                 estado_nuevo_id=expediente.estado_id,
             )
             .order_by("-fecha")
-            .update(observaciones=observaciones)
+            .first()
         )
+        if historial_actual:
+            historial_actual.observaciones = observaciones
+            historial_actual.save(update_fields=["observaciones"])
 
 
 def _build_resumen_importacion_alerta(*, creados_total=0, errores_actuales=0):

--- a/celiaquia/services/expediente_service/impl.py
+++ b/celiaquia/services/expediente_service/impl.py
@@ -17,7 +17,9 @@ def _estado_id(nombre: str) -> int:
     return EstadoExpediente.objects.get_or_create(nombre=nombre)[0].pk
 
 
-def _set_estado(expediente: Expediente, nombre: str, usuario=None, observaciones=None) -> None:
+def _set_estado(
+    expediente: Expediente, nombre: str, usuario=None, observaciones=None
+) -> None:
     """Actualiza el estado del expediente y el usuario modificador."""
 
     expediente.estado_id = _estado_id(nombre)
@@ -126,7 +128,6 @@ def _build_observaciones_importacion(result: dict) -> str:
             "errores_actuales": errores,
         }
     )
-
 
 
 class ExpedienteService:
@@ -242,4 +243,3 @@ class ExpedienteService:
             "Técnico %s asignado al expediente %s", tecnico.username, expediente.pk
         )
         return expediente
-

--- a/celiaquia/services/expediente_service/impl.py
+++ b/celiaquia/services/expediente_service/impl.py
@@ -1,9 +1,10 @@
 import logging
+import json
 from functools import lru_cache
 from django.db import transaction
 from django.core.exceptions import ValidationError
 from django.contrib.auth import get_user_model
-from celiaquia.models import EstadoExpediente, Expediente
+from celiaquia.models import EstadoExpediente, Expediente, ExpedienteEstadoHistorial
 from celiaquia.services.importacion_service import ImportacionService
 from celiaquia.services.legajo_service import LegajoService
 
@@ -16,7 +17,7 @@ def _estado_id(nombre: str) -> int:
     return EstadoExpediente.objects.get_or_create(nombre=nombre)[0].pk
 
 
-def _set_estado(expediente: Expediente, nombre: str, usuario=None) -> None:
+def _set_estado(expediente: Expediente, nombre: str, usuario=None, observaciones=None) -> None:
     """Actualiza el estado del expediente y el usuario modificador."""
 
     expediente.estado_id = _estado_id(nombre)
@@ -25,6 +26,107 @@ def _set_estado(expediente: Expediente, nombre: str, usuario=None) -> None:
         expediente.usuario_modificador = usuario
         update_fields.append("usuario_modificador")
     expediente.save(update_fields=update_fields)
+
+    if observaciones and getattr(expediente, "pk", None):
+        (
+            ExpedienteEstadoHistorial.objects.filter(
+                expediente=expediente,
+                estado_nuevo_id=expediente.estado_id,
+            )
+            .order_by("-fecha")
+            .update(observaciones=observaciones)
+        )
+
+
+def _build_resumen_importacion_alerta(*, creados_total=0, errores_actuales=0):
+    resumen_lineas = [
+        f"Importacion procesada. Se crearon {creados_total} legajos y el expediente paso a EN ESPERA."
+    ]
+    if errores_actuales:
+        resumen_lineas.append(f"Errores detectados: {errores_actuales}.")
+    return "\n".join(resumen_lineas)
+
+
+def _build_excluidos_importacion_alerta(excluidos):
+    excluidos_lineas = []
+    if excluidos:
+        excluidos_lineas.append(
+            f"No se crearon {len(excluidos)} legajos porque ya existen en otro expediente activo."
+        )
+        for item in excluidos[:10]:
+            if not isinstance(item, dict):
+                excluidos_lineas.append(str(item))
+                continue
+            documento = item.get("documento", "-")
+            apellido = item.get("apellido", "-")
+            nombre = item.get("nombre", "-")
+            estado = (
+                item.get("estado_programa")
+                or item.get("estado_expediente_origen")
+                or item.get("motivo")
+                or "-"
+            )
+            expediente_origen = item.get("expediente_origen_id", "-")
+            excluidos_lineas.append(
+                f"- Documento {documento} - {apellido}, {nombre} - {estado} - Exp #{expediente_origen}"
+            )
+        restantes = len(excluidos) - 10
+        if restantes > 0:
+            excluidos_lineas.append(f"... y {restantes} mas.")
+    return "\n".join(excluidos_lineas)
+
+
+def _build_observaciones_importacion(result: dict) -> str:
+    creados = result.get("validos", 0)
+    errores = result.get("errores", 0)
+    excluidos = result.get("excluidos") or []
+
+    resumen_lineas = [
+        f"Importacion procesada. Se crearon {creados} legajos y el expediente paso a EN ESPERA."
+    ]
+    if errores:
+        resumen_lineas.append(f"Errores detectados: {errores}.")
+
+    excluidos_lineas = []
+    if excluidos:
+        excluidos_lineas.append(
+            f"No se crearon {len(excluidos)} legajos porque ya existen en otro expediente activo."
+        )
+        for item in excluidos[:10]:
+            if not isinstance(item, dict):
+                excluidos_lineas.append(str(item))
+                continue
+            documento = item.get("documento", "-")
+            apellido = item.get("apellido", "-")
+            nombre = item.get("nombre", "-")
+            estado = (
+                item.get("estado_programa")
+                or item.get("estado_expediente_origen")
+                or item.get("motivo")
+                or "-"
+            )
+            expediente_origen = item.get("expediente_origen_id", "-")
+            excluidos_lineas.append(
+                f"- Documento {documento} - {apellido}, {nombre} - {estado} - Exp #{expediente_origen}"
+            )
+        restantes = len(excluidos) - 10
+        if restantes > 0:
+            excluidos_lineas.append(f"... y {restantes} mas.")
+
+    return json.dumps(
+        {
+            "resumen": _build_resumen_importacion_alerta(
+                creados_total=creados,
+                errores_actuales=errores,
+            ),
+            "excluidos": _build_excluidos_importacion_alerta(excluidos),
+            "excluidos_detalle": excluidos,
+            "tiene_errores": bool(errores),
+            "creados_total": creados,
+            "errores_actuales": errores,
+        }
+    )
+
 
 
 class ExpedienteService:
@@ -72,7 +174,12 @@ class ExpedienteService:
             result.get("excluidos_count", 0),
         )
 
-        _set_estado(expediente, "EN_ESPERA", usuario)
+        _set_estado(
+            expediente,
+            "EN_ESPERA",
+            usuario,
+            observaciones=_build_observaciones_importacion(result),
+        )
         logger.info("Expediente %s pasó a estado EN_ESPERA", expediente.pk)
 
         return {
@@ -135,3 +242,4 @@ class ExpedienteService:
             "Técnico %s asignado al expediente %s", tecnico.username, expediente.pk
         )
         return expediente
+

--- a/celiaquia/services/importacion_service/impl.py
+++ b/celiaquia/services/importacion_service/impl.py
@@ -433,7 +433,7 @@ def _persistir_legajos_importacion(
     legajos_crear, batch_size, relaciones_familiares, warnings
 ):
     if not legajos_crear:
-        logger.warning("No hay legajos para crear - lista vacía")
+        logger.info("No hay legajos para crear - lista vacia")
         return
 
     try:

--- a/celiaquia/templates/celiaquia/expediente_detail.html
+++ b/celiaquia/templates/celiaquia/expediente_detail.html
@@ -1672,7 +1672,7 @@
                                             -
                                         {% endif %}
                                     </td>
-                                    <td>{{ h.observaciones|default:"-" }}</td>
+                                    <td>{{ h.observaciones_visibles|default:"-"|linebreaksbr }}</td>
                                 </tr>
                             {% empty %}
                                 <tr>

--- a/celiaquia/templates/celiaquia/expediente_detail.html
+++ b/celiaquia/templates/celiaquia/expediente_detail.html
@@ -107,6 +107,18 @@
             </div>
         {% endif %}
         <div id="expediente-alerts"></div>
+        {% if alerta_importacion_resumen %}
+            <div class="alert alert-{{ alerta_importacion_resumen_style }} mb-4"
+                 role="alert">
+                {{ alerta_importacion_resumen|linebreaksbr }}
+            </div>
+        {% endif %}
+        {% if alerta_importacion_excluidos %}
+            <div class="alert alert-{{ alerta_importacion_excluidos_style }} mb-4"
+                 role="alert">
+                {{ alerta_importacion_excluidos|linebreaksbr }}
+            </div>
+        {% endif %}
         <div class="p-3 rounded shadow mb-4"
              style="background-color: #1c2a3a;
                     color: #e0e0e0">

--- a/celiaquia/templates/celiaquia/expediente_detail.html
+++ b/celiaquia/templates/celiaquia/expediente_detail.html
@@ -109,15 +109,11 @@
         <div id="expediente-alerts"></div>
         {% if alerta_importacion_resumen %}
             <div class="alert alert-{{ alerta_importacion_resumen_style }} mb-4"
-                 role="alert">
-                {{ alerta_importacion_resumen|linebreaksbr }}
-            </div>
+                 role="alert">{{ alerta_importacion_resumen|linebreaksbr }}</div>
         {% endif %}
         {% if alerta_importacion_excluidos %}
             <div class="alert alert-{{ alerta_importacion_excluidos_style }} mb-4"
-                 role="alert">
-                {{ alerta_importacion_excluidos|linebreaksbr }}
-            </div>
+                 role="alert">{{ alerta_importacion_excluidos|linebreaksbr }}</div>
         {% endif %}
         <div class="p-3 rounded shadow mb-4"
              style="background-color: #1c2a3a;

--- a/celiaquia/views/expediente.py
+++ b/celiaquia/views/expediente.py
@@ -400,7 +400,9 @@ def _actualizar_alerta_importacion_persistente(
     if not isinstance(payload, dict):
         return
 
-    creados_total = int(payload.get("creados_total") or 0) + int(creados_incremento or 0)
+    creados_total = int(payload.get("creados_total") or 0) + int(
+        creados_incremento or 0
+    )
     errores_vigentes = (
         int(errores_actuales)
         if errores_actuales is not None
@@ -1107,13 +1109,17 @@ class ExpedienteDetailView(DetailView):
         historial = expediente.historial.select_related(
             "estado_anterior", "estado_nuevo", "usuario"
         )
-        historial_estado_actual = historial.filter(
-            estado_nuevo=expediente.estado,
-            observaciones__isnull=False,
-        ).exclude(observaciones="").order_by("-fecha")
-        alerta_importacion_persistente = (
-            historial_estado_actual.values_list("observaciones", flat=True).first()
+        historial_estado_actual = (
+            historial.filter(
+                estado_nuevo=expediente.estado,
+                observaciones__isnull=False,
+            )
+            .exclude(observaciones="")
+            .order_by("-fecha")
         )
+        alerta_importacion_persistente = historial_estado_actual.values_list(
+            "observaciones", flat=True
+        ).first()
         ctx["alerta_importacion_persistente"] = alerta_importacion_persistente
         ctx["alerta_importacion_resumen"] = ""
         ctx["alerta_importacion_resumen_style"] = ""

--- a/celiaquia/views/expediente.py
+++ b/celiaquia/views/expediente.py
@@ -436,6 +436,26 @@ def _build_resumen_importacion_alerta(*, creados_total=0, errores_actuales=0):
     return "\n".join(resumen_lineas)
 
 
+def _formatear_observaciones_historial(observaciones):
+    if not observaciones:
+        return ""
+
+    try:
+        payload = json.loads(observaciones)
+    except (TypeError, ValueError):
+        return observaciones
+
+    if not isinstance(payload, dict):
+        return observaciones
+
+    partes = [
+        str(payload.get(clave)).strip()
+        for clave in ("resumen", "excluidos")
+        if payload.get(clave)
+    ]
+    return "\n".join(partes) or observaciones
+
+
 def _validar_datos_registro_erroneo(payload, provincia_id, fila_excel=0):
     return validar_y_normalizar_payloads_importacion(
         payload=payload,
@@ -1174,9 +1194,14 @@ class ExpedienteDetailView(DetailView):
                 ctx["alerta_importacion_success"] = (
                     resumen_bloque if resumen_bloque_style == "success" else ""
                 )
-        ctx["historial_page_obj"] = Paginator(historial, 5).get_page(
+        historial_page_obj = Paginator(historial, 5).get_page(
             self.request.GET.get("historial_page")
         )
+        for item in historial_page_obj.object_list:
+            item.observaciones_visibles = _formatear_observaciones_historial(
+                item.observaciones
+            )
+        ctx["historial_page_obj"] = historial_page_obj
 
         # Obtener registros erróneos
         registros_erroneos = list(

--- a/celiaquia/views/expediente.py
+++ b/celiaquia/views/expediente.py
@@ -43,9 +43,11 @@ from celiaquia.services.importacion_service import (
     ImportacionService,
     IMPORTACION_EDITABLE_FIELDS,
     IMPORTACION_RESPONSABLE_FIELDS,
+    _beneficiario_tiene_conflicto_importacion,
     _beneficiario_requiere_responsable_importacion,
     _cargar_nacionalidades_cache,
     _cargar_paises_a_nacionalidad_importacion,
+    _precargar_conflictos_y_existentes_importacion,
     _resolver_nacionalidad_payload_importacion,
     validar_y_normalizar_payloads_importacion,
 )
@@ -326,6 +328,112 @@ def _resolver_provincia_id_registro_erroneo(user, expediente):
     return provincia
 
 
+def _deduplicar_excluidos_alerta(excluidos):
+    vistos = set()
+    resultado = []
+    for item in excluidos or []:
+        if isinstance(item, dict):
+            key = (
+                item.get("ciudadano_id"),
+                item.get("documento"),
+                item.get("expediente_origen_id"),
+                item.get("estado_programa"),
+                item.get("estado_expediente_origen"),
+                item.get("motivo"),
+            )
+        else:
+            key = ("raw", str(item))
+        if key in vistos:
+            continue
+        vistos.add(key)
+        resultado.append(item)
+    return resultado
+
+
+def _build_excluidos_importacion_alerta(excluidos):
+    excluidos_lineas = []
+    if excluidos:
+        excluidos_lineas.append(
+            f"No se crearon {len(excluidos)} legajos porque ya existen en otro expediente activo."
+        )
+        for item in excluidos[:10]:
+            if not isinstance(item, dict):
+                excluidos_lineas.append(str(item))
+                continue
+            documento = item.get("documento", "-")
+            apellido = item.get("apellido", "-")
+            nombre = item.get("nombre", "-")
+            estado = (
+                item.get("estado_programa")
+                or item.get("estado_expediente_origen")
+                or item.get("motivo")
+                or "-"
+            )
+            expediente_origen = item.get("expediente_origen_id", "-")
+            excluidos_lineas.append(
+                f"- Documento {documento} - {apellido}, {nombre} - {estado} - Exp #{expediente_origen}"
+            )
+        restantes = len(excluidos) - 10
+        if restantes > 0:
+            excluidos_lineas.append(f"... y {restantes} mas.")
+    return "\n".join(excluidos_lineas)
+
+
+def _actualizar_alerta_importacion_persistente(
+    expediente, *, creados_incremento=0, errores_actuales=None, excluidos_nuevos=None
+):
+    historial_qs = (
+        expediente.historial.filter(estado_nuevo=expediente.estado)
+        .exclude(observaciones__isnull=True)
+        .exclude(observaciones="")
+        .order_by("-fecha")
+    )
+    historial_actual = historial_qs.first()
+    if not historial_actual:
+        return
+
+    try:
+        payload = json.loads(historial_actual.observaciones)
+    except (TypeError, ValueError):
+        return
+
+    if not isinstance(payload, dict):
+        return
+
+    creados_total = int(payload.get("creados_total") or 0) + int(creados_incremento or 0)
+    errores_vigentes = (
+        int(errores_actuales)
+        if errores_actuales is not None
+        else int(payload.get("errores_actuales") or 0)
+    )
+
+    payload["resumen"] = _build_resumen_importacion_alerta(
+        creados_total=creados_total,
+        errores_actuales=errores_vigentes,
+    )
+    excluidos_detalle = _deduplicar_excluidos_alerta(
+        (payload.get("excluidos_detalle") or []) + (excluidos_nuevos or [])
+    )
+    payload["excluidos_detalle"] = excluidos_detalle
+    payload["excluidos"] = _build_excluidos_importacion_alerta(excluidos_detalle)
+    payload["tiene_errores"] = bool(errores_vigentes)
+    payload["creados_total"] = creados_total
+    payload["errores_actuales"] = errores_vigentes
+
+    historial_actual.observaciones = json.dumps(payload)
+    historial_actual.save(update_fields=["observaciones"])
+    return payload
+
+
+def _build_resumen_importacion_alerta(*, creados_total=0, errores_actuales=0):
+    resumen_lineas = [
+        f"Importacion procesada. Se crearon {creados_total} legajos y el expediente paso a EN ESPERA."
+    ]
+    if errores_actuales:
+        resumen_lineas.append(f"Errores detectados: {errores_actuales}.")
+    return "\n".join(resumen_lineas)
+
+
 def _validar_datos_registro_erroneo(payload, provincia_id, fila_excel=0):
     return validar_y_normalizar_payloads_importacion(
         payload=payload,
@@ -543,6 +651,10 @@ class ProcesarExpedienteView(View):
                         "errores": result.get("errores", 0),
                         "excluidos": result.get("excluidos", 0),
                         "excluidos_detalle": result.get("excluidos_detalle", []),
+                        "alerta_resumen": _build_resumen_importacion_alerta(
+                            creados_total=result.get("creados", 0),
+                            errores_actuales=result.get("errores", 0),
+                        ),
                     }
                 )
 
@@ -995,6 +1107,67 @@ class ExpedienteDetailView(DetailView):
         historial = expediente.historial.select_related(
             "estado_anterior", "estado_nuevo", "usuario"
         )
+        historial_estado_actual = historial.filter(
+            estado_nuevo=expediente.estado,
+            observaciones__isnull=False,
+        ).exclude(observaciones="").order_by("-fecha")
+        alerta_importacion_persistente = (
+            historial_estado_actual.values_list("observaciones", flat=True).first()
+        )
+        ctx["alerta_importacion_persistente"] = alerta_importacion_persistente
+        ctx["alerta_importacion_resumen"] = ""
+        ctx["alerta_importacion_resumen_style"] = ""
+        ctx["alerta_importacion_excluidos"] = ""
+        ctx["alerta_importacion_excluidos_style"] = ""
+        ctx["alerta_importacion_warning"] = ""
+        ctx["alerta_importacion_warning_secundario"] = ""
+        ctx["alerta_importacion_success"] = ""
+        if alerta_importacion_persistente:
+            try:
+                alerta_payload = json.loads(alerta_importacion_persistente)
+            except (TypeError, ValueError):
+                alerta_payload = None
+
+            if isinstance(alerta_payload, dict):
+                resumen_alerta = alerta_payload.get("resumen", "")
+                excluidos_alerta = alerta_payload.get("excluidos", "")
+                creados_total = int(alerta_payload.get("creados_total") or 0)
+                tiene_errores = bool(alerta_payload.get("tiene_errores"))
+                resumen_bloque = ""
+                resumen_bloque_style = ""
+                excluidos_bloque = ""
+                excluidos_bloque_style = ""
+
+                # Al volver a entrar al expediente solo se recuperan advertencias
+                # persistentes del estado EN_ESPERA; los mensajes success se
+                # muestran en el flujo inmediato post-importacion / post-subsanacion.
+                if tiene_errores:
+                    resumen_bloque = resumen_alerta
+                    resumen_bloque_style = "warning"
+                    excluidos_bloque = excluidos_alerta
+                    excluidos_bloque_style = "warning" if excluidos_alerta else ""
+                elif creados_total == 0 and excluidos_alerta:
+                    resumen_bloque = "\n".join(
+                        part for part in [resumen_alerta, excluidos_alerta] if part
+                    )
+                    resumen_bloque_style = "warning"
+                elif excluidos_alerta:
+                    excluidos_bloque = excluidos_alerta
+                    excluidos_bloque_style = "warning"
+
+                ctx["alerta_importacion_resumen"] = resumen_bloque
+                ctx["alerta_importacion_resumen_style"] = resumen_bloque_style
+                ctx["alerta_importacion_excluidos"] = excluidos_bloque
+                ctx["alerta_importacion_excluidos_style"] = excluidos_bloque_style
+                ctx["alerta_importacion_warning"] = (
+                    resumen_bloque if resumen_bloque_style == "warning" else ""
+                )
+                ctx["alerta_importacion_warning_secundario"] = (
+                    excluidos_bloque if excluidos_bloque_style == "warning" else ""
+                )
+                ctx["alerta_importacion_success"] = (
+                    resumen_bloque if resumen_bloque_style == "success" else ""
+                )
         ctx["historial_page_obj"] = Paginator(historial, 5).get_page(
             self.request.GET.get("historial_page")
         )
@@ -1743,9 +1916,13 @@ class ReprocesarRegistrosErroneosView(View):
         creados = 0
         errores = 0
         errores_detalle = []
+        excluidos_detalle = []
         relaciones_crear = []
 
         estado_inicial = EstadoLegajo.objects.get(nombre="DOCUMENTO_PENDIENTE")
+        existentes_ids, en_programa, abiertos = (
+            _precargar_conflictos_y_existentes_importacion(expediente)
+        )
 
         provincia_id = _resolver_provincia_id_registro_erroneo(user, expediente)
         if not provincia_id:
@@ -1780,6 +1957,26 @@ class ReprocesarRegistrosErroneosView(View):
                     )
 
                     if ciudadano and ciudadano.pk:
+                        if _beneficiario_tiene_conflicto_importacion(
+                            ciudadano=ciudadano,
+                            offset=registro.fila_excel,
+                            existentes_ids=existentes_ids,
+                            en_programa=en_programa,
+                            abiertos=abiertos,
+                            excluidos=excluidos_detalle,
+                        ):
+                            registro.procesado = True
+                            registro.procesado_en = timezone.now()
+                            registro.mensaje_error = ""
+                            registro.save(
+                                update_fields=[
+                                    "procesado",
+                                    "procesado_en",
+                                    "mensaje_error",
+                                ]
+                            )
+                            continue
+
                         rol_beneficiario = (
                             ExpedienteCiudadano.ROLE_BENEFICIARIO_Y_RESPONSABLE
                             if es_mismo_documento
@@ -1800,6 +1997,7 @@ class ReprocesarRegistrosErroneosView(View):
 
                         if created:
                             creados += 1
+                            existentes_ids.add(ciudadano.pk)
 
                         if datos_responsable and not es_mismo_documento:
                             responsable = CiudadanoService.get_or_create_ciudadano(
@@ -1910,6 +2108,12 @@ class ReprocesarRegistrosErroneosView(View):
         registros_restantes = expediente.registros_erroneos.filter(
             procesado=False
         ).count()
+        alerta_actualizada = _actualizar_alerta_importacion_persistente(
+            expediente,
+            creados_incremento=creados,
+            errores_actuales=registros_restantes,
+            excluidos_nuevos=excluidos_detalle,
+        )
 
         return JsonResponse(
             {
@@ -1917,7 +2121,10 @@ class ReprocesarRegistrosErroneosView(View):
                 "creados": creados,
                 "errores": errores,
                 "errores_detalle": errores_detalle,
+                "excluidos": len(excluidos_detalle),
+                "excluidos_detalle": excluidos_detalle,
                 "registros_restantes": registros_restantes,
+                "alerta_resumen": (alerta_actualizada or {}).get("resumen", ""),
             }
         )
 

--- a/docs/registro/cambios/2026-04-23-celiaquia-alertas-importacion-y-subsanacion-ui.md
+++ b/docs/registro/cambios/2026-04-23-celiaquia-alertas-importacion-y-subsanacion-ui.md
@@ -63,3 +63,11 @@ Resultado:
 - el usuario ve primero el resumen de importacion/subsanacion;
 - los warnings relevantes siguen visibles al volver a entrar al expediente;
 - los success de resumen no quedan pegados indefinidamente, pero tampoco desaparecen por una recarga inmediata durante el tiempo definido para pruebas y operacion.
+
+## Ajuste post-review 2026-04-24
+
+Se corrigieron tres puntos de consistencia:
+
+- el historial de estado mantiene observaciones legibles para el usuario y no muestra el payload JSON tecnico;
+- la persistencia de alertas actualiza solo el ultimo historial del cambio de estado recien generado;
+- el reproceso de registros erroneos muestra warning cuando no crea legajos nuevos y solo suma excluidos por conflicto en otro expediente activo.

--- a/docs/registro/cambios/2026-04-23-celiaquia-alertas-importacion-y-subsanacion-ui.md
+++ b/docs/registro/cambios/2026-04-23-celiaquia-alertas-importacion-y-subsanacion-ui.md
@@ -1,0 +1,65 @@
+# Celiaquia: alertas persistentes y temporales en importacion y subsanacion
+
+Fecha: 2026-04-23
+
+## Contexto
+
+En el detalle de expedientes de Celiaquia, el feedback posterior a la importacion y al reproceso de registros erroneos tenia dos problemas de UX:
+
+- los mensajes mezclaban resumen operativo y detalle de legajos excluidos sin un orden semantico estable;
+- los mensajes de exito y warning no respetaban una regla consistente entre primera visualizacion, recarga y reingreso al expediente.
+
+Esto hacia dificil interpretar rapido que parte del resultado era informativa y que parte seguia requiriendo accion o seguimiento.
+
+## Cambio realizado
+
+Se ordeno el render de alertas persistentes del detalle de expediente para separar:
+
+- `resumen` de importacion/reproceso;
+- `excluidos` por legajos activos en otros expedientes.
+
+Ademas:
+
+- cuando aplica `PARTE A` y `PARTE B`, el resumen siempre se muestra primero;
+- los mensajes de warning persisten mientras el expediente siga en `EN_ESPERA`;
+- el mensaje de exito de `PARTE A` se mantiene como alerta temporal reutilizable durante 2 minutos en el navegador, incluyendo recargas y reapertura de la misma pantalla dentro de ese lapso.
+
+## Decision de UX
+
+Se definio esta regla:
+
+- `warning` persistente para informacion de negocio que sigue vigente al reingresar;
+- `success` temporal para confirmacion operativa inmediata posterior a importacion o subsanacion;
+- orden visual por significado del bloque y no por color del cartel.
+
+Motivo:
+
+- mejorar legibilidad;
+- evitar que el usuario pierda el resumen inmediato de exito;
+- mantener persistente solo la informacion que sigue siendo relevante hasta el cambio de estado.
+
+## Archivos tocados
+
+- `celiaquia/templates/celiaquia/expediente_detail.html`
+- `celiaquia/views/expediente.py`
+- `static/custom/js/expediente_detail.js`
+- `static/custom/js/registros_erroneos.js`
+
+## Validacion
+
+Se validaron helpers y services asociados al flujo del detalle de expediente y a la persistencia de alertas:
+
+```powershell
+docker compose -f BACKOFFICE\docker-compose.yml exec -T django pytest tests/test_expediente_service_unit.py -q
+docker compose -f BACKOFFICE\docker-compose.yml exec -T django pytest tests/test_celiaquia_expediente_view_helpers_unit.py -q
+```
+
+Resultado:
+
+- `36 passed`
+
+## Impacto esperado
+
+- el usuario ve primero el resumen de importacion/subsanacion;
+- los warnings relevantes siguen visibles al volver a entrar al expediente;
+- los success de resumen no quedan pegados indefinidamente, pero tampoco desaparecen por una recarga inmediata durante el tiempo definido para pruebas y operacion.

--- a/docs/registro/cambios/2026-04-23-celiaquia-subsanacion-valida-conflictos-y-ajusta-logs.md
+++ b/docs/registro/cambios/2026-04-23-celiaquia-subsanacion-valida-conflictos-y-ajusta-logs.md
@@ -1,0 +1,77 @@
+# Celiaquia: subsanacion valida conflictos con expedientes activos y reduce ruido de logs
+
+Fecha: 2026-04-23
+
+## Problema
+
+El reproceso de registros erroneos en Celiaquia no reutilizaba la misma validacion de importacion para detectar ciudadanos ya presentes en otro expediente activo.
+
+Eso permitia un caso incorrecto:
+
+- la importacion original excluia beneficiarios por conflicto en otro expediente;
+- un registro con error se corregia;
+- el reproceso podia crear el legajo aunque el ciudadano siguiera en conflicto.
+
+Ademas, el log `No hay legajos para crear - lista vacía` se emitia en nivel `warning`, generando ruido operativo y potencial observabilidad innecesaria.
+
+## Decision
+
+Se reutilizo la misma logica de importacion para validar conflictos durante el reproceso/subsanacion.
+
+Si el ciudadano corregido:
+
+- ya esta dentro del programa en otro expediente, o
+- ya pertenece a otro expediente abierto,
+
+entonces el registro deja de tratarse como error y pasa a computarse como `excluido`, igual que en la importacion original.
+
+En paralelo:
+
+- se persiste `excluidos_detalle` dentro de `observaciones` del historial para poder recalcular alertas posteriores;
+- se baja el log `No hay legajos para crear - lista vacía` de `warning` a `info`.
+
+Con ese cambio no hace falta configuracion extra para Sentry: al no emitirse como warning, deja de calificar como evento reportable por el esquema actual del proyecto.
+
+## Cambio implementado
+
+- `celiaquia/views/expediente.py`
+  - el reproceso precarga conflictos del expediente;
+  - valida cada beneficiario corregido con `_beneficiario_tiene_conflicto_importacion(...)`;
+  - convierte conflictos en `excluidos_detalle`;
+  - actualiza la alerta persistente sumando nuevos excluidos.
+- `celiaquia/services/expediente_service/impl.py`
+  - guarda `excluidos_detalle` en el payload persistido del historial;
+  - centraliza helpers para reconstruir resumen y detalle de excluidos.
+- `celiaquia/services/importacion_service/impl.py`
+  - reduce a `info` el mensaje `No hay legajos para crear - lista vacía`.
+
+## Resultado funcional
+
+Ejemplo esperado:
+
+- importacion inicial: `0 legajos creados, 1 error, 3 legajos ya existen en otro expediente`
+- luego de subsanar el error, si ese beneficiario tambien existe en otro expediente:
+  - resultado consolidado: `0 legajos creados, 0 errores, 4 legajos ya existen en otro expediente`
+
+## Testing
+
+Se reforzaron regresiones para cubrir:
+
+- persistencia de `excluidos_detalle` en observaciones de importacion;
+- recalculo del payload persistente cuando un error corregido pasa a excluido;
+- reproceso que convierte un registro subsanado en excluido por conflicto activo.
+
+Validacion ejecutada:
+
+```powershell
+docker compose -f BACKOFFICE\docker-compose.yml exec -T django pytest tests/test_expediente_service_unit.py -q
+docker compose -f BACKOFFICE\docker-compose.yml exec -T django pytest tests/test_celiaquia_expediente_view_helpers_unit.py -q
+```
+
+Resultado:
+
+- `36 passed`
+
+## Riesgo residual
+
+La regla de exclusiones compartida entre importacion y reproceso depende del mismo precargado de conflictos. Si en el futuro cambia la definicion de expediente activo o de inclusion en programa, conviene mantener sincronizada una unica fuente de verdad para ambos flujos.

--- a/docs/registro/cambios/2026-04-24-pr-1618-ci-admisiones-merge-syntax.md
+++ b/docs/registro/cambios/2026-04-24-pr-1618-ci-admisiones-merge-syntax.md
@@ -1,0 +1,24 @@
+# PR 1618: saneamiento de CI por merge de admisiones
+
+Fecha: 2026-04-24
+
+## Contexto
+
+Los jobs de PR 1618 fallaban antes de ejecutar la logica propia de Celiaquia porque el merge con `development` arrastraba una resolucion incompleta en admisiones:
+
+- `admisiones/views/web_views.py` no compilaba por un `return JsonResponse(...)` sin cerrar.
+- `tests/test_admisiones_web_views_unit.py` no compilaba por una prueba truncada.
+
+Esto bloqueaba `smoke`, `migrations_check`, `mysql_compat` y la suite completa por errores de coleccion.
+
+## Cambio realizado
+
+Se dejo una sola fuente de verdad para el bloqueo de eliminacion documental:
+
+- `AdmisionService.ESTADOS_BLOQUEO_ELIMINACION_DOCUMENTAL` contiene todos los estados cerrados que no admiten borrado.
+- `eliminar_archivo_admision(...)` delega en `AdmisionService.bloquea_eliminacion_documental(...)`.
+- La prueba de view parametriza contra la constante del servicio para evitar que el listado vuelva a duplicarse.
+
+## Resultado esperado
+
+PR 1618 puede mergearse a `development` sin reintroducir el error de sintaxis y conservando el bloqueo de borrado documental para informes finalizados o estados cerrados.

--- a/static/custom/js/expediente_detail.js
+++ b/static/custom/js/expediente_detail.js
@@ -10,6 +10,8 @@
  */
 
 /* ===== Helpers básicos ===== */
+const EXPEDIENTE_SUCCESS_ALERT_DURATION_MS = 120000;
+
 function getCookie(name) {
   const m = document.cookie.match(new RegExp('(^| )' + name + '=([^;]+)'));
   return m ? m[2] : null;
@@ -27,6 +29,69 @@ function ensureAlertsZone() {
   }
   return zone;
 }
+function getExpedienteAlertStorage() {
+  try {
+    if (typeof window !== 'undefined' && window.localStorage) {
+      return window.localStorage;
+    }
+  } catch (_err) {
+    // Sigue con sessionStorage como fallback.
+  }
+  try {
+    if (typeof window !== 'undefined' && window.sessionStorage) {
+      return window.sessionStorage;
+    }
+  } catch (_err) {
+    // Sin storage disponible.
+  }
+  return null;
+}
+function getExpedienteTimedAlertKey() {
+  const expedienteId = document.querySelector('meta[name="expediente-id"]')?.content || 'default';
+  return `expediente-detail-timed-alert:${expedienteId}`;
+}
+function queueTimedAlert(kind, message, durationMs = EXPEDIENTE_SUCCESS_ALERT_DURATION_MS) {
+  const storage = getExpedienteAlertStorage();
+  if (!storage) return;
+  try {
+    storage.setItem(
+      getExpedienteTimedAlertKey(),
+      JSON.stringify({
+        kind,
+        message,
+        expiresAt: Date.now() + durationMs,
+      })
+    );
+  } catch (_err) {
+    // Si el storage no esta disponible, no interrumpe el flujo.
+  }
+}
+function getTimedAlert() {
+  const storage = getExpedienteAlertStorage();
+  if (!storage) return null;
+  try {
+    const key = getExpedienteTimedAlertKey();
+    const raw = storage.getItem(key);
+    if (!raw) return null;
+    const alertData = JSON.parse(raw);
+    if (!alertData?.expiresAt || alertData.expiresAt <= Date.now()) {
+      storage.removeItem(key);
+      return null;
+    }
+    return alertData;
+  } catch (_err) {
+    return null;
+  }
+}
+function clearTimedAlert() {
+  const storage = getExpedienteAlertStorage();
+  if (!storage) return;
+  try {
+    storage.removeItem(getExpedienteTimedAlertKey());
+  } catch (_err) {
+    // Ignorar errores de storage.
+  }
+}
 function showAlert(kind, ...parts) {
   const zone = ensureAlertsZone();
   const msg = parts.map((p) => escapeHtml(String(p))).join('');
@@ -37,11 +102,25 @@ function showAlert(kind, ...parts) {
       </div>`;
 }
 
+if (typeof window !== 'undefined') {
+  window.queueExpedienteTimedAlert = queueTimedAlert;
+}
+
 if (typeof module !== 'undefined') {
   module.exports = { showAlert };
 }
 
 document.addEventListener('DOMContentLoaded', () => {
+  const timedAlert = getTimedAlert();
+  if (timedAlert?.kind && timedAlert?.message) {
+    showAlert(timedAlert.kind, timedAlert.message);
+    const remainingMs = Math.max(0, timedAlert.expiresAt - Date.now());
+    setTimeout(() => {
+      clearTimedAlert();
+      ensureAlertsZone().innerHTML = '';
+    }, remainingMs);
+  }
+
   const editarLegajoMeta = document.querySelector('meta[name="editar-legajo-url-template"]');
   const editarLegajoUrlTemplate = (window.EDITAR_LEGAJO_URL_TEMPLATE ||
     editarLegajoMeta?.getAttribute('content')?.replace('/0/', '/{id}/')) || null;
@@ -253,10 +332,14 @@ document.addEventListener('DOMContentLoaded', () => {
 
         setTimeout(() => {
           const baseMsg =
+            data.alerta_resumen ||
             data.message ||
             `Se crearon ${data.creados ?? '-'} legajos y el expediente pasó a EN ESPERA.`;
           const errorExtra = data.errores ? ` ${data.errores} errores.` : '';
           const alertType = data.errores > 0 ? 'warning' : 'success';
+          if (alertType === 'success' && Number(data.creados ?? 0) > 0) {
+            queueTimedAlert('success', baseMsg, EXPEDIENTE_SUCCESS_ALERT_DURATION_MS);
+          }
           showAlert(alertType, '¡Listo! ', baseMsg, errorExtra);
 
           setTimeout(() => window.location.reload(), 1000);

--- a/static/custom/js/registros_erroneos.js
+++ b/static/custom/js/registros_erroneos.js
@@ -1,4 +1,47 @@
 // Manejo de registros erróneos
+function buildReprocesarRegistrosFeedback(data) {
+    const creados = Number(data?.creados || 0);
+    const errores = Number(data?.errores || 0);
+    const excluidos = Number(data?.excluidos || 0);
+    const partes = [];
+
+    if (creados > 0) {
+        const legajos = creados === 1 ? 'legajo' : 'legajos';
+        const verbo = creados === 1 ? 'creó' : 'crearon';
+        partes.push(`Se ${verbo} ${creados} ${legajos} correctamente.`);
+    } else {
+        partes.push('No se crearon legajos nuevos.');
+    }
+
+    if (excluidos > 0) {
+        const legajos = excluidos === 1 ? 'legajo' : 'legajos';
+        const verbo = excluidos === 1 ? 'no se creó' : 'no se crearon';
+        const existe = excluidos === 1 ? 'existe' : 'existen';
+        partes.push(
+            `${excluidos} ${legajos} ${verbo} porque ya ${existe} en otro expediente activo.`
+        );
+    }
+
+    if (errores > 0) {
+        const registros = errores === 1 ? 'registro' : 'registros';
+        partes.push(`${errores} ${registros} aún tienen errores.`);
+    }
+
+    const kind = errores > 0 || creados === 0 ? 'warning' : 'success';
+    const shouldQueueSuccess =
+        kind === 'success' && creados > 0 && Boolean(data?.alerta_resumen);
+
+    return {
+        kind,
+        message: partes.join(' '),
+        shouldQueueSuccess,
+    };
+}
+
+if (typeof module !== 'undefined') {
+    module.exports = { buildReprocesarRegistrosFeedback };
+}
+
 document.addEventListener('DOMContentLoaded', function() {
     const csrfToken = document.querySelector('meta[name="csrf-token"]')?.content;
 
@@ -127,15 +170,10 @@ document.addEventListener('DOMContentLoaded', function() {
             .then(response => response.json())
             .then(data => {
                 if (data.success) {
-                    let mensaje = `Se crearon ${data.creados} legajos correctamente.`;
-                    if (data.errores > 0) {
-                        mensaje += ` ${data.errores} registros aún tienen errores.`;
-                    }
-                    
+                    const feedback = buildReprocesarRegistrosFeedback(data);
+
                     if (
-                        data.errores === 0 &&
-                        Number(data.creados || 0) > 0 &&
-                        data.alerta_resumen &&
+                        feedback.shouldQueueSuccess &&
                         typeof window.queueExpedienteTimedAlert === 'function'
                     ) {
                         window.queueExpedienteTimedAlert('success', data.alerta_resumen, 120000);
@@ -151,7 +189,7 @@ document.addEventListener('DOMContentLoaded', function() {
                         }
                     }
                     
-                    showAlert('success', mensaje);
+                    showAlert(feedback.kind, feedback.message);
                     setTimeout(() => location.reload(), 1500);
                 } else {
                     showAlert('danger', 'Error: ' + (data.error || 'Error desconocido'));

--- a/static/custom/js/registros_erroneos.js
+++ b/static/custom/js/registros_erroneos.js
@@ -132,6 +132,15 @@ document.addEventListener('DOMContentLoaded', function() {
                         mensaje += ` ${data.errores} registros aún tienen errores.`;
                     }
                     
+                    if (
+                        data.errores === 0 &&
+                        Number(data.creados || 0) > 0 &&
+                        data.alerta_resumen &&
+                        typeof window.queueExpedienteTimedAlert === 'function'
+                    ) {
+                        window.queueExpedienteTimedAlert('success', data.alerta_resumen, 120000);
+                    }
+
                     if (data.registros_restantes === 0) {
                         const btnConfirm = document.getElementById('btn-confirm');
                         if (btnConfirm) {

--- a/tests/js/test_registros_erroneos_feedback.js
+++ b/tests/js/test_registros_erroneos_feedback.js
@@ -1,0 +1,32 @@
+const assert = require('assert');
+
+global.document = {
+  addEventListener: () => {},
+};
+
+const {
+  buildReprocesarRegistrosFeedback,
+} = require('../../static/custom/js/registros_erroneos.js');
+
+const soloExcluidos = buildReprocesarRegistrosFeedback({
+  creados: 0,
+  errores: 0,
+  excluidos: 1,
+});
+
+assert.strictEqual(soloExcluidos.kind, 'warning');
+assert.match(soloExcluidos.message, /No se crearon legajos nuevos/);
+assert.match(soloExcluidos.message, /1 legajo no se creó porque ya existe/);
+assert.doesNotMatch(soloExcluidos.message, /Se crearon 0 legajos correctamente/);
+assert.strictEqual(soloExcluidos.shouldQueueSuccess, false);
+
+const creadosOk = buildReprocesarRegistrosFeedback({
+  creados: 2,
+  errores: 0,
+  excluidos: 0,
+  alerta_resumen: 'Importacion procesada.',
+});
+
+assert.strictEqual(creadosOk.kind, 'success');
+assert.match(creadosOk.message, /Se crearon 2 legajos correctamente/);
+assert.strictEqual(creadosOk.shouldQueueSuccess, true);

--- a/tests/test_admisiones_web_views_unit.py
+++ b/tests/test_admisiones_web_views_unit.py
@@ -169,23 +169,9 @@ def test_eliminar_archivo_admision_estado_no_permitido_and_success(mocker):
     assert resp2.status_code == 200
 
 
-def test_eliminar_archivo_admision_bloqueado_si_informe_finalizado(mocker):
-    admision = SimpleNamespace(
-        comedor=SimpleNamespace(), estado_admision="informe_tecnico_finalizado"
 @pytest.mark.parametrize(
     "estado_admision",
-    [
-        "informe_tecnico_finalizado",
-        "informe_tecnico_docx_editado",
-        "informe_tecnico_en_revision",
-        "informe_tecnico_en_subsanacion",
-        "informe_tecnico_aprobado",
-        "if_informe_tecnico_cargado",
-        "enviado_a_legales",
-        "enviado_a_acompaniamiento",
-        "descartado",
-        "inactivada",
-    ],
+    module.AdmisionService.ESTADOS_BLOQUEO_ELIMINACION_DOCUMENTAL,
 )
 def test_eliminar_archivo_admision_bloqueado_si_estado_cerrado(mocker, estado_admision):
     admision = SimpleNamespace(

--- a/tests/test_celiaquia_expediente_view_helpers_unit.py
+++ b/tests/test_celiaquia_expediente_view_helpers_unit.py
@@ -133,6 +133,23 @@ def test_actualizar_alerta_importacion_persistente_recalcula_resumen():
     historial_actual.save.assert_called_once_with(update_fields=["observaciones"])
 
 
+def test_formatear_observaciones_historial_muestra_texto_visible_de_payload():
+    payload = {
+        "resumen": "Importacion procesada. Se crearon 0 legajos.",
+        "excluidos": "No se crearon 2 legajos porque ya existen.",
+        "excluidos_detalle": [{"documento": "123"}],
+    }
+
+    assert module._formatear_observaciones_historial(json.dumps(payload)) == (
+        "Importacion procesada. Se crearon 0 legajos.\n"
+        "No se crearon 2 legajos porque ya existen."
+    )
+    assert module._formatear_observaciones_historial("Observacion manual") == (
+        "Observacion manual"
+    )
+    assert module._formatear_observaciones_historial("") == ""
+
+
 def test_registro_erroneo_responsable_requerido_depende_de_edad():
     assert (
         module._registro_erroneo_responsable_requerido(

--- a/tests/test_celiaquia_expediente_view_helpers_unit.py
+++ b/tests/test_celiaquia_expediente_view_helpers_unit.py
@@ -1,6 +1,9 @@
 """Tests for test celiaquia expediente view helpers unit."""
 
+import json
+from contextlib import nullcontext
 from types import SimpleNamespace
+from unittest.mock import Mock
 
 from django.http import JsonResponse
 
@@ -70,6 +73,64 @@ def test_resolver_provincia_registro_erroneo_fallback_a_usuario_expediente():
 
     provincia_id = module._resolver_provincia_id_registro_erroneo(user, expediente)
     assert provincia_id == 33
+
+
+def test_actualizar_alerta_importacion_persistente_recalcula_resumen():
+    payload = {
+        "resumen": "Importacion procesada. Se crearon 0 legajos y el expediente paso a EN ESPERA.\nErrores detectados: 1.",
+        "excluidos": "No se crearon 3 legajos porque ya existen en otro expediente activo.",
+        "excluidos_detalle": [
+            {
+                "documento": "111",
+                "apellido": "Perez",
+                "nombre": "Ana",
+                "estado_expediente_origen": "EN_ESPERA",
+                "expediente_origen_id": 22,
+            }
+        ],
+        "tiene_errores": True,
+        "creados_total": 0,
+        "errores_actuales": 1,
+    }
+    historial_actual = SimpleNamespace(
+        observaciones=json.dumps(payload),
+        save=Mock(),
+    )
+
+    historial_qs = SimpleNamespace(
+        exclude=lambda **kwargs: historial_qs,
+        order_by=lambda *args, **kwargs: historial_qs,
+        first=lambda: historial_actual,
+    )
+    expediente = SimpleNamespace(
+        estado="EN_ESPERA",
+        historial=SimpleNamespace(filter=lambda **kwargs: historial_qs),
+    )
+
+    module._actualizar_alerta_importacion_persistente(
+        expediente,
+        creados_incremento=1,
+        errores_actuales=0,
+        excluidos_nuevos=[
+            {
+                "documento": "222",
+                "apellido": "Gomez",
+                "nombre": "Luis",
+                "estado_expediente_origen": "EN_ESPERA",
+                "expediente_origen_id": 44,
+            }
+        ],
+    )
+
+    actualizado = json.loads(historial_actual.observaciones)
+    assert "Se crearon 1 legajos" in actualizado["resumen"]
+    assert "Errores detectados" not in actualizado["resumen"]
+    assert "No se crearon 2 legajos" in actualizado["excluidos"]
+    assert len(actualizado["excluidos_detalle"]) == 2
+    assert actualizado["tiene_errores"] is False
+    assert actualizado["creados_total"] == 1
+    assert actualizado["errores_actuales"] == 0
+    historial_actual.save.assert_called_once_with(update_fields=["observaciones"])
 
 
 def test_registro_erroneo_responsable_requerido_depende_de_edad():
@@ -875,6 +936,16 @@ def test_actualizar_registro_erroneo_view_paths(mocker):
 
 def test_reprocesar_registros_erroneos_early_branches(mocker):
     view = module.ReprocesarRegistrosErroneosView()
+    class _RegistrosQS:
+        def __init__(self, exists_result):
+            self._exists_result = exists_result
+
+        def exists(self):
+            return self._exists_result
+
+        def __iter__(self):
+            return iter([])
+
     expediente = SimpleNamespace(
         registros_erroneos=SimpleNamespace(filter=mocker.Mock())
     )
@@ -897,9 +968,7 @@ def test_reprocesar_registros_erroneos_early_branches(mocker):
     )
     mocker.patch("celiaquia.views.expediente._is_admin", return_value=True)
     mocker.patch("celiaquia.views.expediente._is_provincial", return_value=True)
-    expediente.registros_erroneos.filter.return_value = SimpleNamespace(
-        exists=lambda: False
-    )
+    expediente.registros_erroneos.filter.return_value = _RegistrosQS(False)
     no_records = module.ReprocesarRegistrosErroneosView.post.__wrapped__(
         view, req_ok, pk=1
     )
@@ -909,12 +978,14 @@ def test_reprocesar_registros_erroneos_early_branches(mocker):
     req_no_prov = SimpleNamespace(
         user=SimpleNamespace(profile=SimpleNamespace(provincia_id=None))
     )
-    expediente.registros_erroneos.filter.return_value = SimpleNamespace(
-        exists=lambda: True
-    )
+    expediente.registros_erroneos.filter.return_value = _RegistrosQS(True)
     mocker.patch(
         "celiaquia.views.expediente.EstadoLegajo.objects.get",
         return_value=SimpleNamespace(),
+    )
+    mocker.patch(
+        "celiaquia.views.expediente._precargar_conflictos_y_existentes_importacion",
+        return_value=(set(), {}, {}),
     )
     mocker.patch(
         "celiaquia.views.expediente._resolver_provincia_id_registro_erroneo",
@@ -924,6 +995,99 @@ def test_reprocesar_registros_erroneos_early_branches(mocker):
         view, req_no_prov, pk=1
     )
     assert no_prov.status_code == 400
+
+
+def test_reprocesar_registros_erroneos_convierte_conflicto_en_excluido(mocker):
+    view = module.ReprocesarRegistrosErroneosView()
+    class _RegistrosQS:
+        def __init__(self, registros):
+            self._registros = registros
+
+        def exists(self):
+            return True
+
+        def __iter__(self):
+            return iter(self._registros)
+
+    registro = SimpleNamespace(
+        pk=5,
+        fila_excel=7,
+        datos_raw={"documento": "123"},
+        mensaje_error="error previo",
+        save=mocker.Mock(),
+    )
+    registros_manager = SimpleNamespace(
+        filter=mocker.Mock(
+            side_effect=[
+                _RegistrosQS([registro]),
+                SimpleNamespace(count=lambda: 0),
+            ]
+        )
+    )
+    expediente = SimpleNamespace(registros_erroneos=registros_manager)
+
+    mocker.patch(
+        "celiaquia.views.expediente.get_object_or_404", return_value=expediente
+    )
+    mocker.patch(
+        "celiaquia.views.expediente._can_manage_registros_erroneos", return_value=True
+    )
+    mocker.patch(
+        "celiaquia.views.expediente.EstadoLegajo.objects.get",
+        return_value=SimpleNamespace(),
+    )
+    mocker.patch(
+        "celiaquia.views.expediente._resolver_provincia_id_registro_erroneo",
+        return_value=1,
+    )
+    mocker.patch(
+        "celiaquia.views.expediente._precargar_conflictos_y_existentes_importacion",
+        return_value=(set(), {}, {99: {"expediente_id": 221}}),
+    )
+    mocker.patch(
+        "celiaquia.views.expediente._validar_datos_registro_erroneo",
+        return_value=({"documento": "123"}, None, False),
+    )
+    ciudadano = SimpleNamespace(pk=99, documento="123", apellido="Perez", nombre="Ana")
+    mocker.patch.object(
+        module.CiudadanoService,
+        "get_or_create_ciudadano",
+        return_value=ciudadano,
+    )
+    excluido_mock = mocker.patch(
+        "celiaquia.views.expediente._beneficiario_tiene_conflicto_importacion",
+        side_effect=lambda **kwargs: kwargs["excluidos"].append(
+            {
+                "documento": "123",
+                "apellido": "Perez",
+                "nombre": "Ana",
+                "estado_expediente_origen": "EN_ESPERA",
+                "expediente_origen_id": 221,
+            }
+        )
+        or True,
+    )
+    actualizar_mock = mocker.patch(
+        "celiaquia.views.expediente._actualizar_alerta_importacion_persistente",
+        return_value={"resumen": "Importacion procesada. Se crearon 0 legajos y el expediente paso a EN ESPERA."},
+    )
+    mocker.patch("celiaquia.views.expediente.transaction.atomic", side_effect=lambda: nullcontext())
+    mocker.patch("celiaquia.views.expediente.timezone.now", return_value="ahora")
+
+    request = SimpleNamespace(user=SimpleNamespace())
+    response = module.ReprocesarRegistrosErroneosView.post.__wrapped__(
+        view, request, pk=1
+    )
+
+    payload = json.loads(response.content)
+    assert response.status_code == 200
+    assert payload["creados"] == 0
+    assert payload["errores"] == 0
+    assert payload["excluidos"] == 1
+    assert payload["registros_restantes"] == 0
+    assert excluido_mock.called
+    assert actualizar_mock.call_args.kwargs["excluidos_nuevos"][0]["documento"] == "123"
+    registro.save.assert_called_once()
 
 
 def test_eliminar_registro_erroneo_view_paths(mocker):

--- a/tests/test_celiaquia_expediente_view_helpers_unit.py
+++ b/tests/test_celiaquia_expediente_view_helpers_unit.py
@@ -936,6 +936,7 @@ def test_actualizar_registro_erroneo_view_paths(mocker):
 
 def test_reprocesar_registros_erroneos_early_branches(mocker):
     view = module.ReprocesarRegistrosErroneosView()
+
     class _RegistrosQS:
         def __init__(self, exists_result):
             self._exists_result = exists_result
@@ -999,6 +1000,7 @@ def test_reprocesar_registros_erroneos_early_branches(mocker):
 
 def test_reprocesar_registros_erroneos_convierte_conflicto_en_excluido(mocker):
     view = module.ReprocesarRegistrosErroneosView()
+
     class _RegistrosQS:
         def __init__(self, registros):
             self._registros = registros
@@ -1069,9 +1071,14 @@ def test_reprocesar_registros_erroneos_convierte_conflicto_en_excluido(mocker):
     )
     actualizar_mock = mocker.patch(
         "celiaquia.views.expediente._actualizar_alerta_importacion_persistente",
-        return_value={"resumen": "Importacion procesada. Se crearon 0 legajos y el expediente paso a EN ESPERA."},
+        return_value={
+            "resumen": "Importacion procesada. Se crearon 0 legajos y el expediente paso a EN ESPERA."
+        },
     )
-    mocker.patch("celiaquia.views.expediente.transaction.atomic", side_effect=lambda: nullcontext())
+    mocker.patch(
+        "celiaquia.views.expediente.transaction.atomic",
+        side_effect=lambda: nullcontext(),
+    )
     mocker.patch("celiaquia.views.expediente.timezone.now", return_value="ahora")
 
     request = SimpleNamespace(user=SimpleNamespace())

--- a/tests/test_expediente_service_unit.py
+++ b/tests/test_expediente_service_unit.py
@@ -29,6 +29,40 @@ def test_estado_helpers(mocker):
     exp2.save.assert_called_with(update_fields=["estado", "usuario_modificador"])
 
 
+def test_set_estado_observaciones_actualiza_solo_ultimo_historial(mocker):
+    historial_actual = SimpleNamespace(observaciones="", save=mocker.Mock())
+
+    class HistorialQS:
+        def order_by(self, *args):
+            assert args == ("-fecha",)
+            return self
+
+        def first(self):
+            return historial_actual
+
+    filter_mock = mocker.patch(
+        "celiaquia.services.expediente_service.ExpedienteEstadoHistorial.objects.filter",
+        return_value=HistorialQS(),
+    )
+    mocker.patch("celiaquia.services.expediente_service._estado_id", return_value=3)
+
+    expediente = SimpleNamespace(
+        pk=8,
+        estado_id=None,
+        usuario_modificador=None,
+        save=mocker.Mock(),
+    )
+    observaciones = '{"resumen": "Importacion procesada."}'
+
+    module._set_estado(
+        expediente, "EN_ESPERA", usuario="u", observaciones=observaciones
+    )
+
+    filter_mock.assert_called_once_with(expediente=expediente, estado_nuevo_id=3)
+    assert historial_actual.observaciones == observaciones
+    historial_actual.save.assert_called_once_with(update_fields=["observaciones"])
+
+
 def test_build_observaciones_importacion_resume_excluidos():
     out = json.loads(
         module._build_observaciones_importacion(

--- a/tests/test_expediente_service_unit.py
+++ b/tests/test_expediente_service_unit.py
@@ -1,6 +1,7 @@
 """Tests for test expediente service unit."""
 
 from types import SimpleNamespace
+import json
 
 import pytest
 from django.core.exceptions import ValidationError
@@ -26,6 +27,52 @@ def test_estado_helpers(mocker):
     exp2 = SimpleNamespace(save=mocker.Mock(), estado_id=None, usuario_modificador=None)
     module._set_estado(exp2, "X", usuario="u")
     exp2.save.assert_called_with(update_fields=["estado", "usuario_modificador"])
+
+
+def test_build_observaciones_importacion_resume_excluidos():
+    out = json.loads(
+        module._build_observaciones_importacion(
+            {
+                "validos": 0,
+                "errores": 1,
+                "excluidos": [
+                    {
+                        "documento": "123",
+                        "apellido": "Perez",
+                        "nombre": "Ana",
+                        "estado_programa": "ACEPTADO",
+                        "expediente_origen_id": 77,
+                    }
+                ],
+            }
+        )
+    )
+    assert "Se crearon 0 legajos" in out["resumen"]
+    assert "Errores detectados: 1." in out["resumen"]
+    assert "No se crearon 1 legajos" in out["excluidos"]
+    assert "Documento 123" in out["excluidos"]
+    assert "Exp #77" in out["excluidos"]
+    assert out["excluidos_detalle"][0]["documento"] == "123"
+    assert out["tiene_errores"] is True
+    assert out["creados_total"] == 0
+    assert out["errores_actuales"] == 1
+
+
+def test_build_observaciones_importacion_sin_errores_deja_resumen_en_success():
+    out = json.loads(
+        module._build_observaciones_importacion(
+            {
+                "validos": 2,
+                "errores": 0,
+                "excluidos": [],
+            }
+        )
+    )
+    assert "Se crearon 2 legajos" in out["resumen"]
+    assert out["excluidos"] == ""
+    assert out["tiene_errores"] is False
+    assert out["creados_total"] == 2
+    assert out["errores_actuales"] == 0
 
 
 def test_create_expediente_and_provincia_guard(mocker):
@@ -74,6 +121,7 @@ def test_procesar_expediente_validations_and_success(mocker):
         "excluidos_detalle": ["x"],
     }
     assert set_estado.call_count == 2
+    assert set_estado.call_args_list[1].kwargs["observaciones"]
 
 
 class _LegajosQS:


### PR DESCRIPTION
# Información de la Tarea
Vincular el #ISSUE
https://github.com/dsocial118/SISOC/issues/1561

### **Resumen de la Solución:** 
-Se realizaron modificaciones en los mensajes al usuario sobre:
Expedientes creados, errores y legajos que pertenecen a otro expediente

- Se bajo nivel de logs en los casos de expedientes sin legajos - lista vacia - a Info, ya no se levantan en Sentry.

- Se modifico logica cuando se subsanan legajos:
- - Antes: Permitia crear legajos que pertenecen a otros expedientes activos
- - Despues: Se utiliza la misma validacion que en la importacion, en caso de que ya exista en otro expediente, se suma a los no creados.

### **Información Adicional:**
-

# Descripción de los Cambios

### **Cambios:**
-

# Cómo Testear los Cambios

### **Pruebas Automáticas:**
-

### **Prubeas Manuales:**
-

# Metadata para documentación automática

- Contexto funcional:
- Tipo de cambio:
- Área principal:
- Resumen para changelog:
- Impacto usuario:
- Riesgos / rollback:

# Capturas de Pantalla
