### PR TITLE
Unicidad cuil

### DIFF
--- a/organizaciones/forms.py
+++ b/organizaciones/forms.py
@@ -13,6 +13,10 @@ class OrganizacionForm(forms.ModelForm):
         required=False,
         widget=forms.HiddenInput,
     )
+    cuil_duplicado_confirmado_valor = forms.CharField(
+        required=False,
+        widget=forms.HiddenInput,
+    )
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
@@ -66,6 +70,7 @@ class OrganizacionForm(forms.ModelForm):
         cleaned_data = super().clean()
         cuit = cleaned_data.get("cuit")
         confirmado = cleaned_data.get("cuil_duplicado_confirmado")
+        cuit_confirmado = cleaned_data.get("cuil_duplicado_confirmado_valor")
 
         if cuit is not None:
             exclude_pk = (
@@ -75,11 +80,14 @@ class OrganizacionForm(forms.ModelForm):
             if exclude_pk:
                 qs = qs.exclude(pk=exclude_pk)
 
-            if qs.exists() and not confirmado:
-                raise forms.ValidationError(
-                    "El CUIL ingresado ya está registrado en otra organización. "
-                    "Revisá la advertencia y confirmá para continuar.",
-                    code="cuil_duplicado_sin_confirmar",
+            if qs.exists() and (not confirmado or cuit_confirmado != str(cuit)):
+                self.add_error(
+                    "cuit",
+                    forms.ValidationError(
+                        "El CUIL ingresado ya está registrado en otra organización. "
+                        "Revisá la advertencia y confirmá para continuar.",
+                        code="cuil_duplicado_sin_confirmar",
+                    ),
                 )
 
         return cleaned_data

--- a/organizaciones/forms.py
+++ b/organizaciones/forms.py
@@ -68,7 +68,9 @@ class OrganizacionForm(forms.ModelForm):
         confirmado = cleaned_data.get("cuil_duplicado_confirmado")
 
         if cuit is not None:
-            exclude_pk = self.instance.pk if self.instance and self.instance.pk else None
+            exclude_pk = (
+                self.instance.pk if self.instance and self.instance.pk else None
+            )
             qs = Organizacion.objects.filter(cuit=cuit)
             if exclude_pk:
                 qs = qs.exclude(pk=exclude_pk)

--- a/organizaciones/forms.py
+++ b/organizaciones/forms.py
@@ -9,6 +9,11 @@ from core.models import Municipio, Provincia, Localidad
 
 
 class OrganizacionForm(forms.ModelForm):
+    cuil_duplicado_confirmado = forms.BooleanField(
+        required=False,
+        widget=forms.HiddenInput,
+    )
+
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
 
@@ -56,6 +61,26 @@ class OrganizacionForm(forms.ModelForm):
 
         if localidad:
             self.fields["localidad"].initial = localidad
+
+    def clean(self):
+        cleaned_data = super().clean()
+        cuit = cleaned_data.get("cuit")
+        confirmado = cleaned_data.get("cuil_duplicado_confirmado")
+
+        if cuit is not None:
+            exclude_pk = self.instance.pk if self.instance and self.instance.pk else None
+            qs = Organizacion.objects.filter(cuit=cuit)
+            if exclude_pk:
+                qs = qs.exclude(pk=exclude_pk)
+
+            if qs.exists() and not confirmado:
+                raise forms.ValidationError(
+                    "El CUIL ingresado ya está registrado en otra organización. "
+                    "Revisá la advertencia y confirmá para continuar.",
+                    code="cuil_duplicado_sin_confirmar",
+                )
+
+        return cleaned_data
 
     class Meta:
         model = Organizacion

--- a/organizaciones/migrations/0011_remove_organizacion_cuit_unique.py
+++ b/organizaciones/migrations/0011_remove_organizacion_cuit_unique.py
@@ -13,6 +13,7 @@ class Migration(migrations.Migration):
             name="cuit",
             field=models.BigIntegerField(
                 blank=True,
+                db_index=True,
                 null=True,
                 validators=[MinValueValidator(0), MaxValueValidator(99999999999)],
             ),

--- a/organizaciones/migrations/0011_remove_organizacion_cuit_unique.py
+++ b/organizaciones/migrations/0011_remove_organizacion_cuit_unique.py
@@ -1,0 +1,20 @@
+from django.db import migrations, models
+from django.core.validators import MaxValueValidator, MinValueValidator
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("organizaciones", "0010_organizacion_telefono_idx"),
+    ]
+
+    operations = [
+        migrations.AlterField(
+            model_name="organizacion",
+            name="cuit",
+            field=models.BigIntegerField(
+                blank=True,
+                null=True,
+                validators=[MinValueValidator(0), MaxValueValidator(99999999999)],
+            ),
+        ),
+    ]

--- a/organizaciones/models.py
+++ b/organizaciones/models.py
@@ -114,6 +114,7 @@ class Organizacion(SoftDeleteModelMixin, models.Model):
     cuit = models.BigIntegerField(
         blank=True,
         null=True,
+        db_index=True,
         validators=[MinValueValidator(0), MaxValueValidator(99999999999)],
     )
     telefono = models.BigIntegerField(blank=True, null=True)

--- a/organizaciones/models.py
+++ b/organizaciones/models.py
@@ -114,7 +114,6 @@ class Organizacion(SoftDeleteModelMixin, models.Model):
     cuit = models.BigIntegerField(
         blank=True,
         null=True,
-        unique=True,
         validators=[MinValueValidator(0), MaxValueValidator(99999999999)],
     )
     telefono = models.BigIntegerField(blank=True, null=True)

--- a/organizaciones/templates/organizacion_form.html
+++ b/organizaciones/templates/organizacion_form.html
@@ -81,7 +81,9 @@
                                 </span>
 
                                 <!-- Advertencia de CUIL duplicado -->
-                                <div id="cuil-warning" class="alert alert-warning d-none mt-2" role="alert">
+                                <div id="cuil-warning"
+                                     class="alert alert-warning d-none mt-2"
+                                     role="alert">
                                     <strong><i class="fas fa-exclamation-triangle mr-1"></i>Atención:</strong>
                                     Este CUIL ya está registrado en las siguientes organizaciones:
                                     <div class="table-responsive mt-2">
@@ -99,11 +101,12 @@
                                                     <th>Localidad</th>
                                                 </tr>
                                             </thead>
-                                            <tbody id="cuil-duplicados-tbody"></tbody>
+                                            <tbody id="cuil-duplicados-tbody">
+                                            </tbody>
                                         </table>
                                     </div>
                                     <div class="form-check mt-1">
-                                        <input class="form-check-input" type="checkbox" id="cuil-confirmar-check">
+                                        <input class="form-check-input" type="checkbox" id="cuil-confirmar-check" />
                                         <label class="form-check-label font-weight-bold" for="cuil-confirmar-check">
                                             Revisé la información y confirmo la creación del nuevo registro
                                         </label>

--- a/organizaciones/templates/organizacion_form.html
+++ b/organizaciones/templates/organizacion_form.html
@@ -32,6 +32,7 @@
                   enctype="multipart/form-data">
                 {% csrf_token %}
                 {{ form.cuil_duplicado_confirmado }}
+                {{ form.cuil_duplicado_confirmado_valor }}
 
                 <!-- Indicador de progreso global -->
                 <div class="progress-indicator">
@@ -271,8 +272,10 @@
         var tbody = document.getElementById("cuil-duplicados-tbody");
         var confirmarCheck = document.getElementById("cuil-confirmar-check");
         var hiddenConfirmado = document.getElementById("id_cuil_duplicado_confirmado");
+        var hiddenConfirmadoValor = document.getElementById("id_cuil_duplicado_confirmado_valor");
         var submitBtn = document.querySelector('#organizacionForm button[type="submit"]');
         var debounceTimer = null;
+        var requestSeq = 0;
 
         function escapeHtml(str) {
             var div = document.createElement("div");
@@ -280,12 +283,17 @@
             return div.innerHTML;
         }
 
+        function clearConfirmation(disableSubmit) {
+            confirmarCheck.checked = false;
+            hiddenConfirmado.value = "";
+            hiddenConfirmadoValor.value = "";
+            if (submitBtn) submitBtn.disabled = Boolean(disableSubmit);
+        }
+
         function resetWarning() {
             warningBox.classList.add("d-none");
             tbody.innerHTML = "";
-            confirmarCheck.checked = false;
-            hiddenConfirmado.value = "";
-            if (submitBtn) submitBtn.disabled = false;
+            clearConfirmation(false);
         }
 
         function showWarning(orgs) {
@@ -303,29 +311,30 @@
                     "</tr>";
             }).join("");
             warningBox.classList.remove("d-none");
