### PR TITLE
feat(dispositivos): ocultar campos _otro hasta seleccionar la opción

### DIFF
--- a/dispositivos/templates/dispositivos_form.html
+++ b/dispositivos/templates/dispositivos_form.html
@@ -86,7 +86,10 @@
                             <div class="col-md-4">{{ form.tipo_gestion|as_crispy_field }}</div>
                         </div>
                         <div class="form-group row">
-                            <div class="col-md-4">{{ form.tipo_gestion_otra|as_crispy_field }}</div>
+                            <div id="wrapper-tipo_gestion_otra"
+                                 class="col-md-4 {% if form.tipo_gestion.value != 'otra' %}d-none{% endif %}">
+                                {{ form.tipo_gestion_otra|as_crispy_field }}
+                            </div>
                             <div class="col-md-4">{{ form.razon_social|as_crispy_field }}</div>
                         </div>
                         <div class="form-group row">
@@ -130,7 +133,10 @@
                     <div class="section-body collapse show" id="section-caracteristicas">
                         <div class="form-group row">
                             <div class="col-md-4">{{ form.tipo_dispositivo|as_crispy_field }}</div>
-                            <div class="col-md-4">{{ form.tipo_dispositivo_otro|as_crispy_field }}</div>
+                            <div id="wrapper-tipo_dispositivo_otro"
+                                 class="col-md-4 {% if form.tipo_dispositivo.value != 'otro' %}d-none{% endif %}">
+                                {{ form.tipo_dispositivo_otro|as_crispy_field }}
+                            </div>
                         </div>
                         <div class="form-group row">
                             <div class="col-md-4">{{ form.modalidad_funcionamiento|as_crispy_field }}</div>
@@ -168,15 +174,23 @@
                         <div class="form-group row">
                             <div class="col-md-4">
                                 {{ form.poblacion_destinataria|as_crispy_field }}
-                                <div class="row">
-                                    <div class="col-md-8">{{ form.poblacion_destinataria_otro|as_crispy_field }}</div>
-                                </div>
+                                {% with sel=form.poblacion_destinataria.value %}
+                                    <div class="row">
+                                        <div id="wrapper-poblacion_destinataria_otro"
+                                             class="col-md-8 {% if not sel or 'otro' not in sel %}d-none{% endif %}">
+                                            {{ form.poblacion_destinataria_otro|as_crispy_field }}
+                                        </div>
+                                    </div>
+                                {% endwith %}
                             </div>
                             <div class="col-md-4">
                                 {{ form.franja_etaria_destinataria|as_crispy_field }}
                                 <div class="row">
                                     <div class="col-md-6">{{ form.tiempo_permanencia_promedio|as_crispy_field }}</div>
-                                    <div class="col-md-6">{{ form.tiempo_permanencia_otro|as_crispy_field }}</div>
+                                    <div id="wrapper-tiempo_permanencia_otro"
+                                         class="col-md-6 {% if form.tiempo_permanencia_promedio.value != 'otro' %}d-none{% endif %}">
+                                        {{ form.tiempo_permanencia_otro|as_crispy_field }}
+                                    </div>
                                 </div>
                             </div>
                         </div>
@@ -208,17 +222,32 @@
                         <div class="form-group row">
                             <div class="col-md-4">
                                 {{ form.modalidad_ingreso|as_crispy_field }}
-                                {{ form.modalidad_ingreso_otro|as_crispy_field }}
+                                {% with sel=form.modalidad_ingreso.value %}
+                                    <div id="wrapper-modalidad_ingreso_otro"
+                                         class="{% if not sel or 'otro' not in sel %}d-none{% endif %}">
+                                        {{ form.modalidad_ingreso_otro|as_crispy_field }}
+                                    </div>
+                                {% endwith %}
                             </div>
                             <div class="col-md-4">
                                 {{ form.documentacion_ingreso|as_crispy_field }}
-                                {{ form.documentacion_ingreso_otro|as_crispy_field }}
+                                {% with sel=form.documentacion_ingreso.value %}
+                                    <div id="wrapper-documentacion_ingreso_otro"
+                                         class="{% if not sel or 'otro' not in sel %}d-none{% endif %}">
+                                        {{ form.documentacion_ingreso_otro|as_crispy_field }}
+                                    </div>
+                                {% endwith %}
                             </div>
                         </div>
                         <div class="form-group row">
                             <div class="col-md-4">
                                 {{ form.requisitos_ingreso|as_crispy_field }}
-                                {{ form.requisitos_ingreso_otro|as_crispy_field }}
+                                {% with sel=form.requisitos_ingreso.value %}
+                                    <div id="wrapper-requisitos_ingreso_otro"
+                                         class="{% if not sel or 'otro' not in sel %}d-none{% endif %}">
+                                        {{ form.requisitos_ingreso_otro|as_crispy_field }}
+                                    </div>
+                                {% endwith %}
                             </div>
                         </div>
                     </div>
