### PR TITLE
fix(centrodeinfancia): actualizar tests de fecha_inicio al comportamiento actual

### DIFF
--- a/centrodeinfancia/tests/test_centrodeinfancia_form.py
+++ b/centrodeinfancia/tests/test_centrodeinfancia_form.py
@@ -495,7 +495,8 @@ def test_form_precarga_fecha_inicio_en_input_date():
 
     form = CentroDeInfanciaForm(instance=centro)
 
-    assert form.fields["fecha_inicio"].widget.input_type == "date"
+    # fecha_inicio se redefinió como CharField (año solo, AAAA) — usa TextInput
+    assert form.fields["fecha_inicio"].widget.input_type == "text"
     assert 'value="2024-05-04"' in str(form["fecha_inicio"])
 
 

--- a/centrodeinfancia/tests/test_formulario_cdi_views.py
+++ b/centrodeinfancia/tests/test_formulario_cdi_views.py
@@ -572,7 +572,7 @@ def test_detalle_cdi_muestra_nuevos_paneles_y_campos(client):
     assert "Asociacion Civil Horizonte" in content
     assert "20-44535030-4" in content
     assert "detalle@example.com" in content
-    assert "20/05/2024" in content
+    assert "2024" in content  # vista muestra solo el año de fecha_inicio
     assert "1234" in content
     assert "Latitud:" in content
     assert "Longitud:" in content


### PR DESCRIPTION
## Summary

- Dos tests de `centrodeinfancia` fallan en la release PR #1749 (`development → main`) porque no se actualizaron cuando `fecha_inicio` cambió de "fecha completa con `DateInput`" a "solo año con `CharField`/`TextInput`".
- No hay regresión funcional — el comportamiento del form y la vista ya son correctos; los tests simplemente asertaban el estado anterior.

**Cambios:**
- `test_form_precarga_fecha_inicio_en_input_date`: cambia `input_type == "date"` → `"text"` (el campo ahora es `CharField` con `TextInput`).
- `test_detalle_cdi_muestra_nuevos_paneles_y_campos`: cambia `"20/05/2024"` → `"2024"` (la vista muestra `str(fecha_inicio.year)` desde el commit que introdujo el cambio de UX).

## Test plan

- [ ] CI verde en este PR — los 2 tests que fallan en #1749 deben pasar.
- [ ] Mergear este PR a `development` y luego re-triggerear #1749 para confirmar que `pytest` pasa.

🤖 Generated with [Claude Code](https://claude.com/claude-code)