-            confirmarCheck.checked = false;
-            hiddenConfirmado.value = "";
-            if (submitBtn) submitBtn.disabled = true;
+            clearConfirmation(true);
         }
 
         confirmarCheck.addEventListener("change", function () {
             if (confirmarCheck.checked) {
                 hiddenConfirmado.value = "true";
+                hiddenConfirmadoValor.value = cuitInput ? cuitInput.value.trim() : "";
                 if (submitBtn) submitBtn.disabled = false;
             } else {
-                hiddenConfirmado.value = "";
-                if (submitBtn) submitBtn.disabled = true;
+                clearConfirmation(true);
             }
         });
 
         if (cuitInput) {
             cuitInput.addEventListener("input", function () {
                 clearTimeout(debounceTimer);
+                requestSeq += 1;
                 var val = cuitInput.value.trim();
+                clearConfirmation(!warningBox.classList.contains("d-none"));
                 if (!val || isNaN(val)) {
                     resetWarning();
                     return;
                 }
+                var currentSeq = requestSeq;
                 debounceTimer = setTimeout(function () {
                     var url = cuilCheckAjaxUrl + "?cuil=" + encodeURIComponent(val);
                     if (organizacionPk) {
@@ -334,13 +343,20 @@
                     fetch(url, { headers: { "X-Requested-With": "XMLHttpRequest" } })
                         .then(function (r) { return r.json(); })
                         .then(function (data) {
+                            if (currentSeq !== requestSeq || cuitInput.value.trim() !== val) {
+                                return;
+                            }
                             if (data.organizaciones && data.organizaciones.length > 0) {
                                 showWarning(data.organizaciones);
                             } else {
                                 resetWarning();
                             }
                         })
-                        .catch(function () { resetWarning(); });
+                        .catch(function () {
+                            if (currentSeq === requestSeq && cuitInput.value.trim() === val) {
+                                resetWarning();
+                            }
+                        });
                 }, 400);
             });
         }

--- a/organizaciones/templates/organizacion_form.html
+++ b/organizaciones/templates/organizacion_form.html
@@ -31,6 +31,7 @@
                   class="w-100"
                   enctype="multipart/form-data">
                 {% csrf_token %}
+                {{ form.cuil_duplicado_confirmado }}
 
                 <!-- Indicador de progreso global -->
                 <div class="progress-indicator">
@@ -78,6 +79,36 @@
                                     <i class="fas fa-info-circle"></i>
                                     <span class="tooltip-text">CUIT de 11 dígitos</span>
                                 </span>
+
+                                <!-- Advertencia de CUIL duplicado -->
+                                <div id="cuil-warning" class="alert alert-warning d-none mt-2" role="alert">
+                                    <strong><i class="fas fa-exclamation-triangle mr-1"></i>Atención:</strong>
+                                    Este CUIL ya está registrado en las siguientes organizaciones:
+                                    <div class="table-responsive mt-2">
+                                        <table class="table table-sm table-bordered mb-2" id="cuil-duplicados-tabla">
+                                            <thead class="thead-light">
+                                                <tr>
+                                                    <th>Nombre</th>
+                                                    <th>Tipo de entidad</th>
+                                                    <th>Subtipo</th>
+                                                    <th>Teléfono</th>
+                                                    <th>Email</th>
+                                                    <th>Domicilio</th>
+                                                    <th>Provincia</th>
+                                                    <th>Municipio</th>
+                                                    <th>Localidad</th>
+                                                </tr>
+                                            </thead>
+                                            <tbody id="cuil-duplicados-tbody"></tbody>
+                                        </table>
+                                    </div>
+                                    <div class="form-check mt-1">
+                                        <input class="form-check-input" type="checkbox" id="cuil-confirmar-check">
+                                        <label class="form-check-label font-weight-bold" for="cuil-confirmar-check">
+                                            Revisé la información y confirmo la creación del nuevo registro
+                                        </label>
+                                    </div>
+                                </div>
                             </div>
                         </div>
                         <div class="form-group row">
@@ -222,9 +253,94 @@
     <script nonce="{{ request.csp_nonce }}">
         var ajaxLoadMunicipiosUrl = "{% url 'ajax_load_municipios' %}";
         var ajaxLoadLocalidadesUrl = "{% url 'ajax_load_localidades' %}";
+        var cuilCheckAjaxUrl = "{{ cuil_check_ajax_url }}";
+        var organizacionPk = "{{ organizacion_pk|default:'' }}";
     </script>
 
     <!-- Scripts externos -->
     <script src="{% static 'custom/js/ubicacionSelects.js' %}"></script>
     <script src="{% static 'custom/js/organizacionesform.js' %}"></script>
+
+    <script nonce="{{ request.csp_nonce }}">
+    (function () {
+        var cuitInput = document.getElementById("id_cuit");
+        var warningBox = document.getElementById("cuil-warning");
+        var tbody = document.getElementById("cuil-duplicados-tbody");
+        var confirmarCheck = document.getElementById("cuil-confirmar-check");
+        var hiddenConfirmado = document.getElementById("id_cuil_duplicado_confirmado");
+        var submitBtn = document.querySelector('#organizacionForm button[type="submit"]');
+        var debounceTimer = null;
+
+        function escapeHtml(str) {
+            var div = document.createElement("div");
+            div.appendChild(document.createTextNode(str || ""));
+            return div.innerHTML;
+        }
+
+        function resetWarning() {
+            warningBox.classList.add("d-none");
+            tbody.innerHTML = "";
+            confirmarCheck.checked = false;
+            hiddenConfirmado.value = "";
+            if (submitBtn) submitBtn.disabled = false;
+        }
+
+        function showWarning(orgs) {
+            tbody.innerHTML = orgs.map(function (o) {
+                return "<tr>" +
+                    "<td>" + escapeHtml(o.nombre) + "</td>" +
+                    "<td>" + escapeHtml(o.tipo_entidad) + "</td>" +
+                    "<td>" + escapeHtml(o.subtipo_entidad) + "</td>" +
+                    "<td>" + escapeHtml(o.telefono) + "</td>" +
+                    "<td>" + escapeHtml(o.email) + "</td>" +
+                    "<td>" + escapeHtml(o.domicilio) + "</td>" +
+                    "<td>" + escapeHtml(o.provincia) + "</td>" +
+                    "<td>" + escapeHtml(o.municipio) + "</td>" +
+                    "<td>" + escapeHtml(o.localidad) + "</td>" +
+                    "</tr>";
+            }).join("");
+            warningBox.classList.remove("d-none");
+            confirmarCheck.checked = false;
+            hiddenConfirmado.value = "";
+            if (submitBtn) submitBtn.disabled = true;
+        }
+
+        confirmarCheck.addEventListener("change", function () {
+            if (confirmarCheck.checked) {
+                hiddenConfirmado.value = "true";
+                if (submitBtn) submitBtn.disabled = false;
+            } else {
+                hiddenConfirmado.value = "";
+                if (submitBtn) submitBtn.disabled = true;
+            }
+        });
+
+        if (cuitInput) {
+            cuitInput.addEventListener("input", function () {
+                clearTimeout(debounceTimer);
+                var val = cuitInput.value.trim();
+                if (!val || isNaN(val)) {
+                    resetWarning();
+                    return;
+                }
+                debounceTimer = setTimeout(function () {
+                    var url = cuilCheckAjaxUrl + "?cuil=" + encodeURIComponent(val);
+                    if (organizacionPk) {
+                        url += "&exclude=" + encodeURIComponent(organizacionPk);
+                    }
+                    fetch(url, { headers: { "X-Requested-With": "XMLHttpRequest" } })
+                        .then(function (r) { return r.json(); })
+                        .then(function (data) {
+                            if (data.organizaciones && data.organizaciones.length > 0) {
+                                showWarning(data.organizaciones);
+                            } else {
+                                resetWarning();
+                            }
+                        })
+                        .catch(function () { resetWarning(); });
+                }, 400);
+            });
+        }
+    })();
+    </script>
 {% endblock %}

--- a/organizaciones/tests.py
+++ b/organizaciones/tests.py
@@ -1,10 +1,15 @@
-"""Tests for tests."""
+"""Tests for organizaciones."""
 
-from django.contrib.auth.models import User
-from django.test import RequestFactory, TestCase
+import json
+
+from django.contrib.auth.models import User, Permission
+from django.test import RequestFactory, TestCase, Client
+from django.urls import reverse
 
 from organizaciones.models import Organizacion, TipoEntidad
 from organizaciones.views import OrganizacionDetailView
+from organizaciones.forms import OrganizacionForm
+from core.models import Provincia
 
 
 class OrganizacionDetailViewTests(TestCase):
@@ -51,3 +56,86 @@ class OrganizacionDetailViewTests(TestCase):
 
         self.assertFalse(context["avales"])
         self.assertEqual(context["tipo_entidad"], tipo_entidad)
+
+
+class CuilDuplicadoFormTests(TestCase):
+    """Tests del flujo de CUIL duplicado en OrganizacionForm."""
+
+    CUIL = 20123456789
+
+    def setUp(self):
+        self.provincia = Provincia.objects.create(nombre="Buenos Aires")
+        self.existente = Organizacion.objects.create(
+            nombre="Org Existente", cuit=self.CUIL, provincia=self.provincia
+        )
+
+    def _form_data(self, extra=None):
+        data = {
+            "nombre": "Org Nueva",
+            "cuit": str(self.CUIL),
+            "fecha_vencimiento": "2030-01-01",
+            "provincia": str(self.provincia.pk),
+        }
+        if extra:
+            data.update(extra)
+        return data
+
+    def test_cuil_duplicado_sin_confirmacion_es_invalido(self):
+        form = OrganizacionForm(data=self._form_data())
+        self.assertFalse(form.is_valid())
+        self.assertIn("cuil_duplicado_sin_confirmar", [e.code for e in form.non_field_errors().as_data()])
+
+    def test_cuil_duplicado_con_confirmacion_es_valido(self):
+        form = OrganizacionForm(data=self._form_data({"cuil_duplicado_confirmado": "true"}))
+        self.assertTrue(form.is_valid(), form.errors)
+
+    def test_cuil_unico_no_requiere_confirmacion(self):
+        form = OrganizacionForm(data=self._form_data({"cuit": 20999999990}))
+        self.assertTrue(form.is_valid(), form.errors)
+
+    def test_edicion_propio_cuil_no_requiere_confirmacion(self):
+        """Al editar una org, su propio CUIL no dispara la advertencia."""
+        form = OrganizacionForm(data=self._form_data(), instance=self.existente)
+        self.assertTrue(form.is_valid(), form.errors)
+
+    def test_multiples_orgs_mismo_cuil_permitidas(self):
+        """Verificar que la DB permite CUILs repetidos sin error de integridad."""
+        Organizacion.objects.create(nombre="Org Duplicada", cuit=self.CUIL)
+        self.assertEqual(Organizacion.objects.filter(cuit=self.CUIL).count(), 2)
+
+
+class CuilCheckAjaxTests(TestCase):
+    """Tests del endpoint AJAX de verificación de CUIL."""
+
+    CUIL = 20123456780
+
+    def setUp(self):
+        self.user = User.objects.create_user(username="tester2", password="secret")
+        perm = Permission.objects.get(codename="view_organizacion")
+        self.user.user_permissions.add(perm)
+        self.client = Client()
+        self.client.login(username="tester2", password="secret")
+        self.org = Organizacion.objects.create(nombre="Org Ajax", cuit=self.CUIL)
+        self.url = reverse("organizacion_cuil_check_ajax")
+
+    def test_retorna_organizaciones_con_cuil_existente(self):
+        response = self.client.get(self.url, {"cuil": str(self.CUIL)})
+        self.assertEqual(response.status_code, 200)
+        data = json.loads(response.content)
+        self.assertEqual(len(data["organizaciones"]), 1)
+        self.assertEqual(data["organizaciones"][0]["nombre"], "Org Ajax")
+
+    def test_retorna_vacio_con_cuil_inexistente(self):
+        response = self.client.get(self.url, {"cuil": "20999999990"})
+        data = json.loads(response.content)
+        self.assertEqual(data["organizaciones"], [])
+
+    def test_exclude_excluye_la_org_en_edicion(self):
+        response = self.client.get(self.url, {"cuil": str(self.CUIL), "exclude": str(self.org.pk)})
+        data = json.loads(response.content)
+        self.assertEqual(data["organizaciones"], [])
+
+    def test_cuil_no_numerico_retorna_vacio(self):
+        response = self.client.get(self.url, {"cuil": "abc"})
+        data = json.loads(response.content)
+        self.assertEqual(data["organizaciones"], [])

--- a/organizaciones/tests.py
+++ b/organizaciones/tests.py
@@ -83,10 +83,15 @@ class CuilDuplicadoFormTests(TestCase):
     def test_cuil_duplicado_sin_confirmacion_es_invalido(self):
         form = OrganizacionForm(data=self._form_data())
         self.assertFalse(form.is_valid())
-        self.assertIn("cuil_duplicado_sin_confirmar", [e.code for e in form.non_field_errors().as_data()])
+        self.assertIn(
+            "cuil_duplicado_sin_confirmar",
+            [e.code for e in form.non_field_errors().as_data()],
+        )
 
     def test_cuil_duplicado_con_confirmacion_es_valido(self):
-        form = OrganizacionForm(data=self._form_data({"cuil_duplicado_confirmado": "true"}))
+        form = OrganizacionForm(
+            data=self._form_data({"cuil_duplicado_confirmado": "true"})
+        )
         self.assertTrue(form.is_valid(), form.errors)
 
     def test_cuil_unico_no_requiere_confirmacion(self):
@@ -131,7 +136,9 @@ class CuilCheckAjaxTests(TestCase):
         self.assertEqual(data["organizaciones"], [])
 
     def test_exclude_excluye_la_org_en_edicion(self):
-        response = self.client.get(self.url, {"cuil": str(self.CUIL), "exclude": str(self.org.pk)})
+        response = self.client.get(
+            self.url, {"cuil": str(self.CUIL), "exclude": str(self.org.pk)}
+        )
         data = json.loads(response.content)
         self.assertEqual(data["organizaciones"], [])
 

--- a/organizaciones/tests.py
+++ b/organizaciones/tests.py
@@ -83,16 +83,38 @@ class CuilDuplicadoFormTests(TestCase):
     def test_cuil_duplicado_sin_confirmacion_es_invalido(self):
         form = OrganizacionForm(data=self._form_data())
         self.assertFalse(form.is_valid())
+        self.assertIn("cuit", form.errors)
         self.assertIn(
             "cuil_duplicado_sin_confirmar",
-            [e.code for e in form.non_field_errors().as_data()],
+            [e.code for e in form.errors.as_data()["cuit"]],
         )
 
     def test_cuil_duplicado_con_confirmacion_es_valido(self):
         form = OrganizacionForm(
-            data=self._form_data({"cuil_duplicado_confirmado": "true"})
+            data=self._form_data(
+                {
+                    "cuil_duplicado_confirmado": "true",
+                    "cuil_duplicado_confirmado_valor": str(self.CUIL),
+                }
+            )
         )
         self.assertTrue(form.is_valid(), form.errors)
+
+    def test_cuil_duplicado_rechaza_confirmacion_de_otro_cuil(self):
+        form = OrganizacionForm(
+            data=self._form_data(
+                {
+                    "cuil_duplicado_confirmado": "true",
+                    "cuil_duplicado_confirmado_valor": "20999999990",
+                }
+            )
+        )
+        self.assertFalse(form.is_valid())
+        self.assertIn("cuit", form.errors)
+        self.assertIn(
+            "cuil_duplicado_sin_confirmar",
+            [e.code for e in form.errors.as_data()["cuit"]],
+        )
 
     def test_cuil_unico_no_requiere_confirmacion(self):
         form = OrganizacionForm(data=self._form_data({"cuit": 20999999990}))
@@ -107,6 +129,15 @@ class CuilDuplicadoFormTests(TestCase):
         """Verificar que la DB permite CUILs repetidos sin error de integridad."""
         Organizacion.objects.create(nombre="Org Duplicada", cuit=self.CUIL)
         self.assertEqual(Organizacion.objects.filter(cuit=self.CUIL).count(), 2)
+
+
+class OrganizacionModelTests(TestCase):
+    """Tests del contrato de persistencia de Organizacion."""
+
+    def test_cuit_conserva_indice_no_unico_para_busquedas(self):
+        field = Organizacion._meta.get_field("cuit")
+        self.assertFalse(field.unique)
+        self.assertTrue(field.db_index)
 
 
 class CuilCheckAjaxTests(TestCase):

--- a/organizaciones/urls.py
+++ b/organizaciones/urls.py
@@ -15,6 +15,7 @@ from organizaciones.views import (
     AvalDeleteView,
     sub_tipo_entidad_ajax,
     organizaciones_ajax,
+    cuil_check_ajax,
 )
 from organizaciones.views_export import OrganizacionExportView
 
@@ -117,5 +118,12 @@ urlpatterns = [
             organizaciones_ajax
         ),
         name="organizaciones_ajax",
+    ),
+    path(
+        "organizaciones/cuil-check/ajax/",
+        permissions_any_required(["organizaciones.view_organizacion"])(
+            cuil_check_ajax
+        ),
+        name="organizacion_cuil_check_ajax",
     ),
 ]

