### PR TITLE
Fix dni

### DIFF
--- a/comedores/services/comedor_service/impl.py
+++ b/comedores/services/comedor_service/impl.py
@@ -1176,25 +1176,19 @@ class ComedorService:
 
     @staticmethod
     def _buscar_ciudadano_existente_por_dni_renaper(dni_str):
-        # Buscar primero por documento_unico_key para encontrar solo registros
-        # ESTANDAR verificados. Esto evita retornar un duplicado ambiguo cuando
-        # hay múltiples ciudadanos con el mismo DNI (DNI_NO_VALIDADO_RENAPER).
+        # Buscar primero por documento_unico_key (solo registros ESTANDAR verificados).
         doc_key = f"DNI_{dni_str}"
         ciudadano = Ciudadano.objects.filter(documento_unico_key=doc_key).first()
         if ciudadano:
             return ciudadano
-        # Fallback: si el backfill aún no corrió o el registro es previo a Fase 1,
-        # buscar por documento directo prefiriendo ESTANDAR.
-        ciudadano = Ciudadano.objects.filter(
-            tipo_documento=Ciudadano.DOCUMENTO_DNI,
-            documento=int(dni_str),
-            tipo_registro_identidad=Ciudadano.TIPO_REGISTRO_ESTANDAR,
-        ).first()
-        if ciudadano:
-            return ciudadano
+        # Fallback para registros previos al backfill: busca explícitamente ESTANDAR.
+        # No se retorna ningún ciudadano DNI_NO_VALIDADO_RENAPER ni SIN_DNI: si el
+        # único registro con ese DNI está en revisión, se devuelve None para que
+        # RENAPER pueda consultarse al cargar un nuevo ciudadano.
         return Ciudadano.objects.filter(
             tipo_documento=Ciudadano.DOCUMENTO_DNI,
             documento=int(dni_str),
+            tipo_registro_identidad=Ciudadano.TIPO_REGISTRO_ESTANDAR,
         ).first()
 
     @staticmethod

--- a/comedores/templates/comedor/nomina_form.html
+++ b/comedores/templates/comedor/nomina_form.html
@@ -107,10 +107,12 @@
         {% endif %}
 
         <!-- Formulario Creación de Ciudadano -->
-        {% if request.GET.query and no_resultados %}
+        {% if mostrar_form_ciudadano %}
             <div class="alert alert-info mb-3">
                 <i class="bi bi-exclamation-triangle-fill fs-4"></i>
-                {% if renaper_precarga %}
+                {% if renaper_precarga and ciudadanos %}
+                    Se encontraron coincidencias pendientes de revisión. Se precargaron datos desde RENAPER; confirme para crear y agregar a la nómina.
+                {% elif renaper_precarga %}
                     No se encontraron coincidencias en el sistema. Se precargaron datos desde RENAPER; confirme para crear y agregar a la nómina.
                 {% else %}
                     No se encontraron coincidencias.

--- a/comedores/views/nomina.py
+++ b/comedores/views/nomina.py
@@ -169,11 +169,14 @@ class NominaCreateView(LoginRequiredMixin, CreateView):
         renaper_precarga = bool(renaper_data) or (
             self.request.POST.get("origen_dato") == "renaper"
         )
