### PR TITLE
Predeploy: saneamiento release main 2026-04-24

### DIFF
--- a/.github/workflows/pr-docs.yml
+++ b/.github/workflows/pr-docs.yml
@@ -1,4 +1,4 @@
-name: Documentación automática de PR
+name: Documentacion automatica de PR
 
 permissions:
     contents: write
@@ -37,10 +37,28 @@ jobs:
                   GITHUB_EVENT_PATH: ${{ github.event_path }}
               run: python scripts/ci/pr_doc_automation.py
 
-            - name: Commit automático de artefactos
-              if: github.event.pull_request.head.repo.full_name == github.repository
+            - name: Reportar artefactos para ramas protegidas
+              if: github.event.pull_request.head.repo.full_name == github.repository && (github.event.pull_request.head.ref == 'development' || github.event.pull_request.head.ref == 'main')
               run: |
-                  if git diff --quiet -- docs/registro/prs docs/contexto/features docs/registro/releases/pending; then
+                  if git diff --quiet -- docs/registro/prs docs/contexto/features docs/registro/releases/pending CHANGELOG.md; then
+                    echo "No hay cambios generados para reportar."
+                    exit 0
+                  fi
+
+                  {
+                    echo "### Artefactos spec-as-source generados"
+                    echo ""
+                    echo "La rama origen \`${{ github.event.pull_request.head.ref }}\` esta protegida; no se intenta push directo desde el workflow."
+                    echo ""
+                    echo '```diff'
+                    git diff -- docs/registro/prs docs/contexto/features docs/registro/releases/pending CHANGELOG.md
+                    echo '```'
+                  } >> "$GITHUB_STEP_SUMMARY"
+
+            - name: Commit automatico de artefactos
+              if: github.event.pull_request.head.repo.full_name == github.repository && github.event.pull_request.head.ref != 'development' && github.event.pull_request.head.ref != 'main'
+              run: |
+                  if git diff --quiet -- docs/registro/prs docs/contexto/features docs/registro/releases/pending CHANGELOG.md; then
                     echo "No hay cambios generados para commitear."
                     exit 0
                   fi
@@ -48,6 +66,6 @@ jobs:
                   git config user.name "github-actions[bot]"
                   git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
 
-                  git add docs/registro/prs docs/contexto/features docs/registro/releases/pending
-                  git commit -m "docs(ci): actualizar artefactos automáticos del PR #${{ github.event.pull_request.number }}"
+                  git add docs/registro/prs docs/contexto/features docs/registro/releases/pending CHANGELOG.md
+                  git commit -m "docs(ci): actualizar artefactos automaticos del PR #${{ github.event.pull_request.number }}"
                   git push

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
-<!-- AUTO-GENERATED RELEASE START: 2026-04-23 -->
-# Versión SISOC 23.04.2026
+<!-- AUTO-GENERATED RELEASE START: 2026-04-24 -->
+# Versión SISOC 24.04.2026
 
 ## Nuevas Funcionalidades
 
@@ -21,7 +21,7 @@
 - Ajustes en Celiaquía para rechazo con motivo, reprocesos RENAPER, exportación SINTyS y localización de datos inválidos sin perder trazabilidad para el usuario.
 - Corrección de infraestructura y release para que `.env.example`, la resolución de dependencias y los jobs de lint/bootstrap no fallen por configuraciones inválidas o entradas vacías.
 
-<!-- AUTO-GENERATED RELEASE END: 2026-04-23 -->
+<!-- AUTO-GENERATED RELEASE END: 2026-04-24 -->
 
 <!-- AUTO-GENERATED RELEASE START: 2026-04-09 -->
 # Versión SISOC 09.04.2026

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@
 - Correcciones en VAT, Ciudadanos y Acompañamientos para resolver regresiones de edición, merges de migraciones y compatibilidad de vouchers/fixtures sin romper el flujo productivo reciente.
 - Ajustes en Celiaquía para rechazo con motivo, reprocesos RENAPER, exportación SINTyS y localización de datos inválidos sin perder trazabilidad para el usuario.
 - Corrección de infraestructura y release para que `.env.example`, la resolución de dependencias y los jobs de lint/bootstrap no fallen por configuraciones inválidas o entradas vacías.
