### PR TITLE
[predeploy] Saneamiento development -> main 2026-05-06

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,25 +3,25 @@
 
 ## Nuevas Funcionalidades
 
-- [VAT] Centros VAT soportan multiples referentes CFP y revisores CFPRevisor, con migracion del referente legacy y scopes diferenciados para lectura y gestion.
-- [PWA/Comedores] La seccion Formacion mobile pasa a cursos dinamicos administrables desde web, con segmentacion por programa, imagenes normalizadas y cursos recomendados.
-- [CDI] Centros de Infancia incorporan oferta de servicios multiple y edicion integral de registros de nomina desde la superficie existente.
-- [Celiaquia] Expedientes incorporan auditoria del Excel masivo vigente, con usuario/fecha de carga, usuario/fecha de procesamiento y descarga para roles habilitados.
+- [VAT] Centros VAT soportan múltiples referentes CFP y revisores CFPRevisor, con migración del referente legacy y scopes diferenciados para lectura y gestión.
+- [PWA/Comedores] La sección Formación mobile pasa a cursos dinámicos administrables desde web, con segmentación por programa, imágenes normalizadas y cursos recomendados.
+- [CDI] Centros de Infancia incorporan oferta de servicios múltiple y edición integral de registros de nómina desde la superficie existente.
+- [Celiaquia] Expedientes incorporan auditoría del Excel masivo vigente, con usuario/fecha de carga, usuario/fecha de procesamiento y descarga para roles habilitados.
 
 ## Actualizaciones
 
 - [sin-area] Release mobile a main sin arrastrar development. (PR #1660)
-- [Admisiones] La edicion de numero de expediente queda acotada al flujo de Tecnicos, con condiciones de visibilidad y UX contextual.
-- [VAT Web/API] Se agregan consulta de estado de voucher por DNI, ajustes de inscripcion web y fallback de localidades para ubicaciones adicionales de centros.
-- [Importacion de expedientes] Se incorpora `Mes de Convenio` y automatizacion de estados de comedores para lotes de Alimentar Comunidad.
-- [Ciudadanos/Comedores] Listados, busquedas y nominas respetan el estado de revision de identidad para evitar altas con ciudadanos pendientes.
+- [Admisiones] La edición de número de expediente queda acotada al flujo de Técnicos, con condiciones de visibilidad y UX contextual.
+- [VAT Web/API] Se agregan consulta de estado de voucher por DNI, ajustes de inscripción web y fallback de localidades para ubicaciones adicionales de centros.
+- [Importación de expedientes] Se incorpora `Mes de Convenio` y automatización de estados de comedores para lotes de Alimentar Comunidad.
+- [Ciudadanos/Comedores] Listados, búsquedas y nóminas respetan el estado de revisión de identidad para evitar altas con ciudadanos pendientes.
 
-## Correccion de Errores
+## Corrección de Errores
 
 - [Celiaquia] El detalle de expediente acota relaciones familiares a legajos activos del expediente y no hereda roles desde expedientes eliminados.
 - [CDF] El listado de responsables evita el conteo global caro con joins y reduce el riesgo de timeouts en `/beneficiarios/responsables/`.
-- [Importar expediente] Los cambios de estado actualizan `Comedor.ultimo_estado` sin disparar la sincronizacion completa de comedor hacia GESTIONAR.
-- [Core/UI] Se estabiliza la paginacion compartida y filtros asociados en listados pesados.
+- [Importar expediente] Los cambios de estado actualizan `Comedor.ultimo_estado` sin disparar la sincronización completa de comedor hacia GESTIONAR.
+- [Core/UI] Se estabiliza la paginación compartida y filtros asociados en listados pesados.
 <!-- AUTO-GENERATED RELEASE END: 2026-05-06 -->
 
 <!-- AUTO-GENERATED RELEASE START: 2026-04-24 -->

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,27 @@
 <!-- AUTO-GENERATED RELEASE START: 2026-05-06 -->
 # Versión SISOC 06.05.2026
 
+## Nuevas Funcionalidades
+
+- [VAT] Centros VAT soportan multiples referentes CFP y revisores CFPRevisor, con migracion del referente legacy y scopes diferenciados para lectura y gestion.
+- [PWA/Comedores] La seccion Formacion mobile pasa a cursos dinamicos administrables desde web, con segmentacion por programa, imagenes normalizadas y cursos recomendados.
+- [CDI] Centros de Infancia incorporan oferta de servicios multiple y edicion integral de registros de nomina desde la superficie existente.
+- [Celiaquia] Expedientes incorporan auditoria del Excel masivo vigente, con usuario/fecha de carga, usuario/fecha de procesamiento y descarga para roles habilitados.
+
 ## Actualizaciones
 
 - [sin-area] Release mobile a main sin arrastrar development. (PR #1660)
+- [Admisiones] La edicion de numero de expediente queda acotada al flujo de Tecnicos, con condiciones de visibilidad y UX contextual.
+- [VAT Web/API] Se agregan consulta de estado de voucher por DNI, ajustes de inscripcion web y fallback de localidades para ubicaciones adicionales de centros.
+- [Importacion de expedientes] Se incorpora `Mes de Convenio` y automatizacion de estados de comedores para lotes de Alimentar Comunidad.
+- [Ciudadanos/Comedores] Listados, busquedas y nominas respetan el estado de revision de identidad para evitar altas con ciudadanos pendientes.
+
+## Correccion de Errores
+
+- [Celiaquia] El detalle de expediente acota relaciones familiares a legajos activos del expediente y no hereda roles desde expedientes eliminados.
+- [CDF] El listado de responsables evita el conteo global caro con joins y reduce el riesgo de timeouts en `/beneficiarios/responsables/`.
+- [Importar expediente] Los cambios de estado actualizan `Comedor.ultimo_estado` sin disparar la sincronizacion completa de comedor hacia GESTIONAR.
+- [Core/UI] Se estabiliza la paginacion compartida y filtros asociados en listados pesados.
 <!-- AUTO-GENERATED RELEASE END: 2026-05-06 -->
 
 <!-- AUTO-GENERATED RELEASE START: 2026-04-24 -->

--- a/VAT/templates/vat/centros/partials/centro_cursos_panel.html
+++ b/VAT/templates/vat/centros/partials/centro_cursos_panel.html
@@ -331,61 +331,204 @@
     </div>
 
     {% if can_manage_centro %}
-    <div class="modal fade"
-         id="modalCurso"
-         tabindex="-1"
-         aria-labelledby="modalCursoLabel"
-         aria-hidden="true">
-        <div class="modal-dialog modal-lg">
-            <div class="modal-content">
-                <div class="modal-header">
-                    <h5 class="modal-title" id="modalCursoLabel">Nuevo Curso</h5>
-                    <button type="button"
-                            class="btn-close"
-                            data-bs-dismiss="modal"
-                            aria-label="Close"></button>
-                </div>
-                <form id="formCurso"
-                      method="post"
-                      action="{% url 'vat_curso_create' %}?centro={{ centro.id }}">
-                    {% csrf_token %}
-                    <div class="modal-body">
-                        <div id="planEstudioSeleccionadoInfo"
-                             class="alert alert-info d-none"
-                             role="status"
-                             aria-live="polite"></div>
-                        <div class="row">
-                            {% for field in curso_form %}
-                                {% if field.is_hidden %}
-                                    {{ field }}
-                                {% elif field.html_name == 'plan_estudio' %}
-                                    <div class="col-12 mb-3">
-                                        <label for="openPlanCurricularSelector" class="form-label fw-bold">
-                                            {{ field.label }}
-                                            {% if field.field.required %}<span class="text-danger">*</span>{% endif %}
-                                        </label>
-                                        <div class="d-none">{{ field }}</div>
-                                        <button type="button"
-                                                id="openPlanCurricularSelector"
-                                                class="btn btn-outline-primary w-100 d-flex justify-content-between align-items-center">
-                                            <span id="planCurricularSelectorButtonLabel">Seleccionar plan curricular</span>
-                                            <i class="fas fa-table-list"></i>
-                                        </button>
-                                        <div id="planCurricularSelectorSummary" class="small text-muted mt-2">No hay plan curricular seleccionado.</div>
-                                        {% if field.errors %}<div class="text-danger small mt-1">{{ field.errors.0 }}</div>{% endif %}
-                                        {% if field.help_text %}<div class="form-text">{{ field.help_text }}</div>{% endif %}
-                                    </div>
-                                {% elif field.html_name == 'voucher_parametrias' %}
-                                    <div class="col-12 mb-3">
-                                        <label for="{{ field.id_for_label }}" class="form-label fw-bold">
-                                            {{ field.label }}
-                                            {% if field.field.required %}<span class="text-danger">*</span>{% endif %}
-                                        </label>
+        <div class="modal fade"
+             id="modalCurso"
+             tabindex="-1"
+             aria-labelledby="modalCursoLabel"
+             aria-hidden="true">
+            <div class="modal-dialog modal-lg">
+                <div class="modal-content">
+                    <div class="modal-header">
+                        <h5 class="modal-title" id="modalCursoLabel">Nuevo Curso</h5>
+                        <button type="button"
+                                class="btn-close"
+                                data-bs-dismiss="modal"
+                                aria-label="Close"></button>
+                    </div>
+                    <form id="formCurso"
+                          method="post"
+                          action="{% url 'vat_curso_create' %}?centro={{ centro.id }}">
+                        {% csrf_token %}
+                        <div class="modal-body">
+                            <div id="planEstudioSeleccionadoInfo"
+                                 class="alert alert-info d-none"
+                                 role="status"
+                                 aria-live="polite"></div>
+                            <div class="row">
+                                {% for field in curso_form %}
+                                    {% if field.is_hidden %}
                                         {{ field }}
-                                        {% if field.errors %}<div class="text-danger small mt-1">{{ field.errors.0 }}</div>{% endif %}
-                                        {% if field.help_text %}<div class="form-text">{{ field.help_text }}</div>{% endif %}
-                                    </div>
-                                {% else %}
+                                    {% elif field.html_name == 'plan_estudio' %}
+                                        <div class="col-12 mb-3">
+                                            <label for="openPlanCurricularSelector" class="form-label fw-bold">
+                                                {{ field.label }}
+                                                {% if field.field.required %}<span class="text-danger">*</span>{% endif %}
+                                            </label>
+                                            <div class="d-none">{{ field }}</div>
+                                            <button type="button"
+                                                    id="openPlanCurricularSelector"
+                                                    class="btn btn-outline-primary w-100 d-flex justify-content-between align-items-center">
+                                                <span id="planCurricularSelectorButtonLabel">Seleccionar plan curricular</span>
+                                                <i class="fas fa-table-list"></i>
+                                            </button>
+                                            <div id="planCurricularSelectorSummary" class="small text-muted mt-2">No hay plan curricular seleccionado.</div>
+                                            {% if field.errors %}<div class="text-danger small mt-1">{{ field.errors.0 }}</div>{% endif %}
+                                            {% if field.help_text %}<div class="form-text">{{ field.help_text }}</div>{% endif %}
+                                        </div>
+                                    {% elif field.html_name == 'voucher_parametrias' %}
+                                        <div class="col-12 mb-3">
+                                            <label for="{{ field.id_for_label }}" class="form-label fw-bold">
+                                                {{ field.label }}
+                                                {% if field.field.required %}<span class="text-danger">*</span>{% endif %}
+                                            </label>
+                                            {{ field }}
+                                            {% if field.errors %}<div class="text-danger small mt-1">{{ field.errors.0 }}</div>{% endif %}
+                                            {% if field.help_text %}<div class="form-text">{{ field.help_text }}</div>{% endif %}
+                                        </div>
+                                    {% else %}
+                                        <div class="col-md-6 mb-3">
+                                            <label for="{{ field.id_for_label }}" class="form-label fw-bold">
+                                                {{ field.label }}
+                                                {% if field.field.required %}<span class="text-danger">*</span>{% endif %}
+                                            </label>
+                                            {{ field }}
+                                            {% if field.errors %}<div class="text-danger small mt-1">{{ field.errors.0 }}</div>{% endif %}
+                                            {% if field.help_text %}<div class="form-text">{{ field.help_text }}</div>{% endif %}
+                                        </div>
+                                    {% endif %}
+                                {% endfor %}
+                            </div>
+                        </div>
+                        <div class="modal-footer">
+                            <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Cancelar</button>
+                            <button type="submit" class="btn btn-primary">Guardar</button>
+                        </div>
+                    </form>
+                </div>
+            </div>
+        </div>
+
+        <div class="modal fade"
+             id="modalPlanCurricularSelector"
+             tabindex="-1"
+             aria-labelledby="modalPlanCurricularSelectorLabel"
+             aria-hidden="true">
+            <div class="modal-dialog modal-xl modal-dialog-scrollable">
+                <div class="modal-content">
+                    <div class="modal-header">
+                        <h5 class="modal-title" id="modalPlanCurricularSelectorLabel">Seleccionar Plan Curricular</h5>
+                        <button type="button"
+                                class="btn-close"
+                                data-bs-dismiss="modal"
+                                aria-label="Close"></button>
+                    </div>
+                    <div class="modal-body">
+                        <div class="row g-2 align-items-end mb-3">
+                            <div class="col-lg-6">
+                                <label for="planCurricularSelectorSearch"
+                                       class="form-label small fw-semibold text-uppercase mb-1"
+                                       style="letter-spacing:.05em">Buscar</label>
+                                <input type="search"
+                                       id="planCurricularSelectorSearch"
+                                       class="form-control form-control-sm"
+                                       placeholder="Buscar por plan, sector o normativa"
+                                       autocomplete="off" />
+                            </div>
+                            <div class="col-sm-6 col-lg-3">
+                                <label for="planCurricularSelectorSector"
+                                       class="form-label small fw-semibold text-uppercase mb-1"
+                                       style="letter-spacing:.05em">Sector</label>
+                                <select id="planCurricularSelectorSector"
+                                        class="form-select form-select-sm select2"
+                                        data-width="100%"
+                                        data-dropdown-parent="#modalPlanCurricularSelector">
+                                    <option value="">Todos los sectores</option>
+                                </select>
+                            </div>
+                        </div>
+                        <div class="table-responsive border rounded">
+                            <table class="table table-hover align-middle mb-0"
+                                   id="tablaPlanCurricularSelector">
+                                <thead class="table-light">
+                                    <tr>
+                                        <th>Plan Curricular</th>
+                                        <th>Sector</th>
+                                        <th>Modalidad</th>
+                                        <th>Normativa</th>
+                                        <th class="text-end">Acción</th>
+                                    </tr>
+                                </thead>
+                                <tbody>
+                                    {% for plan in curso_form.plan_estudio.field.queryset %}
+                                        <tr data-plan-selector-row="1"
+                                            data-plan-id="{{ plan.id }}"
+                                            data-plan-label="{% if plan.nombre %}{{ plan.nombre }}{% elif plan.titulo_referencia %}{{ plan.titulo_referencia.nombre }}{% else %}{{ plan.sector.nombre }}{% endif %}"
+                                            data-plan-sector="{{ plan.sector.nombre|default:'' }}"
+                                            data-plan-normativa="{{ plan.normativa|default:'' }}">
+                                            <td class="fw-semibold">
+                                                {% if plan.nombre %}
+                                                    {{ plan.nombre }}
+                                                {% elif plan.titulo_referencia %}
+                                                    {{ plan.titulo_referencia.nombre }}
+                                                {% else %}
+                                                    {{ plan.sector.nombre }}
+                                                {% endif %}
+                                            </td>
+                                            <td>{{ plan.sector.nombre|default:"-" }}</td>
+                                            <td>{{ plan.modalidad_cursada.nombre|default:"-" }}</td>
+                                            <td>{{ plan.normativa|default:"-" }}</td>
+                                            <td class="text-end">
+                                                <button type="button"
+                                                        class="btn btn-sm btn-outline-primary"
+                                                        data-plan-selector-choose="1">Seleccionar</button>
+                                            </td>
+                                        </tr>
+                                    {% empty %}
+                                        <tr>
+                                            <td colspan="5" class="text-center py-4 text-muted">
+                                                No hay planes curriculares activos disponibles para este centro.
+                                            </td>
+                                        </tr>
+                                    {% endfor %}
+                                </tbody>
+                            </table>
+                        </div>
+                        <div id="planCurricularSelectorEmpty"
+                             class="text-center py-4 text-muted d-none">
+                            <i class="fas fa-filter fa-2x mb-2 opacity-50"></i>
+                            <p class="mb-0">No hay planes curriculares que coincidan con los filtros.</p>
+                        </div>
+                    </div>
+                    <div class="modal-footer">
+                        <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Cerrar</button>
+                    </div>
+                </div>
+            </div>
+        </div>
+
+        <div class="modal fade"
+             id="modalComisionCurso"
+             tabindex="-1"
+             aria-labelledby="modalComisionCursoLabel"
+             aria-hidden="true">
+            <div class="modal-dialog modal-lg">
+                <div class="modal-content">
+                    <div class="modal-header">
+                        <h5 class="modal-title" id="modalComisionCursoLabel">Nueva Comisión de Curso</h5>
+                        <button type="button"
+                                class="btn-close"
+                                data-bs-dismiss="modal"
+                                aria-label="Close"></button>
+                    </div>
+                    <form id="formComisionCurso"
+                          method="post"
+                          action="{% url 'vat_comision_curso_create' %}">
+                        {% csrf_token %}
+                        <div class="modal-body">
+                            <div class="alert alert-light border small mb-3 d-none"
+                                 id="cursoSeleccionadoInfo"></div>
+                            <div class="row">
+                                {% for field in comision_curso_form %}
                                     <div class="col-md-6 mb-3">
                                         <label for="{{ field.id_for_label }}" class="form-label fw-bold">
                                             {{ field.label }}
@@ -395,159 +538,16 @@
                                         {% if field.errors %}<div class="text-danger small mt-1">{{ field.errors.0 }}</div>{% endif %}
                                         {% if field.help_text %}<div class="form-text">{{ field.help_text }}</div>{% endif %}
                                     </div>
-                                {% endif %}
-                            {% endfor %}
-                        </div>
-                    </div>
-                    <div class="modal-footer">
-                        <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Cancelar</button>
-                        <button type="submit" class="btn btn-primary">Guardar</button>
-                    </div>
-                </form>
-            </div>
-        </div>
-    </div>
-
-    <div class="modal fade"
-         id="modalPlanCurricularSelector"
-         tabindex="-1"
-         aria-labelledby="modalPlanCurricularSelectorLabel"
-         aria-hidden="true">
-        <div class="modal-dialog modal-xl modal-dialog-scrollable">
-            <div class="modal-content">
-                <div class="modal-header">
-                    <h5 class="modal-title" id="modalPlanCurricularSelectorLabel">Seleccionar Plan Curricular</h5>
-                    <button type="button"
-                            class="btn-close"
-                            data-bs-dismiss="modal"
-                            aria-label="Close"></button>
-                </div>
-                <div class="modal-body">
-                    <div class="row g-2 align-items-end mb-3">
-                        <div class="col-lg-6">
-                            <label for="planCurricularSelectorSearch"
-                                   class="form-label small fw-semibold text-uppercase mb-1"
-                                   style="letter-spacing:.05em">Buscar</label>
-                            <input type="search"
-                                   id="planCurricularSelectorSearch"
-                                   class="form-control form-control-sm"
-                                   placeholder="Buscar por plan, sector o normativa"
-                                   autocomplete="off" />
-                        </div>
-                        <div class="col-sm-6 col-lg-3">
-                            <label for="planCurricularSelectorSector"
-                                   class="form-label small fw-semibold text-uppercase mb-1"
-                                   style="letter-spacing:.05em">Sector</label>
-                            <select id="planCurricularSelectorSector"
-                                    class="form-select form-select-sm select2"
-                                    data-width="100%"
-                                    data-dropdown-parent="#modalPlanCurricularSelector">
-                                <option value="">Todos los sectores</option>
-                            </select>
-                        </div>
-                    </div>
-                    <div class="table-responsive border rounded">
-                        <table class="table table-hover align-middle mb-0"
-                               id="tablaPlanCurricularSelector">
-                            <thead class="table-light">
-                                <tr>
-                                    <th>Plan Curricular</th>
-                                    <th>Sector</th>
-                                    <th>Modalidad</th>
-                                    <th>Normativa</th>
-                                    <th class="text-end">Acción</th>
-                                </tr>
-                            </thead>
-                            <tbody>
-                                {% for plan in curso_form.plan_estudio.field.queryset %}
-                                    <tr data-plan-selector-row="1"
-                                        data-plan-id="{{ plan.id }}"
-                                        data-plan-label="{% if plan.nombre %}{{ plan.nombre }}{% elif plan.titulo_referencia %}{{ plan.titulo_referencia.nombre }}{% else %}{{ plan.sector.nombre }}{% endif %}"
-                                        data-plan-sector="{{ plan.sector.nombre|default:'' }}"
-                                        data-plan-normativa="{{ plan.normativa|default:'' }}">
-                                        <td class="fw-semibold">
-                                            {% if plan.nombre %}
-                                                {{ plan.nombre }}
-                                            {% elif plan.titulo_referencia %}
-                                                {{ plan.titulo_referencia.nombre }}
-                                            {% else %}
-                                                {{ plan.sector.nombre }}
-                                            {% endif %}
-                                        </td>
-                                        <td>{{ plan.sector.nombre|default:"-" }}</td>
-                                        <td>{{ plan.modalidad_cursada.nombre|default:"-" }}</td>
-                                        <td>{{ plan.normativa|default:"-" }}</td>
-                                        <td class="text-end">
-                                            <button type="button"
-                                                    class="btn btn-sm btn-outline-primary"
-                                                    data-plan-selector-choose="1">Seleccionar</button>
-                                        </td>
-                                    </tr>
-                                {% empty %}
-                                    <tr>
-                                        <td colspan="5" class="text-center py-4 text-muted">
-                                            No hay planes curriculares activos disponibles para este centro.
-                                        </td>
-                                    </tr>
                                 {% endfor %}
-                            </tbody>
-                        </table>
-                    </div>
-                    <div id="planCurricularSelectorEmpty"
-                         class="text-center py-4 text-muted d-none">
-                        <i class="fas fa-filter fa-2x mb-2 opacity-50"></i>
-                        <p class="mb-0">No hay planes curriculares que coincidan con los filtros.</p>
-                    </div>
-                </div>
-                <div class="modal-footer">
-                    <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Cerrar</button>
-                </div>
-            </div>
-        </div>
-    </div>
-
-    <div class="modal fade"
-         id="modalComisionCurso"
-         tabindex="-1"
-         aria-labelledby="modalComisionCursoLabel"
-         aria-hidden="true">
-        <div class="modal-dialog modal-lg">
-            <div class="modal-content">
-                <div class="modal-header">
-                    <h5 class="modal-title" id="modalComisionCursoLabel">Nueva Comisión de Curso</h5>
-                    <button type="button"
-                            class="btn-close"
-                            data-bs-dismiss="modal"
-                            aria-label="Close"></button>
-                </div>
-                <form id="formComisionCurso"
-                      method="post"
-                      action="{% url 'vat_comision_curso_create' %}">
-                    {% csrf_token %}
-                    <div class="modal-body">
-                        <div class="alert alert-light border small mb-3 d-none"
-                             id="cursoSeleccionadoInfo"></div>
-                        <div class="row">
-                            {% for field in comision_curso_form %}
-                                <div class="col-md-6 mb-3">
-                                    <label for="{{ field.id_for_label }}" class="form-label fw-bold">
-                                        {{ field.label }}
-                                        {% if field.field.required %}<span class="text-danger">*</span>{% endif %}
-                                    </label>
-                                    {{ field }}
-                                    {% if field.errors %}<div class="text-danger small mt-1">{{ field.errors.0 }}</div>{% endif %}
-                                    {% if field.help_text %}<div class="form-text">{{ field.help_text }}</div>{% endif %}
-                                </div>
-                            {% endfor %}
+                            </div>
                         </div>
-                    </div>
-                    <div class="modal-footer">
-                        <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Cancelar</button>
-                        <button type="submit" class="btn btn-primary">Guardar</button>
-                    </div>
-                </form>
+                        <div class="modal-footer">
+                            <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Cancelar</button>
+                            <button type="submit" class="btn btn-primary">Guardar</button>
+                        </div>
+                    </form>
+                </div>
             </div>
         </div>
-    </div>
     {% endif %}
 </div>

--- a/docs/registro/cambios/2026-05-06-predeploy-development-main.md
+++ b/docs/registro/cambios/2026-05-06-predeploy-development-main.md
@@ -2,26 +2,26 @@
 
 ## Contexto
 
-Se preparo el corte `development -> main` con worktree aislada desde
+Se preparó el corte `development -> main` con worktree aislada desde
 `origin/development`, comparando el diff real contra `origin/main`.
 
 ## Cambios de saneamiento
 
-- Se actualizo el bloque superior de `CHANGELOG.md` para reflejar el corte de
+- Se actualizó el bloque superior de `CHANGELOG.md` para reflejar el corte de
   release del 2026-05-06, tomando como fuente los cambios documentados en
   `docs/registro/cambios/` y el diff `origin/main..origin/development`.
-- Se declaro `serializer_class` en el endpoint PWA de Formacion para que la
-  generacion OpenAPI no quede ambigua en el nuevo `CursoAppMobilePWAViewSet`.
+- Se declaró `serializer_class` en el endpoint PWA de Formación para que la
+  generación OpenAPI no quede ambigua en el nuevo `CursoAppMobilePWAViewSet`.
 
 ## Impacto
 
 El saneamiento no cambia reglas de negocio. El endpoint PWA conserva la misma
 respuesta y el changelog queda listo para que el PR final exacto
-`development -> main` muestre el alcance funcional de la promocion.
+`development -> main` muestre el alcance funcional de la promoción.
 
-## Validacion esperada
+## Validación esperada
 
 - `python manage.py makemigrations --check --dry-run`
 - `python manage.py check`
 - `python manage.py spectacular --file /tmp/schema.yml --validate`
-- Tests focalizados del endpoint PWA de Formacion y del generador de changelog.
+- Tests focalizados del endpoint PWA de Formación y del generador de changelog.

--- a/docs/registro/cambios/2026-05-06-predeploy-development-main.md
+++ b/docs/registro/cambios/2026-05-06-predeploy-development-main.md
@@ -1,0 +1,27 @@
+# 2026-05-06 - Predeploy development a main
+
+## Contexto
+
+Se preparo el corte `development -> main` con worktree aislada desde
+`origin/development`, comparando el diff real contra `origin/main`.
+
+## Cambios de saneamiento
+
+- Se actualizo el bloque superior de `CHANGELOG.md` para reflejar el corte de
+  release del 2026-05-06, tomando como fuente los cambios documentados en
+  `docs/registro/cambios/` y el diff `origin/main..origin/development`.
+- Se declaro `serializer_class` en el endpoint PWA de Formacion para que la
+  generacion OpenAPI no quede ambigua en el nuevo `CursoAppMobilePWAViewSet`.
+
+## Impacto
+
+El saneamiento no cambia reglas de negocio. El endpoint PWA conserva la misma
+respuesta y el changelog queda listo para que el PR final exacto
+`development -> main` muestre el alcance funcional de la promocion.
+
+## Validacion esperada
+
+- `python manage.py makemigrations --check --dry-run`
+- `python manage.py check`
+- `python manage.py spectacular --file /tmp/schema.yml --validate`
+- Tests focalizados del endpoint PWA de Formacion y del generador de changelog.

--- a/pwa/api_views.py
+++ b/pwa/api_views.py
@@ -211,6 +211,7 @@ class MensajeEspacioPWAViewSet(viewsets.ViewSet):
 
 @extend_schema(tags=["PWA Formacion"])
 class CursoAppMobilePWAViewSet(viewsets.ViewSet):
+    serializer_class = CursoAppMobilePWASerializer
     authentication_classes = [TokenAuthentication]
     permission_classes = [IsAuthenticated, IsPWARepresentativeForComedor]
 

--- a/pwa/curso_app_mobile_serializers.py
+++ b/pwa/curso_app_mobile_serializers.py
@@ -20,7 +20,7 @@ class CursoAppMobilePWASerializer(serializers.ModelSerializer):
             "imagen_url",
         )
 
-    def get_imagen_url(self, obj):
+    def get_imagen_url(self, obj) -> str | None:
         if not obj.imagen:
             return None
         request = self.context.get("request")

--- a/tests/test_expediente_service_unit.py
+++ b/tests/test_expediente_service_unit.py
@@ -136,7 +136,7 @@ def test_procesar_expediente_validations_and_success(mocker):
             SimpleNamespace(excel_masivo=None), usuario="u"
         )
 
