### PR TITLE
feat(dispositivos): aplicar textos del Google Form modelo de referencia

### DIFF
--- a/dispositivos/forms.py
+++ b/dispositivos/forms.py
@@ -29,8 +29,14 @@ class DispositivoForm(forms.ModelForm):
     POBLACION_DESTINATARIA_CHOICES = [
         ("hombres", "Hombres"),
         ("mujeres", "Mujeres"),
-        ("familia_monoparental", "Familia monoparental"),
-        ("familia_nuclear", "Familia nuclear"),
+        (
+            "familia_monoparental",
+            "Familia monoparental (un solo adulto con hijos/as.)",
+        ),
+        (
+            "familia_nuclear",
+            "Familia nuclear (pareja -o dos adultos- con hijos/as.)",
+        ),
         ("lgbtiq", "Personas LGBTIQ+"),
         ("otro", "Otro"),
     ]
@@ -133,7 +139,7 @@ class DispositivoForm(forms.ModelForm):
         ("otro", "Otro"),
     ]
     ARTICULACIONES_CHOICES = [
-        ("salud", "Salud"),
+        ("salud", "Salud (hospitales, centros de salud, salud mental)"),
         ("consumos", "Consumos problemáticos"),
         ("desarrollo_social", "Desarrollo social"),
         ("justicia", "Justicia y asesoramiento legal"),
@@ -141,12 +147,199 @@ class DispositivoForm(forms.ModelForm):
         ("genero", "Género y violencias"),
         ("empleo", "Empleo y formación laboral"),
         ("discapacidad", "Discapacidad"),
-        ("seguridad", "Seguridad"),
-        ("organizaciones_comunitarias", "Organizaciones comunitarias"),
+        ("seguridad", "Seguridad (policía/comisarías)"),
+        (
+            "organizaciones_comunitarias",
+            "Organizaciones comunitarias (comedores, roperos, etc.)",
+        ),
         ("documentacion", "Organismos de documentación/migraciones"),
         ("ninguna", NINGUNA_LABEL),
         ("otro", "Otro"),
     ]
