### PR TITLE
fix(comedor): alinear botones de cards al fondo (#1700)

### DIFF
--- a/comedores/templates/comedor/comedor_mes_ejecucion_card.html
+++ b/comedores/templates/comedor/comedor_mes_ejecucion_card.html
@@ -2,7 +2,7 @@
     <div class="card-header py-1">
         <h6 class="fw-bold my-1 text-center">Mes de ejecuci&oacute;n</h6>
     </div>
-    <div class="card-body">
+    <div class="card-body d-flex flex-column">
         {% if mes_ejecucion_resumen.expediente %}
             {% with expediente=mes_ejecucion_resumen.expediente %}
                 <p class="mb-0 fs-7">
@@ -30,7 +30,7 @@
         {% else %}
             <p class="mb-0 fs-7">No hay expedientes de pago cargados para este comedor.</p>
         {% endif %}
-        <div class="mt-3 d-flex flex-column flex-sm-row justify-content-center gap-2">
+        <div class="mt-auto pt-3 d-flex flex-column flex-sm-row justify-content-center gap-2">
             <a href="{% url 'expedientespagos_list' comedor.id %}"
                class="btn btn-primary px-2 py-1 fs-7 w-100 w-sm-auto">Ver m&aacute;s</a>
         </div>

--- a/comedores/templates/comedor/comedor_transacciones_card.html
+++ b/comedores/templates/comedor/comedor_transacciones_card.html
@@ -3,7 +3,7 @@
         <div class="card-header py-1">
             <h4 class="fw-bold my-1 text-center">Transacciones - Naci&oacute;n Servicios</h4>
         </div>
-        <div class="card-body">
+        <div class="card-body d-flex flex-column">
             <p class="mb-0 fs-7">
                 Per&iacute;odo: <strong>{{ resumen_dw_transacciones.periodo_display }}</strong>
             </p>
@@ -19,7 +19,7 @@
             <p class="mb-0 fs-7">
                 Saldo Remanente: <strong>{{ resumen_dw_transacciones.saldo_display }}</strong>
             </p>
-            <div class="mt-3 d-flex flex-column flex-sm-row justify-content-center gap-2">
+            <div class="mt-auto pt-3 d-flex flex-column flex-sm-row justify-content-center gap-2">
                 <a href="{% url 'comedor_transacciones_detalle' comedor.id %}"
                    class="btn btn-primary px-2 py-1 fs-7 w-100 w-sm-auto">Ver detalles</a>
             </div>


### PR DESCRIPTION
## Summary

- Las cards **Transacciones - Nación Servicios** y **Mes de ejecución** del legajo del comedor viven lado a lado en `col-lg-6` con `h-100`, así que igualan altura. Pero los botones *Ver detalles* / *Ver más* quedaban pegados al contenido, descolocados cuando una card tenía menos líneas que la otra (o cuando una venía vacía mostrando *"No hay expedientes de pago cargados para este comedor."*). Reportado en #1700 como issue estético post-merge.
- Convierto el `card-body` en contenedor flex vertical (`d-flex flex-column`) y empujo el wrapper del botón con `mt-auto` para que siempre quede pegado al fondo. Reemplazo `mt-3` por `pt-3` en ese wrapper para preservar el aire previo entre contenido y botón.

Cambio mínimo, 4 líneas en 2 templates, sin tocar lógica de vistas ni CSS global.

## Test plan

- [ ] Abrir el legajo de un comedor PAC (`programa_id = 2`) con `resumen_dw_transacciones` y `mostrar_mes_ejecucion` activos.
- [ ] Verificar que la card **Transacciones - Nación Servicios** (contenido corto) muestra *Ver detalles* alineado al fondo, a la misma altura que *Ver más* de **Mes de ejecución**.
- [ ] Forzar el caso vacío de **Mes de ejecución** (sin expedientes de pago) y confirmar que el botón *Ver más* sigue al fondo aunque el body sea casi vacío.
- [ ] Verificar en breakpoint mobile (`col-12`) que las cards apilan y los botones siguen al fondo de cada una.

🤖 Generated with [Claude Code](https://claude.com/claude-code)