### PR TITLE
[codex] Ajusta card de mes de ejecucion

### DIFF
--- a/comedores/templates/comedor/comedor_detail.html
+++ b/comedores/templates/comedor/comedor_detail.html
@@ -1186,11 +1186,22 @@
 {% endif %}
 </div>
 </div>
-{% if resumen_dw_transacciones %}
-    <div class="mt-3">{% include "comedor/comedor_transacciones_card.html" %}</div>
+</div>
+</div>
+{% if resumen_dw_transacciones or mostrar_mes_ejecucion %}
+    <div class="row mt-3">
+        {% if resumen_dw_transacciones %}
+            <div class="col-12 col-lg-6 mb-3 mb-lg-0">
+                {% include "comedor/comedor_transacciones_card.html" %}
+            </div>
+        {% endif %}
+        {% if mostrar_mes_ejecucion %}
+            <div class="col-12 col-lg-6 {% if not resumen_dw_transacciones %}ms-lg-auto{% endif %}">
+                {% include "comedor/comedor_mes_ejecucion_card.html" %}
+            </div>
+        {% endif %}
+    </div>
 {% endif %}
-</div>
-</div>
 </div>
 <!-- /Cuadros con datos, Avisos y Detalles Admision-->
 <!-- Nomina-->
@@ -1556,55 +1567,6 @@
     <!-- /Capacitaciones -->
 {% endif %}
 <!-- Modal Intervención -->
-{% if mostrar_mes_ejecucion %}
-    <div class="card mb-3">
-        <div class="card-header d-flex flex-wrap align-items-center justify-content-between gap-2">
-            <h5 class="mb-0">Mes de ejecucion</h5>
-            <a href="{% url 'expedientespagos_list' comedor.id %}"
-               class="btn btn-sm btn-outline-primary">
-                <i class="bi bi-box-arrow-up-right me-1"></i>Ver mas
-            </a>
-        </div>
-        <div class="card-body">
-            {% if mes_ejecucion_resumen.expediente %}
-                {% with expediente=mes_ejecucion_resumen.expediente %}
-                    <div class="row g-3">
-                        <div class="col-12 col-md-6 col-xl-3">
-                            <small class="text-muted d-block">Expediente del convenio</small>
-                            <strong>{{ expediente.expediente_convenio|default:"-" }}</strong>
-                        </div>
-                        <div class="col-12 col-md-6 col-xl-3">
-                            <small class="text-muted d-block">Expediente de pago</small>
-                            <strong>{{ expediente.expediente_pago|default:"-" }}</strong>
-                        </div>
-                        <div class="col-12 col-md-6 col-xl-3">
-                            <small class="text-muted d-block">Cantidad de prestaciones</small>
-                            <strong>{{ mes_ejecucion_resumen.cantidad_prestaciones|default:"0" }}</strong>
-                        </div>
-                        <div class="col-12 col-md-6 col-xl-3">
-                            <small class="text-muted d-block">Monto total de prestaciones</small>
-                            <strong>${{ mes_ejecucion_resumen.monto_total|default:"0" }}</strong>
-                        </div>
-                        <div class="col-12 col-md-4 col-xl-2">
-                            <small class="text-muted d-block">Mes de pago</small>
-                            <strong>{{ expediente.mes_pago|default:"-" }}</strong>
-                        </div>
-                        <div class="col-12 col-md-4 col-xl-2">
-                            <small class="text-muted d-block">Año</small>
-                            <strong>{{ expediente.ano|default:"-" }}</strong>
-                        </div>
-                        <div class="col-12 col-md-4 col-xl-2">
-                            <small class="text-muted d-block">Mes de ejecucion</small>
-                            <strong>{{ expediente.mes_convenio|default:"-" }}</strong>
-                        </div>
-                    </div>
-                {% endwith %}
-            {% else %}
-                <p class="mb-0 text-muted">No hay expedientes de pago cargados para este comedor.</p>
-            {% endif %}
-        </div>
-    </div>
-{% endif %}
 <div class="modal fade"
      id="modalIntervencion"
      tabindex="-1"