+
+    FIELD_LABELS_AND_HELP = {
+        "nombre_institucion": {
+            "label": "Nombre completo de la institución",
+        },
+        "tipo_gestion": {
+            "label": "Tipo de gestión del dispositivo",
+            "help_text": (
+                "Refiere al tipo de institución que gestiona el dispositivo o "
+                "a la modalidad de sostenimiento bajo la que funciona."
+            ),
+        },
+        "razon_social": {"label": "Razón social"},
+        "cuit_institucion": {
+            "label": "CUIT de la institución",
+            "help_text": "Debe ingresar los 11 dígitos sin puntos ni guiones",
+        },
+        "correo_electronico": {
+            "label": "Correo electrónico",
+            "help_text": (
+                "En caso de poseer un correo institucional, indique el mismo"
+            ),
+        },
+        "responsable_nombre_completo": {
+            "label": "Nombre completo del responsable del dispositivo",
+        },
+        "responsable_dni": {
+            "label": "DNI del responsable del dispositivo",
+            "help_text": "Solo números sin puntos",
+        },
+        "tipo_dispositivo": {
+            "label": "Tipo de dispositivo",
+            "help_text": (
+                "Refiere a la categoría del dispositivo según el tipo de "
+                "servicio principal que brinda a las personas en situación de "
+                "calle."
+            ),
+        },
+        "modalidad_funcionamiento": {"label": "Modalidad de funcionamiento"},
+        "dias_atencion": {
+            "label": "Días de atención",
+            "help_text": (
+                "Marque todos los días en los que el dispositivo se encuentra "
+                "en funcionamiento."
+            ),
+        },
+        "horarios_funcionamiento": {"label": "Horario de funcionamiento"},
+        "capacidad_total_plazas": {
+            "label": "Capacidad total de plazas",
+            "help_text": (
+                "Indique la cantidad máxima de personas que el dispositivo "
+                "puede alojar simultáneamente."
+            ),
+        },
+        "poblacion_destinataria": {
+            "label": "Población destinataria del dispositivo",
+            "help_text": (
+                "Seleccione todas las opciones que correspondan según la "
+                "población a la que está dirigido el dispositivo. Puede marcar "
+                "más de una opción."
+            ),
+        },
+        "franja_etaria_destinataria": {
+            "label": "Franja etaria de la población destinataria",
+            "help_text": (
+                "Seleccione todas las opciones que correspondan según la "
+                "población a la que está dirigido el dispositivo. Puede marcar "
+                "más de una opción."
+            ),
+        },
+        "tiempo_permanencia_promedio": {
+            "label": "Tiempo promedio de permanencia en el dispositivo",
+            "help_text": (
+                "Refiere al tiempo promedio que las personas suelen permanecer "
+                "en el dispositivo. Considere la estadía habitual, no casos "
+                "excepcionales."
+            ),
+        },
+        "modalidad_ingreso": {
+            "label": "Modalidad de ingreso al dispositivo",
+            "help_text": (
+                "Indique las modalidades a través de las cuales las personas "
+                "acceden al dispositivo. Puede seleccionar más de una opción."
+            ),
+        },
+        "documentacion_ingreso": {
+            "label": "Documentación necesaria para el ingreso",
+            "help_text": (
+                "Indique la documentación que se solicita a las personas para "
+                "habilitar su ingreso al dispositivo. Puede seleccionar más de "
+                "una opción. En caso de requerir, puede agregar una opción "
+                'adicional en "Otros".'
+            ),
+        },
+        "requisitos_ingreso": {
+            "label": "Requisitos para el ingreso",
+            "help_text": (
+                "Indique los requisitos y condiciones que se solicitan a las "
+                "personas para ingresar y permanecer en el dispositivo (por "
+                "ejemplo, horarios, firma de acuerdos, restricciones). Puede "
+                "seleccionar más de una opción."
+            ),
+        },
+        "tipos_actividades_formativas": {
+            "label": "¿Qué tipo de actividades formativas se ofrecen?",
+            "help_text": (
+                "Seleccione los servicios y prestaciones que el dispositivo "
+                "brinda de manera habitual a las personas atendidas o "
+                "alojadas. Puede marcar más de una opción."
+            ),
+        },
+        "actividades_certificacion_oficial": {
+            "label": ("¿Las actividades formativas cuentan con certificación oficial?"),
+        },
+        "registra_informacion_personas": {
+            "label": (
+                "¿El dispositivo registra información sobre las personas "
+                "alojadas o asistidas?"
+            ),
+        },
+        "modo_registro": {"label": "¿De qué manera realizan ese registro?"},
+        "tipo_informacion_registrada": {
+            "label": "¿Qué tipo de información registran?",
+            "help_text": (
+                "Seleccione los tipos de información que el dispositivo "
+                "registra sobre las personas atendidas. Puede marcar más de "
+                'una opción. En caso de corresponder, puede agregar otras en "Otros".'
+            ),
+        },
+        "infraestructura_disponible": {
+            "label": "Infraestructura disponible",
+            "help_text": (
+                "Seleccione todas las que corresponda. Puede marcar más de "
+                'una opción. En caso de requerir, puede agregar otras en "Otros".'
+            ),
+        },
+        "infraestructura_accesibilidad": {
+            "label": "Infraestructura de Accesibilidad",
+            "help_text": (
+                "Seleccione todas las que corresponda. Puede marcar más de "
+                'una opción. En caso de requerir, puede agregar otras en "Otros".'
+            ),
+        },
+        "principales_limitaciones": {
+            "label": "Principales limitaciones del dispositivo",
+            "help_text": (
+                "Indicar brevemente las principales dificultades que enfrenta "
+                "el dispositivo en su funcionamiento."
+            ),
+        },
+        "necesidades_prioritarias": {
+            "label": "Necesidades prioritarias",
+            "help_text": (
+                "Indicar necesidades materiales, de capacitación o "
+                "fortalecimiento institucional."
+            ),
+        },
+        "articulaciones_institucionales": {
+            "label": "¿Con qué tipos de instituciones articula habitualmente?",
+        },
+        "observaciones_adicionales": {
+            "label": "Observaciones adicionales",
+            "help_text": (
+                "Puede utilizar este espacio para agregar comentarios, "
+                "aclaraciones o información adicional sobre el dispositivo "
+                "que considere relevante."
+            ),
+        },
+        "documentacion_dispositivo": {
+            "label": "Adjuntar documentación del dispositivo",
+            "help_text": (
+                "Puede adjuntar documentación institucional vinculada al "
+                "funcionamiento del dispositivo, por ejemplo: protocolos o "
+                "circuitos de admisión, manuales de funcionamiento, "
+                "reglamentos internos, guías de intervención, materiales "
+                "institucionales sobre el dispositivo. PDF, JPG o PNG. "
+                "Máximo 10 MB."
+            ),
+        },
+        "documentacion_dispositivo_adicional_1": {"label": "Documentación adicional 1"},
+        "documentacion_dispositivo_adicional_2": {"label": "Documentación adicional 2"},
+        "documentacion_dispositivo_adicional_3": {"label": "Documentación adicional 3"},
+        "documentacion_dispositivo_adicional_4": {"label": "Documentación adicional 4"},
+    }
 
     dias_atencion = forms.MultipleChoiceField(
         required=False,
@@ -276,26 +469,27 @@ class DispositivoForm(forms.ModelForm):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
         self._configure_geography_fields()
-        self.fields["documentacion_dispositivo"].label = "Documentación del dispositivo"
-        self.fields["documentacion_dispositivo_adicional_1"].label = (
-            "Documentación adicional 1"
-        )
-        self.fields["documentacion_dispositivo_adicional_2"].label = (
-            "Documentación adicional 2"
-        )
-        self.fields["documentacion_dispositivo_adicional_3"].label = (
-            "Documentación adicional 3"
-        )
-        self.fields["documentacion_dispositivo_adicional_4"].label = (
-            "Documentación adicional 4"
-        )
+        self._apply_field_texts()
+        self._configure_upload_fields()
+        self._configure_numeric_inputs()
+        self._apply_widgets()
+
+    def _apply_field_texts(self):
+        for field_name, texts in self.FIELD_LABELS_AND_HELP.items():
+            if field_name not in self.fields:
+                continue
+            if "label" in texts:
+                self.fields[field_name].label = texts["label"]
+            if "help_text" in texts:
+                self.fields[field_name].help_text = texts["help_text"]
+
+    def _configure_upload_fields(self):
         for field_name in DOCUMENTACION_UPLOAD_FIELDS:
             self.fields[field_name].widget.attrs["accept"] = DOCUMENTACION_ACCEPT_ATTR
-            self.fields[field_name].help_text = "PDF, JPG o PNG. Máximo 10 MB."
+            if not self.fields[field_name].help_text:
+                self.fields[field_name].help_text = "PDF, JPG o PNG. Máximo 10 MB."
 
-        self.fields["cuit_institucion"].help_text = (
-            "Debe ingresar los 11 dígitos sin puntos ni guiones"
-        )
+    def _configure_numeric_inputs(self):
         self.fields["cuit_institucion"].widget.attrs.update(
             {"inputmode": "numeric", "pattern": r"\d{11}", "maxlength": "11"}
         )
@@ -303,8 +497,6 @@ class DispositivoForm(forms.ModelForm):
             {"inputmode": "numeric", "pattern": r"\d{7,8}", "maxlength": "8"}
         )
         self.fields["telefono_contacto"].widget.attrs["inputmode"] = "numeric"