--- a/organizaciones/urls.py
+++ b/organizaciones/urls.py
@@ -121,9 +121,7 @@ urlpatterns = [
     ),
     path(
         "organizaciones/cuil-check/ajax/",
-        permissions_any_required(["organizaciones.view_organizacion"])(
-            cuil_check_ajax
-        ),
+        permissions_any_required(["organizaciones.view_organizacion"])(cuil_check_ajax),
         name="organizacion_cuil_check_ajax",
     ),
 ]

--- a/organizaciones/views.py
+++ b/organizaciones/views.py
@@ -284,6 +284,8 @@ class OrganizacionCreateView(LoginRequiredMixin, CreateView):
 
     def get_context_data(self, **kwargs):
         context = super().get_context_data(**kwargs)
+        context["cuil_check_ajax_url"] = reverse("organizacion_cuil_check_ajax")
+        context["organizacion_pk"] = None
         return context
 
     def form_valid(self, form):
@@ -435,6 +437,8 @@ class OrganizacionUpdateView(LoginRequiredMixin, UpdateView):
 
     def get_context_data(self, **kwargs):
         context = super().get_context_data(**kwargs)
+        context["cuil_check_ajax_url"] = reverse("organizacion_cuil_check_ajax")
+        context["organizacion_pk"] = self.object.pk
         return context
 
     def form_valid(self, form):
