### PR TITLE
feat(admisiones): resync tipo_entidad <-> admision, reset documental y GDE por admision (#1605)

### DIFF
--- a/admisiones/forms/admisiones_forms.py
+++ b/admisiones/forms/admisiones_forms.py
@@ -9,6 +9,7 @@ from admisiones.models.admisiones import (
     FormularioProyectoDeConvenio,
     DocumentosExpediente,
     ArchivoAdmision,
+    NumeroGdeOrganizacion,
 )
 
 
@@ -16,10 +17,24 @@ def _ultimo_numero_gde(admision, documentacion_nombre):
     if not admision:
         return None
 
-    return (
+    candidato_admision = (
         ArchivoAdmision.objects.filter(
             admision=admision,
             documentacion__nombre=documentacion_nombre,
+        )
+        .exclude(numero_gde__isnull=True)
+        .exclude(numero_gde="")
+        .order_by("-modificado", "-id")
+        .values_list("numero_gde", flat=True)
+        .first()
+    )
+    if candidato_admision:
+        return candidato_admision
+
+    return (
+        NumeroGdeOrganizacion.objects.filter(
+            admision=admision,
+            archivo_organizacion__documentacion__nombre=documentacion_nombre,
         )
         .exclude(numero_gde__isnull=True)
         .exclude(numero_gde="")

--- a/admisiones/migrations/0059_admision_tipo_entidad_origen.py
+++ b/admisiones/migrations/0059_admision_tipo_entidad_origen.py
@@ -1,0 +1,50 @@
+from django.db import migrations, models
+
+
+def forwards_backfill(apps, schema_editor):
+    """Inicializa ``tipo_entidad_origen`` con el ``tipo_entidad`` actual de la
+    organizacion del comedor asociado. Para admisiones sin organizacion o sin
+    tipo_entidad la columna queda en ``NULL`` (no hay desincronizacion posible
+    hasta que la organizacion adquiera un tipo).
+    """
+
+    Admision = apps.get_model("admisiones", "Admision")
+    qs = (
+        Admision.objects.exclude(comedor__organizacion__tipo_entidad__isnull=True)
+        .select_related("comedor__organizacion")
+        .only("id", "comedor__organizacion__tipo_entidad_id")
+    )
+    for admision in qs.iterator(chunk_size=500):
+        organizacion = getattr(getattr(admision, "comedor", None), "organizacion", None)
+        tipo_id = getattr(organizacion, "tipo_entidad_id", None)
+        if tipo_id and admision.tipo_entidad_origen_id != tipo_id:
+            admision.tipo_entidad_origen_id = tipo_id
+            admision.save(update_fields=["tipo_entidad_origen"])
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("admisiones", "0058_alter_admision_estado_admision"),
+        ("organizaciones", "0013_archivoorganizacion_numero_gde"),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name="admision",
+            name="tipo_entidad_origen",
+            field=models.ForeignKey(
+                blank=True,
+                help_text=(
+                    "Snapshot del tipo de entidad de la organizacion en el"
+                    " momento en que la admision quedo sincronizada"
+                    " (creacion, resync manual o aceptacion de divergencia)."
+                ),
+                null=True,
+                on_delete=models.deletion.SET_NULL,
+                related_name="admisiones_con_snapshot",
+                to="organizaciones.tipoentidad",
+                verbose_name="Tipo de entidad de origen",
+            ),
+        ),
+        migrations.RunPython(forwards_backfill, migrations.RunPython.noop),
+    ]

--- a/admisiones/migrations/0060_numero_gde_organizacion.py
+++ b/admisiones/migrations/0060_numero_gde_organizacion.py
@@ -1,0 +1,112 @@
+from django.conf import settings
+from django.db import migrations, models
+
+
+def forwards_backfill(apps, schema_editor):
+    """Si una organizacion tiene ``ArchivoOrganizacion.numero_gde`` cargado y
+    existe una unica admision asociada al comedor de esa organizacion, copiamos
+    el valor para no perderlo. Si hay mas de una admision, no copiamos para
+    evitar ambiguedad (cada admision pasara a manejar su propio GDE)."""
+
+    ArchivoOrganizacion = apps.get_model("organizaciones", "ArchivoOrganizacion")
+    Admision = apps.get_model("admisiones", "Admision")
+    NumeroGdeOrganizacion = apps.get_model("admisiones", "NumeroGdeOrganizacion")
+
+    archivos = ArchivoOrganizacion.objects.exclude(numero_gde__isnull=True).exclude(
+        numero_gde=""
+    )
+    for archivo in archivos.iterator(chunk_size=500):
+        admisiones_ids = list(
+            Admision.objects.filter(
+                comedor__organizacion_id=archivo.organizacion_id
+            ).values_list("id", flat=True)
+        )
+        if len(admisiones_ids) != 1:
+            continue
+        NumeroGdeOrganizacion.objects.update_or_create(
+            admision_id=admisiones_ids[0],
+            archivo_organizacion_id=archivo.id,
+            defaults={"numero_gde": archivo.numero_gde},
+        )
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("admisiones", "0059_admision_tipo_entidad_origen"),
+        ("organizaciones", "0013_archivoorganizacion_numero_gde"),
+        migrations.swappable_dependency(settings.AUTH_USER_MODEL),
+    ]
+
+    operations = [
+        migrations.CreateModel(
+            name="NumeroGdeOrganizacion",
+            fields=[
+                (
+                    "id",
+                    models.BigAutoField(
+                        auto_created=True,
+                        primary_key=True,
+                        serialize=False,
+                        verbose_name="ID",
+                    ),
+                ),
+                (
+                    "numero_gde",
+                    models.CharField(
+                        blank=True,
+                        help_text=(
+                            "Numero de expediente GDE asignado por la"
+                            " admision al documento de la organizacion."
+                        ),
+                        max_length=50,
+                        null=True,
+                        verbose_name="Numero de GDE",
+                    ),
+                ),
+                ("creado", models.DateTimeField(auto_now_add=True)),
+                ("modificado", models.DateTimeField(auto_now=True)),
+                (
+                    "admision",
+                    models.ForeignKey(
+                        on_delete=models.deletion.CASCADE,
+                        related_name="numeros_gde_organizacion",
+                        to="admisiones.admision",
+                    ),
+                ),
+                (
+                    "archivo_organizacion",
+                    models.ForeignKey(
+                        on_delete=models.deletion.CASCADE,
+                        related_name="numeros_gde_por_admision",
+                        to="organizaciones.archivoorganizacion",
+                    ),
+                ),
+                (
+                    "modificado_por",
+                    models.ForeignKey(
+                        blank=True,
+                        null=True,
+                        on_delete=models.deletion.SET_NULL,
+                        related_name="numeros_gde_organizacion_modificados",
+                        to=settings.AUTH_USER_MODEL,
+                    ),
+                ),
+            ],
+            options={
+                "verbose_name": (
+                    "Numero GDE de archivo de organizacion por admision"
+                ),
+                "verbose_name_plural": (
+                    "Numeros GDE de archivos de organizacion por admision"
+                ),
+            },
+        ),
+        migrations.AddConstraint(
+            model_name="numerogdeorganizacion",
+            constraint=models.UniqueConstraint(
+                fields=("admision", "archivo_organizacion"),
+                name="unq_gde_admision_archivoorg",
+            ),
+        ),
+        migrations.RunPython(forwards_backfill, migrations.RunPython.noop),
+    ]

--- a/admisiones/models/admisiones.py
+++ b/admisiones/models/admisiones.py
@@ -119,6 +119,19 @@ class Admision(models.Model):
     tipo_convenio = models.ForeignKey(
         TipoConvenio, on_delete=models.SET_NULL, null=True
     )
+    tipo_entidad_origen = models.ForeignKey(
+        "organizaciones.TipoEntidad",
+        on_delete=models.SET_NULL,
+        null=True,
+        blank=True,
+        related_name="admisiones_con_snapshot",
+        verbose_name="Tipo de entidad de origen",
+        help_text=(
+            "Snapshot del tipo de entidad de la organizacion en el momento en"
+            " que la admision quedo sincronizada (creacion, resync manual o"
+            " aceptacion de divergencia)."
+        ),
+    )
     num_expediente = models.CharField(max_length=255, blank=True, null=True)
     num_if = models.CharField(max_length=100, blank=True, null=True)
     legales_num_if = models.CharField(max_length=100, blank=True, null=True)
@@ -1178,3 +1191,55 @@ class InformeTecnicoComplementarioPDF(models.Model):
 
     def __str__(self):
         return f"PDF Complementario Final - Admision #{self.admision_id}"
+
+
+class NumeroGdeOrganizacion(models.Model):
+    """Vincula un ``ArchivoOrganizacion`` con una ``Admision`` para registrar el
+    Numero de GDE propio de esa combinacion. Permite que el mismo documento de
+    la organizacion tenga distintos GDE en distintas admisiones."""
+
+    admision = models.ForeignKey(
+        Admision,
+        on_delete=models.CASCADE,
+        related_name="numeros_gde_organizacion",
+    )
+    archivo_organizacion = models.ForeignKey(
+        "organizaciones.ArchivoOrganizacion",
+        on_delete=models.CASCADE,
+        related_name="numeros_gde_por_admision",
+    )
+    numero_gde = models.CharField(
+        "Numero de GDE",
+        max_length=50,
+        blank=True,
+        null=True,
+        help_text="Numero de expediente GDE asignado por la admision al documento de la organizacion.",
+    )
+    creado = models.DateTimeField(auto_now_add=True)
+    modificado = models.DateTimeField(auto_now=True)
+    modificado_por = models.ForeignKey(
+        settings.AUTH_USER_MODEL,
+        on_delete=models.SET_NULL,
+        null=True,
+        blank=True,
+        related_name="numeros_gde_organizacion_modificados",
+    )
+
+    class Meta:
+        constraints = [
+            models.UniqueConstraint(
+                fields=["admision", "archivo_organizacion"],
+                name="unq_gde_admision_archivoorg",
+            )
+        ]
+        verbose_name = "Numero GDE de archivo de organizacion por admision"
+        verbose_name_plural = (
+            "Numeros GDE de archivos de organizacion por admision"
+        )
+
+    def __str__(self):
+        return (
+            f"Admision #{self.admision_id} - "
+            f"Archivo Org #{self.archivo_organizacion_id} - "
+            f"GDE={self.numero_gde or '-'}"
+        )

--- a/admisiones/services/admisiones_service/impl.py
+++ b/admisiones/services/admisiones_service/impl.py
@@ -20,6 +20,7 @@ from admisiones.models.admisiones import (
     InformeTecnico,
     InformeTecnicoPDF,
     InformeComplementario,
+    NumeroGdeOrganizacion,
 )
 from admisiones.forms.admisiones_forms import (
     CaratularForm,
@@ -285,7 +286,10 @@ class AdmisionService:
 
     @staticmethod
     def _serializar_documentacion_organizacion(
-        org_doc, archivo=None, admision_doc=None
+        org_doc,
+        archivo=None,
+        admision_doc=None,
+        numero_gde_admision=None,
     ):
         estado_display, estado_valor = AdmisionService._estado_display_y_valor(
             archivo.estado if archivo else "pendiente"
@@ -294,12 +298,13 @@ class AdmisionService:
             "id": f"org-{org_doc.id}",
             "documentacion_id": admision_doc.id if admision_doc else None,
             "archivo_id": None,
+            "archivo_organizacion_id": archivo.id if archivo else None,
             "nombre": org_doc.nombre,
             "obligatorio": org_doc.obligatorio,
             "estado": estado_display,
             "estado_valor": estado_valor,
             "archivo_url": archivo.archivo.url if archivo and archivo.archivo else None,
-            "numero_gde": archivo.numero_gde if archivo else None,
+            "numero_gde": numero_gde_admision,
             "fecha_vencimiento": archivo.fecha_vencimiento if archivo else None,
             "observaciones": archivo.observaciones if archivo else None,
             "es_personalizado": False,
@@ -385,6 +390,12 @@ class AdmisionService:
         archivos_org = AdmisionService._get_archivos_organizacion_vigentes(
             admision, categoria
         )
+        numeros_gde_por_archivo_org = (
+            AdmisionService._get_numeros_gde_organizacion_por_archivo(
+                admision,
+                [archivo.id for archivo in archivos_org.values() if archivo],
+            )
+        )
         documentos = []
         for org_doc in org_docs:
             org_key = AdmisionService._normalizar_nombre_documental(org_doc.nombre)
@@ -393,6 +404,11 @@ class AdmisionService:
             archivo_admision = (
                 archivos_por_documentacion.get(admision_doc.id)
                 if admision_doc
+                else None
+            )
+            numero_gde_admision = (
+                numeros_gde_por_archivo_org.get(archivo_org.id)
+                if archivo_org
                 else None
             )
             if archivo_admision:
@@ -414,19 +430,35 @@ class AdmisionService:
                         "fecha_vencimiento": (
                             archivo_org.fecha_vencimiento if archivo_org else None
                         ),
+                        "archivo_organizacion_id": (
+                            archivo_org.id if archivo_org else None
+                        ),
                     }
                 )
+                if numero_gde_admision is not None:
+                    doc_serializado["numero_gde"] = numero_gde_admision
             else:
                 doc_serializado = (
                     AdmisionService._serializar_documentacion_organizacion(
                         org_doc,
                         archivo_org,
                         admision_doc=admision_doc,
+                        numero_gde_admision=numero_gde_admision,
                     )
                 )
             documentos.append(doc_serializado)
 
         return documentos, ids_documentacion_admision_usados
+
+    @staticmethod
+    def _get_numeros_gde_organizacion_por_archivo(admision, archivo_org_ids):
+        if not admision or not archivo_org_ids:
+            return {}
+        registros = NumeroGdeOrganizacion.objects.filter(
+            admision=admision,
+            archivo_organizacion_id__in=archivo_org_ids,
+        ).values_list("archivo_organizacion_id", "numero_gde")
+        return {archivo_id: numero for archivo_id, numero in registros}
 
     @staticmethod
     def _build_documentos_update_context(
@@ -804,6 +836,10 @@ class AdmisionService:
         puede_editar_convenio_numero,
         puede_editar_num_expediente,
     ):