-
-        self._apply_widgets()
 
     def _apply_widgets(self):
         for field in self.fields.values():

--- a/dispositivos/templates/dispositivos_form.html
+++ b/dispositivos/templates/dispositivos_form.html
@@ -68,7 +68,9 @@
                             </div>
                             <div class="section-title-group">
                                 <h3 class="section-title">Identificación del dispositivo</h3>
-                                <p class="section-subtitle">Datos generales e institución responsable</p>
+                                <p class="section-subtitle">
+                                    Esta sección releva los datos generales del dispositivo, su localización, la información de contacto institucional y los datos de la persona responsable.
+                                </p>
                             </div>
                         </div>
                         <div class="section-status">
@@ -124,7 +126,9 @@
                             </div>
                             <div class="section-title-group">
                                 <h3 class="section-title">Características del dispositivo</h3>
-                                <p class="section-subtitle">Tipo, modalidad, capacidad y horarios</p>
+                                <p class="section-subtitle">
+                                    En esta sección se releva el tipo de dispositivo y su modalidad de atención. Seleccione la opción que mejor describa su funcionamiento principal. En caso de realizar múltiples actividades, priorice aquella que define su función principal.
+                                </p>
                             </div>
                         </div>
                         <div class="section-status">
@@ -164,7 +168,9 @@
                             </div>
                             <div class="section-title-group">
                                 <h3 class="section-title">Población destinataria</h3>
