### PR TITLE
fix(celiaquia): Visualizar motivos en legajos rechazados

### DIFF
--- a/celiaquia/templates/celiaquia/expediente_detail.html
+++ b/celiaquia/templates/celiaquia/expediente_detail.html
@@ -432,7 +432,12 @@
                                     </div>
                                 </td>
                                 <td>
-                                    {% if leg.subsanacion_motivo %}
+                                    {% if leg.observacion_tecnica_texto %}
+                                        {% if leg.observacion_tecnica_titulo %}
+                                            <small class="d-block text-muted">{{ leg.observacion_tecnica_titulo }}</small>
+                                        {% endif %}
+                                        <small class="text-break">{{ leg.observacion_tecnica_texto|truncatechars:80 }}</small>
+                                    {% elif leg.subsanacion_motivo %}
                                         <small class="text-break">{{ leg.subsanacion_motivo|truncatechars:80 }}</small>
                                     {% else %}
                                         <span class="text-muted"></span>

--- a/celiaquia/templates/celiaquia/expediente_detail.html
+++ b/celiaquia/templates/celiaquia/expediente_detail.html
@@ -492,7 +492,7 @@
                                                 <div class="col-lg-4 col-md-7">
                                                     {% if is_prov %}
                                                         {% if leg.observacion_tecnica_texto %}
-                                                            <div class="small muted">{{ leg.observacion_tecnica_titulo|default:"ObservaciÃ³n tÃ©cnica" }}:</div>
+                                                            <div class="small muted">{{ leg.observacion_tecnica_titulo|default:"Observación técnica" }}:</div>
                                                             <div class="mt-1">
                                                                 <div class="p-2 rounded"
                                                                      style="background:rgba(255,255,255,.04);
@@ -526,7 +526,7 @@
                                                         {% endif %}
                                                     {% else %}
                                                         {% if leg.observacion_tecnica_texto %}
-                                                            <div class="small muted">{{ leg.observacion_tecnica_titulo|default:"ObservaciÃ³n tÃ©cnica" }}:</div>
+                                                            <div class="small muted">{{ leg.observacion_tecnica_titulo|default:"Observación técnica" }}:</div>
                                                             <div class="mt-1">
                                                                 <div class="p-2 rounded"
                                                                      style="background:rgba(255,255,255,.04);
@@ -740,7 +740,7 @@
                                         {% endif %}
                                     {% else %}
                                         {% if leg.observacion_tecnica_texto %}
-                                            <div class="small muted">{{ leg.observacion_tecnica_titulo|default:"ObservaciÃ³n tÃ©cnica" }}:</div>
+                                            <div class="small muted">{{ leg.observacion_tecnica_titulo|default:"Observación técnica" }}:</div>
                                             <div class="mt-1">
                                                 <div class="p-2 rounded"
                                                      style="background:rgba(255,255,255,.04);

--- a/celiaquia/templates/celiaquia/expediente_detail.html
+++ b/celiaquia/templates/celiaquia/expediente_detail.html
@@ -494,12 +494,14 @@
                                                         {% if leg.observacion_tecnica_texto %}
                                                             <div class="small muted">{{ leg.observacion_tecnica_titulo|default:"ObservaciÃ³n tÃ©cnica" }}:</div>
                                                             <div class="mt-1">
-                                                                <div class="p-2 rounded" style="background:rgba(255,255,255,.04); border:1px solid rgba(255,255,255,.08)">
+                                                                <div class="p-2 rounded"
+                                                                     style="background:rgba(255,255,255,.04);
+                                                                            border:1px solid rgba(255,255,255,.08)">
                                                                     <span class="d-block text-break">{{ leg.observacion_tecnica_texto }}</span>
                                                                 </div>
                                                             </div>
                                                         {% else %}
-                                                        {% comment %}
+                                                            {% comment %}
                                                         <div class="small muted">Observación (subsanación):</div>
                                                         <div class="mt-1">
                                                             {% if leg.subsanacion_motivo %}
@@ -510,7 +512,7 @@
                                                                 <span class="muted">-</span>
                                                             {% endif %}
                                                         </div>
-                                                        {% endcomment %}
+                                                            {% endcomment %}
                                                         {% endif %}
                                                         {% if leg.subsanacion_renaper_comentario %}
                                                             <div class="small muted mt-2">Respuesta provincia:</div>
@@ -740,7 +742,9 @@
                                         {% if leg.observacion_tecnica_texto %}
                                             <div class="small muted">{{ leg.observacion_tecnica_titulo|default:"ObservaciÃ³n tÃ©cnica" }}:</div>
                                             <div class="mt-1">
-                                                <div class="p-2 rounded" style="background:rgba(255,255,255,.04); border:1px solid rgba(255,255,255,.08)">
+                                                <div class="p-2 rounded"
+                                                     style="background:rgba(255,255,255,.04);
+                                                            border:1px solid rgba(255,255,255,.08)">
                                                     <span class="d-block text-break">{{ leg.observacion_tecnica_texto }}</span>
                                                 </div>
                                             </div>

