### PR TITLE
feat(dispositivos): mostrar slots

### DIFF
--- a/dispositivos/templates/dispositivos_form.html
+++ b/dispositivos/templates/dispositivos_form.html
@@ -479,7 +479,8 @@
                             </div>
 
                             <!-- Slot: Adicional 1 -->
-                            <div class="doc-slot" data-field="documentacion_dispositivo_adicional_1">
+                            <div class="doc-slot {% if not form.instance.documentacion_dispositivo_adicional_1 %}d-none{% endif %}"
+                                 data-field="documentacion_dispositivo_adicional_1">
                                 <div class="doc-slot-header">
                                     <i class="fas fa-file"></i>
                                     Documentación adicional 1
@@ -549,7 +550,8 @@
                             </div>
 
                             <!-- Slot: Adicional 2 -->
-                            <div class="doc-slot" data-field="documentacion_dispositivo_adicional_2">
+                            <div class="doc-slot {% if not form.instance.documentacion_dispositivo_adicional_2 %}d-none{% endif %}"
+                                 data-field="documentacion_dispositivo_adicional_2">
                                 <div class="doc-slot-header">
                                     <i class="fas fa-file"></i>
                                     Documentación adicional 2
@@ -619,7 +621,8 @@
                             </div>
 
                             <!-- Slot: Adicional 3 -->
-                            <div class="doc-slot" data-field="documentacion_dispositivo_adicional_3">
+                            <div class="doc-slot {% if not form.instance.documentacion_dispositivo_adicional_3 %}d-none{% endif %}"
+                                 data-field="documentacion_dispositivo_adicional_3">
                                 <div class="doc-slot-header">
                                     <i class="fas fa-file"></i>
                                     Documentación adicional 3
@@ -689,7 +692,8 @@
                             </div>
 
                             <!-- Slot: Adicional 4 -->
-                            <div class="doc-slot" data-field="documentacion_dispositivo_adicional_4">
+                            <div class="doc-slot {% if not form.instance.documentacion_dispositivo_adicional_4 %}d-none{% endif %}"
+                                 data-field="documentacion_dispositivo_adicional_4">
                                 <div class="doc-slot-header">
                                     <i class="fas fa-file"></i>
                                     Documentación adicional 4
@@ -759,6 +763,10 @@
                             </div>
 
                         </div>
+
+                        <button type="button" id="btn-add-doc" class="btn btn-outline-primary mt-3">
+                            <i class="fas fa-plus mr-1"></i> Añadir archivo
+                        </button>
                     </div>
                 </div>
 

--- a/dispositivos/tests/test_dispositivos_views.py
+++ b/dispositivos/tests/test_dispositivos_views.py
@@ -239,3 +239,69 @@ def test_formulario_muestra_secciones_modernas(client, user_con_permisos):
         'class="d-none"'
         in contenido[registro_detalle_index : registro_detalle_index + 200]
     )