-                                <p class="section-subtitle">Perfil y franjas etarias de las personas atendidas</p>
+                                <p class="section-subtitle">
+                                    En esta sección se releva el perfil de la población destinataria del dispositivo, incluyendo características sociodemográficas y el tiempo de permanencia habitual.
+                                </p>
                             </div>
                         </div>
                         <div class="section-status">
@@ -212,7 +218,9 @@
                             </div>
                             <div class="section-title-group">
                                 <h3 class="section-title">Modalidad de ingreso</h3>
-                                <p class="section-subtitle">Cómo acceden las personas al dispositivo</p>
+                                <p class="section-subtitle">
+                                    En esta sección se releva cómo acceden las personas al dispositivo, qué documentación se solicita al momento del ingreso y cuáles son los requisitos o condiciones establecidos para su admisión.
+                                </p>
                             </div>
                         </div>
                         <div class="section-status">
@@ -268,7 +276,9 @@
                             </div>
                             <div class="section-title-group">
                                 <h3 class="section-title">Servicios brindados</h3>
-                                <p class="section-subtitle">Prestaciones y actividades ofrecidas</p>
+                                <p class="section-subtitle">
+                                    En esta sección se releva el tipo de servicios y prestaciones que el dispositivo brinda a las personas. Considere aquellas que se ofrecen de manera habitual.
+                                </p>
                             </div>
                         </div>
                         <div class="section-status">
@@ -318,7 +328,9 @@
                             </div>
                             <div class="section-title-group">
                                 <h3 class="section-title">Sistema de registro de personas usuarias</h3>
-                                <p class="section-subtitle">Cómo se registra la información de quienes asisten</p>
+                                <p class="section-subtitle">
+                                    En esta sección se releva si el dispositivo registra información sobre las personas atendidas, los medios utilizados para ese registro y el tipo de información que se releva.
+                                </p>
                             </div>
                         </div>
                         <div class="section-status">
@@ -367,7 +379,9 @@
                             </div>
                             <div class="section-title-group">
                                 <h3 class="section-title">Infraestructura y necesidades</h3>
-                                <p class="section-subtitle">Espacios disponibles y limitaciones del dispositivo</p>
+                                <p class="section-subtitle">
+                                    En esta sección se releva la infraestructura disponible del dispositivo, incluyendo condiciones de accesibilidad, así como las principales limitaciones o necesidades identificadas en su funcionamiento.
+                                </p>
                             </div>
                         </div>
                         <div class="section-status">
@@ -418,7 +432,9 @@
                             </div>
                             <div class="section-title-group">
                                 <h3 class="section-title">Articulaciones institucionales</h3>
-                                <p class="section-subtitle">Organismos y redes con las que trabaja el dispositivo</p>
+                                <p class="section-subtitle">
+                                    En esta sección se releva con qué tipos de instituciones el dispositivo articula de manera habitual para la atención, derivación o acompañamiento de las personas.
+                                </p>
                             </div>
                         </div>
                         <div class="section-status">
@@ -453,8 +469,10 @@
                                 <i class="fas fa-file-alt"></i>
                             </div>
                             <div class="section-title-group">