@@ -249,14 +278,24 @@
                         <div class="form-group row">
                             <div class="col-md-4">
                                 {{ form.servicios_brindados|as_crispy_field }}
-                                {{ form.servicios_brindados_otro|as_crispy_field }}
+                                {% with sel=form.servicios_brindados.value %}
+                                    <div id="wrapper-servicios_brindados_otro"
+                                         class="{% if not sel or 'otro' not in sel %}d-none{% endif %}">
+                                        {{ form.servicios_brindados_otro|as_crispy_field }}
+                                    </div>
+                                {% endwith %}
                             </div>
                             <div class="col-md-4">
                                 {{ form.ofrece_actividades_formativas|as_crispy_field }}
                                 <div id="actividades-detalle"
                                      class="{% if form.ofrece_actividades_formativas.value != 'si' %}d-none{% endif %}">
                                     {{ form.tipos_actividades_formativas|as_crispy_field }}
-                                    {{ form.tipos_actividades_formativas_otro|as_crispy_field }}
+                                    {% with sel=form.tipos_actividades_formativas.value %}
+                                        <div id="wrapper-tipos_actividades_formativas_otro"
+                                             class="{% if not sel or 'otro' not in sel %}d-none{% endif %}">
+                                            {{ form.tipos_actividades_formativas_otro|as_crispy_field }}
+                                        </div>
+                                    {% endwith %}
                                     {{ form.actividades_certificacion_oficial|as_crispy_field }}
                                 </div>
                             </div>
@@ -294,11 +333,19 @@
                             <div class="form-group row">
                                 <div class="col-md-4">
                                     {{ form.modo_registro|as_crispy_field }}
-                                    {{ form.modo_registro_otro|as_crispy_field }}
+                                    <div id="wrapper-modo_registro_otro"
+                                         class="{% if form.modo_registro.value != 'otro' %}d-none{% endif %}">
+                                        {{ form.modo_registro_otro|as_crispy_field }}
+                                    </div>
                                 </div>
                                 <div class="col-md-4">
                                     {{ form.tipo_informacion_registrada|as_crispy_field }}
-                                    {{ form.tipo_informacion_registrada_otro|as_crispy_field }}
+                                    {% with sel=form.tipo_informacion_registrada.value %}
+                                        <div id="wrapper-tipo_informacion_registrada_otro"
+                                             class="{% if not sel or 'otro' not in sel %}d-none{% endif %}">
+                                            {{ form.tipo_informacion_registrada_otro|as_crispy_field }}
+                                        </div>
+                                    {% endwith %}
                                 </div>
                             </div>
                         </div>
@@ -330,11 +377,21 @@
                         <div class="form-group row">
                             <div class="col-md-4">
                                 {{ form.infraestructura_disponible|as_crispy_field }}
-                                {{ form.infraestructura_disponible_otro|as_crispy_field }}
+                                {% with sel=form.infraestructura_disponible.value %}
+                                    <div id="wrapper-infraestructura_disponible_otro"
+                                         class="{% if not sel or 'otro' not in sel %}d-none{% endif %}">
+                                        {{ form.infraestructura_disponible_otro|as_crispy_field }}
+                                    </div>
+                                {% endwith %}
                             </div>
                             <div class="col-md-4">
                                 {{ form.infraestructura_accesibilidad|as_crispy_field }}
-                                {{ form.infraestructura_accesibilidad_otro|as_crispy_field }}
+                                {% with sel=form.infraestructura_accesibilidad.value %}
+                                    <div id="wrapper-infraestructura_accesibilidad_otro"
+                                         class="{% if not sel or 'otro' not in sel %}d-none{% endif %}">
+                                        {{ form.infraestructura_accesibilidad_otro|as_crispy_field }}
+                                    </div>
+                                {% endwith %}
                             </div>
                         </div>
                         <div class="form-group row">
@@ -369,7 +426,12 @@
                         <div class="form-group row">
                             <div class="col-md-4">
                                 {{ form.articulaciones_institucionales|as_crispy_field }}
-                                {{ form.articulaciones_institucionales_otro|as_crispy_field }}
+                                {% with sel=form.articulaciones_institucionales.value %}
+                                    <div id="wrapper-articulaciones_institucionales_otro"
+                                         class="{% if not sel or 'otro' not in sel %}d-none{% endif %}">
+                                        {{ form.articulaciones_institucionales_otro|as_crispy_field }}
+                                    </div>
+                                {% endwith %}
                             </div>
                         </div>
                     </div>

