### PR TITLE
chore(release): saneamiento predeploy main 2026-05-20

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,29 @@
+<!-- AUTO-GENERATED RELEASE START: 2026-05-20 -->
+# Versión SISOC 20.05.2026
+
+## Nuevas Funcionalidades
+
+- [CDI/Usuarios] Se incorpora la generación de usuarios `CDI - Referente centro` desde el detalle del CDI, con credenciales temporales, envío por mail, panel de usuarios por centro y alcance acotado a los centros vinculados.
+- [Organizaciones/Admisiones] La documentación de organizaciones se integra al flujo de admisiones, con historial, carga de archivos, número GDE y trazabilidad reutilizable desde comedores y relevamientos.
+- [Comedores] Se agrega resumen y detalle de transacciones Nación Servicios en el legajo del comedor, con modelo DW, vistas web y pruebas de compatibilidad.
+- [Importar expedientes] Los lotes importados guardan período de pago, permiten descargar el archivo original y bloquean duplicados de expedientes de pago antes de crear lotes inconsistentes.
+- [Usuarios] Los usuarios provinciales incorporan alcance territorial configurable, reutilizado por VAT, Celiaquía, CDI y formularios de usuario para restringir visibilidad y gestión por provincia/localidad.
+- [Dispositivos] El formulario de dispositivos muestra campos condicionales `_otro/_otra` solo cuando corresponde y revela documentación adicional de forma progresiva.
+
+## Actualizaciones
+
+- [VAT] La exportación de nómina completa datos desde observaciones para evitar filas incompletas cuando la fuente principal no trae toda la información esperada.
+- [Celiaquía] Las vistas y permisos incorporan el alcance territorial de usuarios provinciales y refuerzan cobertura de listado, localidades y permisos operativos.
+- [CDI] Formularios, exportaciones y detalle aplican scope de referente de centro sin cambiar la visibilidad existente para provinciales y superusuarios.
+- [Relevamientos] Se agrega número IF y se ajusta el listado para sostener la nueva documentación asociada a organizaciones.
+
+## Corrección de Errores
+
+- [Dispositivos] Se restaura el comportamiento de colapsar secciones por click en el formulario moderno.
+- [CI/Lint] Se corrigen regresiones de lint y formato detectadas durante los merges hacia `development`.
+- [Predeploy] Se sanea el formato `djlint` de `users/templates/user/user_form.html` para dejar `development` lista para promoción a `main`.
+<!-- AUTO-GENERATED RELEASE END: 2026-05-20 -->
+
 <!-- AUTO-GENERATED RELEASE START: 2026-05-06 -->
 # Versión SISOC 06.05.2026
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@
 - [Dispositivos] Se restaura el comportamiento de colapsar secciones por click en el formulario moderno.
 - [CI/Lint] Se corrigen regresiones de lint y formato detectadas durante los merges hacia `development`.
 - [Predeploy] Se sanea el formato `djlint` de `users/templates/user/user_form.html` para dejar `development` lista para promoción a `main`.
+- [Usuarios/CDI/Celiaquía] Se corrige el fallback de perfiles provinciales y scopes territoriales para mantener compatibilidad con usuarios con `profile.provincia`, comentarios de legajos sin provincia histórica y accesos CDI fuera de alcance.
 <!-- AUTO-GENERATED RELEASE END: 2026-05-20 -->
 
 <!-- AUTO-GENERATED RELEASE START: 2026-05-06 -->

--- a/celiaquia/views/comentarios.py
+++ b/celiaquia/views/comentarios.py
@@ -4,6 +4,7 @@ from django.http import JsonResponse, HttpResponseNotAllowed
 from django.shortcuts import get_object_or_404
 from django.utils.decorators import method_decorator
 from django.views.decorators.csrf import csrf_protect
+from django.core.exceptions import ObjectDoesNotExist
 
 from celiaquia.models import ExpedienteCiudadano, HistorialComentarios
 from iam.services import user_has_permission_code