+- Saneamiento de predeploy para respetar cierres explícitos de revisión manual de identidad, mantener la nómina de Comedores compatible con ciudadanos ya revisados y evitar bloqueos de lint/docs en la promoción a `main`.
 
 <!-- AUTO-GENERATED RELEASE END: 2026-04-24 -->
 

--- a/ciudadanos/models.py
+++ b/ciudadanos/models.py
@@ -290,7 +290,7 @@ class Ciudadano(SoftDeleteModelMixin, models.Model):
             return f"{self.tipo_documento}_{self.documento}"
         return None
 
-    def normalizar_identidad(self):
+    def normalizar_identidad(self, preservar_revision_manual=False):
         changed_fields = set()
         tipo = self.tipo_registro_identidad or self.TIPO_REGISTRO_ESTANDAR
 
@@ -322,15 +322,22 @@ class Ciudadano(SoftDeleteModelMixin, models.Model):
         changed_fields |= self._set_identity_field(
             "documento_unico_key", self.build_documento_unico_key()
         )
-        changed_fields |= self._set_identity_field(
-            "requiere_revision_manual",
-            tipo in (self.TIPO_REGISTRO_SIN_DNI, self.TIPO_REGISTRO_DNI_NO_VALIDADO),
-        )
+        if not preservar_revision_manual:
+            changed_fields |= self._set_identity_field(
+                "requiere_revision_manual",
+                tipo
+                in (self.TIPO_REGISTRO_SIN_DNI, self.TIPO_REGISTRO_DNI_NO_VALIDADO),
+            )
         return changed_fields
 
     def save(self, *args, **kwargs):
-        changed_fields = self.normalizar_identidad()
         update_fields = kwargs.get("update_fields")
+        preservar_revision_manual = (
+            update_fields is not None and "requiere_revision_manual" in update_fields
+        )
+        changed_fields = self.normalizar_identidad(
+            preservar_revision_manual=preservar_revision_manual
+        )
         if update_fields is not None and changed_fields:
             kwargs["update_fields"] = set(update_fields) | changed_fields
         return super().save(*args, **kwargs)

--- a/docs/registro/cambios/2026-04-20-celiaquia-rechazo-con-motivo.md
+++ b/docs/registro/cambios/2026-04-20-celiaquia-rechazo-con-motivo.md
@@ -26,4 +26,3 @@
 
 ## Límites / entorno
 - La corrida local de `celiaquia/tests/test_expediente_detail.py` queda bloqueada en este entorno Windows por una dependencia nativa faltante de `weasyprint` (`libgobject-2.0-0`) al cargar el árbol completo de URLs de Django.
-

--- a/docs/registro/cambios/2026-04-24-predeploy-saneamiento-release-main.md
+++ b/docs/registro/cambios/2026-04-24-predeploy-saneamiento-release-main.md
@@ -14,6 +14,13 @@ worktree aislada y PR final obligatorio `development -> main`.
   el body del PR antes de usar el fallback historico del proximo miercoles.
 - `CHANGELOG.md` queda fechado para el PR final del 2026-04-24.
 - Se corrigieron tres finales de archivo marcados por `git diff --check`.
+- Ciudadanos respeta el cierre explicito de `requiere_revision_manual` cuando
+  el campo se guarda de forma intencional. Esto permite que Comedores acepte en
+  nomina a personas con DNI no validado por RENAPER cuya revision manual ya fue
+  cerrada.
+- `IntervencionCreateView` mueve validacion y asignacion de campos a helpers
+  chicos para que el lint completo no bloquee el release por complejidad
+  ciclomatica en la vista.
 
 ## Riesgo mitigado
 