--- a/celiaquia/templates/celiaquia/expediente_detail.html
+++ b/celiaquia/templates/celiaquia/expediente_detail.html
@@ -491,6 +491,14 @@
                                                 <!-- Col 2: Observaciones -->
                                                 <div class="col-lg-4 col-md-7">
                                                     {% if is_prov %}
+                                                        {% if leg.observacion_tecnica_texto %}
+                                                            <div class="small muted">{{ leg.observacion_tecnica_titulo|default:"ObservaciÃ³n tÃ©cnica" }}:</div>
+                                                            <div class="mt-1">
+                                                                <div class="p-2 rounded" style="background:rgba(255,255,255,.04); border:1px solid rgba(255,255,255,.08)">
+                                                                    <span class="d-block text-break">{{ leg.observacion_tecnica_texto }}</span>
+                                                                </div>
+                                                            </div>
+                                                        {% else %}
                                                         {% comment %}
                                                         <div class="small muted">Observación (subsanación):</div>
                                                         <div class="mt-1">
@@ -503,6 +511,7 @@
                                                             {% endif %}
                                                         </div>
                                                         {% endcomment %}
+                                                        {% endif %}
                                                         {% if leg.subsanacion_renaper_comentario %}
                                                             <div class="small muted mt-2">Respuesta provincia:</div>
                                                             <div class="mt-1">
@@ -514,18 +523,29 @@
                                                             </div>
                                                         {% endif %}
                                                     {% else %}
-                                                        <div class="small muted">Comentario enviado a provincia:</div>
-                                                        <div class="mt-1">
-                                                            {% if leg.subsanacion_motivo %}
+                                                        {% if leg.observacion_tecnica_texto %}
+                                                            <div class="small muted">{{ leg.observacion_tecnica_titulo|default:"ObservaciÃ³n tÃ©cnica" }}:</div>
+                                                            <div class="mt-1">
                                                                 <div class="p-2 rounded"
                                                                      style="background:rgba(255,255,255,.04);
                                                                             border:1px solid rgba(255,255,255,.08)">
-                                                                    <span class="d-block text-break">{{ leg.subsanacion_motivo }}</span>
+                                                                    <span class="d-block text-break">{{ leg.observacion_tecnica_texto }}</span>
                                                                 </div>
-                                                            {% else %}
-                                                                <span class="muted">-</span>
-                                                            {% endif %}
-                                                        </div>
+                                                            </div>
+                                                        {% else %}
+                                                            <div class="small muted">Comentario enviado a provincia:</div>
+                                                            <div class="mt-1">
+                                                                {% if leg.subsanacion_motivo %}
+                                                                    <div class="p-2 rounded"
+                                                                         style="background:rgba(255,255,255,.04);
+                                                                                border:1px solid rgba(255,255,255,.08)">
+                                                                        <span class="d-block text-break">{{ leg.subsanacion_motivo }}</span>
+                                                                    </div>
+                                                                {% else %}
+                                                                    <span class="muted">-</span>
+                                                                {% endif %}
+                                                            </div>
+                                                        {% endif %}
                                                         {% if leg.subsanacion_renaper_comentario %}
                                                             <div class="small muted mt-2">Respuesta de provincia:</div>
                                                             <div class="mt-1">
@@ -717,18 +737,14 @@
                                             </div>
                                         {% endif %}
                                     {% else %}
-                                        {% comment %}
-                                        <div class="small muted">Comentario enviado a provincia:</div>
-                                        <div class="mt-1">
-                                            {% if leg.subsanacion_motivo %}
+                                        {% if leg.observacion_tecnica_texto %}
+                                            <div class="small muted">{{ leg.observacion_tecnica_titulo|default:"ObservaciÃ³n tÃ©cnica" }}:</div>
+                                            <div class="mt-1">
                                                 <div class="p-2 rounded" style="background:rgba(255,255,255,.04); border:1px solid rgba(255,255,255,.08)">
-                                                    <span class="d-block text-break">{{ leg.subsanacion_motivo }}</span>
+                                                    <span class="d-block text-break">{{ leg.observacion_tecnica_texto }}</span>
                                                 </div>
-                                            {% else %}
-                                                <span class="muted">-</span>
-                                            {% endif %}
-                                        </div>
-                                        {% endcomment %}
+                                            </div>
+                                        {% endif %}
                                         {% if leg.subsanacion_renaper_comentario %}
                                             <div class="small muted mt-2">Respuesta de provincia:</div>
                                             <div class="mt-1">

--- a/celiaquia/tests/test_expediente_detail.py
+++ b/celiaquia/tests/test_expediente_detail.py
@@ -1,5 +1,6 @@
 """Tests de regresión para detalle de expedientes en Celiaquía."""
 
+import re
 from datetime import date
 
 import pytest