-    exp = SimpleNamespace(pk=8, excel_masivo="file")
+    exp = SimpleNamespace(pk=8, excel_masivo="file", save=mocker.Mock())
     mocker.patch(
         "celiaquia.services.expediente_service.ImportacionService.importar_legajos_desde_excel",
         return_value={
@@ -157,6 +157,12 @@ def test_procesar_expediente_validations_and_success(mocker):
     }
     assert set_estado.call_count == 2
     assert set_estado.call_args_list[1].kwargs["observaciones"]
+    exp.save.assert_called_once_with(
+        update_fields=[
+            "excel_masivo_procesado_por",
+            "excel_masivo_procesado_en",
+        ]
+    )
 
 
 class _LegajosQS:


### PR DESCRIPTION
## Resumen

Este PR sanea `development` para preparar la promocion exacta `development -> main` del 2026-05-06. La branch fue rebaseada sobre `origin/development` vigente (`e402b4d`) despues de la incorporacion de #1690.

## Cambios aplicados

- Actualiza el bloque superior de `CHANGELOG.md` con el alcance del corte `origin/development` contra `origin/main`.
- Documenta el saneamiento en `docs/registro/cambios/2026-05-06-predeploy-development-main.md`.
- Declara `serializer_class` en `CursoAppMobilePWAViewSet` y tipa `imagen_url` para que el nuevo endpoint PWA de Formacion no quede como contrato OpenAPI ambiguo.
- Ajusta el test unitario de Celiaquia para cubrir la persistencia de `excel_masivo_procesado_por` y `excel_masivo_procesado_en`, que era la causa raiz del job `pytest` rojo en el PR final `development -> main`.
- Aplica el formato `djlint` requerido por el PR final en `VAT/templates/vat/centros/partials/centro_cursos_panel.html`; el diff es solo whitespace (`git diff -w` sin cambios semanticos).
- Resuelve los comentarios de review sobre tildes y consistencia del bloque nuevo de `CHANGELOG.md` y el registro de cambios.

## Evidencia de analisis

- Base inicial analizada: `origin/development` en `59c8f4f1d` contra `origin/main` en `fdc98eb5b`.
- Base vigente de este PR: `origin/development` en `e402b4d` luego de #1690.
- Comparacion release inicial: `origin/main...origin/development` = `0 140`; luego #1690 agrego 2 commits mas al head de `development`.
- Diff release vigente del PR final: 152 archivos, 9248 inserciones, 1579 eliminaciones.
- Modulos principales: VAT, centrodeinfancia, comedores/PWA, Celiaquia, importarexpediente, ciudadanos, organizaciones, admisiones, core/templates.
- Falla investigada 1: `tests/test_expediente_service_unit.py::test_procesar_expediente_validations_and_success` fallaba porque el stub no tenia `save`, aunque el servicio productivo debe guardar campos de auditoria sobre un modelo `Expediente` real.
- Falla investigada 2: `Formateo y linteo/autofix` del PR final fallaba porque `djlint --reformat` dejaba cambios pendientes en templates del corte.
- Review #1688: los 3 threads de Copilot quedaron obsoletos despues de corregir acentos.

## Pruebas ejecutadas

- `docker compose -f docker-compose.yml -f docker-compose.codex.yml build django` -> OK.
- `docker compose -f docker-compose.yml -f docker-compose.codex.yml run --rm --no-deps -T django python manage.py makemigrations --check --dry-run` -> OK, `No changes detected`; warning no bloqueante por MySQL no levantado en modo `--no-deps`.
- `docker compose -f docker-compose.yml -f docker-compose.codex.yml run --rm --no-deps -T django python manage.py check` -> OK.
- `docker compose ... python manage.py check --deploy` con variables equivalentes a `release-sanity` -> exit 0; quedan warnings historicos de OpenAPI/seguridad que no bloquean el comando.
- `docker compose ... python manage.py spectacular --file /tmp/schema.yml --validate` -> exit 0; el error del nuevo `CursoAppMobilePWAViewSet` fue removido. Quedan errores historicos de otros ViewSet.
- `docker compose ... python manage.py collectstatic --noinput` -> OK, 388 static files; warnings historicos de archivos admin duplicados.
- `docker compose ... black --check pwa/api_views.py pwa/curso_app_mobile_serializers.py --config pyproject.toml` -> OK.
- `docker compose ... pylint pwa/api_views.py pwa/curso_app_mobile_serializers.py --rcfile=.pylintrc` -> OK, 10.00/10.
- `docker compose ... pytest tests/test_pwa_formacion_api.py tests/test_pr_doc_automation_unit.py -q` -> 11 passed.
- `docker compose ... pytest tests/test_expediente_service_unit.py -q` -> 9 passed.
- `docker compose ... pytest tests/test_expediente_service_unit.py::test_procesar_expediente_validations_and_success tests/test_pwa_formacion_api.py tests/test_pr_doc_automation_unit.py -q` luego del rebase -> 12 passed.
- `docker compose ... djlint <23 templates del PR final> --reformat --configuration=.djlintrc` -> deja 0 cambios adicionales despues del formato aplicado.
- `docker compose ... djlint <23 templates del PR final> --check --configuration=.djlintrc` -> OK, 0 files would be updated.
- `docker compose ... python -c "Path(...).read_text(encoding='utf-8')"` sobre docs tocados -> OK.
- `docker compose ... pytest -m smoke` -> 459 passed, 1748 deselected, 3 warnings.
- `git diff --check` / `git diff -w --exit-code` sobre el template formateado -> OK.
- GitHub Actions sobre #1688 (`89f3332a`) -> `Escaneo de secretos`, `Documentacion automatica de PR`, `Formateo y linteo` y `Tests automatizados` success; en tests pasaron `smoke`, `migrations_check`, `mysql_compat`, `pytest` y `deploy_guard`.

## Riesgos remanentes

- Este PR debe mergearse a `development` antes de considerar GO el PR draft final `development -> main`.
- El corte trae migraciones de VAT, Celiaquia, CDI, Comedores, Expedientes de pago y Organizaciones; requiere ventana con migraciones aplicadas antes de trafico productivo.
- Persisten warnings historicos de OpenAPI en modulos no tocados por este saneamiento; no son nuevos bloqueantes, pero siguen siendo deuda tecnica.
- La validacion autoritativa final del release debe repetirse sobre el PR `development -> main` despues de mergear este PR.

## Metadata para automatizacion

- Tipo de cambio: fix
- Area principal: release
- Resumen changelog: Saneamiento de predeploy development a main 2026-05-06
- Impacto usuario: No cambia reglas funcionales; mejora trazabilidad del release, contrato OpenAPI del endpoint PWA de Formacion y estabilidad de CI del corte.
- Pruebas automaticas: ver seccion `Pruebas ejecutadas`.
- Pruebas manuales: validar en el PR final que los checks requeridos de GitHub Actions queden verdes luego de mergear este PR.
- Riesgos rollback: revertir este PR revierte changelog/documentacion, metadatos OpenAPI del endpoint nuevo, ajuste del test unitario de auditoria masiva y formato whitespace de template VAT.