+        organizacion = getattr(
+            getattr(admision, "comedor", None), "organizacion", None
+        )
+        tipo_entidad_actual = getattr(organizacion, "tipo_entidad", None)
         return {
             "documentos": documentos_context["documentos"],
             "documentos_personalizados": documentos_context[
@@ -831,6 +867,13 @@ class AdmisionService:
             "botones_disponibles": botones_disponibles,
             "puede_editar_convenio_numero": puede_editar_convenio_numero,
             "puede_editar_num_expediente": puede_editar_num_expediente,
+            "admision_desincronizada": AdmisionService.admision_desincronizada(
+                admision
+            ),
+            "tipo_entidad_actual_organizacion": tipo_entidad_actual,
+            "tipo_entidad_origen_snapshot": getattr(
+                admision, "tipo_entidad_origen", None
+            ),
         }
 
     @staticmethod
@@ -1029,6 +1072,82 @@ class AdmisionService:
         admision.save()
         AdmisionService.actualizar_estado_admision(admision, "seleccionar_convenio")
         ArchivoAdmision.objects.filter(admision=admision).delete()
+
+    @staticmethod
+    def admision_desincronizada(admision):
+        """Indica si el ``tipo_entidad_origen`` snapshotado en la admision
+        difiere del ``tipo_entidad`` actual de la organizacion."""
+
+        organizacion = getattr(
+            getattr(admision, "comedor", None), "organizacion", None
+        )
+        if not organizacion:
+            return False
+        tipo_actual_id = getattr(organizacion, "tipo_entidad_id", None)
+        snapshot_id = getattr(admision, "tipo_entidad_origen_id", None)
+        if not tipo_actual_id or not snapshot_id:
+            return False
+        return tipo_actual_id != snapshot_id
+
+    @staticmethod
+    def resync_admision_desde_organizacion(admision):
+        """Resetea la admision usando como fuente la organizacion: borra todos
+        los ``ArchivoAdmision``, vuelve el estado a ``convenio_seleccionado``,
+        ajusta ``tipo_convenio`` segun el nuevo ``tipo_entidad`` y actualiza el
+        snapshot."""
+
+        organizacion = getattr(
+            getattr(admision, "comedor", None), "organizacion", None
+        )
+        if not organizacion:
+            return False, "La admision no tiene organizacion asociada."
+
+        nuevo_convenio = AdmisionService.resolver_tipo_convenio_desde_organizacion(
+            organizacion
+        )
+        if not nuevo_convenio:
+            return (
+                False,
+                "No se pudo resolver el Tipo de Convenio desde el Tipo de Entidad de la organizacion.",
+            )
+
+        AdmisionService._aplicar_cambio_convenio_y_reset_documentos(
+            admision, nuevo_convenio
+        )
+        admision.tipo_entidad_origen_id = organizacion.tipo_entidad_id
+        admision.save(update_fields=["tipo_entidad_origen"])
+        AdmisionService.congelar_documentacion_organizacional(admision)
+        logger.info(
+            "Admision resincronizada desde la organizacion",
+            extra={
+                "admision_pk": admision.pk,
+                "tipo_entidad_id": organizacion.tipo_entidad_id,
+            },
+        )
+        return True, "Admision actualizada desde el Legajo de la Organizacion."
+
+    @staticmethod
+    def aceptar_desincronizacion_admision(admision):
+        """Mantiene el estado actual de la admision pero actualiza el snapshot
+        de ``tipo_entidad_origen`` para que la advertencia desaparezca hasta el
+        proximo cambio en la organizacion."""
+
+        organizacion = getattr(
+            getattr(admision, "comedor", None), "organizacion", None
+        )
+        if not organizacion:
+            return False, "La admision no tiene organizacion asociada."
+
+        admision.tipo_entidad_origen_id = organizacion.tipo_entidad_id
+        admision.save(update_fields=["tipo_entidad_origen"])
+        logger.info(
+            "Desincronizacion aceptada en admision",
+            extra={
+                "admision_pk": admision.pk,
+                "tipo_entidad_id": organizacion.tipo_entidad_id,
+            },
+        )
+        return True, "Continuara operando con la informacion actual de la admision."
 
     @staticmethod
     def update_convenio(admision, nuevo_convenio_id):
@@ -1842,6 +1961,7 @@ class AdmisionService:
                 estado=estado_inicial,
                 tipo="incorporacion",
                 estado_admision="convenio_seleccionado",
+                tipo_entidad_origen=getattr(comedor.organizacion, "tipo_entidad", None),
             )
             AdmisionService.congelar_documentacion_organizacional(admision)
 
@@ -2132,6 +2252,110 @@ class AdmisionService:
             )
 
             return {"success": False, "error": str(e)}
+
+    @staticmethod
+    def actualizar_numero_gde_organizacion_ajax(request):
+        """Actualiza el numero GDE asociado a un ``ArchivoOrganizacion`` para
+        una admision puntual usando el modelo ``NumeroGdeOrganizacion``.
+        Reglas:
+        - solo se permite cuando ``ArchivoOrganizacion.estado == 'Aceptado'``,
+        - solo el tecnico de la dupla (o superuser) puede editar,
+        - se aplican las mismas restricciones documentales que para los
+          ``ArchivoAdmision`` (informe tecnico ya no en borrador).
+        """
+
+        archivo_org_id = (request.POST.get("archivo_organizacion_id") or "").strip()
+        admision_id = (request.POST.get("admision_id") or "").strip()
+        numero_gde = (request.POST.get("numero_gde") or "").strip() or None
+        try:
+            if not archivo_org_id or not admision_id:
+                return AdmisionService._build_error_response_actualizar_numero_gde(
+                    "Faltan parametros admision o archivo de organizacion."
+                )
+
+            admision = get_object_or_404(
+                Admision.objects.select_related("comedor__organizacion"),
+                pk=admision_id,
+            )
+            archivo_org = get_object_or_404(
+                ArchivoOrganizacion.objects.select_related("organizacion"),
+                pk=archivo_org_id,
+            )
+
+            organizacion_admision = getattr(
+                getattr(admision, "comedor", None), "organizacion", None
+            )
+            if (
+                not organizacion_admision
+                or organizacion_admision.pk != archivo_org.organizacion_id
+            ):
+                return AdmisionService._build_error_response_actualizar_numero_gde(
+                    "El archivo no pertenece a la organizacion de la admision."
+                )
+
+            if archivo_org.estado != ArchivoOrganizacion.ESTADO_ACEPTADO:
+                return AdmisionService._build_error_response_actualizar_numero_gde(
+                    "Solo se puede actualizar el numero GDE en documentos aceptados."
+                )
+
+            if not (
+                request.user.is_superuser
+                or AdmisionService._verificar_permiso_dupla(
+                    request.user, admision.comedor
+                )
+            ):
+                return AdmisionService._build_error_response_actualizar_numero_gde(
+                    "No tiene permisos para editar este documento."
+                )
+
+            error_modificacion = (
+                AdmisionService._validar_modificacion_documental_por_tecnico(
+                    request.user, admision
+                )
+            )
+            if error_modificacion:
+                return AdmisionService._build_error_response_actualizar_numero_gde(
+                    error_modificacion
+                )
+
+            registro, _ = NumeroGdeOrganizacion.objects.get_or_create(
+                admision=admision,
+                archivo_organizacion=archivo_org,
+                defaults={"modificado_por": request.user},
+            )
+            valor_anterior = registro.numero_gde
+            registro.numero_gde = numero_gde
+            registro.modificado_por = request.user
+            registro.save(
+                update_fields=["numero_gde", "modificado_por", "modificado"]
+            )
+
+            AdmisionService._limpiar_if_gde_admision_por_cambio_documental(admision)
+
+            logger.info(
+                "Numero GDE de organizacion actualizado",
+                extra={
+                    "admision_id": admision.id,
+                    "archivo_organizacion_id": archivo_org.id,
+                    "valor_anterior": valor_anterior,
+                    "valor_nuevo": numero_gde,
+                },
+            )
+            return {
+                "success": True,
+                "numero_gde": registro.numero_gde,
+                "valor_anterior": valor_anterior,
+            }
+        except Exception as exc:
+            logger.exception(
+                "Error en actualizar_numero_gde_organizacion_ajax",
+                extra={
+                    "archivo_organizacion_id": archivo_org_id,
+                    "admision_id": admision_id,
+                    "numero_gde": numero_gde,
+                },
+            )
+            return {"success": False, "error": str(exc)}
 
     @staticmethod
     def _build_error_response_actualizar_convenio_numero(message):

--- a/admisiones/services/tipo_convenio_resolver.py
+++ b/admisiones/services/tipo_convenio_resolver.py
@@ -1,0 +1,84 @@
+"""Helper compartido entre ``admisiones`` y ``organizaciones`` para mapear
+``Organizacion.tipo_entidad`` con ``DocumentacionOrganizacion.categoria`` y con
+``TipoConvenio``.
+
+La heuristica historica vive en ``organizaciones/views.py`` (por nombre) y en
+``admisiones/services/admisiones_service/impl.py`` (por id). Este modulo
+centraliza ambas para evitar drift.
+"""
+
+from organizaciones.models import DocumentacionOrganizacion
+
+from admisiones.models.admisiones import Admision, TipoConvenio
+
+
+CATEGORIA_POR_TIPO_CONVENIO_ID = {
+    1: DocumentacionOrganizacion.CATEGORIA_BASE,
+    2: DocumentacionOrganizacion.CATEGORIA_ECLESIASTICA,
+    3: DocumentacionOrganizacion.CATEGORIA_PERSONERIA,
+}
+
+TIPO_CONVENIO_ID_POR_CATEGORIA = {
+    categoria: tipo_id for tipo_id, categoria in CATEGORIA_POR_TIPO_CONVENIO_ID.items()
+}
+
+
+def categoria_para_tipo_entidad(tipo_entidad, subtipo_entidad=None):
+    """Resuelve la categoria documental aplicable a una organizacion segun el
+    nombre de su ``tipo_entidad`` (y opcionalmente del ``subtipo_entidad``).
+    Replica la heuristica historica utilizada en ``organizaciones/views.py``.
+    """
+
+    textos = " ".join(
+        str(valor or "")
+        for valor in (
+            getattr(tipo_entidad, "nombre", "") if tipo_entidad else "",
+            getattr(subtipo_entidad, "nombre", "") if subtipo_entidad else "",
+        )
+    ).lower()
+    if "ecles" in textos or "culto" in textos:
+        return DocumentacionOrganizacion.CATEGORIA_ECLESIASTICA
+    if "base" in textos or "hecho" in textos:
+        return DocumentacionOrganizacion.CATEGORIA_BASE
+    return DocumentacionOrganizacion.CATEGORIA_PERSONERIA
+
+
+def categoria_para_organizacion(organizacion):
+    if not organizacion:
+        return DocumentacionOrganizacion.CATEGORIA_PERSONERIA
+    return categoria_para_tipo_entidad(
+        getattr(organizacion, "tipo_entidad", None),
+        getattr(organizacion, "subtipo_entidad", None),
+    )
+
+
+def tipo_convenio_para_organizacion(organizacion):
+    """Devuelve la instancia de ``TipoConvenio`` que corresponde al
+    ``tipo_entidad`` de la organizacion. Si no se puede resolver, retorna
+    ``None``.
+    """
+
+    categoria = categoria_para_organizacion(organizacion)
+    tipo_convenio_id = TIPO_CONVENIO_ID_POR_CATEGORIA.get(categoria)
+    if not tipo_convenio_id:
+        return None
+    return TipoConvenio.objects.filter(pk=tipo_convenio_id).first()
+
+
+def admision_desincronizada(admision):
+    """Indica si la ``admision`` quedo desincronizada respecto al
+    ``tipo_entidad`` actual de la organizacion de su comedor. Se considera
+    desincronizada cuando el snapshot guardado en ``tipo_entidad_origen``
+    difiere del ``tipo_entidad`` actual.
+    """
+
+    if not isinstance(admision, Admision):
+        return False
+    organizacion = getattr(getattr(admision, "comedor", None), "organizacion", None)
+    if not organizacion:
+        return False
+    tipo_actual_id = getattr(organizacion, "tipo_entidad_id", None)
+    snapshot_id = getattr(admision, "tipo_entidad_origen_id", None)
+    if not tipo_actual_id or not snapshot_id:
+        return False
+    return tipo_actual_id != snapshot_id

--- a/admisiones/templates/admisiones/admisiones_tecnicos_form.html
+++ b/admisiones/templates/admisiones/admisiones_tecnicos_form.html
@@ -38,6 +38,74 @@
             {% endfor %}
         </div>
     </div>
+    {% if admision_desincronizada and not admision.enviada_a_archivo %}
+        <div class="row mb-3">
+            <div class="col-12">
+                <div class="alert alert-warning" role="alert" id="alertResyncConvenio">
+                    <h5 class="alert-heading">
+                        <i class="fas fa-exclamation-triangle"></i> El tipo de convenio fue actualizado desde el Legajo de la Organización
+                    </h5>
+                    <p class="mb-2">
+                        Para continuar con la admisión debe seleccionar una de las siguientes opciones:
+                    </p>
+                    <div class="row align-items-end g-2">
+                        <div class="col-md-8">
+                            <select id="accionResyncConvenio"
+                                    class="form-select"
+                                    required>
+                                <option value="" selected disabled>Seleccione una opción...</option>
+                                <option value="actualizar">Actualizar Información desde Legajo Organización</option>
+                                <option value="continuar">Continuar operando con la Admisión actual</option>
+                            </select>
+                        </div>
+                        <div class="col-md-4 d-grid">
+                            <button type="button"
+                                    class="btn btn-warning"
+                                    id="btnAplicarResyncConvenio"
+                                    disabled>Aplicar</button>
+                        </div>
+                    </div>
+                    <div class="small text-muted mt-2">
+                        Tipo de Entidad actual de la Organización:
+                        <strong>{{ tipo_entidad_actual_organizacion|default:"Sin información" }}</strong>.
+                        Tipo registrado en esta admisión:
+                        <strong>{{ tipo_entidad_origen_snapshot|default:"Sin información" }}</strong>.
+                    </div>
+                </div>
+            </div>
+        </div>
+        <div class="modal fade"
+             id="modalConfirmarResyncConvenio"
+             data-bs-backdrop="static"
+             data-bs-keyboard="false"
+             tabindex="-1"
+             aria-labelledby="modalConfirmarResyncConvenioLabel"
+             aria-hidden="true">
+            <div class="modal-dialog modal-dialog-centered">
+                <div class="modal-content">
+                    <div class="modal-header">
+                        <h5 class="modal-title" id="modalConfirmarResyncConvenioLabel">
+                            <i class="fas fa-exclamation-triangle text-warning mr-2"></i>
+                            Confirmar acción
+                        </h5>
+                        <button type="button"
+                                class="btn-close"
+                                data-bs-dismiss="modal"
+                                aria-label="Close"></button>
+                    </div>
+                    <div class="modal-body">
+                        <p id="modalConfirmarResyncConvenioMensaje" class="mb-0"></p>
+                    </div>
+                    <div class="modal-footer">
+                        <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Cancelar</button>
+                        <button type="button" class="btn btn-primary" id="btnConfirmarResyncConvenio">
+                            Confirmar
+                        </button>
+                    </div>
+                </div>
+            </div>
+        </div>
+    {% endif %}
     {% if mostrar_informe_complementario %}
         <div class="row mb-3">
             <div class="col-12">
