### PR TITLE
fix(admisiones): lazy init de tipo_entidad_origen para admisiones legacy

### DIFF
--- a/admisiones/services/admisiones_service/impl.py
+++ b/admisiones/services/admisiones_service/impl.py
@@ -1074,9 +1074,31 @@ class AdmisionService:
         ArchivoAdmision.objects.filter(admision=admision).delete()
 
     @staticmethod
+    def _asegurar_snapshot_tipo_entidad(admision):
+        """Inicializa ``tipo_entidad_origen`` cuando esta vacio adoptando el
+        ``tipo_entidad`` actual de la organizacion. Cubre admisiones legacy
+        anteriores a la introduccion del snapshot y admisiones creadas por
+        flujos que no lo seteaban.
+        """
+
+        if getattr(admision, "tipo_entidad_origen_id", None):
+            return
+        organizacion = getattr(
+            getattr(admision, "comedor", None), "organizacion", None
+        )
+        tipo_actual_id = getattr(organizacion, "tipo_entidad_id", None)
+        if not tipo_actual_id:
+            return
+        admision.tipo_entidad_origen_id = tipo_actual_id
+        admision.save(update_fields=["tipo_entidad_origen"])
+
+    @staticmethod
     def admision_desincronizada(admision):
         """Indica si el ``tipo_entidad_origen`` snapshotado en la admision
-        difiere del ``tipo_entidad`` actual de la organizacion."""
+        difiere del ``tipo_entidad`` actual de la organizacion. Si el snapshot
+        esta vacio (admisiones legacy) se inicializa con el valor actual y se
+        considera sincronizada hasta el proximo cambio.
+        """
 
         organizacion = getattr(
             getattr(admision, "comedor", None), "organizacion", None
@@ -1084,8 +1106,11 @@ class AdmisionService:
         if not organizacion:
             return False
         tipo_actual_id = getattr(organizacion, "tipo_entidad_id", None)
+        if not tipo_actual_id:
+            return False
+        AdmisionService._asegurar_snapshot_tipo_entidad(admision)
         snapshot_id = getattr(admision, "tipo_entidad_origen_id", None)
-        if not tipo_actual_id or not snapshot_id:
+        if not snapshot_id:
             return False
         return tipo_actual_id != snapshot_id
 

--- a/admisiones/tests/test_resync_admision.py
+++ b/admisiones/tests/test_resync_admision.py
@@ -92,8 +92,8 @@ def test_admision_desincronizada_devuelve_true_cuando_org_cambia_tipo(
     assert admision_desincronizada(admision) is True
 
 
-def test_admision_desincronizada_false_si_falta_snapshot_o_tipo_actual(
-    estado_inicial, tipo_entidades, tipos_convenio
+def test_admision_desincronizada_false_si_falta_tipo_actual(
+    estado_inicial, tipos_convenio
 ):
     organizacion = Organizacion.objects.create(nombre="Org sin tipo")
     comedor = Comedor.objects.create(nombre="Comedor sin tipo", organizacion=organizacion)
@@ -105,11 +105,39 @@ def test_admision_desincronizada_false_si_falta_snapshot_o_tipo_actual(
 
     assert AdmisionService.admision_desincronizada(admision) is False
 
-    organizacion.tipo_entidad = tipo_entidades["juridica"]
+
+def test_admision_legacy_sin_snapshot_se_inicializa_lazy(
+    estado_inicial, tipo_entidades, tipos_convenio
+):
+    """Una admision creada antes del snapshot (o por un flujo que no lo seteaba)
+    debe adoptar como base el ``tipo_entidad`` actual de la organizacion la
+    primera vez que se evalua la desincronizacion."""
+
+    organizacion = Organizacion.objects.create(
+        nombre="Org legacy", tipo_entidad=tipo_entidades["juridica"]
+    )
+    comedor = Comedor.objects.create(
+        nombre="Comedor legacy", organizacion=organizacion
+    )
+    admision = Admision.objects.create(
+        comedor=comedor,
+        tipo_convenio=tipos_convenio["juridica"],
+        estado=estado_inicial,
+    )
+    assert admision.tipo_entidad_origen_id is None
+
+    desincronizada = AdmisionService.admision_desincronizada(admision)
+
+    admision.refresh_from_db()
+    assert desincronizada is False
+    assert admision.tipo_entidad_origen_id == tipo_entidades["juridica"].id
+
+    # Despues del lazy init, un cambio en la organizacion si debe disparar la
+    # advertencia.
+    organizacion.tipo_entidad = tipo_entidades["eclesiastica"]
     organizacion.save(update_fields=["tipo_entidad"])
     admision.refresh_from_db()
-
-    assert AdmisionService.admision_desincronizada(admision) is False
+    assert AdmisionService.admision_desincronizada(admision) is True
 
 
 def test_resync_admision_borra_archivos_y_actualiza_snapshot(

--- a/comedores/services/comedor_service/impl.py
+++ b/comedores/services/comedor_service/impl.py
@@ -1571,6 +1571,9 @@ class ComedorService:
         nueva_admision = Admision.objects.create(
             comedor=comedor,
             tipo=tipo_admision,
+            tipo_entidad_origen=getattr(
+                getattr(comedor, "organizacion", None), "tipo_entidad", None
+            ),
         )
         messages.success(
             request,


### PR DESCRIPTION
El banner de resync no se mostraba en admisiones creadas antes del snapshot (o por flujos como crear_admision_desde_comedor que no lo seteaban), porque `admision_desincronizada` retornaba False cuando snapshot=None.

Cambios:
- `_asegurar_snapshot_tipo_entidad`: si el snapshot esta vacio pero la organizacion tiene tipo_entidad, lo adopta como base. La primera consulta deja la admision "sincronizada"; cambios posteriores en la organizacion disparan el banner correctamente.
- `crear_admision_desde_comedor` (comedor_service) ahora setea `tipo_entidad_origen` al crear la admision.
- Test nuevo cubre el caso legacy: snapshot vacio → init → divergencia detectada.

# Información de la Tarea
Vincular el #ISSUE

### **Resumen de la Solución:** 
-

### **Información Adicional:**
-

# Descripción de los Cambios

### **Cambios:**
-

# Cómo Testear los Cambios

### **Pruebas Automáticas:**
-

### **Prubeas Manuales:**
-

# Metadata para documentación automática

- Contexto funcional:
- Tipo de cambio:
- Área principal:
- Resumen para changelog:
- Impacto usuario:
- Riesgos / rollback:

# Capturas de Pantalla