@@ -26,4 +33,6 @@ codigo funcional.
 
 - `git diff --check`
 - Tests unitarios de `scripts/ci/pr_doc_automation.py`
+- Regresiones de identidad/nomina de Comedores y modelo de Ciudadanos
+- `pylint` sobre `intervenciones/views.py`
 - Checks de GitHub Actions del PR de saneamiento y del PR final a `main`

--- a/docs/registro/cambios/2026-04-24-predeploy-saneamiento-release-main.md
+++ b/docs/registro/cambios/2026-04-24-predeploy-saneamiento-release-main.md
@@ -1,0 +1,29 @@
+# Predeploy development -> main 2026-04-24
+
+## Contexto
+
+Se preparo un nuevo predeploy entre `origin/development` y `origin/main` con
+worktree aislada y PR final obligatorio `development -> main`.
+
+## Saneamiento aplicado
+
+- `pr-docs.yml` deja de intentar push directo cuando el head del PR es una
+  rama protegida (`development` o `main`) y reporta el diff generado en el
+  summary del job.
+- `scripts/ci/pr_doc_automation.py` respeta una fecha de release explicita en
+  el body del PR antes de usar el fallback historico del proximo miercoles.
+- `CHANGELOG.md` queda fechado para el PR final del 2026-04-24.
+- Se corrigieron tres finales de archivo marcados por `git diff --check`.
+
+## Riesgo mitigado
+
+El PR final a `main` usa `development` como rama origen. Si el workflow intentaba
+commitear artefactos desde esa rama protegida, GitHub podia rechazar el push con
+reglas de proteccion de rama y bloquear el release por automatizacion, no por
+codigo funcional.
+
+## Validacion esperada
+
+- `git diff --check`
+- Tests unitarios de `scripts/ci/pr_doc_automation.py`
+- Checks de GitHub Actions del PR de saneamiento y del PR final a `main`

--- a/intervenciones/views.py
+++ b/intervenciones/views.py
@@ -36,6 +36,46 @@ def _resolve_valid_admision(comedor, raw_admision_id):
     ).first()
 
 
+INTERVENCION_FIELD_MAPPING = {
+    "tipo_intervencion": TipoIntervencion,
+    "subintervencion": SubIntervencion,
+    "destinatario": "Destinatario",
+    "fecha": "Fecha",
+    "forma_contacto": "Forma de Contacto",
+    "observaciones": "Descripcion",
+    "tiene_documentacion": "Documentacion Adjunta",
+}
+
+
+def _validar_subintervencion_requerida(form):
+    tipo_intervencion = form.cleaned_data.get("tipo_intervencion")
+    if not tipo_intervencion:
+        return True
+
+    if not tipo_intervencion.subintervenciones.exists():
+        form.cleaned_data["subintervencion"] = None
+        return True
+
+    if form.cleaned_data.get("subintervencion"):
+        return True
+
+    form.add_error("subintervencion", "Debe seleccionar una subintervencion.")
+    return False
+
+
+def _asignar_campo_intervencion(instance, field, model, value):
+    if isinstance(model, type) and not isinstance(value, model):
+        value = model.objects.get(id=value)
+    setattr(instance, field, value)
+
+
+def _aplicar_campos_intervencion(form):
+    for field, model in INTERVENCION_FIELD_MAPPING.items():
+        value = form.cleaned_data.get(field)
+        if value is not None:
+            _asignar_campo_intervencion(form.instance, field, model, value)
+
+
 @login_required
 @require_GET
 def sub_estados_intervenciones_ajax(request):
@@ -144,39 +184,10 @@ class IntervencionCreateView(LoginRequiredMixin, CreateView):
         if admision is not None:
             form.instance.admision = admision
 