--- a/dispositivos/tests/test_dispositivos_views.py
+++ b/dispositivos/tests/test_dispositivos_views.py
@@ -239,3 +239,101 @@ def test_formulario_muestra_secciones_modernas(client, user_con_permisos):
         'class="d-none"'
         in contenido[registro_detalle_index : registro_detalle_index + 200]
     )
+
+
+WRAPPERS_OTRO = [
+    "wrapper-tipo_gestion_otra",
+    "wrapper-tipo_dispositivo_otro",
+    "wrapper-poblacion_destinataria_otro",
+    "wrapper-tiempo_permanencia_otro",
+    "wrapper-modalidad_ingreso_otro",
+    "wrapper-documentacion_ingreso_otro",
+    "wrapper-requisitos_ingreso_otro",
+    "wrapper-servicios_brindados_otro",
+    "wrapper-tipos_actividades_formativas_otro",
+    "wrapper-modo_registro_otro",
+    "wrapper-tipo_informacion_registrada_otro",
+    "wrapper-infraestructura_disponible_otro",
+    "wrapper-infraestructura_accesibilidad_otro",
+    "wrapper-articulaciones_institucionales_otro",
+]
+
+
+def _tag_for(contenido, wrapper_id):
+    needle = f'id="{wrapper_id}"'
+    idx = contenido.find(needle)
+    assert idx != -1, f"No se encontró {wrapper_id} en el template"
+    tag_end = contenido.find(">", idx)
+    return contenido[idx:tag_end]
+
+
+@pytest.mark.django_db
+def test_formulario_oculta_todos_los_wrappers_otro_en_creacion(
+    client, user_con_permisos
+):
+    client.force_login(user_con_permisos)
+
+    response = client.get(reverse("dispositivos_crear"))
+
+    assert response.status_code == 200
+    contenido = response.content.decode("utf-8")
+    for wrapper_id in WRAPPERS_OTRO:
+        tag = _tag_for(contenido, wrapper_id)
+        assert "d-none" in tag, f"{wrapper_id} debe iniciar con d-none"
+
+
+@pytest.mark.django_db
+def test_formulario_muestra_wrappers_otro_cuando_dispositivo_tiene_valor(
+    client, user_con_permisos, provincia_municipio
+):
+    provincia, municipio = provincia_municipio
+    client.force_login(user_con_permisos)
+
+    dispositivo = _crear_dispositivo(
+        provincia,
+        municipio,
+        indice=99887766,
+        nombre_institucion="Dispositivo Otros",
+        cuit_institucion="20998877661",
+        responsable_dni="99887766",
+        tipo_gestion="otra",
+        tipo_gestion_otra="Cooperativa local",
+        tipo_dispositivo="otro",
+        tipo_dispositivo_otro="Centro mixto",
+        poblacion_destinataria=["otro"],
+        poblacion_destinataria_otro="Personas migrantes",
+        tiempo_permanencia_promedio="otro",
+        tiempo_permanencia_otro="Variable",
+        modalidad_ingreso=["otro"],
+        modalidad_ingreso_otro="Acuerdo municipal",
+        documentacion_ingreso=["otro"],
+        documentacion_ingreso_otro="Acta",
+        requisitos_ingreso=["otro"],
+        requisitos_ingreso_otro="Compromiso",
+        servicios_brindados=["otro"],
+        servicios_brindados_otro="Talleres",
+        registra_informacion_personas="si",
+        modo_registro="otro",
+        modo_registro_otro="Sistema propio",
+        tipo_informacion_registrada=["otro"],
+        tipo_informacion_registrada_otro="Trayectoria",
+        infraestructura_disponible=["otro"],
+        infraestructura_disponible_otro="Patio",
+        infraestructura_accesibilidad=["otro"],
+        infraestructura_accesibilidad_otro="Ascensor",
+        articulaciones_institucionales=["otro"],
+        articulaciones_institucionales_otro="Iglesia local",
+        ofrece_actividades_formativas="si",
+        tipos_actividades_formativas=["otro"],
+        tipos_actividades_formativas_otro="Talleres ad-hoc",
+    )
+
+    response = client.get(reverse("dispositivos_editar", kwargs={"pk": dispositivo.pk}))
+
+    assert response.status_code == 200
+    contenido = response.content.decode("utf-8")
+    for wrapper_id in WRAPPERS_OTRO:
+        tag = _tag_for(contenido, wrapper_id)
+        assert (
+            "d-none" not in tag
+        ), f"{wrapper_id} no debe tener d-none cuando 'otro' está seleccionado"

