### PR TITLE
fix(organizaciones): materializar archivos heredados en admisiones an…

### DIFF
--- a/organizaciones/test_update_view_tipo_entidad.py
+++ b/organizaciones/test_update_view_tipo_entidad.py
@@ -8,6 +8,13 @@ from django.contrib.auth.models import Permission
 from django.test import Client
 from django.urls import reverse
 
+from admisiones.models.admisiones import (
+    Admision,
+    ArchivoAdmision,
+    EstadoAdmision,
+    TipoConvenio,
+)
+from comedores.models import Comedor
 from core.models import Provincia
 from organizaciones.models import (
     ArchivoOrganizacion,
@@ -164,3 +171,89 @@ def test_volver_al_tipo_anterior_no_recupera_archivos_borrados(
         ).count()
         == 0
     )
+
+
+def test_cambio_tipo_entidad_materializa_archivos_en_admision_activa(
+    organizacion_con_documentos, tipos, usuario
+):
+    """Si una admision activa esta viendo los archivos de la organizacion como
+    heredados, al cambiar el `tipo_entidad` los archivos deben clonarse a
+    `ArchivoAdmision` ANTES de borrarlos. Asi el tecnico que elija "Continuar
+    operando con la Admision actual" no pierde la documentacion."""
+
+    # EstadoAdmision con id=2 lo requiere
+    # _sincronizar_estado_documental_si_corresponde cuando todos los
+    # obligatorios estan aceptados.
+    EstadoAdmision.objects.create(nombre="Inicial")
+    EstadoAdmision.objects.create(nombre="Avanzada")
+    tipo_convenio = TipoConvenio.objects.create(
+        pk=3, nombre="Personería Jurídica"
+    )
+    comedor = Comedor.objects.create(
+        nombre="Comedor afectado", organizacion=organizacion_con_documentos
+    )
+    admision = Admision.objects.create(
+        comedor=comedor,
+        tipo_convenio=tipo_convenio,
+        tipo_entidad_origen=tipos["juridica"],
+        estado_admision="documentacion_en_proceso",
+    )
+    assert ArchivoAdmision.objects.filter(admision=admision).count() == 0
+
+    client = Client()
+    client.force_login(usuario)
+    url = reverse(
+        "organizacion_editar", kwargs={"pk": organizacion_con_documentos.pk}
+    )
+
+    response = client.post(
+        url, _post_payload(organizacion_con_documentos, tipos["eclesiastica"])
+    )
+
+    assert response.status_code in (302, 303), response.content[:300]
+    assert (
+        ArchivoOrganizacion.objects.filter(
+            organizacion=organizacion_con_documentos
+        ).count()
+        == 0
+    ), "El legajo se debe vaciar"
+    archivos_clonados = ArchivoAdmision.objects.filter(admision=admision)
+    assert archivos_clonados.count() == 2, (
+        "Los 2 archivos heredados deben quedar materializados en la admision "
+        "para preservar el progreso ante 'Continuar operando'"
+    )
+
+
+def test_cambio_tipo_entidad_no_materializa_en_admisiones_archivadas(
+    organizacion_con_documentos, tipos, usuario
+):
+    """Admisiones ya enviadas a archivo no deben recibir clones — ya son
+    historico inmutable."""
+
+    tipo_convenio = TipoConvenio.objects.create(
+        pk=3, nombre="Personería Jurídica"
+    )
+    comedor = Comedor.objects.create(
+        nombre="Comedor archivado", organizacion=organizacion_con_documentos
+    )
+    admision = Admision.objects.create(
+        comedor=comedor,
+        tipo_convenio=tipo_convenio,
+        tipo_entidad_origen=tipos["juridica"],
+        estado_admision="documentacion_en_proceso",
+        enviada_a_archivo=True,
+    )
+
+    client = Client()
+    client.force_login(usuario)
+    url = reverse(
+        "organizacion_editar", kwargs={"pk": organizacion_con_documentos.pk}
+    )
+
+    client.post(
+        url, _post_payload(organizacion_con_documentos, tipos["eclesiastica"])
+    )
+
+    assert (
+        ArchivoAdmision.objects.filter(admision=admision).count() == 0
+    ), "Una admision archivada no debe recibir clones materializados"

--- a/organizaciones/views.py
+++ b/organizaciones/views.py
@@ -676,6 +676,22 @@ class OrganizacionUpdateView(LoginRequiredMixin, UpdateView):
         ).get(pk=self.object.pk)
         self.object = form.save()
         if tipo_entidad_anterior_id != self.object.tipo_entidad_id:
+            # Antes de borrar los ArchivoOrganizacion del legajo, materializar
+            # los archivos heredados en cada admision activa de la organizacion.
+            # Asi, si el tecnico elige "Continuar operando", su admision conserva
+            # los archivos como ArchivoAdmision propios; si elige "Actualizar
+            # Información desde Legajo Organización", el reset posterior los
+            # destruira igualmente.
+            from admisiones.models.admisiones import Admision
+            from admisiones.services.admisiones_service import AdmisionService
+
+            admisiones_afectadas = Admision.objects.filter(
+                comedor__organizacion=self.object,
+                enviada_a_archivo=False,
+            ).select_related("comedor__organizacion")
+            for admision in admisiones_afectadas:
+                AdmisionService.congelar_documentacion_organizacional(admision)
+
             ArchivoOrganizacion.objects.filter(organizacion=self.object).delete()
             messages.warning(
                 self.request,


### PR DESCRIPTION
…tes de borrar legajo

Al cambiar el tipo_entidad de una Organizacion, los `ArchivoOrganizacion` se borran (Seccion 2). Pero las admisiones activas que los mostraban como "heredados" perdian la referencia, lo que rompia la opcion "Continuar operando con la Admision actual" (Seccion 1.4) — la admision quedaba sin documentos aun cuando el tecnico explicitamente eligio mantener el progreso.

Fix: antes de borrar los `ArchivoOrganizacion`, invocamos `AdmisionService.congelar_documentacion_organizacional` para cada admision no archivada de la organizacion. Asi cada admision conserva su propia copia como `ArchivoAdmision`.

- Si el tecnico elige "Actualizar" -> `resync` borra todos los ArchivoAdmision (incluidos los clones recien creados) y arranca limpio con la nueva categoria. Sin cambios netos.
- Si el tecnico elige "Continuar" -> los ArchivoAdmision clonados quedan en la admision y se siguen mostrando como documentos de la organizacion.

Tests nuevos:
- materializa archivos heredados en admision activa al cambiar tipo
- NO materializa en admisiones ya archivadas (`enviada_a_archivo=True`)

# Información de la Tarea
Vincular el #ISSUE

### **Resumen de la Solución:** 
-

### **Información Adicional:**
-

# Descripción de los Cambios

### **Cambios:**
-

# Cómo Testear los Cambios

### **Pruebas Automáticas:**
-

### **Prubeas Manuales:**
-

# Metadata para documentación automática

- Contexto funcional:
- Tipo de cambio:
- Área principal:
- Resumen para changelog:
- Impacto usuario:
- Riesgos / rollback:

# Capturas de Pantalla