@@ -579,6 +583,44 @@ def sub_tipo_entidad_ajax(request):
 
     data = [{"id": subtipo.id, "text": subtipo.nombre} for subtipo in subtipo_entidades]
     return JsonResponse(data, safe=False)
+
+
+@login_required
+def cuil_check_ajax(request):
+    """
+    Devuelve las organizaciones activas que ya tienen el CUIL ingresado.
+    Parámetro opcional `exclude` para ignorar la org que se está editando.
+    """
+    cuil_raw = request.GET.get("cuil", "").strip()
+    exclude_pk = request.GET.get("exclude", "").strip()
+
+    if not cuil_raw or not cuil_raw.isdigit():
+        return JsonResponse({"organizaciones": []})
+
+    cuil = int(cuil_raw)
+    qs = Organizacion.objects.filter(cuit=cuil).select_related(
+        "tipo_entidad", "subtipo_entidad", "provincia", "municipio", "localidad"
+    )
+    if exclude_pk and exclude_pk.isdigit():
+        qs = qs.exclude(pk=int(exclude_pk))
+
+    data = [
+        {
+            "id": org.pk,
+            "nombre": org.nombre,
+            "cuit": org.cuit,
+            "telefono": str(org.telefono) if org.telefono is not None else "",
+            "email": org.email or "",
+            "tipo_entidad": org.tipo_entidad.nombre if org.tipo_entidad else "",
+            "subtipo_entidad": org.subtipo_entidad.nombre if org.subtipo_entidad else "",
+            "domicilio": org.domicilio or "",
+            "provincia": str(org.provincia) if org.provincia else "",
+            "municipio": str(org.municipio) if org.municipio else "",
+            "localidad": str(org.localidad) if org.localidad else "",
+        }
+        for org in qs
+    ]
+    return JsonResponse({"organizaciones": data})
 
 
 @login_required