@@ -17,6 +18,21 @@ from celiaquia.models import (
 from core.models import Provincia
 from ciudadanos.models import Ciudadano, GrupoFamiliar
 from users.models import Profile
+
+
+def _legajo_row_html(response, legajo_id):
+    html = response.content.decode()
+    pattern = (
+        rf'<tr class="legajo-row"(?:(?!</tr>).)*data-search="{legajo_id} [^"]*"'
+        r"(?:(?!</tr>).)*</tr>"
+    )
+    match = re.search(
+        pattern,
+        html,
+        flags=re.DOTALL,
+    )
+    assert match is not None
+    return match.group(0)
 
 
 @pytest.mark.django_db
@@ -183,6 +199,9 @@ def test_expediente_detail_expone_motivo_rechazo_para_provincia(client):
     legajo_ctx = response.context["legajos_enriquecidos"][0]
     assert legajo_ctx.observacion_tecnica_titulo == "Motivo del Rechazo"
     assert legajo_ctx.observacion_tecnica_texto == "Documento ilegible"
+    row_html = _legajo_row_html(response, legajo.pk)
+    assert "Motivo del Rechazo" in row_html
+    assert "Documento ilegible" in row_html
     assert "Motivo del Rechazo" in response.content.decode()
     assert "Documento ilegible" in response.content.decode()
 
@@ -229,5 +248,8 @@ def test_expediente_detail_expone_motivo_rechazo_para_tecnico(client):
     legajo_ctx = response.context["legajos_enriquecidos"][0]
     assert legajo_ctx.observacion_tecnica_titulo == "Motivo del Rechazo"
     assert legajo_ctx.observacion_tecnica_texto == "Falta certificado"
+    row_html = _legajo_row_html(response, legajo.pk)
+    assert "Motivo del Rechazo" in row_html
+    assert "Falta certificado" in row_html
     assert "Motivo del Rechazo" in response.content.decode()
     assert "Falta certificado" in response.content.decode()

--- a/celiaquia/tests/test_expediente_detail.py
+++ b/celiaquia/tests/test_expediente_detail.py
@@ -185,3 +185,49 @@ def test_expediente_detail_expone_motivo_rechazo_para_provincia(client):
     assert legajo_ctx.observacion_tecnica_texto == "Documento ilegible"
     assert "Motivo del Rechazo" in response.content.decode()
     assert "Documento ilegible" in response.content.decode()
+
+
+@pytest.mark.django_db
+def test_expediente_detail_expone_motivo_rechazo_para_tecnico(client):
+    user = User.objects.create_user(username="tecnico_rechazo", password="pass")
+    permission = Permission.objects.get(
+        content_type__app_label="celiaquia",
+        codename="view_expediente",
+    )
+    user.user_permissions.add(permission)
+
+    estado_expediente = EstadoExpediente.objects.create(nombre="EN_ESPERA_TEC")
+    estado_legajo = EstadoLegajo.objects.create(nombre="DOCUMENTO_PENDIENTE_TEC")
+    expediente = Expediente.objects.create(
+        usuario_provincia=user,
+        estado=estado_expediente,
+    )
+    ciudadano = Ciudadano.objects.create(
+        apellido="Gomez",
+        nombre="Mario",
+        fecha_nacimiento=date(1992, 7, 10),
+        documento=30111222,
+    )
+    legajo = ExpedienteCiudadano.objects.create(
+        expediente=expediente,
+        ciudadano=ciudadano,
+        estado=estado_legajo,
+        revision_tecnico=RevisionTecnico.RECHAZADO,
+    )
+    HistorialValidacionTecnica.objects.create(
+        legajo=legajo,
+        estado_anterior=RevisionTecnico.PENDIENTE,
+        estado_nuevo=RevisionTecnico.RECHAZADO,
+        usuario=user,
+        motivo="Falta certificado",
+    )
+
+    client.force_login(user)
+    response = client.get(reverse("expediente_detail", args=[expediente.pk]))
+
+    assert response.status_code == 200
+    legajo_ctx = response.context["legajos_enriquecidos"][0]
+    assert legajo_ctx.observacion_tecnica_titulo == "Motivo del Rechazo"
+    assert legajo_ctx.observacion_tecnica_texto == "Falta certificado"
+    assert "Motivo del Rechazo" in response.content.decode()
+    assert "Falta certificado" in response.content.decode()


### PR DESCRIPTION
# Información de la Tarea
Vincular el #ISSUE

### **Resumen de la Solución:** 
- Se soluciono error en la visualizacion de las observaciones para los legajos rechazados, se estaba guardando pero no visualizando

### **Información Adicional:**
-

# Descripción de los Cambios

### **Cambios:**
-

# Cómo Testear los Cambios

### **Pruebas Automáticas:**
-

### **Prubeas Manuales:**
-

# Metadata para documentación automática

- Contexto funcional:
- Tipo de cambio:
- Área principal:
- Resumen para changelog:
- Impacto usuario:
- Riesgos / rollback:

# Capturas de Pantalla