@@ -936,9 +1004,11 @@
                      data-csrf-token="{{ csrf_token }}"
                      data-url-actualizar-estado="{% url 'actualizar_estado_archivo' %}"
                      data-url-actualizar-numero-gde="{% url 'actualizar_numero_gde_archivo' %}"
+                     data-url-actualizar-numero-gde-organizacion="{% url 'actualizar_numero_gde_organizacion_admision' %}"
                      data-url-actualizar-convenio-numero="{% url 'actualizar_convenio_numero' %}"
                      data-url-actualizar-num-expediente="{% url 'actualizar_num_expediente' %}"
                      data-url-crear-documento-personalizado="{% url 'documento_personalizado_crear' admision.id %}"
+                     data-url-resync-convenio="{% url 'admision_resync_convenio' admision.id %}"
                      data-admision-id="{{ admision.id }}"
                      hidden></div>
                 {% if not admision.tipo_convenio and not admision.enviada_a_archivo %}
@@ -953,6 +1023,7 @@
                 <script src="{% static 'custom/js/admisionestecnico.js' %}"></script>
                 <script src="{% static 'custom/js/admisionesactualizarestado.js' %}"></script>
                 <script src="{% static 'custom/js/admisionesTecnicoCrear.js' %}"></script>
+                <script src="{% static 'custom/js/admisionResyncConvenio.js' %}"></script>
                 <script nonce="{{ request.csp_nonce }}">
                         document.addEventListener('DOMContentLoaded', function() {
                             const tooltipTriggerList = [].slice.call(document.querySelectorAll('[data-bs-toggle="tooltip"]'));

--- a/admisiones/templates/admisiones/includes/documento_row.html
+++ b/admisiones/templates/admisiones/includes/documento_row.html
@@ -158,6 +158,49 @@
                         </button>
                     </div>
                 </div>
+            {% elif doc.archivo_organizacion_id and not doc.archivo_id and request.user.is_superuser or doc.archivo_organizacion_id and not doc.archivo_id and request.user|has_any_perm:"comedores.view_comedor,admisiones.view_admision,acompanamientos.view_informacionrelevante" or doc.archivo_organizacion_id and not doc.archivo_id and request.user|has_perm_code:"auth.role_tecnico_comedor" or doc.archivo_organizacion_id and not doc.archivo_id and request.user|has_any_group:"Tecnico Comedor" %}
+                <!-- Modo vista para documentos puros de organizacion -->
+                <div id="gde-org-display-{{ doc.archivo_organizacion_id }}"
+                     class="gde-display"
+                     data-call-click="activarEdicionGDEOrganizacion"
+                     data-call-args="[{{ doc.archivo_organizacion_id }}]">
+                    {% if doc.numero_gde %}
+                        <span class="text-success fw-bold">{{ doc.numero_gde }}</span>
+                        <i class="bi bi-pencil-square ms-2 text-muted"
+                           style="cursor: pointer"
+                           title="Editar número GDE"></i>
+                    {% else %}
+                        <span class="text-muted">Sin número GDE</span>
+                        <i class="bi bi-plus-circle ms-2 text-primary"
+                           style="cursor: pointer"
+                           title="Agregar número GDE"></i>
+                    {% endif %}
+                </div>
+                <!-- Modo edición para documentos puros de organizacion -->
+                <div id="gde-org-edit-{{ doc.archivo_organizacion_id }}"
+                     class="gde-edit d-none">
+                    <div class="d-flex align-items-center">
+                        <input type="text"
+                               class="form-control form-control-sm me-2"
+                               id="gde-org-input-{{ doc.archivo_organizacion_id }}"
+                               value="{{ doc.numero_gde|default_if_none:'' }}"
+                               placeholder="Ingrese número GDE"
+                               maxlength="50"
+                               style="max-width: 150px" />
+                        <button class="btn btn-success btn-sm me-1"
+                                data-call-click="guardarNumeroGDEOrganizacion"
+                                data-call-args="[{{ doc.archivo_organizacion_id }}]"
+                                title="Guardar">
+                            <i class="bi bi-check"></i>
+                        </button>
+                        <button class="btn btn-secondary btn-sm"
+                                data-call-click="cancelarEdicionGDEOrganizacion"
+                                data-call-args="[{{ doc.archivo_organizacion_id }}]"
+                                title="Cancelar">
+                            <i class="bi bi-x"></i>
+                        </button>
+                    </div>
+                </div>
             {% else %}
                 {% if doc.numero_gde %}
                     <span class="text-success fw-bold">{{ doc.numero_gde }}</span>

--- a/admisiones/tests/test_numero_gde_organizacion.py
+++ b/admisiones/tests/test_numero_gde_organizacion.py
@@ -1,0 +1,261 @@
+"""Tests para el flujo de Numero GDE de archivos de organizacion vistos desde
+una Admision (Seccion 3 del issue #1605)."""
+
+import pytest
+from django.contrib.auth import get_user_model
+from django.test import RequestFactory
+
+from admisiones.models.admisiones import (
+    Admision,
+    EstadoAdmision,
+    NumeroGdeOrganizacion,
+    TipoConvenio,
+)
+from admisiones.services.admisiones_service import AdmisionService
+from comedores.models import Comedor
+from duplas.models import Dupla
+from organizaciones.models import (
+    ArchivoOrganizacion,
+    DocumentacionOrganizacion,
+    Organizacion,
+    TipoEntidad,
+)
+
+
+pytestmark = pytest.mark.django_db
+User = get_user_model()
+
+
+@pytest.fixture
+def tecnico():
+    return User.objects.create_user(username="tecnico_gde", password="pwd")
+
+
+@pytest.fixture
+def abogado():
+    return User.objects.create_user(username="abogado_gde", password="pwd")
+
+
+@pytest.fixture
+def superuser():
+    return User.objects.create_superuser(username="su_gde", password="pwd")
+
+
+@pytest.fixture
+def setup_org(tecnico, abogado):
+    tipo = TipoEntidad.objects.create(nombre="Personería Jurídica")
+    dupla = Dupla.objects.create(
+        nombre="Dupla GDE", estado="Activo", abogado=abogado
+    )
+    dupla.tecnico.add(tecnico)
+    organizacion = Organizacion.objects.create(
+        nombre="Org GDE", tipo_entidad=tipo
+    )
+    comedor = Comedor.objects.create(
+        nombre="Comedor GDE", organizacion=organizacion, dupla=dupla
+    )
+    EstadoAdmision.objects.create(nombre="Pendiente")
+    tipo_convenio = TipoConvenio.objects.create(pk=3, nombre="Personería Jurídica")
+    admision = Admision.objects.create(
+        comedor=comedor,
+        tipo_convenio=tipo_convenio,
+        tipo_entidad_origen=tipo,
+        estado_admision="documentacion_en_proceso",
+    )
+    documentacion_org = DocumentacionOrganizacion.objects.create(
+        nombre="DNI Presidente",
+        categoria=DocumentacionOrganizacion.CATEGORIA_PERSONERIA,
+        obligatorio=True,
+    )
+    archivo_org = ArchivoOrganizacion.objects.create(
+        organizacion=organizacion,
+        documentacion=documentacion_org,
+        archivo="organizaciones/test-doc.pdf",
+        estado=ArchivoOrganizacion.ESTADO_ACEPTADO,
+    )
+    return {
+        "admision": admision,
+        "archivo_org": archivo_org,
+        "tipo_entidad": tipo,
+        "documentacion_org": documentacion_org,
+    }
+
+
+def _build_request(user, data):
+    request = RequestFactory().post(
+        "/ajax/actualizar-numero-gde-organizacion/", data=data
+    )
+    request.user = user
+    return request
+
+
+def test_actualizar_numero_gde_organizacion_crea_registro(setup_org, superuser):
+    request = _build_request(
+        superuser,
+        {
+            "admision_id": setup_org["admision"].pk,
+            "archivo_organizacion_id": setup_org["archivo_org"].pk,
+            "numero_gde": "GDE-2026-000001",
+        },
+    )
+
+    resultado = AdmisionService.actualizar_numero_gde_organizacion_ajax(request)
+
+    assert resultado["success"] is True
+    assert resultado["numero_gde"] == "GDE-2026-000001"
+    assert resultado["valor_anterior"] is None
+    registro = NumeroGdeOrganizacion.objects.get(
+        admision=setup_org["admision"],
+        archivo_organizacion=setup_org["archivo_org"],
+    )
+    assert registro.numero_gde == "GDE-2026-000001"
+    assert registro.modificado_por_id == superuser.id
+
+
+def test_actualizar_numero_gde_organizacion_actualiza_existente(
+    setup_org, superuser
+):
+    NumeroGdeOrganizacion.objects.create(
+        admision=setup_org["admision"],
+        archivo_organizacion=setup_org["archivo_org"],
+        numero_gde="GDE-PREVIO",
+    )
+
+    request = _build_request(
+        superuser,
+        {
+            "admision_id": setup_org["admision"].pk,
+            "archivo_organizacion_id": setup_org["archivo_org"].pk,
+            "numero_gde": "GDE-NUEVO",
+        },
+    )
+    resultado = AdmisionService.actualizar_numero_gde_organizacion_ajax(request)
+
+    assert resultado["success"] is True
+    assert resultado["valor_anterior"] == "GDE-PREVIO"
+    assert resultado["numero_gde"] == "GDE-NUEVO"
+    assert NumeroGdeOrganizacion.objects.count() == 1
+
+
+def test_actualizar_numero_gde_organizacion_rechaza_no_aceptado(
+    setup_org, superuser
+):
+    setup_org["archivo_org"].estado = ArchivoOrganizacion.ESTADO_A_VALIDAR
+    setup_org["archivo_org"].save(update_fields=["estado"])
+
+    request = _build_request(
+        superuser,
+        {
+            "admision_id": setup_org["admision"].pk,
+            "archivo_organizacion_id": setup_org["archivo_org"].pk,
+            "numero_gde": "GDE-X",
+        },
+    )
+    resultado = AdmisionService.actualizar_numero_gde_organizacion_ajax(request)
+
+    assert resultado["success"] is False
+    assert "aceptados" in resultado["error"].lower()
+    assert NumeroGdeOrganizacion.objects.count() == 0
+
+
+def test_actualizar_numero_gde_organizacion_rechaza_archivo_de_otra_org(
+    setup_org, superuser
+):
+    otra_org = Organizacion.objects.create(
+        nombre="Otra Org", tipo_entidad=setup_org["tipo_entidad"]
+    )
+    archivo_otra = ArchivoOrganizacion.objects.create(
+        organizacion=otra_org,
+        documentacion=setup_org["documentacion_org"],
+        archivo="organizaciones/otra-doc.pdf",
+        estado=ArchivoOrganizacion.ESTADO_ACEPTADO,
+    )
+
+    request = _build_request(
+        superuser,
+        {
+            "admision_id": setup_org["admision"].pk,
+            "archivo_organizacion_id": archivo_otra.pk,
+            "numero_gde": "GDE-Y",
+        },
+    )
+    resultado = AdmisionService.actualizar_numero_gde_organizacion_ajax(request)
+
+    assert resultado["success"] is False
+    assert "organizacion" in resultado["error"].lower()
+
+
+def test_actualizar_numero_gde_organizacion_rechaza_usuario_sin_permisos(
+    setup_org,
+):
+    extranio = User.objects.create_user(username="extranio", password="pwd")
+    request = _build_request(
+        extranio,
+        {
+            "admision_id": setup_org["admision"].pk,
+            "archivo_organizacion_id": setup_org["archivo_org"].pk,
+            "numero_gde": "GDE-Z",
+        },
+    )
+    resultado = AdmisionService.actualizar_numero_gde_organizacion_ajax(request)
+
+    assert resultado["success"] is False
+    assert "permisos" in resultado["error"].lower()
+
+
+def test_misma_organizacion_dos_admisiones_no_comparten_gde(setup_org, superuser):
+    """3.3 — el GDE es por admision, aunque el doc-org sea el mismo."""
+
+    # Crear segunda admision sobre el mismo comedor/organizacion
+    otra_admision = Admision.objects.create(
+        comedor=setup_org["admision"].comedor,
+        tipo_convenio=setup_org["admision"].tipo_convenio,
+        tipo_entidad_origen=setup_org["tipo_entidad"],
+        estado_admision="documentacion_en_proceso",
+    )
+
+    AdmisionService.actualizar_numero_gde_organizacion_ajax(
+        _build_request(
+            superuser,
+            {
+                "admision_id": setup_org["admision"].pk,
+                "archivo_organizacion_id": setup_org["archivo_org"].pk,
+                "numero_gde": "GDE-ADM-1",
+            },
+        )
+    )
+    AdmisionService.actualizar_numero_gde_organizacion_ajax(
+        _build_request(
+            superuser,
+            {
+                "admision_id": otra_admision.pk,
+                "archivo_organizacion_id": setup_org["archivo_org"].pk,
+                "numero_gde": "GDE-ADM-2",
+            },
+        )
+    )
+
+    registros = {
+        reg.admision_id: reg.numero_gde
+        for reg in NumeroGdeOrganizacion.objects.filter(
+            archivo_organizacion=setup_org["archivo_org"]
+        )
+    }
+    assert registros[setup_org["admision"].pk] == "GDE-ADM-1"
+    assert registros[otra_admision.pk] == "GDE-ADM-2"
+
+
+def test_numero_gde_organizacion_unique_admision_archivo(setup_org):
+    """El constraint unique evita duplicados por admision + archivo_organizacion."""
+
+    NumeroGdeOrganizacion.objects.create(
+        admision=setup_org["admision"],
+        archivo_organizacion=setup_org["archivo_org"],
+        numero_gde="A",
+    )
+    with pytest.raises(Exception):
+        NumeroGdeOrganizacion.objects.create(
+            admision=setup_org["admision"],
+            archivo_organizacion=setup_org["archivo_org"],
+            numero_gde="B",
+        )

--- a/admisiones/tests/test_resync_admision.py
+++ b/admisiones/tests/test_resync_admision.py
@@ -1,0 +1,210 @@
+"""Tests para el flujo de resincronizacion Admision <-> Organizacion (Seccion 1
+del issue #1605)."""
+
+import pytest
+
+from admisiones.models.admisiones import (
+    Admision,
+    ArchivoAdmision,
+    Documentacion,
+    EstadoAdmision,
+    TipoConvenio,
+)
+from admisiones.services.admisiones_service import AdmisionService
+from admisiones.services.tipo_convenio_resolver import (
+    admision_desincronizada,
+    categoria_para_organizacion,
+)
+from comedores.models import Comedor
+from organizaciones.models import (
+    DocumentacionOrganizacion,
+    Organizacion,
+    TipoEntidad,
+)
+
+
+pytestmark = pytest.mark.django_db
+
+
+@pytest.fixture
+def estado_inicial():
+    return EstadoAdmision.objects.create(nombre="Pendiente")
+
+
+@pytest.fixture
+def tipo_entidades():
+    juridica = TipoEntidad.objects.create(nombre="Personería Jurídica")
+    eclesiastica = TipoEntidad.objects.create(
+        nombre="Personería Jurídica Eclesiástica"
+    )
+    hecho = TipoEntidad.objects.create(nombre="Asociación de Hecho")
+    return {"juridica": juridica, "eclesiastica": eclesiastica, "hecho": hecho}
+
+
+@pytest.fixture
+def tipos_convenio():
+    base = TipoConvenio.objects.create(pk=1, nombre="Organización Base")
+    eclesiastica = TipoConvenio.objects.create(
+        pk=2, nombre="Personería Jurídica Eclesiástica"
+    )
+    juridica = TipoConvenio.objects.create(pk=3, nombre="Personería Jurídica")
+    return {"base": base, "eclesiastica": eclesiastica, "juridica": juridica}
+
+
+def _crear_admision(tipo_entidad, tipo_convenio, estado_inicial):
+    organizacion = Organizacion.objects.create(
+        nombre="Org Test", tipo_entidad=tipo_entidad
+    )
+    comedor = Comedor.objects.create(
+        nombre="Comedor Test", organizacion=organizacion
+    )
+    return Admision.objects.create(
+        comedor=comedor,
+        tipo_convenio=tipo_convenio,
+        tipo_entidad_origen=tipo_entidad,
+        estado=estado_inicial,
+        estado_admision="documentacion_en_proceso",
+    )
+
+
+def test_admision_desincronizada_devuelve_false_cuando_snapshot_coincide(
+    estado_inicial, tipo_entidades, tipos_convenio
+):
+    admision = _crear_admision(
+        tipo_entidades["juridica"], tipos_convenio["juridica"], estado_inicial
+    )
+
+    assert AdmisionService.admision_desincronizada(admision) is False
+    assert admision_desincronizada(admision) is False
+
+
+def test_admision_desincronizada_devuelve_true_cuando_org_cambia_tipo(
+    estado_inicial, tipo_entidades, tipos_convenio
+):
+    admision = _crear_admision(
+        tipo_entidades["juridica"], tipos_convenio["juridica"], estado_inicial
+    )
+    admision.comedor.organizacion.tipo_entidad = tipo_entidades["eclesiastica"]
+    admision.comedor.organizacion.save(update_fields=["tipo_entidad"])
+    admision.refresh_from_db()
+
+    assert AdmisionService.admision_desincronizada(admision) is True
+    assert admision_desincronizada(admision) is True
+
+
+def test_admision_desincronizada_false_si_falta_snapshot_o_tipo_actual(
+    estado_inicial, tipo_entidades, tipos_convenio
+):
+    organizacion = Organizacion.objects.create(nombre="Org sin tipo")
+    comedor = Comedor.objects.create(nombre="Comedor sin tipo", organizacion=organizacion)
+    admision = Admision.objects.create(
+        comedor=comedor,
+        tipo_convenio=tipos_convenio["juridica"],
+        estado=estado_inicial,
+    )
+
+    assert AdmisionService.admision_desincronizada(admision) is False
+
+    organizacion.tipo_entidad = tipo_entidades["juridica"]
+    organizacion.save(update_fields=["tipo_entidad"])
+    admision.refresh_from_db()
+
+    assert AdmisionService.admision_desincronizada(admision) is False
+
+
+def test_resync_admision_borra_archivos_y_actualiza_snapshot(
+    estado_inicial, tipo_entidades, tipos_convenio
+):
+    admision = _crear_admision(
+        tipo_entidades["juridica"], tipos_convenio["juridica"], estado_inicial
+    )
+    documentacion = Documentacion.objects.create(nombre="DNI", obligatorio=True)
+    documentacion.convenios.add(tipos_convenio["juridica"])
+    ArchivoAdmision.objects.create(
+        admision=admision,
+        documentacion=documentacion,
+        estado="Aceptado",
+        archivo="admisiones/test.pdf",
+    )
+    admision.comedor.organizacion.tipo_entidad = tipo_entidades["eclesiastica"]
+    admision.comedor.organizacion.save(update_fields=["tipo_entidad"])
+
+    ok, mensaje = AdmisionService.resync_admision_desde_organizacion(admision)
+
+    assert ok is True
+    assert "Legajo" in mensaje
+    admision.refresh_from_db()
+    assert admision.tipo_entidad_origen_id == tipo_entidades["eclesiastica"].id
+    assert (
+        admision.tipo_convenio_id == tipos_convenio["eclesiastica"].id
+    ), "El tipo_convenio debe quedar mapeado al nuevo tipo_entidad"
+    assert (
+        ArchivoAdmision.objects.filter(admision=admision).count() == 0
+    ), "Todos los archivos previos deben quedar eliminados"
+
+
+def test_resync_admision_falla_si_no_hay_organizacion(estado_inicial):
+    admision = Admision.objects.create(
+        comedor=None, estado=estado_inicial, estado_admision="documentacion_en_proceso"
+    )
+
+    ok, mensaje = AdmisionService.resync_admision_desde_organizacion(admision)
+
+    assert ok is False
+    assert "organizacion" in mensaje.lower()
+
+
+def test_aceptar_desincronizacion_solo_actualiza_snapshot(
+    estado_inicial, tipo_entidades, tipos_convenio
+):
+    admision = _crear_admision(
+        tipo_entidades["juridica"], tipos_convenio["juridica"], estado_inicial
+    )
+    documentacion = Documentacion.objects.create(nombre="DNI", obligatorio=True)
+    documentacion.convenios.add(tipos_convenio["juridica"])
+    archivo = ArchivoAdmision.objects.create(
+        admision=admision,
+        documentacion=documentacion,
+        estado="Aceptado",
+        archivo="admisiones/test.pdf",
+    )
+    admision.comedor.organizacion.tipo_entidad = tipo_entidades["eclesiastica"]
+    admision.comedor.organizacion.save(update_fields=["tipo_entidad"])
+
+    ok, _ = AdmisionService.aceptar_desincronizacion_admision(admision)
+
+    assert ok is True
+    admision.refresh_from_db()
+    assert admision.tipo_entidad_origen_id == tipo_entidades["eclesiastica"].id
+    assert (
+        admision.tipo_convenio_id == tipos_convenio["juridica"].id
+    ), "El tipo_convenio NO debe modificarse al aceptar la desincronizacion"
+    assert ArchivoAdmision.objects.filter(pk=archivo.pk).exists(), (
+        "Los archivos previos deben preservarse al continuar con la admision"
+    )
+    assert AdmisionService.admision_desincronizada(admision) is False
+
+
+def test_categoria_para_organizacion_mapea_por_nombre(tipo_entidades):
+    org_juridica = Organizacion.objects.create(
+        nombre="J", tipo_entidad=tipo_entidades["juridica"]
+    )
+    org_eclesiastica = Organizacion.objects.create(
+        nombre="E", tipo_entidad=tipo_entidades["eclesiastica"]
+    )
+    org_hecho = Organizacion.objects.create(
+        nombre="H", tipo_entidad=tipo_entidades["hecho"]
+    )
+
+    assert (
+        categoria_para_organizacion(org_juridica)
+        == DocumentacionOrganizacion.CATEGORIA_PERSONERIA
+    )
+    assert (
+        categoria_para_organizacion(org_eclesiastica)
+        == DocumentacionOrganizacion.CATEGORIA_ECLESIASTICA
+    )
+    assert (
+        categoria_para_organizacion(org_hecho)
+        == DocumentacionOrganizacion.CATEGORIA_BASE
+    )

--- a/admisiones/urls/web_urls.py
+++ b/admisiones/urls/web_urls.py
@@ -5,9 +5,11 @@ from admisiones.views.web_views import (
     eliminar_archivo_admision,
     actualizar_estado_archivo,
     actualizar_numero_gde_archivo,
+    actualizar_numero_gde_organizacion_admision,
     actualizar_convenio_numero,
     actualizar_num_expediente,
     crear_documento_personalizado,
+    resync_convenio_admision,
     AdmisionesTecnicosListView,
     AdmisionesTecnicosUpdateView,
     AdmisionDetailView,
@@ -123,6 +125,16 @@ urlpatterns = [
         "ajax/actualizar-numero-gde/",
         actualizar_numero_gde_archivo,
         name="actualizar_numero_gde_archivo",
+    ),
+    path(
+        "ajax/actualizar-numero-gde-organizacion/",
+        actualizar_numero_gde_organizacion_admision,
+        name="actualizar_numero_gde_organizacion_admision",
+    ),
+    path(
+        "admisiones/<int:admision_pk>/resync-convenio/",
+        resync_convenio_admision,
+        name="admision_resync_convenio",
     ),
     path(
         "ajax/actualizar-convenio-numero/",

--- a/admisiones/views/web_views.py
+++ b/admisiones/views/web_views.py
@@ -646,6 +646,59 @@ def actualizar_numero_gde_archivo(request):
 
 @login_required
 @require_POST
+def actualizar_numero_gde_organizacion_admision(request):
+    resultado = AdmisionService.actualizar_numero_gde_organizacion_ajax(request)
+
+    response_data = {
+        "success": resultado.get("success"),
+        "numero_gde": resultado.get("numero_gde"),
+        "valor_anterior": resultado.get("valor_anterior"),
+    }
+
+    if not resultado.get("success"):
+        response_data["error"] = resultado.get("error", "Error desconocido")
+        return JsonResponse(response_data, status=400)
+
+    return JsonResponse(response_data)
+
+
+@login_required
+@require_POST
+def resync_convenio_admision(request, admision_pk):
+    accion = (request.POST.get("accion") or "").strip().lower()
+    admision = get_object_or_404(
+        Admision.objects.select_related("comedor__organizacion"), pk=admision_pk
+    )
+
+    if accion == "actualizar":
+        ok, mensaje = AdmisionService.resync_admision_desde_organizacion(admision)
+    elif accion == "continuar":
+        ok, mensaje = AdmisionService.aceptar_desincronizacion_admision(admision)
+    else:
+        return JsonResponse(
+            {"success": False, "error": "Accion invalida."}, status=400
+        )
+
+    if not ok:
+        return JsonResponse({"success": False, "error": mensaje}, status=400)
+
+    if accion == "actualizar":
+        messages.success(request, mensaje)
+    else:
+        messages.info(request, mensaje)
+    return JsonResponse(
+        {
+            "success": True,
+            "mensaje": mensaje,
+            "redirect": reverse(
+                "admisiones_tecnicos_editar", kwargs={"pk": admision.pk}
+            ),
+        }
+    )
+
+
+@login_required
+@require_POST
 def actualizar_convenio_numero(request):
     resultado = AdmisionService.actualizar_convenio_numero_ajax(request)
 

--- a/docs/plans/2026-05-22-issue-1605-jcamiloparra-design.md
+++ b/docs/plans/2026-05-22-issue-1605-jcamiloparra-design.md
@@ -1,0 +1,259 @@
+# Plan — Issue #1605 (comentario jcamiloparra, 2026-05-22)
+
+Rama propuesta: `codex/issue-1605-resync-tipo-entidad`
+Fecha: 2026-05-22
+Estado: pendiente de aprobacion.
+
+## Contexto
+
+El comentario [#4519271427](https://github.com/dsocial118/SISOC/issues/1605#issuecomment-4519271427) identifica tres problemas vinculados entre el legajo de Organizacion y la Admision tecnica:
+
+1. **Desincronizacion** entre `Admision.tipo_convenio` y `Organizacion.tipo_entidad` cuando este ultimo se modifica despues de iniciar la admision. La admision puede quedar "trabada" con documentacion incompatible.
+2. **Bug**: al cambiar `tipo_entidad` en el legajo Organizacion, el sistema sigue exponiendo documentos adjuntos previos (de otra categoria), arrastrando estado obsoleto.
+3. **Numero de GDE** vive hoy en `ArchivoOrganizacion`. La regla operativa es que el GDE debe ser propiedad de la Admision (puede repetirse el archivo de organizacion en varias admisiones, cada una con su GDE).
+
+Las tres secciones se atacan **en orden** porque la solucion de la #2 deja en estado limpio el legajo organizacion, lo que simplifica el reset que pide la #1 (opcion "Actualizar desde Legajo"). La #3 es independiente de las anteriores pero comparte la vista `documento_row.html`.
+
+## Hallazgos previos clave
+
+- `Admision.tipo_convenio` → FK a `TipoConvenio` (admisiones/models/admisiones.py).
+- `Organizacion.tipo_entidad` → FK a `TipoEntidad` (organizaciones/models.py).
+- Mapa hardcodeado `CATEGORIA_ORGANIZACIONAL_POR_TIPO_CONVENIO` en [admisiones/services/admisiones_service/impl.py:89-93](admisiones/services/admisiones_service/impl.py) traduce `tipo_convenio_id` ↔ `DocumentacionOrganizacion.categoria`.
+- Mapa por nombre `_categoria_documental_organizacion` en [organizaciones/views.py:117](organizaciones/views.py) traduce `tipo_entidad.nombre` ↔ `categoria` por palabras clave ("ecles", "base", "hecho").
+- `AdmisionService._aplicar_cambio_convenio_y_reset_documentos` en [admisiones/services/admisiones_service/impl.py:987](admisiones/services/admisiones_service/impl.py) ya reusable.
+- Modal previo de cambio de convenio en [admisiones/templates/admisiones/admisiones_tecnicos_form.html:546-588](admisiones/templates/admisiones/admisiones_tecnicos_form.html) sirve como referencia visual.
+- Endpoint AJAX GDE Admision: `actualizar_numero_gde_archivo` ([admisiones/views/web_views.py:629](admisiones/views/web_views.py)) ya valida `estado == "Aceptado"`.
+- Endpoint AJAX GDE Organizacion: `actualizar_gde_documento_organizacion` ([organizaciones/views.py:926](organizaciones/views.py)) NO valida estado.
+- `OrganizacionUpdateView.form_valid` ([organizaciones/views.py:642-661](organizaciones/views.py)) hoy guarda sin reaccionar a cambios.
+- Autocomplete GDE en informe tecnico: `_ultimo_numero_gde` ([admisiones/forms/admisiones_forms.py:15](admisiones/forms/admisiones_forms.py)).
+
+## Diseno helper compartido
+
+Se centraliza el mapeo `TipoEntidad → TipoConvenio` (hoy disperso entre el dict por id y el matching por nombre). Nuevo helper:
+
+- `admisiones/services/tipo_convenio_resolver.py` (modulo nuevo, sin estado):
+  - `categoria_para_tipo_entidad(tipo_entidad) -> str` (reusa la heuristica de `_categoria_documental_organizacion`).
+  - `tipo_convenio_para_tipo_entidad(tipo_entidad) -> TipoConvenio | None` (mapea categoria → `TipoConvenio` via `CATEGORIA_ORGANIZACIONAL_POR_TIPO_CONVENIO` invertido).
+  - `admision_desincronizada(admision) -> bool`.
+
+`organizaciones/views.py` y `admisiones/services/admisiones_service/impl.py` deben pasar a importarlo en lugar de duplicar logica.
+
+---
+
+## Seccion 1 — Resync Admision ↔ Organizacion (1.1 a 1.5)
+
+### Modelo
+
+Agregar a `Admision`:
+
+- `tipo_entidad_origen` → FK `TipoEntidad`, `on_delete=SET_NULL`, nullable. Snapshot del `tipo_entidad` de la organizacion en el momento en que la admision quedo en sync (creacion, "Actualizar desde Legajo", o "Continuar operando").
+
+Migracion separada (no destructiva): backfill = `comedor.organizacion.tipo_entidad` al momento de la migracion para todas las admisiones existentes.
+
+### Servicio
+
+Agregar a `AdmisionService` (admisiones/services/admisiones_service/impl.py):
+
+- `esta_desincronizada(admision)`:
+  - `org_te = admision.comedor.organizacion.tipo_entidad`
+  - Devuelve `True` si `admision.tipo_entidad_origen_id != org_te.id` (y ambos no nulos).
+- `resync_admision_desde_organizacion(admision)`:
+  - Resuelve `nuevo_convenio = tipo_convenio_para_tipo_entidad(org.tipo_entidad)`.
+  - Reusa `_aplicar_cambio_convenio_y_reset_documentos` (ya borra `ArchivoAdmision` y resetea estado).
+  - `admision.tipo_entidad_origen = org.tipo_entidad; admision.save(...)`.
+  - Registrar audit log.
+- `aceptar_desincronizacion_admision(admision)`:
+  - Solo `admision.tipo_entidad_origen = org.tipo_entidad; admision.save(...)`. No toca documentos ni estado.
+
+### URL + view
+
+Nueva URL en `admisiones/urls/web_urls.py`:
+
+```
+path("admisiones/<int:pk>/resync-convenio/", resync_convenio_admision, name="admision_resync_convenio")
+```
+
+Vista `resync_convenio_admision` (admisiones/views/web_views.py): `@require_POST`, recibe `accion = "actualizar" | "continuar"`, delega al service, responde JSON `{success, redirect}` o `{success, mensaje}`.
+
+### Template
+
+En [admisiones/templates/admisiones/admisiones_tecnicos_form.html](admisiones/templates/admisiones/admisiones_tecnicos_form.html):
+
+1. **Banner** sobre el cuerpo del formulario, condicional a `admision_desincronizada` (booleano que pasa la view):
+   - `alert alert-warning` no dismissable.
+   - Texto: "El tipo de convenio fue actualizado desde el Legajo de la Organizacion. Para continuar con la admision debe seleccionar una de las siguientes opciones".
+   - `<select id="accionResyncConvenio" required>` con 2 `<option>` (placeholder + 2 valores).
+   - Boton "Aplicar" deshabilitado hasta que se elija.
+
+2. **Modal secundario** `modalConfirmarResync` que al confirmar emite POST al endpoint nuevo. El mensaje cambia segun la opcion:
+   - actualizar: "La informacion de la Admision se actualizara desde el Legajo de la Organizacion y se perdera el progreso realizado. Esta seguro de continuar?"
+   - continuar: "Continuara gestionando la Admision con la informacion ya procesada, sin las ultimas actualizaciones realizadas al Legajo de la Organizacion correpondiente. Esta seguro de continuar?"
+
+3. **Bloqueo de UI**: mientras `admision_desincronizada == True`, agregar `pointer-events:none; opacity:.5` al resto del formulario via clase `.admision-bloqueada-por-resync`. Asi se obliga al usuario a elegir (1.2).
+
+### JS
+
+Nuevo archivo `static/custom/js/admisionResyncConvenio.js`:
+- Listener del select → habilita boton aplicar.
+- Click aplicar → abre `modalConfirmarResync` con texto correspondiente.
+- Confirm → fetch al endpoint, recarga la pagina al exito (la admision quedara en sync, banner desaparece).
+
+### Sincronizacion
+
+- Pasar a la view (`AdmisionTecnicoEditView.get_context_data`) el flag `admision_desincronizada = AdmisionService.esta_desincronizada(self.object)`.
+- En el momento de **crear** una admision (donde sea que se persista por primera vez) setear `tipo_entidad_origen = comedor.organizacion.tipo_entidad`. Buscar el create handler en [admisiones/services/admisiones_service/impl.py](admisiones/services/admisiones_service/impl.py) (`procesar_post_caratulacion` y el flow de creacion).
+
+---
+
+## Seccion 2 — Reset documentacion al cambiar tipo_entidad (2.1, 2.2)
+
+### Backend
+
+Modificar `OrganizacionUpdateView` ([organizaciones/views.py:642](organizaciones/views.py)):
+
+```python
+def form_valid(self, form):
+    anterior = Organizacion.objects.only("tipo_entidad_id").get(pk=self.object.pk)
+    tipo_anterior_id = anterior.tipo_entidad_id
+    self.object = form.save()
+    if tipo_anterior_id != self.object.tipo_entidad_id:
+        ArchivoOrganizacion.objects.filter(organizacion=self.object).delete()
+    return HttpResponseRedirect(self.get_success_url())
+```
+
+Decisiones:
+- Borrar TODOS los `ArchivoOrganizacion` de la org (no solo los de la categoria), para cubrir 2.2 (volver a un tipo previo deja igualmente lista vacia).
+- Borrado fisico (no soft-delete) porque la documentacion asociada cambia de categoria — mantenerla generaria registros huerfanos.
+- Si la admision ya consumio esos archivos, la Seccion 1 cubrira la desincronizacion en la admision.
+
+### UI confirmacion
+
+Agregar modal de confirmacion en [organizaciones/templates/organizacion_form.html](organizaciones/templates/organizacion_form.html) cuando el `<select>` `tipo_entidad` cambia respecto al valor original:
+
+- Mensaje: "Cambiar el Tipo de Entidad reiniciara la documentacion cargada para esta Organizacion. Esta seguro?"
+- Si cancela → revertir el select al valor original.
+- Si confirma → continuar normal con el submit.
+
+Esto satisface la mencion del primer comentario (1.3 del comentario original): "Asi como actualmente existe una advertencia que se visualiza cuando se modifica el tipo de convenio desde la admision, debe implementarse un cartel de advertencia cuando se modifique el `Tipo de Entidad` desde el legajo organizacion".
+
+### Cleanup
+
+Eliminar (o ignorar) el fetch JS de `tipo_entidad` que solo refresca el `subtipo_entidad` (organizacionesform.js:65-102) si entra en conflicto con el nuevo modal. Mantener el refresco pero condicionarlo a la confirmacion.
+
+---
+
+## Seccion 3 — Numero GDE propiedad de la Admision (3.1 a 3.4)
+
+### Modelo nuevo
+
+`admisiones/models/numero_gde_organizacion.py`:
+
+```python
+class NumeroGdeOrganizacion(models.Model):
+    admision = models.ForeignKey(Admision, on_delete=models.CASCADE, related_name="numeros_gde_organizacion")
+    archivo_organizacion = models.ForeignKey("organizaciones.ArchivoOrganizacion", on_delete=models.CASCADE, related_name="numeros_gde_por_admision")
+    numero_gde = models.CharField(max_length=50, blank=True, null=True)
+    creado = models.DateTimeField(auto_now_add=True)
+    modificado = models.DateTimeField(auto_now=True)
+    modificado_por = models.ForeignKey(settings.AUTH_USER_MODEL, on_delete=models.SET_NULL, null=True, blank=True)
+
+    class Meta:
+        constraints = [models.UniqueConstraint(fields=["admision", "archivo_organizacion"], name="unq_gde_admision_archivoorg")]
+```
+
+Migracion incluye **backfill** opcional: si `ArchivoOrganizacion.numero_gde` esta seteado y existe admision asociada, crear el registro `NumeroGdeOrganizacion` correspondiente (solo si hay forma univoca; si la org tiene varias admisiones, no copiar para evitar ambiguedad — dejar en blanco y registrar en el changelog).
+
+### Cambios en serializacion
+
+`AdmisionService._build_documentos_organizacionales_update_context` ([admisiones/services/admisiones_service/impl.py:335](admisiones/services/admisiones_service/impl.py)):
+- Para cada `archivo_org`, buscar (o crear lazy) el `NumeroGdeOrganizacion` para la admision actual.
+- En el dict serializado, exponer `numero_gde` desde ese registro (no desde `archivo_org.numero_gde`).
+- Agregar key `numero_gde_record_id` para que el front sepa que endpoint llamar.
+
+### Template
+
+`admisiones/templates/admisiones/includes/documento_row.html`:
+- Ajustar la celda `gde-{{ doc.id }}` ([linea 110](admisiones/templates/admisiones/includes/documento_row.html)) para:
+  - Si `doc.es_documento_organizacion` y `doc.estado == "Aceptado"` → usar el endpoint nuevo (con `numero_gde_record_id`).
+  - Si no → comportamiento actual (admision propia).
+- El check `doc.estado == "Aceptado"` ya queda igual (3.4 ya cumplido para admision, lo extendemos a org-docs).
+
+### Nuevo endpoint AJAX
+
+`admisiones/urls/web_urls.py`:
+```
+path("ajax/actualizar-numero-gde-organizacion/", actualizar_numero_gde_organizacion_admision, name="actualizar_numero_gde_organizacion_admision")
+```
+
+Vista en [admisiones/views/web_views.py](admisiones/views/web_views.py): recibe `archivo_organizacion_id` + `admision_id` + `numero_gde`; valida que el `ArchivoOrganizacion.estado == "Aceptado"`; valida permisos (mismo `_puede_editar_numero_gde`); hace `update_or_create` del `NumeroGdeOrganizacion`.
+
+### Quitar GDE editable del Legajo Organizacion
+
+[organizaciones/templates/organizaciones/partials/documentacion_organizacion_row.html](organizaciones/templates/organizaciones/partials/documentacion_organizacion_row.html):
+- Reemplazar el bloque editable de `numero_gde` por: solo lectura, leyenda informativa "El numero GDE se gestiona desde cada Admision".
+
+Endpoint `organizacion_documento_gde` queda **deprecado**: cambiar a `@require_GET` con 410 Gone o eliminar la ruta + tests cercanos. Decision: eliminar para no dejar codigo muerto.
+
+### Autocomplete informe tecnico
+
+`_ultimo_numero_gde` en [admisiones/forms/admisiones_forms.py:15](admisiones/forms/admisiones_forms.py):
+- Hoy solo busca en `ArchivoAdmision`. Extender para que tambien busque en `NumeroGdeOrganizacion` (por la misma admision, ordenado por modificado).
+- Si la documentacion en cuestion es de organizacion, priorizar el valor org-side; sino, mantener el comportamiento actual.
+
+---
+
+## Orden de implementacion
+
+1. **Helper compartido** `tipo_convenio_resolver` (sin breaking changes).
+2. **Seccion 2** primero — es la base limpia y desbloquea testing manual de la #1.
+3. **Seccion 1** — depende de #2 para que la opcion "Actualizar desde Legajo" deje un legajo coherente.
+4. **Seccion 3** — independiente, pero comparte template `documento_row.html` con #1; mejor despues para no entrelazar conflictos de merge.
+
+Cada seccion = 1 commit revisable independiente. Si el alcance crece, separar por modelo/migracion + UI.
+
+## Archivos clave
+
+| Archivo | Cambio |
+|---|---|
+| `admisiones/models/admisiones.py` | + campo `tipo_entidad_origen` |
+| `admisiones/models/numero_gde_organizacion.py` | nuevo modelo |
+| `admisiones/migrations/00XX_*` | dos migraciones nuevas (campo + modelo) con backfill |
+| `admisiones/services/tipo_convenio_resolver.py` | nuevo, centraliza mapeo |
+| `admisiones/services/admisiones_service/impl.py` | + `esta_desincronizada`, `resync_admision_desde_organizacion`, `aceptar_desincronizacion_admision`, ajuste `_build_documentos_organizacionales_update_context` |
+| `admisiones/forms/admisiones_forms.py` | extender `_ultimo_numero_gde` |
+| `admisiones/views/web_views.py` | 2 endpoints nuevos |
+| `admisiones/urls/web_urls.py` | 2 rutas nuevas; revisar contexto que pasa al template |
+| `admisiones/templates/admisiones/admisiones_tecnicos_form.html` | banner + modal de resync |
+| `admisiones/templates/admisiones/includes/documento_row.html` | GDE org-doc editable |
+| `static/custom/js/admisionResyncConvenio.js` | nuevo |
+| `organizaciones/views.py` | `OrganizacionUpdateView.form_valid` reset + remover `actualizar_gde_documento_organizacion` |
+| `organizaciones/urls.py` | remover ruta `organizacion_documento_gde` |
+| `organizaciones/templates/organizacion_form.html` | modal confirmacion cambio tipo_entidad |
+| `organizaciones/templates/organizaciones/partials/documentacion_organizacion_row.html` | GDE solo lectura |
+
+## Validacion
+
+Manual (post-cambio):
+1. **Seccion 2**: ir a Organizacion → cambiar `tipo_entidad` → confirmar advertencia → verificar que el listado de documentos queda vacio. Volver al tipo anterior → sigue vacio.
+2. **Seccion 1 escenario A**: admision en `Documentacion en Proceso` → cambiar `tipo_entidad` de la org → volver a la admision → ver banner. Elegir "Actualizar" → confirmar → admision queda reseteada, en estado inicial, con docs de la nueva categoria.
+3. **Seccion 1 escenario B**: idem, pero elegir "Continuar" → banner desaparece, admision sigue como estaba.
+4. **Seccion 3**: admision con doc de organizacion en estado `Aceptado` → editar GDE desde la admision → guardar → recargar → persiste. Verificar que la misma org doc en otra admision puede tener otro GDE. Verificar que el form de informe tecnico autocompleta.
+
+Automatizada:
+- `pytest admisiones/tests/test_tipo_convenio_resolver.py` (nuevo)
+- `pytest admisiones/tests/test_resync.py` (nuevo)
+- `pytest organizaciones/tests/test_update_view.py` (extender)
+- `pytest admisiones/tests/test_numero_gde_organizacion.py` (nuevo)
+- `powershell -ExecutionPolicy Bypass -File scripts/ai/codex_run.ps1 validate`
+
+## Registro
+
+Al cerrar la PR:
+- `docs/registro/cambios/2026-05-22-issue-1605-resync-tipo-entidad.md`
+- `docs/registro/decisiones/2026-05-22-numero-gde-propiedad-admision.md`
+
+## Supuestos
+
+1. La heuristica por nombre actual de `_categoria_documental_organizacion` es la fuente de verdad oficial. Si el equipo quiere migrar a un mapeo explicito (FK directa entre `TipoEntidad` ↔ `TipoConvenio`), se hace en una decision aparte; este plan lo encapsula en un helper para que el cambio futuro sea de un solo lugar.
+2. El reset destructivo de `ArchivoOrganizacion` (Seccion 2) es aceptable porque la documentacion previa pierde validez al cambiar categoria. Si se requiere preservar historico, habria que mover a soft-delete; queda fuera de este plan.
+3. La accion "Continuar operando con la Admision actual" deja el snapshot actualizado, lo que significa que un cambio posterior de `tipo_entidad` volvera a disparar el banner. Esto matchea la lectura literal del spec (cada cambio nuevo debe pedir decision).

--- a/docs/registro/cambios/2026-05-22-issue-1605-resync-tipo-entidad.md
+++ b/docs/registro/cambios/2026-05-22-issue-1605-resync-tipo-entidad.md
@@ -1,0 +1,77 @@
+# 2026-05-22 — Issue #1605: resync tipo_entidad ↔ admision, reset documental y GDE por admision
+
+Rama: `codex/issue-1605-resync-tipo-entidad`
+Plan: [docs/plans/2026-05-22-issue-1605-jcamiloparra-design.md](../../plans/2026-05-22-issue-1605-jcamiloparra-design.md)
+
+## Resumen
+
+Implementa los tres requerimientos del comentario [#4519271427](https://github.com/dsocial118/SISOC/issues/1605#issuecomment-4519271427) reportado por jcamiloparra:
+
+1. **Seccion 1** — advertencia + opciones cuando el `Tipo de Entidad` de la Organizacion cambia despues de creada la Admision.
+2. **Seccion 2** — al modificar `Tipo de Entidad` desde el Legajo de la Organizacion, la documentacion del legajo se reinicia (sin adjuntos).
+3. **Seccion 3** — el `Numero de GDE` pasa a ser propiedad de la Admision incluso para los documentos administrados desde la Organizacion (modelo `NumeroGdeOrganizacion`).
+
+## Modelos / migraciones
+
+- `Admision.tipo_entidad_origen` (FK `organizaciones.TipoEntidad`, nullable). Snapshot del `tipo_entidad` con el que la admision quedo sincronizada (creacion / resync / aceptacion). Migracion: [0059_admision_tipo_entidad_origen.py](../../../admisiones/migrations/0059_admision_tipo_entidad_origen.py) (incluye backfill).
+- `NumeroGdeOrganizacion(admision, archivo_organizacion, numero_gde)` con unique_together. Reemplaza el uso editable de `ArchivoOrganizacion.numero_gde` (el campo queda en el modelo por compatibilidad historica). Migracion: [0060_numero_gde_organizacion.py](../../../admisiones/migrations/0060_numero_gde_organizacion.py) (incluye backfill conservador: solo copia GDE org-side si existe exactamente una admision asociada).
+
+## Servicios
+
+- Nuevo helper compartido: [`admisiones/services/tipo_convenio_resolver.py`](../../../admisiones/services/tipo_convenio_resolver.py). Centraliza el mapeo `tipo_entidad -> categoria documental -> TipoConvenio` para evitar drift entre `organizaciones/views.py` y `admisiones_service`.
+- `AdmisionService.admision_desincronizada(admision)` compara el snapshot `tipo_entidad_origen` con el `tipo_entidad` actual de la organizacion.
+- `AdmisionService.resync_admision_desde_organizacion(admision)` reusa `_aplicar_cambio_convenio_y_reset_documentos` (borra `ArchivoAdmision`, resetea estado, ajusta `tipo_convenio`) y actualiza el snapshot.
+- `AdmisionService.aceptar_desincronizacion_admision(admision)` solo actualiza el snapshot al `tipo_entidad` actual para silenciar la advertencia hasta el proximo cambio.
+- `AdmisionService.actualizar_numero_gde_organizacion_ajax(request)` valida `ArchivoOrganizacion.estado == "Aceptado"`, permisos dupla/superuser, restriccion documental por informe tecnico, y persiste el GDE en `NumeroGdeOrganizacion` (`update_or_create`).
+- `AdmisionService._build_documentos_organizacionales_update_context` y `_serializar_documentacion_organizacion` ahora exponen `archivo_organizacion_id` + `numero_gde` desde `NumeroGdeOrganizacion` (no desde `ArchivoOrganizacion.numero_gde`).
+- `admisiones/forms/admisiones_forms.py::_ultimo_numero_gde` extiende la busqueda a `NumeroGdeOrganizacion` cuando no hay valor en `ArchivoAdmision`.
+- `AdmisionService.create_admision` setea `tipo_entidad_origen = comedor.organizacion.tipo_entidad` al crear la admision.
+
+## Vistas / URLs
+
+- Nuevas rutas en [`admisiones/urls/web_urls.py`](../../../admisiones/urls/web_urls.py):
+  - `ajax/actualizar-numero-gde-organizacion/` → `actualizar_numero_gde_organizacion_admision` (POST, persiste `NumeroGdeOrganizacion`).
+  - `admisiones/<int:admision_pk>/resync-convenio/` → `resync_convenio_admision` (POST con `accion="actualizar"|"continuar"`).
+- `OrganizacionUpdateView.form_valid` (organizaciones/views.py) detecta cambio de `tipo_entidad` y borra todos los `ArchivoOrganizacion` de la organizacion (cubre 2.1 y 2.2).
+- Removida la vista `actualizar_gde_documento_organizacion` y la ruta `organizacion_documento_gde` (no estaba referenciada por templates; reemplazada por el flujo admision-side).
+
+## Templates / JS
+
+- [`admisiones_tecnicos_form.html`](../../../admisiones/templates/admisiones/admisiones_tecnicos_form.html): banner de desincronizacion con `<select>` obligatorio (Actualizar / Continuar) + modal de confirmacion con textos exactos del spec. Configurable via `admision_desincronizada`, `tipo_entidad_actual_organizacion`, `tipo_entidad_origen_snapshot` que ahora pasa `_build_response_update_context`.
+- [`documento_row.html`](../../../admisiones/templates/admisiones/includes/documento_row.html): para documentos de organizacion en estado Aceptado sin `ArchivoAdmision`, expone editor GDE con id `gde-org-{archivo_organizacion_id}` que llama al endpoint nuevo. Mantiene el comportamiento previo para `ArchivoAdmision`.
+- Nuevo [`static/custom/js/admisionResyncConvenio.js`](../../../static/custom/js/admisionResyncConvenio.js): maneja el flujo banner → modal → POST.
+- [`admisionesactualizarestado.js`](../../../static/custom/js/admisionesactualizarestado.js): nuevas funciones `activarEdicionGDEOrganizacion`, `guardarNumeroGDEOrganizacion`, etc., reutilizando el config `admisiones-tecnicos-config`.
+- [`organizacion_form.html`](../../../organizaciones/templates/organizacion_form.html): la advertencia previa al cambiar `tipo_entidad` se reforzo (ahora explicita el reset de documentacion) y se agrego modal de confirmacion antes de enviar el form.
+
+## Validacion
+
+Corrida via Docker (`docker compose up -d` + `pytest`):
+
+```
+pytest admisiones organizaciones --tb=short -q
+56 passed in 18.33s
+```
+
+Tests nuevos (17 casos, todos pasan):
+
+- [admisiones/tests/test_resync_admision.py](../../../admisiones/tests/test_resync_admision.py) — `admision_desincronizada`, `resync_admision_desde_organizacion`, `aceptar_desincronizacion_admision`, mapeo de categorias.
+- [admisiones/tests/test_numero_gde_organizacion.py](../../../admisiones/tests/test_numero_gde_organizacion.py) — flujo completo de `actualizar_numero_gde_organizacion_ajax`, unique constraint, GDE por admision.
+- [organizaciones/test_update_view_tipo_entidad.py](../../../organizaciones/test_update_view_tipo_entidad.py) — reset de `ArchivoOrganizacion` al cambiar `tipo_entidad` (incluye caso "volver al tipo anterior").
+
+Adicional:
+- `python manage.py check` → 0 issues.
+- `python manage.py makemigrations --check --dry-run` → No changes detected.
+
+## Riesgos / supuestos
+
+1. La heuristica de mapeo `tipo_entidad -> tipo_convenio` sigue siendo por nombre (`AdmisionService.resolver_tipo_convenio_desde_organizacion`). Si se renombra un `TipoEntidad` con palabras fuera del patron (`personeria`, `ecles`, `culto`, `base`, `hecho`), la admision podria no resincronizar. El helper nuevo encapsula esto para facilitar una migracion futura a una FK explicita.
+2. El reset de `ArchivoOrganizacion` es destructivo (no soft-delete). Si se necesita preservar historico, hay que migrar el modelo a soft-delete (fuera de scope).
+3. El campo `ArchivoOrganizacion.numero_gde` queda intacto en DB para no perder datos historicos. El flujo nuevo lo ignora; queda como candidato a remover en una migracion futura.
+4. La opcion "Continuar operando con la Admision actual" actualiza el snapshot, por lo que un cambio posterior de `tipo_entidad` volvera a disparar el banner — lectura literal del spec.
+
+## Como probar manualmente
+
+1. **Seccion 2**: editar una Organizacion, cambiar `Tipo de Entidad`, confirmar el modal y verificar que el listado de documentos del legajo queda vacio (incluso si se vuelve al tipo anterior).
+2. **Seccion 1A**: con una admision en `Documentacion en Proceso`, cambiar `tipo_entidad` desde la organizacion, volver a la admision, elegir "Actualizar Informacion desde Legajo Organizacion" → confirmar → admision queda en `convenio_seleccionado`, documentos eliminados, `tipo_convenio` recalculado.
+3. **Seccion 1B**: misma situacion, elegir "Continuar operando" → confirmar → la admision sigue como estaba y el banner desaparece.
+4. **Seccion 3**: con una admision que muestra un documento de Organizacion en estado `Aceptado`, editar el `Numero de GDE` desde la admision, recargar, confirmar persistencia. Replicar el escenario en una segunda admision con la misma org para verificar que cada una tiene su propio GDE.

--- a/organizaciones/templates/organizacion_form.html
+++ b/organizaciones/templates/organizacion_form.html
@@ -123,7 +123,8 @@
                                 <div id="tipo-entidad-warning"
                                      class="alert alert-warning d-none mt-2"
                                      role="alert">
-                                    Al modificar el Tipo de Entidad, puede cambiar el Tipo de Convenio y la documentación requerida en las admisiones vinculadas.
+                                    <strong><i class="fas fa-exclamation-triangle mr-1"></i>Atención:</strong>
+                                    Al cambiar el Tipo de Entidad se reiniciará la documentación del legajo (se eliminarán los archivos ya cargados). Las admisiones vinculadas mostrarán una advertencia para resincronizarse o continuar.
                                 </div>
                             </div>
                             <div class="col-md-6">{{ form.subtipo_entidad|as_crispy_field }}</div>
@@ -252,12 +253,52 @@
                         <button type="button" data-history-back="true" class="btn btn-secondary mr-2">
                             <i class="fas fa-times mr-1"></i> Cancelar
                         </button>
-                        <button class="btn btn-success" type="submit">
+                        <button class="btn btn-success" type="submit" id="organizacionSubmitBtn">
                             <i class="fas fa-save mr-1"></i> Guardar organización
                         </button>
                     </div>
                 </div>
             </form>
+
+            <!-- Modal: confirmacion de cambio de Tipo de Entidad -->
+            <div class="modal fade"
+                 id="modalConfirmarTipoEntidad"
+                 tabindex="-1"
+                 aria-labelledby="modalConfirmarTipoEntidadLabel"
+                 aria-hidden="true">
+                <div class="modal-dialog modal-dialog-centered">
+                    <div class="modal-content">
+                        <div class="modal-header">
+                            <h5 class="modal-title" id="modalConfirmarTipoEntidadLabel">
+                                <i class="fas fa-exclamation-triangle text-warning mr-2"></i>
+                                Confirmar cambio de Tipo de Entidad
+                            </h5>
+                            <button type="button"
+                                    class="btn-close"
+                                    data-bs-dismiss="modal"
+                                    aria-label="Close"></button>
+                        </div>
+                        <div class="modal-body">
+                            <p>
+                                Al cambiar el <strong>Tipo de Entidad</strong> se reiniciara
+                                el listado de documentos del legajo de la organizacion (se
+                                eliminaran los archivos ya cargados).
+                            </p>
+                            <p class="mb-0">
+                                Ademas, las admisiones vinculadas mostraran una advertencia
+                                para resincronizarse o continuar con la informacion actual.
+                            </p>
+                            <p class="mt-2 mb-0"><strong>¿Esta seguro de continuar?</strong></p>
+                        </div>
+                        <div class="modal-footer">
+                            <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Cancelar</button>
+                            <button type="button" class="btn btn-warning" id="confirmarCambioTipoEntidadBtn">
+                                Confirmar cambio
+                            </button>
+                        </div>
+                    </div>
+                </div>
+            </div>
         </div>
     </div>
 {% endblock %}
@@ -293,6 +334,31 @@
             tipoEntidadInput.addEventListener("change", function () {
                 var changed = organizacionPk && tipoEntidadInput.value !== tipoEntidadOriginal;
                 tipoEntidadWarning.classList.toggle("d-none", !changed);
+            });
+        }
+
+        var organizacionForm = document.getElementById("organizacionForm");
+        var modalEl = document.getElementById("modalConfirmarTipoEntidad");
+        var confirmarTipoEntidadBtn = document.getElementById("confirmarCambioTipoEntidadBtn");
+        var tipoEntidadConfirmado = false;
+        if (organizacionForm && modalEl && tipoEntidadInput && confirmarTipoEntidadBtn) {
+            var modalInstance = bootstrap.Modal.getOrCreateInstance(modalEl);
+            organizacionForm.addEventListener("submit", function (event) {
+                if (!organizacionPk) {
+                    return;
+                }
+                var changed = tipoEntidadInput.value !== tipoEntidadOriginal;
+                if (changed && !tipoEntidadConfirmado) {
+                    event.preventDefault();
+                    modalInstance.show();
+                }
+            });
+            confirmarTipoEntidadBtn.addEventListener("click", function () {
+                tipoEntidadConfirmado = true;
+                modalInstance.hide();
+                organizacionForm.requestSubmit
+                    ? organizacionForm.requestSubmit()
+                    : organizacionForm.submit();
             });
         }
 

--- a/organizaciones/test_update_view_tipo_entidad.py
+++ b/organizaciones/test_update_view_tipo_entidad.py
@@ -1,0 +1,166 @@
+"""Tests para la Seccion 2 del issue #1605: al cambiar el ``tipo_entidad`` de
+una ``Organizacion`` desde el legajo, el listado de documentos
+(``ArchivoOrganizacion``) debe reiniciarse."""
+
+import pytest
+from django.contrib.auth import get_user_model
+from django.contrib.auth.models import Permission
+from django.test import Client
+from django.urls import reverse
+
+from core.models import Provincia
+from organizaciones.models import (
+    ArchivoOrganizacion,
+    DocumentacionOrganizacion,
+    Organizacion,
+    TipoEntidad,
+)
+
+
+pytestmark = pytest.mark.django_db
+User = get_user_model()
+
+
+@pytest.fixture
+def usuario():
+    user = User.objects.create_user(username="org_editor", password="pwd")
+    permiso = Permission.objects.get(
+        content_type__app_label="organizaciones", codename="view_organizacion"
+    )
+    user.user_permissions.add(permiso)
+    return user
+
+
+@pytest.fixture
+def tipos():
+    juridica = TipoEntidad.objects.create(nombre="Personería Jurídica")
+    eclesiastica = TipoEntidad.objects.create(
+        nombre="Personería Jurídica Eclesiástica"
+    )
+    return {"juridica": juridica, "eclesiastica": eclesiastica}
+
+
+@pytest.fixture
+def provincia():
+    return Provincia.objects.create(nombre="Buenos Aires")
+
+
+@pytest.fixture
+def organizacion_con_documentos(tipos, provincia):
+    organizacion = Organizacion.objects.create(
+        nombre="Org con docs", tipo_entidad=tipos["juridica"], provincia=provincia
+    )
+    doc_a = DocumentacionOrganizacion.objects.create(
+        nombre="Acta Constitutiva",
+        categoria=DocumentacionOrganizacion.CATEGORIA_PERSONERIA,
+        obligatorio=True,
+    )
+    doc_b = DocumentacionOrganizacion.objects.create(
+        nombre="Estatuto",
+        categoria=DocumentacionOrganizacion.CATEGORIA_PERSONERIA,
+        obligatorio=True,
+    )
+    ArchivoOrganizacion.objects.create(
+        organizacion=organizacion,
+        documentacion=doc_a,
+        archivo="organizaciones/test-a.pdf",
+        estado=ArchivoOrganizacion.ESTADO_ACEPTADO,
+    )
+    ArchivoOrganizacion.objects.create(
+        organizacion=organizacion,
+        documentacion=doc_b,
+        archivo="organizaciones/test-b.pdf",
+        estado=ArchivoOrganizacion.ESTADO_A_VALIDAR,
+    )
+    return organizacion
+
+
+def _post_payload(organizacion, tipo_entidad):
+    return {
+        "nombre": organizacion.nombre,
+        "cuit": "",
+        "telefono": "",
+        "email": "",
+        "domicilio": "",
+        "localidad": "",
+        "partido": "",
+        "provincia": str(organizacion.provincia_id),
+        "municipio": "",
+        "tipo_entidad": str(tipo_entidad.pk),
+        "subtipo_entidad": "",
+        "fecha_vencimiento": "2030-01-01",
+        "sigla": "",
+        "cuil_duplicado_confirmado": "",
+        "cuil_duplicado_confirmado_valor": "",
+    }
+
+
+def test_cambio_tipo_entidad_borra_todos_los_archivos(
+    organizacion_con_documentos, tipos, usuario
+):
+    client = Client()
+    client.force_login(usuario)
+    url = reverse("organizacion_editar", kwargs={"pk": organizacion_con_documentos.pk})
+
+    response = client.post(
+        url, _post_payload(organizacion_con_documentos, tipos["eclesiastica"])
+    )
+
+    assert response.status_code in (302, 303), response.content[:300]
+    organizacion_con_documentos.refresh_from_db()
+    assert organizacion_con_documentos.tipo_entidad_id == tipos["eclesiastica"].pk
+    assert (
+        ArchivoOrganizacion.objects.filter(
+            organizacion=organizacion_con_documentos
+        ).count()
+        == 0
+    ), "Al cambiar tipo_entidad todos los ArchivoOrganizacion deben borrarse"
+
+
+def test_sin_cambio_de_tipo_entidad_no_borra_archivos(
+    organizacion_con_documentos, tipos, usuario
+):
+    client = Client()
+    client.force_login(usuario)
+    url = reverse("organizacion_editar", kwargs={"pk": organizacion_con_documentos.pk})
+
+    response = client.post(
+        url, _post_payload(organizacion_con_documentos, tipos["juridica"])
+    )
+
+    assert response.status_code in (302, 303)
+    assert (
+        ArchivoOrganizacion.objects.filter(
+            organizacion=organizacion_con_documentos
+        ).count()
+        == 2
+    ), "Si tipo_entidad no cambia, los archivos deben preservarse"
+
+
+def test_volver_al_tipo_anterior_no_recupera_archivos_borrados(
+    organizacion_con_documentos, tipos, usuario
+):
+    """2.2 — Si despues de cambiar se vuelve al tipo anterior, los archivos
+    eliminados NO se recuperan: el listado debe seguir vacio."""
+
+    client = Client()
+    client.force_login(usuario)
+    url = reverse("organizacion_editar", kwargs={"pk": organizacion_con_documentos.pk})
+
+    # Primer cambio: eclesiastica → borra todo
+    client.post(
+        url, _post_payload(organizacion_con_documentos, tipos["eclesiastica"])
+    )
+    # Volver al tipo anterior
+    client.post(
+        url, _post_payload(organizacion_con_documentos, tipos["juridica"])
+    )
+
+    organizacion_con_documentos.refresh_from_db()
+    assert organizacion_con_documentos.tipo_entidad_id == tipos["juridica"].pk
+    assert (
+        ArchivoOrganizacion.objects.filter(
+            organizacion=organizacion_con_documentos
+        ).count()
+        == 0
+    )

--- a/organizaciones/urls.py
+++ b/organizaciones/urls.py
@@ -13,7 +13,6 @@ from organizaciones.views import (
     FirmanteUpdateView,
     FirmanteDeleteView,
     AvalDeleteView,
-    actualizar_gde_documento_organizacion,
     actualizar_estado_documento_organizacion,
     actualizar_vencimiento_documento_organizacion,
     historial_documento_organizacion,
@@ -86,13 +85,6 @@ urlpatterns = [
             actualizar_estado_documento_organizacion
         ),
         name="organizacion_documento_estado",
-    ),
-    path(
-        "organizaciones/documentacion/<int:archivo_id>/gde/",
-        permissions_any_required(ORGANIZACION_DOCUMENTACION_PERMS)(
-            actualizar_gde_documento_organizacion
-        ),
-        name="organizacion_documento_gde",
     ),
     path(
         "organizaciones/documentacion/<int:archivo_id>/vencimiento/",

--- a/organizaciones/views.py
+++ b/organizaciones/views.py
@@ -662,14 +662,26 @@ class OrganizacionUpdateView(LoginRequiredMixin, UpdateView):
         context = super().get_context_data(**kwargs)
         context["cuil_check_ajax_url"] = reverse("organizacion_cuil_check_ajax")
         context["organizacion_pk"] = self.object.pk
+        context["tipo_entidad_actual_id"] = (
+            self.object.tipo_entidad_id if self.object else None
+        )
         return context
 
     def form_valid(self, form):
-        if form.is_valid():
-            self.object = form.save()
-            return HttpResponseRedirect(self.get_success_url())
-        else:
+        if not form.is_valid():
             return self.form_invalid(form)
+
+        tipo_entidad_anterior_id = Organizacion.objects.values_list(
+            "tipo_entidad_id", flat=True
+        ).get(pk=self.object.pk)
+        self.object = form.save()
+        if tipo_entidad_anterior_id != self.object.tipo_entidad_id:
+            ArchivoOrganizacion.objects.filter(organizacion=self.object).delete()
+            messages.warning(
+                self.request,
+                "Se reinicio la documentacion del legajo porque cambio el Tipo de Entidad.",
+            )
+        return HttpResponseRedirect(self.get_success_url())
 
     def get_success_url(self):
         return reverse("organizacion_detalle", kwargs={"pk": self.object.pk})
@@ -929,35 +941,6 @@ def actualizar_estado_documento_organizacion(request, archivo_id):
         {
             "success": True,
             "estado": archivo.estado,
-            "html": _render_documentacion_organizacion_row(
-                request, archivo.organizacion, archivo.documentacion
-            ),
-            "row_id": archivo.documentacion_id,
-        }
-    )
-
-
-@login_required
-@require_POST
-def actualizar_gde_documento_organizacion(request, archivo_id):
-    archivo = get_object_or_404(
-        ArchivoOrganizacion.objects.select_related("organizacion", "documentacion"),
-        pk=archivo_id,
-    )
-    if not _puede_modificar_documentacion_organizacion(
-        request.user, archivo.organizacion
-    ):
-        return JsonResponse(
-            {"success": False, "error": "Sin permisos para modificar este documento."},
-            status=403,
-        )
-    archivo.numero_gde = (request.POST.get("numero_gde") or "").strip() or None
-    archivo.modificado_por = request.user
-    archivo.save(update_fields=["numero_gde", "modificado_por", "modificado"])
-    return JsonResponse(
-        {
-            "success": True,
-            "numero_gde": archivo.numero_gde,
             "html": _render_documentacion_organizacion_row(
                 request, archivo.organizacion, archivo.documentacion
             ),

--- a/static/custom/js/admisionResyncConvenio.js
+++ b/static/custom/js/admisionResyncConvenio.js
@@ -1,0 +1,111 @@
+(function () {
+    "use strict";
+
+    function getConfig() {
+        return document.getElementById("admisiones-tecnicos-config");
+    }
+
+    function getCsrfToken() {
+        var config = getConfig();
+        if (!config) return "";
+        return config.dataset.csrfToken || "";
+    }
+
+    function getResyncUrl() {
+        var config = getConfig();
+        if (!config) return "";
+        return config.dataset.urlResyncConvenio || "";
+    }
+
+    function mensajeParaAccion(accion) {
+        if (accion === "actualizar") {
+            return (
+                "La información de la Admisión se actualizará desde el Legajo de la " +
+                "Organización y se perderá el progreso realizado. " +
+                "¿Está seguro de continuar?"
+            );
+        }
+        if (accion === "continuar") {
+            return (
+                "Continuará gestionando la Admisión con la información ya procesada, " +
+                "sin las últimas actualizaciones realizadas al Legajo de la Organización " +
+                "correspondiente. ¿Está seguro de continuar?"
+            );
+        }
+        return "";
+    }
+
+    function inicializar() {
+        var selectAccion = document.getElementById("accionResyncConvenio");
+        var btnAplicar = document.getElementById("btnAplicarResyncConvenio");
+        var modalEl = document.getElementById("modalConfirmarResyncConvenio");
+        var mensajeEl = document.getElementById("modalConfirmarResyncConvenioMensaje");
+        var btnConfirmar = document.getElementById("btnConfirmarResyncConvenio");
+        if (!selectAccion || !btnAplicar || !modalEl || !mensajeEl || !btnConfirmar) {
+            return;
+        }
+        var modalInstance = bootstrap.Modal.getOrCreateInstance(modalEl);
+
+        selectAccion.addEventListener("change", function () {
+            btnAplicar.disabled = !selectAccion.value;
+        });
+
+        btnAplicar.addEventListener("click", function () {
+            var accion = selectAccion.value;
+            if (!accion) return;
+            mensajeEl.textContent = mensajeParaAccion(accion);
+            btnConfirmar.dataset.accion = accion;
+            modalInstance.show();
+        });
+
+        btnConfirmar.addEventListener("click", function () {
+            var accion = btnConfirmar.dataset.accion;
+            if (!accion) return;
+            btnConfirmar.disabled = true;
+            var url = getResyncUrl();
+            if (!url) {
+                alert("No se pudo determinar la URL del endpoint de resincronización.");
+                btnConfirmar.disabled = false;
+                return;
+            }
+            fetch(url, {
+                method: "POST",
+                headers: {
+                    "X-CSRFToken": getCsrfToken(),
+                    "Content-Type": "application/x-www-form-urlencoded",
+                    "X-Requested-With": "XMLHttpRequest",
+                },
+                body: new URLSearchParams({ accion: accion }),
+            })
+                .then(function (response) {
+                    return response.json().then(function (data) {
+                        return { ok: response.ok, data: data };
+                    });
+                })
+                .then(function (payload) {
+                    if (!payload.ok || !payload.data || payload.data.success === false) {
+                        var error =
+                            (payload.data && payload.data.error) ||
+                            "No se pudo aplicar la acción.";
+                        alert(error);
+                        btnConfirmar.disabled = false;
+                        return;
+                    }
+                    modalInstance.hide();
+                    var redirect =
+                        (payload.data && payload.data.redirect) || window.location.href;
+                    window.location.href = redirect;
+                })
+                .catch(function () {
+                    alert("Ocurrió un error al aplicar la acción.");
+                    btnConfirmar.disabled = false;
+                });
+        });
+    }
+
+    if (document.readyState === "loading") {
+        document.addEventListener("DOMContentLoaded", inicializar);
+    } else {
+        inicializar();
+    }
+})();

--- a/static/custom/js/admisionesactualizarestado.js
+++ b/static/custom/js/admisionesactualizarestado.js
@@ -532,6 +532,115 @@ function actualizarNumeroGDELegacy(documentoId, numeroGDE) {
     actualizarNumeroGDE(documentoId, numeroGDE);
 }
 
+// --- Numero GDE para documentos puros de Organizacion vistos desde la Admision ---
+
+function activarEdicionGDEOrganizacion(archivoOrgId) {
+    const displayDiv = document.getElementById(`gde-org-display-${archivoOrgId}`);
+    const editDiv = document.getElementById(`gde-org-edit-${archivoOrgId}`);
+    const input = document.getElementById(`gde-org-input-${archivoOrgId}`);
+    if (displayDiv && editDiv && input) {
+        displayDiv.classList.add("d-none");
+        editDiv.classList.remove("d-none");
+        input.focus();
+    }
+}
+
+function cancelarEdicionGDEOrganizacion(archivoOrgId) {
+    const displayDiv = document.getElementById(`gde-org-display-${archivoOrgId}`);
+    const editDiv = document.getElementById(`gde-org-edit-${archivoOrgId}`);
+    const input = document.getElementById(`gde-org-input-${archivoOrgId}`);
+    if (displayDiv && editDiv && input) {
+        const valorOriginal = displayDiv.querySelector("span").textContent;
+        input.value = valorOriginal === "Sin número GDE" ? "" : valorOriginal;
+        editDiv.classList.add("d-none");
+        displayDiv.classList.remove("d-none");
+    }
+}
+
+function guardarNumeroGDEOrganizacion(archivoOrgId) {
+    const input = document.getElementById(`gde-org-input-${archivoOrgId}`);
+    const numeroGDE = input ? input.value.trim() : "";
+    actualizarNumeroGDEOrganizacion(archivoOrgId, numeroGDE);
+}
+
+function actualizarVistaGDEOrganizacion(archivoOrgId, numeroGDE) {
+    const displayDiv = document.getElementById(`gde-org-display-${archivoOrgId}`);
+    const input = document.getElementById(`gde-org-input-${archivoOrgId}`);
+    if (!displayDiv || !input) return;
+    input.value = numeroGDE || "";
+    displayDiv.innerHTML = "";
+    const span = document.createElement("span");
+    if (numeroGDE) {
+        span.className = "text-success fw-bold";
+        span.textContent = numeroGDE;
+        displayDiv.appendChild(span);
+        const icon = document.createElement("i");
+        icon.className = "bi bi-pencil-square ms-2 text-muted";
+        icon.style.cursor = "pointer";
+        icon.title = "Editar número GDE";
+        displayDiv.appendChild(icon);
+    } else {
+        span.className = "text-muted";
+        span.textContent = "Sin número GDE";
+        displayDiv.appendChild(span);
+        const icon = document.createElement("i");
+        icon.className = "bi bi-plus-circle ms-2 text-primary";
+        icon.style.cursor = "pointer";
+        icon.title = "Agregar número GDE";
+        displayDiv.appendChild(icon);
+    }
+}
+
+function volverAModoVistaOrganizacion(archivoOrgId) {
+    const displayDiv = document.getElementById(`gde-org-display-${archivoOrgId}`);
+    const editDiv = document.getElementById(`gde-org-edit-${archivoOrgId}`);
+    if (displayDiv && editDiv) {
+        editDiv.classList.add("d-none");
+        displayDiv.classList.remove("d-none");
+    }
+}
+
+function actualizarNumeroGDEOrganizacion(archivoOrgId, numeroGDE) {
+    const csrfToken = document.querySelector("[name=csrfmiddlewaretoken]").value;
+    const config = document.getElementById("admisiones-tecnicos-config");
+    const url = config ? config.dataset.urlActualizarNumeroGdeOrganizacion : "";
+    const admisionId = config ? config.dataset.admisionId : "";
+    if (!url || !admisionId) {
+        alert("No se pudo actualizar el número GDE.");
+        return;
+    }
+
+    fetch(url, {
+        method: "POST",
+        headers: {
+            "X-CSRFToken": csrfToken,
+            "Content-Type": "application/x-www-form-urlencoded",
+        },
+        body: new URLSearchParams({
+            admision_id: admisionId,
+            archivo_organizacion_id: archivoOrgId,
+            numero_gde: numeroGDE,
+        }),
+    })
+        .then((response) => response.json())
+        .then((data) => {
+            if (!data.success) {
+                alert("Error: " + data.error);
+                const input = document.getElementById(`gde-org-input-${archivoOrgId}`);
+                if (input) input.value = data.valor_anterior || "";
+                return;
+            }
+            const toastEl = document.getElementById("toastGDEExito");
+            if (toastEl) new bootstrap.Toast(toastEl).show();
+            actualizarVistaGDEOrganizacion(archivoOrgId, data.numero_gde);
+            volverAModoVistaOrganizacion(archivoOrgId);
+        })
+        .catch((error) => {
+            console.error("Error al actualizar número GDE de organización:", error);
+            alert("Ocurrió un error al actualizar el número GDE.");
+        });
+}
+
 function activarEdicionConvenioNumero() {
     const displayDiv = document.getElementById("convenio-numero-display");
     const editDiv = document.getElementById("convenio-numero-edit");


### PR DESCRIPTION
## Summary

Resuelve los tres requerimientos del [comentario de @jcamiloparra en #1605](https://github.com/dsocial118/SISOC/issues/1605#issuecomment-4519271427):

- **Sección 1** — Detecta cuando el `tipo_entidad` de la Organización cambió después de creada la Admisión y muestra un banner con select obligatorio (`Actualizar desde Legajo` / `Continuar operando`) + modal de confirmación. Snapshot en `Admision.tipo_entidad_origen`.
- **Sección 2** — Al modificar `tipo_entidad` desde el legajo de Organización se reinicia toda la documentación cargada (`ArchivoOrganizacion`), aun si después se vuelve a un tipo previo.
- **Sección 3** — El `Número de GDE` pasa a ser propiedad de la Admisión vía nuevo modelo `NumeroGdeOrganizacion(admision, archivo_organizacion, numero_gde)`. La edición desde el legajo Organización se desactiva; la UI editable vive en la admisión y solo cuando el documento está en estado `Aceptado`.

Helper compartido `admisiones/services/tipo_convenio_resolver.py` centraliza el mapeo `tipo_entidad → categoría documental → TipoConvenio` (antes disperso entre `organizaciones/views.py` y `admisiones_service`).

## Cambios principales

### Modelos / migraciones
- `Admision.tipo_entidad_origen` (FK `TipoEntidad`, nullable) — migración `0059` con backfill.
- Nuevo modelo `NumeroGdeOrganizacion` con `UniqueConstraint(admision, archivo_organizacion)` — migración `0060` con backfill conservador.

### Servicios
- `AdmisionService.admision_desincronizada`, `resync_admision_desde_organizacion`, `aceptar_desincronizacion_admision`, `actualizar_numero_gde_organizacion_ajax`.
- `_build_documentos_organizacionales_update_context` ahora expone GDE desde `NumeroGdeOrganizacion`.
- `_ultimo_numero_gde` (autocomplete informe técnico) extiende búsqueda al nuevo modelo.

### Views / URLs
- `POST /admisiones/<pk>/resync-convenio/` — resync.
- `POST /ajax/actualizar-numero-gde-organizacion/` — GDE org-doc desde admisión.
- `OrganizacionUpdateView.form_valid` borra `ArchivoOrganizacion` cuando cambia `tipo_entidad`.
- Removida la vista/URL `organizacion_documento_gde` (no estaba referenciada por templates).

### UI
- Banner + modal de resync en `admisiones_tecnicos_form.html` (+ `admisionResyncConvenio.js`).
- Editor de GDE para documentos de organización en `documento_row.html` (con permisos y filtro por estado=Aceptado).
- Advertencia + modal de confirmación al cambiar `tipo_entidad` en `organizacion_form.html`.

## Tests

17 casos nuevos, todos pasan. Suite completa de las apps tocadas (56 tests) en verde:

```
docker compose exec -T django pytest admisiones organizaciones --tb=short -q
56 passed in 18.33s
```

- [admisiones/tests/test_resync_admision.py](https://github.com/dsocial118/SISOC/blob/codex/issue-1605-resync-tipo-entidad/admisiones/tests/test_resync_admision.py) (7 casos)
- [admisiones/tests/test_numero_gde_organizacion.py](https://github.com/dsocial118/SISOC/blob/codex/issue-1605-resync-tipo-entidad/admisiones/tests/test_numero_gde_organizacion.py) (7 casos)
- [organizaciones/test_update_view_tipo_entidad.py](https://github.com/dsocial118/SISOC/blob/codex/issue-1605-resync-tipo-entidad/organizaciones/test_update_view_tipo_entidad.py) (3 casos)

`makemigrations --check --dry-run` ✅ — `manage.py check` ✅.

## Test plan (manual)

- [ ] **Sección 2** — Editar Organización, cambiar `Tipo de Entidad`, confirmar modal. Verificar que el listado de documentos del legajo quedó vacío. Volver al tipo anterior → sigue vacío.
- [ ] **Sección 1A — Actualizar** — Admisión en `Documentación en Proceso`. Cambiar `tipo_entidad` desde la organización. Volver a la admisión → ver banner. Elegir `Actualizar Información desde Legajo Organización` → confirmar. La admisión queda en `convenio_seleccionado`, documentos borrados, `tipo_convenio` recalculado.
- [ ] **Sección 1B — Continuar** — Misma situación, elegir `Continuar operando con la Admisión actual` → confirmar. El banner desaparece, la admisión sigue como estaba.
- [ ] **Sección 3** — Admisión con documento de Organización en estado `Aceptado`. Editar `Número de GDE` desde la admisión → guardar → recargar → persiste. Repetir en otra admisión sobre la misma organización para verificar GDE independiente.
- [ ] **Autocomplete** — Verificar que el formulario de informe técnico autocompleta el número GDE incluyendo valores cargados sobre docs de organización.

## Decisiones de diseño

1. **Snapshot vs flag**: `Admision.tipo_entidad_origen` representa el último estado "en sync". "Continuar operando" actualiza el snapshot → silencia el banner hasta el próximo cambio (lectura literal del spec 1.5).
2. **Borrado destructivo de `ArchivoOrganizacion`** (no soft-delete) al cambiar tipo, para evitar registros huérfanos de otra categoría.
3. **Modelo intermediario `NumeroGdeOrganizacion`** en vez de mover `numero_gde` a `ArchivoAdmision`: cumple 3.3 (mismo doc-org en varias admisiones, cada una con su GDE) con la menor superficie de cambio.
4. `ArchivoOrganizacion.numero_gde` queda en el modelo (sin uso editable) por preservar histórico — candidato a remover en limpieza futura.

Closes #1605

🤖 Generated with [Claude Code](https://claude.com/claude-code)