### PR TITLE
Dispositivos micro ajustes

### DIFF
--- a/dispositivos/forms.py
+++ b/dispositivos/forms.py
@@ -8,6 +8,8 @@ from .validators import DOCUMENTACION_ACCEPT_ATTR, DOCUMENTACION_UPLOAD_FIELDS
 
 
 class DispositivoForm(forms.ModelForm):
+    NINGUNA_LABEL = "Ninguna de las anteriores"
+
     DIAS_ATENCION_CHOICES = [
         ("lunes", "Lunes"),
         ("martes", "Martes"),
@@ -90,7 +92,7 @@ class DispositivoForm(forms.ModelForm):
         ("apoyo_escolar", "Apoyo escolar"),
         ("alfabetizacion", "Alfabetización"),
         ("terminalidad", "Terminalidad educativa (primaria o secundaria)"),
-        ("ninguna", "Ninguna de las anteriores"),
+        ("ninguna", NINGUNA_LABEL),
         ("otro", "Otro"),
     ]
     TIPO_INFO_REGISTRADA_CHOICES = [
@@ -127,6 +129,7 @@ class DispositivoForm(forms.ModelForm):
             "discapacidad_visual_auditiva",
             "Accesibilidad para personas con discapacidad visual o auditiva",
         ),
+        ("ninguna", NINGUNA_LABEL),
         ("otro", "Otro"),
     ]
     ARTICULACIONES_CHOICES = [
@@ -141,7 +144,7 @@ class DispositivoForm(forms.ModelForm):
         ("seguridad", "Seguridad"),
         ("organizaciones_comunitarias", "Organizaciones comunitarias"),
         ("documentacion", "Organismos de documentación/migraciones"),
-        ("ninguna", "Ninguna de las anteriores"),
+        ("ninguna", NINGUNA_LABEL),
         ("otro", "Otro"),
     ]
 
@@ -289,6 +292,18 @@ class DispositivoForm(forms.ModelForm):
         for field_name in DOCUMENTACION_UPLOAD_FIELDS:
             self.fields[field_name].widget.attrs["accept"] = DOCUMENTACION_ACCEPT_ATTR
             self.fields[field_name].help_text = "PDF, JPG o PNG. Máximo 10 MB."
+
+        self.fields["cuit_institucion"].help_text = (
+            "Debe ingresar los 11 dígitos sin puntos ni guiones"
+        )
+        self.fields["cuit_institucion"].widget.attrs.update(
+            {"inputmode": "numeric", "pattern": r"\d{11}", "maxlength": "11"}
+        )
+        self.fields["responsable_dni"].widget.attrs.update(
+            {"inputmode": "numeric", "pattern": r"\d{7,8}", "maxlength": "8"}
+        )
+        self.fields["telefono_contacto"].widget.attrs["inputmode"] = "numeric"
+
         self._apply_widgets()
 
     def _apply_widgets(self):

--- a/dispositivos/templates/dispositivos_form.html
+++ b/dispositivos/templates/dispositivos_form.html
@@ -90,7 +90,13 @@
                                  class="col-md-4 {% if form.tipo_gestion.value != 'otra' %}d-none{% endif %}">
                                 {{ form.tipo_gestion_otra|as_crispy_field }}
                             </div>
-                            <div class="col-md-4">{{ form.razon_social|as_crispy_field }}</div>
+                            <div class="col-md-4">
+                                {{ form.razon_social|as_crispy_field }}
+                                <span class="field-tooltip">
+                                    <i class="fas fa-info-circle"></i>
+                                    <span class="tooltip-text">La Razón Social es la identidad jurídica y obligatoria ante el Estado, utilizada para firmar contratos, emitir facturas y realizar trámites administrativos o legales</span>
+                                </span>
+                            </div>
                         </div>
                         <div class="form-group row">
                             <div class="col-md-4">{{ form.cuit_institucion|as_crispy_field }}</div>
@@ -395,8 +401,10 @@
                             </div>
                         </div>
                         <div class="form-group row">
-                            <div class="col-md-4">{{ form.principales_limitaciones|as_crispy_field }}</div>
-                            <div class="col-md-4">{{ form.necesidades_prioritarias|as_crispy_field }}</div>
+                            <div class="col-md-12">{{ form.principales_limitaciones|as_crispy_field }}</div>
+                        </div>
+                        <div class="form-group row">
+                            <div class="col-md-12">{{ form.necesidades_prioritarias|as_crispy_field }}</div>
                         </div>
                     </div>
                 </div>