-        tipo_intervencion = form.cleaned_data.get("tipo_intervencion")
-        if tipo_intervencion:
-            subintervenciones = tipo_intervencion.subintervenciones.all()
-            if subintervenciones.exists():
-                subintervencion = form.cleaned_data.get("subintervencion")
-                if not subintervencion:
-                    form.add_error(
-                        "subintervencion", "Debe seleccionar una subintervención."
-                    )
-                    return self.form_invalid(form)
-            else:
-                form.cleaned_data["subintervencion"] = None
+        if not _validar_subintervencion_requerida(form):
+            return self.form_invalid(form)
 
-        field_mapping = {
-            "tipo_intervencion": TipoIntervencion,
-            "subintervencion": SubIntervencion,
-            "destinatario": "Destinatario",
-            "fecha": "Fecha",
-            "forma_contacto": "Forma de Contacto",
-            "observaciones": "Descripción",
-            "tiene_documentacion": "Documentación Adjunta",
-        }
-
-        for field, model in field_mapping.items():
-            value = form.cleaned_data.get(field)
-            if value is not None:
-                if isinstance(model, type):
-                    if isinstance(value, model):
-                        setattr(form.instance, field, value)
-                    else:
-                        setattr(form.instance, field, model.objects.get(id=value))
-                else:
-                    setattr(form.instance, field, value)
+        _aplicar_campos_intervencion(form)
 
         form.instance.save()
         next_url = self.request.POST.get("next") or self.request.GET.get("next")

--- a/scripts/ci/pr_doc_automation.py
+++ b/scripts/ci/pr_doc_automation.py
@@ -72,6 +72,11 @@ BODY_FIELD_ALIASES = {
         "riesgos / rollback",
         "riesgos",
     },
+    "fecha_release": {
+        "fecha objetivo de release",
+        "fecha release",
+        "release date",
+    },
     "pruebas_automaticas": {
         "pruebas automaticas",
         "pruebas automáticas",
@@ -173,6 +178,16 @@ def next_wednesday(today: date) -> date:
 
     days_until = (2 - today.weekday()) % 7
     return today + timedelta(days=days_until)
+
+
+def resolve_release_date(metadata: dict[str, str], today: date) -> str:
+    """Resuelve la fecha de release declarada en el PR o el fallback historico."""
+
+    explicit_value = metadata.get("fecha_release", "")
+    match = re.search(r"\d{4}-\d{2}-\d{2}", explicit_value)
+    if match:
+        return date.fromisoformat(match.group(0)).isoformat()
+    return next_wednesday(today).isoformat()
 
 
 def remove_previous_pr_files(directory: Path, pattern: str) -> None:
@@ -691,8 +706,7 @@ def sync_pr_artifacts(
     if pr.base_ref != "main":
         return
 
-    release_target = next_wednesday(today or date.today())
-    release_file_date = release_target.strftime("%Y-%m-%d")
+    release_file_date = resolve_release_date(metadata, today or date.today())
     remove_previous_pr_files(DOCS_RELEASE_PENDING_DIR, f"*-pr-{pr.number}.md")
     pending_note = PendingReleaseNote(
         pr_number=pr.number,

--- a/scripts/ci/pr_doc_automation.py
+++ b/scripts/ci/pr_doc_automation.py
@@ -186,7 +186,10 @@ def resolve_release_date(metadata: dict[str, str], today: date) -> str:
     explicit_value = metadata.get("fecha_release", "")
     match = re.search(r"\d{4}-\d{2}-\d{2}", explicit_value)
     if match:
-        return date.fromisoformat(match.group(0)).isoformat()
+        try:
+            return date.fromisoformat(match.group(0)).isoformat()
+        except ValueError:
+            pass
     return next_wednesday(today).isoformat()
 
 

--- a/static/custom/js/expediente_detail.js
+++ b/static/custom/js/expediente_detail.js
@@ -1932,4 +1932,3 @@ document.addEventListener('DOMContentLoaded', function() {
         });
     }
 });