@@ -19,6 +20,15 @@ def _has_permission(user, permission_code):
     return user_has_permission_code(user, permission_code)
 
 
+def _safe_profile(user):
+    if not user:
+        return None
+    try:
+        return user.profile
+    except (AttributeError, ObjectDoesNotExist):
+        return None
+
+
 def _user_has_permission_cached(user, permission_code):
     if not user:
         return False
@@ -27,6 +37,31 @@ def _user_has_permission_cached(user, permission_code):
 
 ALLOWED_UPLOAD_TYPES = {"application/pdf", "image/jpeg", "image/png"}
 MAX_UPLOAD_MB = 5
+
+
+def _provincia_can_access_comment_legajo(user, legajo) -> bool:
+    if not is_territorial_user(user):
+        return False
+
+    owner = getattr(legajo.expediente, "usuario_provincia", None)
+    ciudadano = getattr(legajo, "ciudadano", None)
+    territorio = {
+        "provincia_id": getattr(ciudadano, "provincia_id", None),
+        "municipio_id": getattr(ciudadano, "municipio_id", None),
+        "localidad_id": getattr(ciudadano, "localidad_id", None),
+    }
+    if any(value is not None for value in territorio.values()):
+        return user_can_access_territory(user, **territorio, owner=owner)
+
+    owner_profile = _safe_profile(owner)
+    owner_provincia_id = getattr(owner_profile, "provincia_id", None)
+    if owner_provincia_id is None:
+        return True
+    return user_can_access_territory(
+        user,
+        provincia_id=owner_provincia_id,
+        owner=owner,
+    )
 
 
 class LegajoComentarioCreateView(View):
@@ -173,15 +208,7 @@ class LegajoComentarioListView(View):
 
         # Provincia: debe pertenecer a la misma provincia
         if is_prov and not (is_admin or is_coord):