--- a/organizaciones/views.py
+++ b/organizaciones/views.py
@@ -612,7 +612,9 @@ def cuil_check_ajax(request):
             "telefono": str(org.telefono) if org.telefono is not None else "",
             "email": org.email or "",
             "tipo_entidad": org.tipo_entidad.nombre if org.tipo_entidad else "",
-            "subtipo_entidad": org.subtipo_entidad.nombre if org.subtipo_entidad else "",
+            "subtipo_entidad": (
+                org.subtipo_entidad.nombre if org.subtipo_entidad else ""
+            ),
             "domicilio": org.domicilio or "",
             "provincia": str(org.provincia) if org.provincia else "",
             "municipio": str(org.municipio) if org.municipio else "",


### PR DESCRIPTION
# Información de la Tarea
Vincular el #ISSUE

## Resumen de la Solución
- Se eliminó la restricción de unicidad del campo `cuil` en el modelo `Organizacion`.
- Al ingresar un CUIL ya existente en el formulario de alta o edición, el sistema muestra una advertencia con los datos de las organizaciones que lo comparten.
- El usuario debe confirmar explícitamente antes de poder guardar.

## Información Adicional
- La validación se aplica tanto en el frontend (AJAX con debounce) como en el backend (`clean()` del formulario), por lo que no puede saltarse omitiendo el JS.
- Al editar una organización, el propio CUIL no dispara la advertencia.
- No se auditan ni reportan los CUILs compartidos; la responsabilidad queda en el usuario que confirma.