+
+
+def _doc_slot_tag(contenido, field):
+    needle = f'data-field="{field}"'
+    idx = contenido.find(needle)
+    assert idx != -1, f"No se encontró slot {field} en el template"
+    tag_start = contenido.rfind("<div", 0, idx)
+    tag_end = contenido.find(">", idx)
+    return contenido[tag_start:tag_end]
+
+
+@pytest.mark.django_db
+def test_formulario_solo_muestra_primer_slot_documento_en_creacion(
+    client, user_con_permisos
+):
+    client.force_login(user_con_permisos)
+
+    response = client.get(reverse("dispositivos_crear"))
+
+    assert response.status_code == 200
+    contenido = response.content.decode("utf-8")
+    principal_tag = _doc_slot_tag(contenido, "documentacion_dispositivo")
+    assert "d-none" not in principal_tag, "El slot principal debe ser visible"
+
+    for field in [
+        "documentacion_dispositivo_adicional_1",
+        "documentacion_dispositivo_adicional_2",
+        "documentacion_dispositivo_adicional_3",
+        "documentacion_dispositivo_adicional_4",
+    ]:
+        tag = _doc_slot_tag(contenido, field)
+        assert "d-none" in tag, f"Slot {field} debe iniciar oculto"
+
+    assert 'id="btn-add-doc"' in contenido
+    assert "Añadir archivo" in contenido
+
+
+@pytest.mark.django_db
+def test_formulario_muestra_slots_con_documentacion_persistida_en_edicion(
+    client, user_con_permisos, provincia_municipio
+):
+    provincia, municipio = provincia_municipio
+    client.force_login(user_con_permisos)
+
+    dispositivo = _crear_dispositivo(
+        provincia,
+        municipio,
+        indice=55667788,
+        nombre_institucion="Dispositivo con docs",
+        cuit_institucion="20556677881",
+        responsable_dni="55667788",
+    )
+    dispositivo.documentacion_dispositivo_adicional_2.save(
+        "doc-2.pdf",
+        SimpleUploadedFile("doc-2.pdf", b"x", content_type="application/pdf"),
+        save=True,
+    )
+
+    response = client.get(reverse("dispositivos_editar", kwargs={"pk": dispositivo.pk}))
+
+    assert response.status_code == 200
+    contenido = response.content.decode("utf-8")
+    tag_2 = _doc_slot_tag(contenido, "documentacion_dispositivo_adicional_2")
+    assert "d-none" not in tag_2, "El slot con archivo persistido debe ser visible"
+    tag_3 = _doc_slot_tag(contenido, "documentacion_dispositivo_adicional_3")
+    assert "d-none" in tag_3, "Slots sin archivo deben mantenerse ocultos"

--- a/static/custom/js/dispositivoFormModerno.js
+++ b/static/custom/js/dispositivoFormModerno.js
@@ -11,6 +11,7 @@ document.addEventListener("DOMContentLoaded", function () {
     initializeMunicipioAjax();
     initializeConditionalFields();
     initializeDocumentSlots();
+    initializeAddDocButton();
 });
 
 // ============================================
@@ -423,6 +424,45 @@ function formatFileSize(bytes) {
     if (bytes < 1024) return bytes + " B";
     if (bytes < 1024 * 1024) return (bytes / 1024).toFixed(1) + " KB";
     return (bytes / (1024 * 1024)).toFixed(1) + " MB";
+}
+
+// ============================================
+// BOTÓN AÑADIR ARCHIVO (slots dinámicos hasta 5)
+// ============================================
+
+const ADDITIONAL_DOC_FIELDS = [
+    "documentacion_dispositivo_adicional_1",
+    "documentacion_dispositivo_adicional_2",
+    "documentacion_dispositivo_adicional_3",
+    "documentacion_dispositivo_adicional_4",
+];
+
+function initializeAddDocButton() {
+    const btn = document.getElementById("btn-add-doc");
+    if (!btn) return;
+
+    const additionalSlots = ADDITIONAL_DOC_FIELDS.map((field) =>
+        document.querySelector(`.doc-slot[data-field="${field}"]`)
+    ).filter(Boolean);
+
+    const updateButtonVisibility = () => {
+        const hasHidden = additionalSlots.some((s) =>
+            s.classList.contains("d-none")
+        );
+        btn.classList.toggle("d-none", !hasHidden);
+    };
+
+    btn.addEventListener("click", () => {
+        const nextHidden = additionalSlots.find((s) =>
+            s.classList.contains("d-none")
+        );
+        if (nextHidden) {
+            nextHidden.classList.remove("d-none");
+            updateButtonVisibility();
+        }
+    });
+
+    updateButtonVisibility();
 }
 
 // ============================================


### PR DESCRIPTION
## Resumen
Cubre los ítems 47 y 48 del evolutivo de Dispositivos / Situación de Calle (issue #1655): mostrar los slots de documentación adicional de a uno, con un botón "Añadir archivo" que revela el siguiente hasta el máximo de 5.

- Template: slot principal siempre visible. Slots adicionales 1-4 arrancan con `d-none` salvo que ya tengan archivo persistido (edición).
- JS: `initializeAddDocButton()` revela el próximo slot oculto en cada click y se auto-oculta cuando los 5 están visibles.
- Sin cambios en modelo / form / backend: los 5 FileField del form siguen como estaban.

## Test plan
- [x] `pytest dispositivos/tests/` → 16/16
- [x] `black --check` + `djlint --check` → limpio
- [x] Probado en UI