--- a/static/custom/js/dispositivoFormModerno.js
+++ b/static/custom/js/dispositivoFormModerno.js
@@ -280,6 +280,26 @@ function moveTooltipsToLabels() {
 // CAMPOS CONDICIONALES (Si/No)
 // ============================================
 
+const OTRO_MULTI_PAIRS = [
+    ["poblacion_destinataria", "poblacion_destinataria_otro"],
+    ["modalidad_ingreso", "modalidad_ingreso_otro"],
+    ["documentacion_ingreso", "documentacion_ingreso_otro"],
+    ["requisitos_ingreso", "requisitos_ingreso_otro"],
+    ["servicios_brindados", "servicios_brindados_otro"],
+    ["tipos_actividades_formativas", "tipos_actividades_formativas_otro"],
+    ["tipo_informacion_registrada", "tipo_informacion_registrada_otro"],
+    ["infraestructura_disponible", "infraestructura_disponible_otro"],
+    ["infraestructura_accesibilidad", "infraestructura_accesibilidad_otro"],
+    ["articulaciones_institucionales", "articulaciones_institucionales_otro"],
+];
+
+const OTRO_SELECT_PAIRS = [
+    ["id_tipo_gestion", "tipo_gestion_otra", "otra"],
+    ["id_tipo_dispositivo", "tipo_dispositivo_otro", "otro"],
+    ["id_tiempo_permanencia_promedio", "tiempo_permanencia_otro", "otro"],
+    ["id_modo_registro", "modo_registro_otro", "otro"],
+];
+
 function initializeConditionalFields() {
     bindConditional(
         "id_ofrece_actividades_formativas",
@@ -288,6 +308,12 @@ function initializeConditionalFields() {
     bindConditional(
         "id_registra_informacion_personas",
         "registro-detalle"
+    );
+    OTRO_MULTI_PAIRS.forEach(([listName, otroField]) =>
+        bindOtroForMulti(listName, otroField)
+    );
+    OTRO_SELECT_PAIRS.forEach(([selectId, otroField, triggerValue]) =>
+        bindOtroForSelect(selectId, otroField, triggerValue)
     );
 }
 
@@ -306,6 +332,50 @@ function bindConditional(selectId, detailId) {
 
     toggle();
     select.addEventListener("change", toggle);
+}
+
+function bindOtroForMulti(listName, otroFieldName) {
+    const wrapper = document.getElementById(`wrapper-${otroFieldName}`);
+    if (!wrapper) return;
+
+    const otroCheckbox = document.querySelector(
+        `input[name="${listName}"][value="otro"]`
+    );
+    if (!otroCheckbox) return;
+
+    const apply = (clearValue) => {
+        const show = otroCheckbox.checked;
+        wrapper.classList.toggle("d-none", !show);
+        if (!show && clearValue) {
+            const input = wrapper.querySelector(
+                "input[type='text'], input:not([type]), textarea"
+            );
+            if (input) input.value = "";
+        }
+    };
+
+    otroCheckbox.addEventListener("change", () => apply(true));
+    apply(false);
+}
+
+function bindOtroForSelect(selectId, otroFieldName, triggerValue) {
+    const select = document.getElementById(selectId);
+    const wrapper = document.getElementById(`wrapper-${otroFieldName}`);
+    if (!select || !wrapper) return;
+
+    const apply = (clearValue) => {
+        const show = select.value === triggerValue;
+        wrapper.classList.toggle("d-none", !show);
+        if (!show && clearValue) {
+            const input = wrapper.querySelector(
+                "input[type='text'], input:not([type]), textarea"
+            );
+            if (input) input.value = "";
+        }
+    };
+
+    select.addEventListener("change", () => apply(true));
+    apply(false);
 }
 
 // ============================================


### PR DESCRIPTION

## Resumen
Cubre 16 ítems del evolutivo de Dispositivos / Situación de Calle (issue #1655) que pedían ocultar los campos `_otro/_otra` hasta que se seleccione la opción correspondiente y forzar obligatoriedad cuando se selecciona.

- Template: 14 wrappers `d-none` server-side por defecto, salvo cuando el campo padre ya tiene "otro" seleccionado (preserva render de POST-con-errors).
- JS: helpers `bindOtroForMulti` y `bindOtroForSelect` + arrays `OTRO_MULTI_PAIRS` / `OTRO_SELECT_PAIRS` con los 14 pares. Limpia el valor al ocultar por interacción, lo preserva al ocultar por render inicial.
- Tests: dos casos de visibilidad inicial (creación y edición con "otro" seleccionado).
- Backend ya validaba obligatoriedad en `_validate_otro_required` — sin cambios.

## Tks cubiertos del evolutivo
3, 14, 18, 21, 23, 25, 27, 28, 31, 33, 35, 37, 39, 44 (los 14 puros) + 29 y 32 (que ya tenían toggle de sección, ahora también ocultan sus `_otro` internos).

## Test plan
- [x] `pytest dispositivos/tests/` → 16/16
- [x] `black --check dispositivos/` → limpio
- [x] `djlint dispositivos_form.html --check` → limpio
- [x] Probado en UI