+        no_resultados = bool(query) and not ciudadanos
+        mostrar_form_ciudadano = bool(query) and (no_resultados or bool(renaper_data))
 
         context.update(
             {
                 "ciudadanos": ciudadanos,
-                "no_resultados": bool(query) and not ciudadanos,
+                "no_resultados": no_resultados,
+                "mostrar_form_ciudadano": mostrar_form_ciudadano,
                 "form_ciudadano": form_ciudadano,
                 "form_nomina_extra": kwargs.get("form_nomina_extra")
                 or NominaExtraForm(),
@@ -458,11 +461,14 @@ class NominaDirectaCreateView(LoginRequiredMixin, CreateView):
         renaper_precarga = bool(renaper_data) or (
             self.request.POST.get("origen_dato") == "renaper"
         )
+        no_resultados = bool(query) and not ciudadanos
+        mostrar_form_ciudadano = bool(query) and (no_resultados or bool(renaper_data))
 
         context.update(
             {
                 "ciudadanos": ciudadanos,
-                "no_resultados": bool(query) and not ciudadanos,
+                "no_resultados": no_resultados,
+                "mostrar_form_ciudadano": mostrar_form_ciudadano,
                 "form_ciudadano": form_ciudadano,
                 "form_nomina_extra": kwargs.get("form_nomina_extra")
                 or NominaExtraForm(),

--- a/comedores/views/nomina.py
+++ b/comedores/views/nomina.py
@@ -9,6 +9,7 @@ from django.urls import reverse_lazy
 from django.views.generic import CreateView, DeleteView, TemplateView, View
 
 from admisiones.models.admisiones import Admision
+from ciudadanos.models import Ciudadano
 from comedores.forms.comedor_form import (
     CiudadanoFormParaNomina,
     NominaExtraForm,
@@ -138,8 +139,12 @@ class NominaCreateView(LoginRequiredMixin, CreateView):
         renaper_data = None
         if query:
             ciudadanos = ComedorService.buscar_ciudadanos_por_documento(query)
+            # RENAPER se consulta cuando no existe ningún ciudadano validado con ese
+            # DNI. Si todos los encontrados están en revisión manual, se consulta
+            # igual para permitir pre-cargar datos y contrastar con el registro previo.
+            hay_validado = any(not c.requiere_revision_manual for c in ciudadanos)
             if (
-                not ciudadanos
+                not hay_validado
                 and query_clean.isdigit()
                 and len(query_clean) >= 7
                 and not form_ciudadano
@@ -208,6 +213,21 @@ class NominaCreateView(LoginRequiredMixin, CreateView):
         ciudadano_id = request.POST.get("ciudadano_id")
 
         if ciudadano_id:
+            # Validación server-side: no se puede agregar a un ciudadano en revisión.
+            try:
+                _c = Ciudadano.objects.only("requiere_revision_manual").get(
+                    pk=ciudadano_id
+                )
+                if _c.requiere_revision_manual:
+                    messages.error(
+                        request,
+                        "Este ciudadano tiene identidad pendiente de revisión "
+                        "y no puede ser agregado a la nómina.",
+                    )
+                    return redirect(self.get_success_url())
+            except Ciudadano.DoesNotExist:
+                pass
+
             # Agregar ciudadano existente
             form_nomina_extra = NominaExtraForm(request.POST)
 
@@ -408,8 +428,9 @@ class NominaDirectaCreateView(LoginRequiredMixin, CreateView):
         renaper_data = None
         if query:
             ciudadanos = ComedorService.buscar_ciudadanos_por_documento(query)
+            hay_validado = any(not c.requiere_revision_manual for c in ciudadanos)
             if (
-                not ciudadanos
+                not hay_validado
                 and query_clean.isdigit()
                 and len(query_clean) >= 7
                 and not form_ciudadano
@@ -458,6 +479,20 @@ class NominaDirectaCreateView(LoginRequiredMixin, CreateView):
         ciudadano_id = request.POST.get("ciudadano_id")
 
         if ciudadano_id:
+            try:
+                _c = Ciudadano.objects.only("requiere_revision_manual").get(
+                    pk=ciudadano_id
+                )
+                if _c.requiere_revision_manual:
+                    messages.error(
+                        request,
+                        "Este ciudadano tiene identidad pendiente de revisión "
+                        "y no puede ser agregado a la nómina.",
+                    )
+                    return redirect(self.get_success_url())
+            except Ciudadano.DoesNotExist:
+                pass
+
             form_nomina_extra = NominaExtraForm(request.POST)
             if not form_nomina_extra.is_valid():
                 messages.error(

--- a/tests/test_nomina_views_unit.py
+++ b/tests/test_nomina_views_unit.py
@@ -150,6 +150,12 @@ def test_nomina_create_post_ciudadano_existente(mocker):
         "comedores.views.nomina._get_admision_del_comedor_or_404",
         return_value=SimpleNamespace(pk=88),
     )
+    # Mock de la validación de identidad agregada en Fix_dni
+    _ciudadano_validado = SimpleNamespace(requiere_revision_manual=False)
+    mocker.patch(
+        "comedores.views.nomina.Ciudadano.objects.only",
+        return_value=SimpleNamespace(get=lambda **kw: _ciudadano_validado),
+    )
 
     form = SimpleNamespace(
         is_valid=lambda: True, cleaned_data={"estado": "A", "observaciones": "o"}

--- a/tests/test_nomina_views_unit.py
+++ b/tests/test_nomina_views_unit.py
@@ -139,6 +139,94 @@ def test_nomina_create_get_context_data_with_renaper(mocker):
     assert form_ciudadano.called
 
 
+def test_nomina_create_get_context_data_muestra_form_si_solo_hay_revision(mocker):
+    mocker.patch(
+        "django.views.generic.base.ContextMixin.get_context_data", return_value={}
+    )
+    mocker.patch(
+        "comedores.views.nomina._get_admision_del_comedor_or_404",
+        return_value=SimpleNamespace(pk=77, comedor="comedor"),
+    )
+    ciudadano_revision = SimpleNamespace(requiere_revision_manual=True)
+    mocker.patch(
+        "comedores.views.nomina.ComedorService.buscar_ciudadanos_por_documento",
+        return_value=[ciudadano_revision],
+    )
+    mocker.patch(
+        "comedores.views.nomina.ComedorService.obtener_datos_ciudadano_desde_renaper",
+        return_value={"success": True, "message": "precargado", "data": {"dni": "1"}},
+    )
+    mocker.patch.object(
+        module.NominaCreateView,
+        "_prepare_renaper_initial_data",
+        return_value={"dni": "1"},
+    )
+    mocker.patch("comedores.views.nomina.messages.info")
+
+    view = module.NominaCreateView()
+    view.kwargs = {"pk": 1, "admision_pk": 77}
+    view.object = None
+    view.request = SimpleNamespace(
+        method="GET",
+        GET={"query": "12345678"},
+        POST={},
+        user=SimpleNamespace(),
+    )
+    mocker.patch.object(view, "get_form", return_value="main_form")
+    mocker.patch("comedores.views.nomina.CiudadanoFormParaNomina", return_value="form")
+    mocker.patch("comedores.views.nomina.NominaExtraForm", return_value="extra")
+
+    ctx = view.get_context_data()
+
+    assert ctx["no_resultados"] is False
+    assert ctx["renaper_precarga"] is True
+    assert ctx["mostrar_form_ciudadano"] is True
+
+
+def test_nomina_directa_get_context_data_muestra_form_si_solo_hay_revision(mocker):
+    mocker.patch(
+        "django.views.generic.base.ContextMixin.get_context_data", return_value={}
+    )
+    mocker.patch(
+        "comedores.views.nomina._get_comedor_directo_or_404",
+        return_value=SimpleNamespace(pk=77),
+    )
+    ciudadano_revision = SimpleNamespace(requiere_revision_manual=True)
+    mocker.patch(
+        "comedores.views.nomina.ComedorService.buscar_ciudadanos_por_documento",
+        return_value=[ciudadano_revision],
+    )
+    mocker.patch(
+        "comedores.views.nomina.ComedorService.obtener_datos_ciudadano_desde_renaper",
+        return_value={"success": True, "message": "precargado", "data": {"dni": "1"}},
+    )
+    mocker.patch.object(
+        module.NominaCreateView,
+        "_prepare_renaper_initial_data",
+        return_value={"dni": "1"},
+    )
+    mocker.patch("comedores.views.nomina.messages.info")
+
+    view = module.NominaDirectaCreateView()
+    view.kwargs = {"pk": 1}
+    view.object = None
+    view.request = SimpleNamespace(
+        method="GET",
+        GET={"query": "12345678"},
+        POST={},
+        user=SimpleNamespace(),
+    )
+    mocker.patch.object(view, "get_form", return_value="main_form")
+    mocker.patch("comedores.views.nomina.CiudadanoFormParaNomina", return_value="form")
+    mocker.patch("comedores.views.nomina.NominaExtraForm", return_value="extra")
+
+    ctx = view.get_context_data()
+
+    assert ctx["no_resultados"] is False
+    assert ctx["renaper_precarga"] is True
+    assert ctx["mostrar_form_ciudadano"] is True
+
+
 def test_nomina_create_post_ciudadano_existente(mocker):
     view = module.NominaCreateView()
     view.kwargs = {"pk": 5, "admision_pk": 88}


### PR DESCRIPTION
# Información de la Tarea

Vincular el #

## Resumen de la Solución

Se corrigieron tres bugs detectados por QA en la feature de identidad ciudadano:

* RENAPER bloqueado para DNIs con registro en revisión.
* Posibilidad de agregar ciudadanos no validados a nómina.
* Fallback de lookup que retornaba registros no `ESTANDAR` como "ya existente".

## Información Adicional

* Los tres fixes son consecuencia directa de la feature `nomina_1329` (modelo de identidad).
* No se modifican modelos ni migraciones — solo lógica de servicios y vistas.
* El bug de RENAPER afectaba especialmente a operadores que intentaban contrastar datos de un DNI ya cargado como `DNI_NO_VALIDADO_RENAPER` con lo que devuelve RENAPER.

---

# Descripción de los Cambios

## Cambios

### `comedores/services/comedor_service/impl.py`

* `_buscar_ciudadano_existente_por_dni_renaper`:

  * Eliminado el tercer fallback que retornaba cualquier ciudadano sin filtro de tipo de registro.
  * Ahora, si no existe un registro `ESTANDAR` con ese DNI, devuelve `None`.
  * Resultado: RENAPER puede consultarse normalmente para nuevos ciudadanos.

### `comedores/views/nomina.py` — GET

*(Aplica a `NominaAdmisionCreateView` y `NominaCreateView`)*

* Se cambia la condición para consultar RENAPER:

  * Antes: `if not ciudadanos`
  * Ahora: `if not hay_validado`

* Resultado:

  * Si el único registro está en revisión manual, se consulta RENAPER igual.
  * Permite al operador ver simultáneamente:

    * El ciudadano en revisión
    * Los datos provenientes de RENAPER

### `comedores/views/nomina.py` — POST

*(Aplica a ambas vistas)*

* Se agrega validación server-side antes de llamar a `agregar_ciudadano_a_nomina`:

  * Si el `ciudadano_id` corresponde a un ciudadano con `requiere_revision_manual=True`:

    * Se rechaza el request con mensaje de error.
    * No llega al service.

* Resultado:

  * Se cierra el bypass por POST directo (aunque el botón en UI ya estaba deshabilitado).

---

# Cómo Testear los Cambios

## Pruebas Automáticas

Los tests existentes de Fase 4 siguen pasando (22/22):

```bash
docker compose exec django python -m pytest \
  tests/test_ciudadano_identidad_lookup_unit.py \
  tests/test_ciudadano_identidad_form_unit.py \
  tests/test_backfill_identidad_unit.py \
  -v
```

## Pruebas Manuales

### Issue 2 — RENAPER desbloqueado para no-ESTANDAR

1. Crear un ciudadano con un DNI.
2. Modificar su estado de identidad a `DNI_NO_VALIDADO_RENAPER`.
3. Guardar.
4. Validar que el ciudadano aparezca en `/ciudadanos/revision/`.
5. Ir a un comedor → Nómina → buscar por ese mismo DNI.

**Resultado esperado:**

* Aparece el ciudadano en revisión en los resultados.
* Debajo, se precargan los datos de RENAPER.

---

### Issue 3 — Nómina bloquea ciudadanos en revisión

**Precondición:**

* Tener un ciudadano con `requiere_revision_manual=True`.

1. Ir a un comedor → Nómina → buscar ese ciudadano por DNI.

**Resultado esperado (UI):**

* El botón "Agregar" aparece deshabilitado.

2. Intentar un POST directo con ese `ciudadano_id` (ej: DevTools o Postman).

**Resultado esperado:**

* Error con mensaje: `"identidad pendiente de revisión"`.
* El ciudadano no se agrega a la nómina.

---

# Metadata para documentación automática

* **Contexto funcional:** Corrección post-deploy de la feature de identidad ciudadano (nómina de comedores)

* **Tipo de cambio:** Bug fix

* **Área principal:** Comedores / Nómina

* **Resumen para changelog:**

  > Fix: RENAPER se consulta aunque exista ciudadano en revisión con mismo DNI; ciudadanos pendientes de revisión no pueden agregarse a nómina.

* **Impacto usuario:**

  * Los operadores pueden contrastar datos de RENAPER con registros en revisión.
  * Se evita el ingreso a nómina de ciudadanos con identidad no validada.

* **Riesgos / rollback:**

  * Sin migraciones.
  * Rollback: revertir `impl.py` y `nomina.py`.
  * Sin impacto en datos existentes en base de datos.