--- a/comedores/templates/comedor/comedor_mes_ejecucion_card.html
+++ b/comedores/templates/comedor/comedor_mes_ejecucion_card.html
@@ -1,0 +1,38 @@
+<div class="card bg-card h-100" id="card-mes-ejecucion">
+    <div class="card-header py-1">
+        <h6 class="fw-bold my-1 text-center">Mes de ejecuci&oacute;n</h6>
+    </div>
+    <div class="card-body">
+        {% if mes_ejecucion_resumen.expediente %}
+            {% with expediente=mes_ejecucion_resumen.expediente %}
+                <p class="mb-0 fs-7">
+                    Expediente del convenio: <strong class="text-uppercase">{{ expediente.expediente_convenio|default:"Sin informaci&oacute;n" }}</strong>
+                </p>
+                <p class="mb-0 fs-7">
+                    Expediente de pago: <strong class="text-uppercase">{{ expediente.expediente_pago|default:"Sin informaci&oacute;n" }}</strong>
+                </p>
+                <p class="mb-0 fs-7">
+                    Cantidad de prestaciones: <strong>{{ mes_ejecucion_resumen.cantidad_prestaciones|default:"0" }}</strong>
+                </p>
+                <p class="mb-0 fs-7">
+                    Monto total de prestaciones: <strong>${{ mes_ejecucion_resumen.monto_total|default:"0" }}</strong>
+                </p>
+                <p class="mb-0 fs-7">
+                    Mes de pago: <strong>{{ expediente.mes_pago|default:"Sin informaci&oacute;n" }}</strong>
+                </p>
+                <p class="mb-0 fs-7">
+                    A&ntilde;o: <strong>{{ expediente.ano|default:"Sin informaci&oacute;n" }}</strong>
+                </p>
+                <p class="mb-0 fs-7">
+                    Mes de ejecuci&oacute;n: <strong>{{ expediente.mes_convenio|default:"Sin informaci&oacute;n" }}</strong>
+                </p>
+            {% endwith %}
+        {% else %}
+            <p class="mb-0 fs-7">No hay expedientes de pago cargados para este comedor.</p>
+        {% endif %}
+        <div class="mt-3 d-flex flex-column flex-sm-row justify-content-center gap-2">
+            <a href="{% url 'expedientespagos_list' comedor.id %}"
+               class="btn btn-primary px-2 py-1 fs-7 w-100 w-sm-auto">Ver m&aacute;s</a>
+        </div>
+    </div>
+</div>

--- a/comedores/templates/comedor/comedor_transacciones_card.html
+++ b/comedores/templates/comedor/comedor_transacciones_card.html
@@ -1,5 +1,5 @@
 {% if resumen_dw_transacciones %}
-    <div class="card bg-card" id="card-transacciones">
+    <div class="card bg-card h-100" id="card-transacciones">
         <div class="card-header py-1">
             <h4 class="fw-bold my-1 text-center">Transacciones - Naci&oacute;n Servicios</h4>
         </div>


### PR DESCRIPTION
## Qué cambió

- Reubica la card `Mes de ejecución` debajo de `Detalles de Admisión`, en la misma fila que `Transacciones - Nación Servicios`.
- Extrae la card de mes de ejecución a un partial propio con el mismo patrón visual de las cards del detalle.
- Ajusta la card de transacciones con `h-100` para emparejar la altura visual en la grilla.

## Impacto

El detalle de comedor mantiene la información de mes de ejecución dentro del bloque visual principal y con presentación consistente con `Detalles de Admisión`.

## Validación

- `git diff --check`
- `git diff --cached --check`
- `python -m djlint comedores\templates\comedor\comedor_mes_ejecucion_card.html comedores\templates\comedor\comedor_transacciones_card.html --check --profile=django`

## Limitaciones

No se pudo correr la validación integral local: Docker no está disponible y el fallback de `.venv` falla por conflicto de dependencias. `manage.py check` tampoco corre con el Python global porque tiene Django 5.2.14, mientras el proyecto fija Django 4.2.27.