### PR TITLE
[codex] Evita sync de comedor al importar estados

### DIFF
--- a/comedores/services/estado_manager/impl.py
+++ b/comedores/services/estado_manager/impl.py
@@ -45,6 +45,7 @@ def registrar_cambio_estado(
             estado_general=estado_general,
             usuario=usuario,
         )
+        manager = getattr(type(comedor), "all_objects", type(comedor).objects)
+        manager.filter(pk=comedor.pk).update(ultimo_estado=historial)
         comedor.ultimo_estado = historial
-        comedor.save(update_fields=["ultimo_estado"])
         return historial

--- a/docs/registro/cambios/2026-05-04-importarexpediente-estados-timeout.md
+++ b/docs/registro/cambios/2026-05-04-importarexpediente-estados-timeout.md
@@ -1,0 +1,37 @@
+# Timeout al importar estados de comedores
+
+## Contexto
+
+La importacion de expedientes actualiza estados de comedores mediante
+`registrar_cambio_estado`. Ese flujo crea un `EstadoHistorial` y actualiza el
+puntero `Comedor.ultimo_estado`.
+
+Antes del cambio, esa actualizacion usaba `comedor.save(update_fields=["ultimo_estado"])`.
+Aunque solo cambiaba el estado operativo, Django disparaba los `pre_save` de
+`Comedor`, incluyendo la sincronizacion completa hacia GESTIONAR y la auditoria
+general del modelo.
+
+## Cambio
+
+`registrar_cambio_estado` ahora actualiza el puntero `ultimo_estado` con
+`QuerySet.update()` dentro de la misma transaccion.
+
+Esto mantiene el historial de estado como fuente del cambio y evita tratar el
+puntero denormalizado como una edicion completa del comedor.
+
+## Impacto
+
+- La importacion sigue creando `EstadoHistorial` y dejando actualizado
+  `Comedor.ultimo_estado`.
+- Los cambios de estado no arman payload completo de comedor hacia GESTIONAR.
+- Se reducen consultas innecesarias a relaciones como `referente` durante lotes
+  grandes.
+- La auditoria funcional del estado queda en `EstadoHistorial`.
+
+## Validacion esperada
+
+Ejecutar el test de regresion:
+
+```bash
+pytest importarexpediente/tests/test_import_flow.py::test_import_estado_update_does_not_sync_comedor_payload -q
+```

--- a/importarexpediente/tests/test_import_flow.py
+++ b/importarexpediente/tests/test_import_flow.py
@@ -453,6 +453,21 @@ def test_import_updates_present_mes_1_to_active_execution(client_logged, tmp_med
     assert estados["en_ejecucion"].estado == EN_EJECUCION
 
 
+def test_import_estado_update_does_not_sync_comedor_payload(
+    client_logged, tmp_media, db, mocker
+):
+    _estado_catalog()
+    programa = _programa_alimentar()
+    comedor = Comedor.objects.create(
+        nombre="Comedor Estado Sin Sync", programa=programa
+    )
+    build_comedor_payload = mocker.patch("comedores.signals.build_comedor_payload")
+
+    _upload_csv_and_import(client_logged, comedor, 1, "EX-2025-ESTADO-SIN-SYNC")
+
+    build_comedor_payload.assert_not_called()
+
+
 def test_import_updates_present_mes_6_to_active_execution_en_plazo(
     client_logged, tmp_media, db
 ):


### PR DESCRIPTION
## Qué cambia

- Actualiza `Comedor.ultimo_estado` con `QuerySet.update()` desde `registrar_cambio_estado`, sin disparar un `save()` completo del comedor.
- Agrega una regresión para verificar que importar estados no arma payload completo de comedor hacia GESTIONAR.
- Documenta la decisión operativa en `docs/registro/cambios/2026-05-04-importarexpediente-estados-timeout.md`.

## Causa raíz

El importador de expedientes cambia estados de muchos comedores. Antes, cada cambio guardaba el comedor con `save(update_fields=["ultimo_estado"])`, lo que disparaba `pre_save`, `build_comedor_payload()` y consultas a relaciones como `referente`. En lotes grandes ese side effect podía agotar el tiempo del worker.

## Impacto

El historial de estados sigue creándose igual y `ultimo_estado` queda actualizado, pero el cambio de estado ya no se trata como una edición completa del Comedor ni dispara sync innecesario a GESTIONAR.

## Validación

- `powershell -ExecutionPolicy Bypass -File scripts\ai\codex_run.ps1 test importarexpediente/tests/test_import_flow.py -q` -> 15 passed
- `powershell -ExecutionPolicy Bypass -File scripts\ai\codex_run.ps1 black-check comedores/services/estado_manager/impl.py importarexpediente/tests/test_import_flow.py` -> OK
- `powershell -ExecutionPolicy Bypass -File scripts\ai\codex_run.ps1 manage check` -> sin issues