---

# Descripción de los Cambios

## Cambios

- `organizaciones/models.py`
  - Se eliminó `unique=True` del campo `cuit` de `Organizacion`.

- `organizaciones/migrations/0011_remove_organizacion_cuit_unique.py`
  - Migración que elimina la constraint `UNIQUE` de la columna en la base de datos.

- `organizaciones/forms.py`
  - Se agregó el campo no-modelo `cuil_duplicado_confirmado` (hidden).
  - Se sobreescribió `clean()` para rechazar el guardado si el CUIL tiene duplicados y el usuario no confirmó.

- `organizaciones/views.py`
  - Nuevo endpoint `cuil_check_ajax` que devuelve las organizaciones activas con el CUIL consultado.
  - Soporta parámetro `exclude` para ignorar la organización en edición.
  - Las vistas `OrganizacionCreateView` y `OrganizacionUpdateView` ahora inyectan:
    - `cuil_check_ajax_url`
    - `organizacion_pk` en el contexto.

- `organizaciones/urls.py`
  - Nueva ruta `organizaciones/cuil-check/ajax/` mapeada a `cuil_check_ajax`.

- `organizaciones/templates/organizacion_form.html`
  - Se añadió:
    - Bloque de advertencia con tabla de duplicados (nombre, tipo/subtipo entidad, teléfono, email, domicilio, provincia, municipio, localidad).
    - Checkbox de confirmación.
    - Script JS inline con debounce de 400ms.