--- a/dispositivos/tests/test_dispositivos_views.py
+++ b/dispositivos/tests/test_dispositivos_views.py
@@ -337,3 +337,27 @@ def test_formulario_muestra_wrappers_otro_cuando_dispositivo_tiene_valor(
         assert (
             "d-none" not in tag
         ), f"{wrapper_id} no debe tener d-none cuando 'otro' está seleccionado"
+
+
+@pytest.mark.django_db
+def test_formulario_micro_ajustes_visibles(client, user_con_permisos):
+    client.force_login(user_con_permisos)
+
+    response = client.get(reverse("dispositivos_crear"))
+
+    assert response.status_code == 200
+    contenido = response.content.decode("utf-8")
+    assert "La Razón Social es la identidad jurídica" in contenido
+    assert "Ninguna de las anteriores" in contenido
+    assert 'inputmode="numeric"' in contenido
+    assert "Debe ingresar los 11 dígitos sin puntos ni guiones" in contenido
+    limitaciones_idx = contenido.index('name="principales_limitaciones"')
+    necesidades_idx = contenido.index('name="necesidades_prioritarias"')
+    bloque_limitaciones = contenido[max(0, limitaciones_idx - 1500) : limitaciones_idx]
+    bloque_necesidades = contenido[max(0, necesidades_idx - 1500) : necesidades_idx]
+    assert (
+        'class="col-md-12"' in bloque_limitaciones
+    ), "Principales limitaciones debe estar en col-md-12"
+    assert (
+        'class="col-md-12"' in bloque_necesidades
+    ), "Necesidades prioritarias debe estar en col-md-12"

--- a/static/custom/js/dispositivoFormModerno.js
+++ b/static/custom/js/dispositivoFormModerno.js
@@ -12,7 +12,27 @@ document.addEventListener("DOMContentLoaded", function () {
     initializeConditionalFields();
     initializeDocumentSlots();
     initializeAddDocButton();
+    initializeNumericInputs();
 });
+
+const NUMERIC_ONLY_INPUT_IDS = [
+    "id_cuit_institucion",
+    "id_responsable_dni",
+    "id_telefono_contacto",
+];
+
+function initializeNumericInputs() {
+    NUMERIC_ONLY_INPUT_IDS.forEach((id) => {
+        const input = document.getElementById(id);
+        if (!input) return;
+        input.addEventListener("input", () => {
+            const stripped = input.value.replace(/\D/g, "");
+            if (stripped !== input.value) {
+                input.value = stripped;
+            }
+        });
+    });
+}
 
 // ============================================
 // SECCIONES COLAPSABLES


### PR DESCRIPTION
## Resumen
Cubre 7 ítems del evolutivo de Dispositivos / Situación de Calle (issue #1655) que no requerían textos del modelo ni cambios estructurales con back-fill.

- **Tk 12** — Tooltip en *Razón Social* con definición jurídica completa.
- **Tk 40** — Opción *"Ninguna de las anteriores"* agregada al listado de Infraestructura de accesibilidad. Se extrajo `NINGUNA_LABEL` como constante de clase para reutilizar en las 3 listas que ya la tenían.
- **Tk 43** — *Principales limitaciones* y *Necesidades prioritarias* pasan a apilarse en filas separadas con `col-md-12`.
- **Tks 5 / 6** — CUIT: `inputmode="numeric"` + `pattern="\d{11}"` + help text *"Debe ingresar los 11 dígitos sin puntos ni guiones"*.
- **Tk 11** — DNI Responsable: `inputmode="numeric"` + `pattern="\d{7,8}"`.
- **Tk 9 parcial** — `telefono_contacto`: `inputmode="numeric"`. El desdoble Prefijo/Teléfono queda para PR posterior porque requiere migración con estrategia de back-fill sobre datos en prod.

Bonus UX: como el form tiene `novalidate`, el atributo `pattern` no muestra mensajes nativos. Se agregó un listener JS que descarta cualquier carácter no numérico al tipear en CUIT/DNI/Teléfono.

## Test plan
- [x] `pytest dispositivos/tests/` → 19/19
- [x] `black --check dispositivos/` → limpio
- [x] `djlint dispositivos/templates/dispositivos_form.html --check` → limpio
- [x] Probado manualmente en UI: tooltip, layout, validaciones numéricas y filtro JS.