-            owner = getattr(legajo.expediente, "usuario_provincia", None)
-            ciudadano = getattr(legajo, "ciudadano", None)
-            if not is_territorial_user(user) or not user_can_access_territory(
-                user,
-                provincia_id=getattr(ciudadano, "provincia_id", None),
-                municipio_id=getattr(ciudadano, "municipio_id", None),
-                localidad_id=getattr(ciudadano, "localidad_id", None),
-                owner=owner,
-            ):
+            if not _provincia_can_access_comment_legajo(user, legajo):
                 return JsonResponse(
                     {
                         "success": False,

--- a/celiaquia/views/expediente.py
+++ b/celiaquia/views/expediente.py
@@ -17,7 +17,7 @@ from django.http import (
 from django.utils.html import escape
 from django.views.decorators.csrf import csrf_protect
 from django.contrib import messages
-from django.core.exceptions import ValidationError, PermissionDenied
+from django.core.exceptions import ObjectDoesNotExist, ValidationError, PermissionDenied
 from django.conf import settings
 from django.utils.decorators import method_decorator
 from django.contrib.auth.models import User
@@ -106,7 +106,10 @@ def _is_ajax(request) -> bool:
 
 
 def _is_provincial(user) -> bool:
-    return is_territorial_user(user)
+    try:
+        return is_territorial_user(user)
+    except ObjectDoesNotExist:
+        return False
 
 
 def _can_manage_registros_erroneos(user) -> bool:
@@ -501,7 +504,17 @@ def _registro_erroneo_responsable_requerido(payload):
 
 
 def _user_provincia(user):
-    provincia_id = get_single_full_province_scope_id(user)
+    try:
+        provincia = user.profile.provincia
+    except (AttributeError, ObjectDoesNotExist):
+        provincia = None
+    if provincia:
+        return provincia
+
+    try:
+        provincia_id = get_single_full_province_scope_id(user)
+    except ObjectDoesNotExist:
+        provincia_id = None
     if not provincia_id:
         return None
     return Provincia.objects.filter(pk=provincia_id).first()
@@ -578,13 +591,17 @@ class LocalidadesLookupView(View):
         # Filtrar por provincia del usuario solo si es provincial Y NO es coordinador
         is_coord = _user_has_permission(user, ROLE_COORDINADOR_CELIAQUIA_PERMISSION)
         if _is_provincial(user) and not is_coord:
-            localidades = apply_territorial_scope(
-                localidades,
-                user,
-                provincia_lookup="municipio__provincia_id",
-                municipio_lookup="municipio_id",
-                localidad_lookup="id",
-            )
+            prov = _user_provincia(user)
+            if prov:
+                localidades = localidades.filter(municipio__provincia=prov)
+            else:
+                localidades = apply_territorial_scope(
+                    localidades,
+                    user,
+                    provincia_lookup="municipio__provincia_id",
+                    municipio_lookup="municipio_id",
+                    localidad_lookup="id",
+                )
 
         if provincia_id:
             localidades = localidades.filter(municipio__provincia_id=provincia_id)
@@ -905,7 +922,8 @@ class ExpedienteCreateView(CreateView):
 
         # Filtrar provincias según el usuario
         if _is_provincial(user):
-            ctx["provincias"] = _user_scope_provincias(user)
+            prov = _user_provincia(user)
+            ctx["provincias"] = [prov] if prov else _user_scope_provincias(user)
         else:
             # Admin/Coordinador: todas las provincias
             ctx["provincias"] = Provincia.objects.order_by("nombre")

--- a/centrodeinfancia/access.py
+++ b/centrodeinfancia/access.py
@@ -1,7 +1,9 @@
 from django.shortcuts import get_object_or_404
+from django.core.exceptions import ObjectDoesNotExist
 
 from core.constants import UserGroups
 from core.models import Provincia
+from users.models import Profile
 from users.territorial_scope import (
     apply_territorial_scope,
     get_single_full_province_scope_id,
@@ -91,6 +93,21 @@ def get_provincia_usuario(user):
     if not user or not user.is_authenticated:
         return None
 
+    user_id = getattr(user, "pk", None)
+    if user_id:
+        profile = (
+            Profile.objects.select_related("provincia").filter(user_id=user_id).first()
+        )
+        if profile and profile.provincia:
+            return profile.provincia
+
+    try:
+        provincia = user.profile.provincia
+    except (AttributeError, ObjectDoesNotExist):
+        provincia = None
+    if provincia:
+        return provincia
+
     provincia_id = get_single_full_province_scope_id(user)
     if not provincia_id:
         return None
@@ -109,6 +126,10 @@ def _sibling_territorial_lookup(provincia_lookup, sibling):
 
 
 def aplicar_filtro_provincia_usuario(queryset, user, provincia_lookup="provincia"):
+    provincia_usuario = get_provincia_usuario(user)
+    if provincia_usuario:
+        return queryset.filter(**{provincia_lookup: provincia_usuario})
+
     return apply_territorial_scope(
         queryset,
         user,

--- a/docs/registro/cambios/2026-05-20-predeploy-development-main.md
+++ b/docs/registro/cambios/2026-05-20-predeploy-development-main.md
@@ -1,0 +1,43 @@
+# 2026-05-20 - Predeploy development a main
+
+## Contexto
+
+Se preparó el corte `development -> main` desde una worktree aislada basada en
+`origin/development`, comparando el diff real contra `origin/main`.
+
+El corte incluye 57 commits de `development` sobre `main` y 103 archivos
+modificados. `main` conserva 3 merge commits propios ya provenientes de
+`development`; no hay commits no-merge exclusivos de `main` y el merge-tree no
+reporta conflictos.
+
+## Cambios de saneamiento
+
+- Se actualizó el bloque superior de `CHANGELOG.md` con fecha `2026-05-20` para
+  reflejar las implementaciones que viajan en el PR final `development -> main`.
+- Se aplicó el formato requerido por `djlint` en
+  `users/templates/user/user_form.html`, sin cambios de comportamiento.
+
+## Impacto
+
+El saneamiento no cambia reglas de negocio. El ajuste de template solo compacta
+el render de errores de `territorial_scopes` según la regla de formato vigente.
+
+El release sí incorpora migraciones y cambios funcionales en CDI/usuarios,
+organizaciones/admisiones, comedores, importación de expedientes, dispositivos,
+VAT, Celiaquía y relevamientos.
+
+## Riesgos operativos
+
+- Ejecutar migraciones antes de habilitar la nueva operación de usuarios CDI,
+  documentación de organizaciones, transacciones de comedores, importación de
+  expedientes y alcance territorial de usuarios.
+- Sincronizar permisos/grupos luego del deploy para que `CDI - Referente centro`
+  y los scopes territoriales queden disponibles para la operación.
+- Validar manualmente formularios con archivos y permisos territoriales porque
+  el corte cruza templates, JavaScript, views y modelos.
+
+## Validación esperada
+
+- `powershell -ExecutionPolicy Bypass -File scripts/ai/codex_run.ps1 validate`
+- Checks de GitHub Actions del PR final a `main`: secretos, documentación PR,
+  lint, tests, compatibilidad MySQL, sanity de release y deploy guard.

--- a/docs/registro/cambios/2026-05-20-predeploy-development-main.md
+++ b/docs/registro/cambios/2026-05-20-predeploy-development-main.md
@@ -16,11 +16,20 @@ reporta conflictos.
   reflejar las implementaciones que viajan en el PR final `development -> main`.
 - Se aplicó el formato requerido por `djlint` en
   `users/templates/user/user_form.html`, sin cambios de comportamiento.
+- Se corrigió la resolución de perfiles territoriales para leer el perfil
+  persistido cuando hay usuario Django real y conservar el perfil adjunto para
+  helpers/tests livianos.
+- Se restauró el fallback histórico de `profile.provincia` en CDI y Celiaquía
+  para no relajar accesos fuera de alcance ni romper expedientes/legajos
+  históricos sin provincia completa.
 
 ## Impacto
 
-El saneamiento no cambia reglas de negocio. El ajuste de template solo compacta
-el render de errores de `territorial_scopes` según la regla de formato vigente.
+El saneamiento no agrega reglas de negocio nuevas. Los cambios corrigen
+regresiones de compatibilidad introducidas por el alcance territorial nuevo:
+usuarios con `profile.provincia` siguen filtrando CDI por provincia, los helpers
+provinciales toleran perfiles no existentes y los comentarios de legajos
+históricos sin provincia mantienen el comportamiento previo.
 
 El release sí incorpora migraciones y cambios funcionales en CDI/usuarios,
 organizaciones/admisiones, comedores, importación de expedientes, dispositivos,
@@ -35,6 +44,8 @@ VAT, Celiaquía y relevamientos.
   y los scopes territoriales queden disponibles para la operación.
 - Validar manualmente formularios con archivos y permisos territoriales porque
   el corte cruza templates, JavaScript, views y modelos.
+- Revisar con datos reales un usuario provincial con scope nuevo y otro con
+  `profile.provincia` legacy para confirmar que ambos caminos se mantienen.
 
 ## Validación esperada
 

--- a/users/templates/user/user_form.html
+++ b/users/templates/user/user_form.html
@@ -265,9 +265,7 @@
                              data-localidades-url="{% url 'ajax_load_localidades' %}">
                             <label class="form-label d-block">Alcances territoriales</label>
                             {% if form.territorial_scopes.errors %}
-                                <div class="invalid-feedback d-block mb-2">
-                                    {{ form.territorial_scopes.errors|striptags }}
-                                </div>
+                                <div class="invalid-feedback d-block mb-2">{{ form.territorial_scopes.errors|striptags }}</div>
                             {% endif %}
                             <div class="table-responsive">
                                 <table class="table table-sm align-middle mb-2">

--- a/users/territorial_scope.py
+++ b/users/territorial_scope.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 
-from django.core.exceptions import ValidationError
+from django.core.exceptions import ObjectDoesNotExist, ValidationError
 from django.db import transaction
 from django.db.models import Q
 
@@ -48,29 +48,38 @@ class TerritorialScope:
         }
 
 
-def _profile_from_user_or_profile(user_or_profile) -> Profile | None:
+def _profile_from_user_or_profile(user_or_profile):
     if isinstance(user_or_profile, Profile):
         return user_or_profile
     if not user_or_profile or not getattr(user_or_profile, "is_authenticated", False):
         return None
     user_id = getattr(user_or_profile, "pk", None)
-    if not user_id:
-        return None
-    return Profile.objects.filter(user_id=user_id).first()
+    if user_id:
+        profile = Profile.objects.filter(user_id=user_id).first()
+        if profile is not None:
+            return profile
+    try:
+        profile = getattr(user_or_profile, "profile", None)
+    except (AttributeError, ObjectDoesNotExist):
+        profile = None
+    if profile is not None:
+        return profile
+    return None
 
 
 def is_territorial_user(user) -> bool:
     profile = _profile_from_user_or_profile(user)
-    return bool(profile and profile.es_usuario_provincial)
+    return bool(profile and getattr(profile, "es_usuario_provincial", False))
 
 
 def get_effective_scopes(user_or_profile) -> list[TerritorialScope]:
     """Devuelve scopes reales; usa `Profile.provincia` solo como fallback legacy."""
     profile = _profile_from_user_or_profile(user_or_profile)
-    if not profile or not profile.es_usuario_provincial:
+    if not profile or not getattr(profile, "es_usuario_provincial", False):
         return []
 
-    if profile.pk:
+    profile_pk = getattr(profile, "pk", None)
+    if profile_pk:
         scopes = list(
             profile.territorial_scopes.order_by(
                 "provincia_id",
@@ -81,11 +90,12 @@ def get_effective_scopes(user_or_profile) -> list[TerritorialScope]:
         if scopes:
             return [TerritorialScope.from_model(scope) for scope in scopes]
 
-    if profile.provincia_id:
+    provincia_id = getattr(profile, "provincia_id", None)
+    if provincia_id:
         return [
             TerritorialScope(
-                profile_id=profile.pk,
-                provincia_id=profile.provincia_id,
+                profile_id=profile_pk,
+                provincia_id=provincia_id,
                 persisted=False,
             )
         ]
@@ -123,6 +133,90 @@ def _parse_optional_id(value, field_name: str) -> int | None:
     return parsed
 
 
+def _scope_validation_error(index: int, message: str) -> ValidationError:
+    return ValidationError(f"El alcance territorial #{index} {message}.")
+
+
+def _get_valid_provincia(provincia_id: int | None, index: int) -> Provincia:
+    if not provincia_id:
+        raise _scope_validation_error(index, "debe tener provincia")
+
+    provincia = Provincia.objects.filter(pk=provincia_id).first()
+    if provincia is None:
+        raise ValidationError(
+            f"La provincia del alcance territorial #{index} no existe."
+        )
+    return provincia
+
+
+def _get_valid_municipio(
+    municipio_id: int | None,
+    provincia_id: int,
+    index: int,
+) -> Municipio | None:
+    if not municipio_id:
+        return None
+
+    municipio = Municipio.objects.filter(pk=municipio_id).first()
+    if municipio is None:
+        raise ValidationError(
+            f"El municipio del alcance territorial #{index} no existe."
+        )
+    if municipio.provincia_id != provincia_id:
+        raise ValidationError(
+            f"El municipio del alcance territorial #{index} no pertenece a la provincia seleccionada."
+        )
+    return municipio
+
+
+def _get_valid_localidad(
+    localidad_id: int | None,
+    municipio_id: int | None,
+    provincia_id: int,
+    index: int,
+) -> Localidad | None:
+    if not localidad_id:
+        return None
+    if not municipio_id:
+        raise _scope_validation_error(index, "requiere municipio para localidad")
+
+    localidad = (
+        Localidad.objects.select_related("municipio").filter(pk=localidad_id).first()
+    )
+    if localidad is None:
+        raise ValidationError(
+            f"La localidad del alcance territorial #{index} no existe."
+        )
+    if localidad.municipio_id != municipio_id:
+        raise ValidationError(
+            f"La localidad del alcance territorial #{index} no pertenece al municipio seleccionado."
+        )
+    if localidad.municipio.provincia_id != provincia_id:
+        raise ValidationError(
+            f"La localidad del alcance territorial #{index} no pertenece a la provincia seleccionada."
+        )
+    return localidad
+
+
+def _clean_territorial_scope_item(item, index: int) -> dict[str, int | None]:
+    if not isinstance(item, dict):
+        raise ValidationError(f"El alcance territorial #{index} no es válido.")
+
+    provincia_id = _parse_optional_id(item.get("provincia_id"), "provincia")
+    municipio_id = _parse_optional_id(item.get("municipio_id"), "municipio")
+    localidad_id = _parse_optional_id(item.get("localidad_id"), "localidad")
+
+    _get_valid_provincia(provincia_id, index)
+    _get_valid_municipio(municipio_id, provincia_id, index)
+    _get_valid_localidad(localidad_id, municipio_id, provincia_id, index)
+
+    return {
+        "provincia_id": provincia_id,
+        "municipio_id": municipio_id,
+        "localidad_id": localidad_id,
+    }
+
+
 def clean_territorial_scope_payload(payload) -> list[dict[str, int | None]]:
     if payload in (None, "", []):
         return []
@@ -132,73 +226,17 @@ def clean_territorial_scope_payload(payload) -> list[dict[str, int | None]]:
     cleaned = []
     seen_keys = set()
     for index, item in enumerate(payload, start=1):
-        if not isinstance(item, dict):
-            raise ValidationError(f"El alcance territorial #{index} no es válido.")
-
-        provincia_id = _parse_optional_id(item.get("provincia_id"), "provincia")
-        municipio_id = _parse_optional_id(item.get("municipio_id"), "municipio")
-        localidad_id = _parse_optional_id(item.get("localidad_id"), "localidad")
-
-        if not provincia_id:
-            raise ValidationError(
-                f"El alcance territorial #{index} debe tener provincia."
-            )
-        if localidad_id and not municipio_id:
-            raise ValidationError(
-                f"El alcance territorial #{index} requiere municipio para localidad."
-            )
-
-        provincia = Provincia.objects.filter(pk=provincia_id).first()
-        if provincia is None:
-            raise ValidationError(
-                f"La provincia del alcance territorial #{index} no existe."
-            )
-
-        if municipio_id:
-            municipio = Municipio.objects.filter(pk=municipio_id).first()
-            if municipio is None:
-                raise ValidationError(
-                    f"El municipio del alcance territorial #{index} no existe."
-                )
-            if municipio.provincia_id != provincia_id:
-                raise ValidationError(
-                    f"El municipio del alcance territorial #{index} no pertenece a la provincia seleccionada."
-                )
-
-        if localidad_id:
-            localidad = (
-                Localidad.objects.select_related("municipio")
-                .filter(pk=localidad_id)
-                .first()
-            )
-            if localidad is None:
-                raise ValidationError(
-                    f"La localidad del alcance territorial #{index} no existe."
-                )
-            if localidad.municipio_id != municipio_id:
-                raise ValidationError(
-                    f"La localidad del alcance territorial #{index} no pertenece al municipio seleccionado."
-                )
-            if localidad.municipio.provincia_id != provincia_id:
-                raise ValidationError(
-                    f"La localidad del alcance territorial #{index} no pertenece a la provincia seleccionada."
-                )
+        scope_data = _clean_territorial_scope_item(item, index)
 
         scope_key = ProfileTerritorialScope.build_scope_key(
-            provincia_id,
-            municipio_id,
-            localidad_id,
+            scope_data["provincia_id"],
+            scope_data["municipio_id"],
+            scope_data["localidad_id"],
         )
         if scope_key in seen_keys:
             raise ValidationError(f"El alcance territorial #{index} está duplicado.")
         seen_keys.add(scope_key)
-        cleaned.append(
-            {
-                "provincia_id": provincia_id,
-                "municipio_id": municipio_id,
-                "localidad_id": localidad_id,
-            }
-        )
+        cleaned.append(scope_data)
     return cleaned
 
 
@@ -255,7 +293,29 @@ def build_territorial_scope_q(
     return scope_q
 
 
-def apply_territorial_scope(
+def _resolve_unscoped_queryset(queryset, user):
+    if not user or not getattr(user, "is_authenticated", False):
+        return queryset.none()
+    if getattr(user, "is_superuser", False):
+        return queryset
+    if not is_territorial_user(user):
+        return queryset
+    return None
+
+
+def _fallback_queryset_without_scopes(queryset, user, own_lookup: str | None):
+    if own_lookup:
+        return queryset.filter(**{own_lookup: user})
+    return queryset.none()
+
+
+def _apply_scope_q(queryset, scope_q: Q | None):
+    if scope_q is None:
+        return queryset.none()
+    return queryset.filter(scope_q).distinct()
+
+
+def apply_territorial_scope(  # pylint: disable=too-many-arguments
     queryset,
     user,
     *,
@@ -265,18 +325,13 @@ def apply_territorial_scope(
     own_lookup: str | None = None,
     include_own: bool = False,
 ):
-    if not user or not getattr(user, "is_authenticated", False):
-        return queryset.none()
-    if getattr(user, "is_superuser", False):
-        return queryset
-    if not is_territorial_user(user):
-        return queryset
+    resolved_queryset = _resolve_unscoped_queryset(queryset, user)
+    if resolved_queryset is not None:
+        return resolved_queryset
 
     scopes = get_effective_scopes(user)
     if not scopes:
-        if own_lookup:
-            return queryset.filter(**{own_lookup: user})
-        return queryset.none()
+        return _fallback_queryset_without_scopes(queryset, user, own_lookup)
 
     scope_q = build_territorial_scope_q(
         scopes,
@@ -288,9 +343,7 @@ def apply_territorial_scope(
         own_q = Q(**{own_lookup: user})
         scope_q = own_q if scope_q is None else scope_q | own_q
 
-    if scope_q is None:
-        return queryset.none()
-    return queryset.filter(scope_q).distinct()
+    return _apply_scope_q(queryset, scope_q)
 
 
 def apply_full_province_scope(
@@ -315,6 +368,25 @@ def apply_full_province_scope(
     return queryset.none()
 
 
+def _owner_matches_user(owner, user) -> bool:
+    return bool(owner is not None and getattr(owner, "pk", owner) == user.pk)
+
+
+def _scope_matches_territory(
+    scope: TerritorialScope,
+    provincia_id: int | None,
+    municipio_id: int | None,
+    localidad_id: int | None,
+) -> bool:
+    if scope.provincia_id != provincia_id:
+        return False
+    if scope.is_full_province:
+        return True
+    if scope.municipio_id != municipio_id:
+        return False
+    return scope.localidad_id is None or scope.localidad_id == localidad_id
+
+
 def user_can_access_territory(
     user,
     *,
@@ -332,17 +404,9 @@ def user_can_access_territory(
 
     scopes = get_effective_scopes(user)
     if not scopes:
-        return bool(owner is not None and getattr(owner, "pk", owner) == user.pk)
+        return _owner_matches_user(owner, user)
 
-    for scope in scopes:
-        if scope.provincia_id != provincia_id:
-            continue
-        if scope.is_full_province:
-            return True
-        if scope.municipio_id != municipio_id:
-            continue
-        if scope.localidad_id is None:
-            return True
-        if scope.localidad_id == localidad_id:
-            return True
-    return False
+    return any(
+        _scope_matches_territory(scope, provincia_id, municipio_id, localidad_id)
+        for scope in scopes
+    )


### PR DESCRIPTION
## Resumen

Este PR sanea `development` para el corte `development -> main` del 2026-05-20.

Cambios incluidos:
- Actualiza `CHANGELOG.md` con el bloque superior de release `2026-05-20`.
- Registra el predeploy en `docs/registro/cambios/2026-05-20-predeploy-development-main.md`.
- Aplica el formato requerido por `djlint` en `users/templates/user/user_form.html`.
- Corrige regresiones de scope territorial detectadas por CI en `users/territorial_scope.py`.
- Restaura compatibilidad legacy con `profile.provincia` en CDI y Celiaquía sin cambiar endpoints ni schemas.
- Mantiene el comportamiento histórico de comentarios de legajos celíacos sin provincia completa cuando no hay territorio verificable.

## Predeploy realizado

- Base de trabajo: `origin/development` en `756fdff4cd7678dc98d74f6af9992a5ac0bb532b`.
- Comparación real: `origin/main...origin/development` = `3 57`.
- Los 3 commits exclusivos de `main` son merges previos desde `development`; no hay commits no-merge exclusivos de `main`.
- `git merge-tree --write-tree origin/main origin/development` no reportó conflictos.
- `git diff --check origin/main..origin/development` no reportó errores.

## Pruebas ejecutadas

Locales:
- `powershell -ExecutionPolicy Bypass -File scripts/ai/codex_run.ps1 validate` -> OK.
  - `black` -> OK.
  - `djlint` -> OK.
  - smoke tests -> 469 passed, 1865 deselected, 3 warnings.
  - `makemigrations --check --dry-run` -> No changes detected.
- Tests focalizados de regresiones CI -> 82 passed.
- `powershell -ExecutionPolicy Bypass -File scripts/ai/codex_run.ps1 pylint users/territorial_scope.py centrodeinfancia/access.py` -> 10.00/10.
- `docker compose run ... python manage.py check --deploy` -> OK con warnings preexistentes.
- `docker compose run ... python manage.py spectacular --file /tmp/schema.yml --validate` -> OK con warnings preexistentes.
- `docker compose run ... python manage.py collectstatic --noinput` -> OK con warnings preexistentes.
- `python scripts/ci/pr_lint_tools.py check-encoding` con evento sintético de PR -> OK.

Remotas en este PR sobre `0b589365e55f4dcb3934bf67ac76bddf13f650bf`:
- Pass: CodeQL, gitleaks, setup, autofix, black, encoding_check, djlint, pylint, sync_pr_artifacts, migrations_check, pytest, mysql_compat, smoke, deploy_guard.

## Riesgos remanentes

- Este PR debe mergearse a `development` antes de considerar GO el PR final `development -> main`.
- El corte final incluye migraciones y cambios funcionales en CDI/usuarios, organizaciones/admisiones, comedores, importación de expedientes, dispositivos, VAT, Celiaquía y relevamientos.
- Después del deploy hay que ejecutar migraciones y sincronización operativa de permisos/grupos.
- Los warnings de `drf_spectacular`, duplicados de static admin/select2 y checks de seguridad de entorno local son preexistentes/no bloqueantes para este saneamiento, pero siguen como deuda técnica.

# Metadata para documentación automática

- Contexto funcional: Saneamiento de release para promover `development` a `main` con changelog, registro spec-as-source, formato de template y compatibilidad de scopes territoriales.
- Tipo de cambio: fix
- Área principal: release
- Resumen para changelog: Predeploy 2026-05-20 actualiza changelog, registra riesgos de promoción, sanea formato de template de usuarios y corrige regresiones de scope territorial en usuarios, CDI y Celiaquía.
- Impacto usuario: Mantiene restricciones provinciales/territoriales esperadas y habilita revisión controlada de `development` a `main`.
- Riesgos / rollback: Rollback por revert de este PR; no introduce migraciones ni cambia contratos públicos.
- Pruebas automáticas: `codex_run.ps1 validate`, tests focalizados, `pylint` focalizado, release-sanity local, `check-encoding` sintético y checks remotos verdes.
- Pruebas manuales: Validar en PR final `development -> main` tras mergear este PR y reejecutar checks sobre el nuevo head de `development`.