- `organizaciones/tests.py`
  - 9 tests nuevos:
    - 5 para el flujo del formulario (`CuilDuplicadoFormTests`)
    - 4 para el endpoint AJAX (`CuilCheckAjaxTests`)

---

# Cómo Testear los Cambios

## Pruebas Automáticas

    docker compose exec django python -m pytest organizaciones/tests.py -v

**Resultado esperado:**
- 12 tests passed.

---

## Pruebas Manuales

1. Aplicar la migración:
       docker compose exec django python manage.py migrate organizaciones

2. Crear una organización con un CUIL cualquiera (ej: `20123456789`).

3. Ir a **Agregar organización** e ingresar el mismo CUIL:
   - Debe aparecer la tabla de advertencia.
   - El botón "Guardar" debe estar deshabilitado.

4. Tildar el checkbox:
   "Revisé la información y confirmo..."
   - El botón debe habilitarse.
   - El formulario debe guardarse correctamente.
   - Resultado: dos organizaciones con el mismo CUIL.

5. Ir a **Editar** una de las organizaciones creadas:
   - Ingresar su propio CUIL.
   - Verificar que no aparece la advertencia.

6. (Opcional) Intentar bypass desde DevTools:
   - Quitar `disabled` del botón sin tildar el checkbox.
   - Enviar el formulario.

   **Resultado esperado:**
   - El backend responde con error:
     "El CUIL ingresado ya está registrado..."

---

# Metadata para documentación automática

- **Contexto funcional:** Gestión de organizaciones — legajo / alta y edición
- **Tipo de cambio:** Mejora funcional (relajación de constraint + advertencia UX)
- **Área principal:** Organizaciones

- **Resumen para changelog:**
  > Se permite registrar múltiples organizaciones con el mismo CUIL. Al ingresar un CUIL duplicado, el sistema muestra una advertencia con datos relevantes y requiere confirmación explícita.

- **Impacto usuario:**
  - Ya no hay rechazo automático por CUIL duplicado.
  - Los operadores pueden ver información existente y tomar decisiones informadas (ej: filiales, subsedes).

- **Riesgos / rollback:**
  - Bajo.
  - Para revertir:
    - Eliminar migración `0011`
    - Restaurar `unique=True` en el modelo
    - Generar nueva migración
  - ⚠️ Solo posible si no existen registros duplicados en la base de datos.

---

# Capturas de Pantalla
<img width="1600" height="531" alt="WhatsApp Image 2026-04-27 at 4 24 42 PM" src="https://github.com/user-attachments/assets/c0649207-15c9-4d6e-81aa-46e5743f455c" />