-                                <h3 class="section-title">Observaciones y documentación</h3>
-                                <p class="section-subtitle">Notas adicionales y archivos adjuntos</p>
+                                <h3 class="section-title">Observaciones y documentación del dispositivo</h3>
+                                <p class="section-subtitle">
+                                    En este espacio puede incorporar información adicional que considere relevante sobre el funcionamiento del dispositivo y que no haya sido contemplada en las preguntas anteriores. También puede adjuntar documentación institucional vinculada al funcionamiento del dispositivo, como protocolos de intervención, circuitos de admisión, manuales de trabajo, reglamentos internos u otros documentos que permitan comprender mejor la modalidad de atención.
+                                </p>
                             </div>
                         </div>
                         <div class="section-status">


### PR DESCRIPTION
## Resumen
Aplica los textos del Google Form modelo de referencia (issue #1655) a las 9 secciones del formulario. Cubre ~22 ítems del evolutivo: tks 1, 2, 4, 8, 13, 15, 16, 17, 19, 20, 22, 24, 26, 30, 34, 36, 38, 41, 42, 45 y 46.

## Cambios

### Form (`dispositivos/forms.py`)
- Nuevo dict de clase **`FIELD_LABELS_AND_HELP`** que centraliza label + help_text para cada campo según el Google Form.
- `__init__` partido en helpers: `_apply_field_texts`, `_configure_upload_fields`, `_configure_numeric_inputs`. Pasa de ~50 statements a 6 y deja de disparar el warning `too-many-statements` de pylint.
- Labels en español sin abreviaturas (Tk 2): "Nombre completo de la institución", "Tipo de gestión del dispositivo", "CUIT de la institución", "Nombre completo del responsable del dispositivo", "DNI del responsable del dispositivo", "Población destinataria del dispositivo", "Franja etaria de la población destinataria", "Tiempo promedio de permanencia en el dispositivo", "Modalidad de ingreso al dispositivo", "Documentación necesaria para el ingreso", "Requisitos para el ingreso", "¿Qué tipo de actividades formativas se ofrecen?", "¿Las actividades formativas cuentan con certificación oficial?", "¿El dispositivo registra información sobre las personas alojadas o asistidas?", "¿De qué manera realizan ese registro?", "¿Qué tipo de información registran?", "Infraestructura de Accesibilidad", "Principales limitaciones del dispositivo", "¿Con qué tipos de instituciones articula habitualmente?", "Adjuntar documentación del dispositivo".
- Help text por campo cuando el modelo lo provee (todos los textos descriptivos que aparecen debajo de las preguntas en el Google Form).
- Opciones extendidas:
  - `POBLACION_DESTINATARIA_CHOICES`: "Familia monoparental (un solo adulto con hijos/as.)" y "Familia nuclear (pareja -o dos adultos- con hijos/as.)".
  - `ARTICULACIONES_CHOICES`: "Salud (hospitales, centros de salud, salud mental)", "Seguridad (policía/comisarías)", "Organizaciones comunitarias (comedores, roperos, etc.)".

### Template (`dispositivos/templates/dispositivos_form.html`)
- Subtítulos de las 9 secciones reemplazados por el texto descriptivo del modelo.
- Sección 9: título cambia de "Observaciones y documentación" a "Observaciones y documentación del dispositivo" (alineación con el Google Form).

## Excluidos en esta PR
Por acuerdo con PM: los campos `domicilio_institucion` y `telefono_contacto` se desdoblan en `dispositivos-desdoble-direccion-telefono` (PR en revisión). Sus labels y help_text se aplicarán en una PR chiquita posterior al merge de esa.

## Test plan
- [x] `pytest dispositivos/tests/` → 19/19
- [x] `black --check dispositivos/` → limpio
- [x] `djlint dispositivos/templates/dispositivos_form.html --check` → limpio
- [x] `pylint --load-plugins=pylint_django dispositivos/forms.py` → sin issues
- [x] Probado en UI por la PM: textos correctos en las 9 secciones.