-

--- a/static/custom/js/registros_erroneos.js
+++ b/static/custom/js/registros_erroneos.js
@@ -478,5 +478,3 @@ document.addEventListener('DOMContentLoaded', function() {
         });
     }
 });
-
-

--- a/tests/test_ciudadanos_models_unit.py
+++ b/tests/test_ciudadanos_models_unit.py
@@ -113,6 +113,25 @@ def test_ciudadano_save_update_fields_incluye_clave_derivada(db):
     assert ciudadano.documento_unico_key == "DNI_30111229"
 
 
+def test_ciudadano_save_update_fields_respeta_revision_manual_explicita(db):
+    ciudadano = Ciudadano.objects.create(
+        nombre="Ana",
+        apellido="Perez",
+        fecha_nacimiento=date(1990, 1, 1),
+        tipo_documento=Ciudadano.DOCUMENTO_DNI,
+        documento=30111230,
+        tipo_registro_identidad=Ciudadano.TIPO_REGISTRO_DNI_NO_VALIDADO,
+        motivo_no_validacion_renaper=Ciudadano.MOTIVO_NO_VALIDADO_OTRO,
+    )
+
+    ciudadano.requiere_revision_manual = False
+    ciudadano.save(update_fields=["requiere_revision_manual"])
+    ciudadano.refresh_from_db()
+
+    assert ciudadano.tipo_registro_identidad == Ciudadano.TIPO_REGISTRO_DNI_NO_VALIDADO
+    assert ciudadano.requiere_revision_manual is False
+
+
 def test_ciudadano_no_validado_permite_dni_duplicado(db):
     for nombre in ("Ana", "Beto"):
         Ciudadano.objects.create(

--- a/tests/test_pr_doc_automation_unit.py
+++ b/tests/test_pr_doc_automation_unit.py
@@ -69,6 +69,20 @@ def test_next_wednesday_devuelve_mismo_dia_si_ya_es_miercoles():
     assert following == date(2026, 3, 18)
 
 
+def test_resolve_release_date_prioriza_fecha_explicita_del_pr():
+    """Permite fijar el corte cuando el PR final declara fecha de release."""
+
+    metadata = pr_doc_automation.parse_pr_body_metadata(
+        "- Fecha objetivo de release: 2026-04-24"
+    )
+
+    explicit = pr_doc_automation.resolve_release_date(metadata, date(2026, 4, 24))
+    fallback = pr_doc_automation.resolve_release_date({}, date(2026, 4, 24))
+
+    assert explicit == "2026-04-24"
+    assert fallback == "2026-04-29"
+
+
 def test_render_changelog_reemplaza_bloque_auto_generado_de_misma_release(tmp_path):
     """Regenera el bloque auto y preserva el historial previo."""
 

--- a/tests/test_pr_doc_automation_unit.py
+++ b/tests/test_pr_doc_automation_unit.py
@@ -83,6 +83,18 @@ def test_resolve_release_date_prioriza_fecha_explicita_del_pr():
     assert fallback == "2026-04-29"
 
 
+def test_resolve_release_date_ignora_fecha_explicita_invalida():
+    """Usa fallback si el body trae un patron de fecha fuera de rango."""
+
+    metadata = pr_doc_automation.parse_pr_body_metadata(
+        "- Fecha objetivo de release: 2026-13-40"
+    )
+
+    assert pr_doc_automation.resolve_release_date(metadata, date(2026, 4, 24)) == (
+        "2026-04-29"
+    )
+
+
 def test_render_changelog_reemplaza_bloque_auto_generado_de_misma_release(tmp_path):
     """Regenera el bloque auto y preserva el historial previo."""
 


### PR DESCRIPTION
## Resumen

Saneamiento minimo para dejar `development` en mejor estado antes del PR final `development -> main`.

## Cambios

- `pr-docs.yml` ya no intenta pushear artefactos cuando el head del PR es `development` o `main`; en esos casos reporta el diff generado en el summary del job.
- `scripts/ci/pr_doc_automation.py` permite fijar una fecha explicita de release desde el body del PR y tolera patrones de fecha invalidos cayendo al fallback historico.
- `CHANGELOG.md` queda fechado para el corte final del 2026-04-24 e incluye el saneamiento de predeploy.
- Se corrigen tres finales de archivo detectados por `git diff --check`.
- Ciudadanos respeta el cierre explicito de `requiere_revision_manual` cuando ese campo se guarda intencionalmente; esto desbloquea la nomina de Comedores para ciudadanos ya revisados manualmente.
- `IntervencionCreateView` extrae validacion/asignacion a helpers para eliminar el bloqueo de `pylint` por complejidad sin cambiar el flujo funcional.
- Se agrega registro spec-as-source del saneamiento.

## Pruebas ejecutadas

- `git diff --check`: OK.
- Docker `pytest tests/test_pr_doc_automation_unit.py -q`: 8 passed.
- Docker `pytest comedores/tests.py::test_agregar_ciudadano_revisado_manualmente_ingresa_a_nomina tests/test_ciudadanos_models_unit.py::test_ciudadano_save_update_fields_respeta_revision_manual_explicita tests/test_pr_doc_automation_unit.py -q`: 9 passed antes de agregar el test de fecha invalida.
- Docker `black --check scripts/ci/pr_doc_automation.py tests/test_pr_doc_automation_unit.py --config pyproject.toml`: OK.
- Docker `black --check ciudadanos/models.py intervenciones/views.py tests/test_ciudadanos_models_unit.py tests/test_pr_doc_automation_unit.py scripts/ci/pr_doc_automation.py --config pyproject.toml`: OK antes del ultimo commit focalizado.
- Docker `pylint scripts/ci/pr_doc_automation.py tests/test_pr_doc_automation_unit.py --rcfile=.pylintrc`: OK.
- Docker `pylint **/*.py --rcfile=.pylintrc`: OK antes del ultimo commit focalizado.
- Docker `pytest -n auto --cov=. --cov-report=term-missing --cov-fail-under=75`: 2096 passed, 1 skipped, 3 warnings, cobertura 81.63% antes del ultimo commit focalizado.
- Docker `pytest -m smoke -q`: 457 passed, 1639 deselected, 3 warnings.
- Docker `python manage.py makemigrations --check --dry-run`: No changes detected. En la corrida sin servicio MySQL levantado emitio warning de host `mysql` no resoluble, con exit 0.
- Docker release sanity local previo: `check --deploy`, `spectacular --validate` y `collectstatic --noinput`: exit 0. `spectacular` mantiene warnings/errores de schema no fatales ya existentes.
- Docker MySQL con puertos alternativos previo: `makemigrations --check --dry-run` OK; `pytest -m mysql_compat -q`: 1 passed, 1 skipped.
- GitHub Actions sobre `a85b2c9`: `Tests automatizados`, `Formateo y linteo`, `Documentacion automatica de PR`, `Escaneo de secretos`, CodeQL y el analisis dinamico completaron success.

## Riesgos remanentes

- El PR final `development -> main` todavia debe re-ejecutar checks sobre `development` despues de mergear este saneamiento.
- Hay riesgos operativos no eliminados por este PR: migraciones con backfills/borrado de datos historicos y ejecucion coordinada del backfill de identidad.
- El helper `scripts/ci/pr_lint_tools.py check-encoding` se verifico en CI de este PR, pero no se reprodujo localmente fuera de Actions porque depende de `GITHUB_EVENT_PATH`.

## Rollback

Revertir este PR restaura el comportamiento anterior de la automatizacion de docs PR, del changelog y de la normalizacion de identidad. No toca migraciones ni infraestructura productiva.