### PR TITLE
fix(admisiones): preservar Número GDE al materializar archivos heredados (#1605)

### DIFF
--- a/admisiones/models/admisiones.py
+++ b/admisiones/models/admisiones.py
@@ -1233,9 +1233,7 @@ class NumeroGdeOrganizacion(models.Model):
             )
         ]
         verbose_name = "Numero GDE de archivo de organizacion por admision"
-        verbose_name_plural = (
-            "Numeros GDE de archivos de organizacion por admision"
-        )
+        verbose_name_plural = "Numeros GDE de archivos de organizacion por admision"
 
     def __str__(self):
         return (

--- a/admisiones/services/admisiones_service/impl.py
+++ b/admisiones/services/admisiones_service/impl.py
@@ -317,17 +317,48 @@ class AdmisionService:
     def _crear_archivo_admision_desde_archivo_organizacion(
         admision, org_doc, archivo_org, documentacion_admision=None
     ):
-        return ArchivoAdmision.objects.create(
+        numero_gde = AdmisionService._resolver_numero_gde_para_clonado(
+            admision, archivo_org
+        )
+        archivo_admision = ArchivoAdmision.objects.create(
             admision=admision,
             documentacion=documentacion_admision,
             nombre_personalizado=None if documentacion_admision else org_doc.nombre,
             archivo=archivo_org.archivo.name,
             estado=archivo_org.estado,
             observaciones=archivo_org.observaciones,
-            numero_gde=None,
+            numero_gde=numero_gde,
             creado_por=archivo_org.creado_por,
             modificado_por=archivo_org.modificado_por,
         )
+        if numero_gde:
+            # El GDE ahora vive en el ArchivoAdmision clonado; el registro
+            # en NumeroGdeOrganizacion para esta combinacion deja de ser
+            # canonico y se elimina para evitar valores divergentes.
+            NumeroGdeOrganizacion.objects.filter(
+                admision=admision, archivo_organizacion=archivo_org
+            ).delete()
+        return archivo_admision
+
+    @staticmethod
+    def _resolver_numero_gde_para_clonado(admision, archivo_org):
+        """Resuelve el numero_gde a usar al materializar un ArchivoOrganizacion
+        como ArchivoAdmision. Prioriza el GDE registrado para esta admision en
+        ``NumeroGdeOrganizacion`` (donde el tecnico carga el valor desde la
+        admision) y cae al ``ArchivoOrganizacion.numero_gde`` historico como
+        fallback.
+        """
+
+        numero_admision = (
+            NumeroGdeOrganizacion.objects.filter(
+                admision=admision, archivo_organizacion=archivo_org
+            )
+            .values_list("numero_gde", flat=True)
+            .first()
+        )
+        if numero_admision:
+            return numero_admision
+        return getattr(archivo_org, "numero_gde", None) or None
 
     @staticmethod
     def _serialize_documentacion(documentacion, archivo=None):

--- a/admisiones/templates/admisiones/admisiones_tecnicos_form.html
+++ b/admisiones/templates/admisiones/admisiones_tecnicos_form.html
@@ -77,9 +77,7 @@
                         </div>
                         <!-- Paso 2: confirmacion -->
                         <div id="modalResyncStepConfirmacion" class="d-none">
-                            <div class="alert alert-warning mb-0" role="alert">
-                                <p id="modalConfirmarResyncConvenioMensaje" class="mb-0"></p>
-                            </div>
+                            <p id="modalConfirmarResyncConvenioMensaje" class="mb-0"></p>
                         </div>
                     </div>
                     <div class="modal-footer">

--- a/admisiones/tests/test_numero_gde_organizacion.py
+++ b/admisiones/tests/test_numero_gde_organizacion.py
@@ -44,13 +44,9 @@ def superuser():
 @pytest.fixture
 def setup_org(tecnico, abogado):
     tipo = TipoEntidad.objects.create(nombre="Personería Jurídica")
-    dupla = Dupla.objects.create(
-        nombre="Dupla GDE", estado="Activo", abogado=abogado
-    )
+    dupla = Dupla.objects.create(nombre="Dupla GDE", estado="Activo", abogado=abogado)
     dupla.tecnico.add(tecnico)
-    organizacion = Organizacion.objects.create(
-        nombre="Org GDE", tipo_entidad=tipo
-    )
+    organizacion = Organizacion.objects.create(nombre="Org GDE", tipo_entidad=tipo)
     comedor = Comedor.objects.create(
         nombre="Comedor GDE", organizacion=organizacion, dupla=dupla
     )
@@ -112,9 +108,7 @@ def test_actualizar_numero_gde_organizacion_crea_registro(setup_org, superuser):
     assert registro.modificado_por_id == superuser.id
 
 
-def test_actualizar_numero_gde_organizacion_actualiza_existente(
-    setup_org, superuser
-):
+def test_actualizar_numero_gde_organizacion_actualiza_existente(setup_org, superuser):
     NumeroGdeOrganizacion.objects.create(
         admision=setup_org["admision"],
         archivo_organizacion=setup_org["archivo_org"],
@@ -137,9 +131,7 @@ def test_actualizar_numero_gde_organizacion_actualiza_existente(
     assert NumeroGdeOrganizacion.objects.count() == 1
 
 
-def test_actualizar_numero_gde_organizacion_rechaza_no_aceptado(
-    setup_org, superuser
-):
+def test_actualizar_numero_gde_organizacion_rechaza_no_aceptado(setup_org, superuser):
     setup_org["archivo_org"].estado = ArchivoOrganizacion.ESTADO_A_VALIDAR
     setup_org["archivo_org"].save(update_fields=["estado"])
 

--- a/admisiones/views/web_views.py
+++ b/admisiones/views/web_views.py
@@ -675,9 +675,7 @@ def resync_convenio_admision(request, admision_pk):
     elif accion == "continuar":
         ok, mensaje = AdmisionService.aceptar_desincronizacion_admision(admision)
     else:
-        return JsonResponse(
-            {"success": False, "error": "Accion invalida."}, status=400
-        )
+        return JsonResponse({"success": False, "error": "Accion invalida."}, status=400)
 
     if not ok:
         return JsonResponse({"success": False, "error": mensaje}, status=400)

--- a/organizaciones/test_update_view_tipo_entidad.py
+++ b/organizaciones/test_update_view_tipo_entidad.py
@@ -265,9 +265,7 @@ def test_materializacion_preserva_numero_gde_desde_admision(
     persistir en el campo `numero_gde` y el registro `NumeroGdeOrganizacion`
     queda eliminado (deja de ser canonico)."""
 
-    admision = _setup_admision_para_materializacion(
-        organizacion_con_documentos, tipos
-    )
+    admision = _setup_admision_para_materializacion(organizacion_con_documentos, tipos)
     archivo_org_a = ArchivoOrganizacion.objects.filter(
         organizacion=organizacion_con_documentos,
         documentacion__nombre="Acta Constitutiva",
@@ -300,9 +298,7 @@ def test_materializacion_fallback_a_numero_gde_legacy_de_archivo_organizacion(
     `ArchivoOrganizacion.numero_gde` (historico) tiene valor, al materializarse
     se usa ese GDE como fallback."""
 
-    admision = _setup_admision_para_materializacion(
-        organizacion_con_documentos, tipos
-    )
+    admision = _setup_admision_para_materializacion(organizacion_con_documentos, tipos)
     archivo_org_a = ArchivoOrganizacion.objects.filter(
         organizacion=organizacion_con_documentos,
         documentacion__nombre="Acta Constitutiva",

--- a/organizaciones/test_update_view_tipo_entidad.py
+++ b/organizaciones/test_update_view_tipo_entidad.py
@@ -12,6 +12,7 @@ from admisiones.models.admisiones import (
     Admision,
     ArchivoAdmision,
     EstadoAdmision,
+    NumeroGdeOrganizacion,
     TipoConvenio,
 )
 from comedores.models import Comedor
@@ -41,9 +42,7 @@ def usuario():
 @pytest.fixture
 def tipos():
     juridica = TipoEntidad.objects.create(nombre="Personería Jurídica")
-    eclesiastica = TipoEntidad.objects.create(
-        nombre="Personería Jurídica Eclesiástica"
-    )
+    eclesiastica = TipoEntidad.objects.create(nombre="Personería Jurídica Eclesiástica")
     return {"juridica": juridica, "eclesiastica": eclesiastica}
 
 
@@ -155,13 +154,9 @@ def test_volver_al_tipo_anterior_no_recupera_archivos_borrados(
     url = reverse("organizacion_editar", kwargs={"pk": organizacion_con_documentos.pk})
 
     # Primer cambio: eclesiastica → borra todo
-    client.post(
-        url, _post_payload(organizacion_con_documentos, tipos["eclesiastica"])
-    )
+    client.post(url, _post_payload(organizacion_con_documentos, tipos["eclesiastica"]))
     # Volver al tipo anterior
-    client.post(
-        url, _post_payload(organizacion_con_documentos, tipos["juridica"])
-    )
+    client.post(url, _post_payload(organizacion_con_documentos, tipos["juridica"]))
 
     organizacion_con_documentos.refresh_from_db()
     assert organizacion_con_documentos.tipo_entidad_id == tipos["juridica"].pk
@@ -186,9 +181,7 @@ def test_cambio_tipo_entidad_materializa_archivos_en_admision_activa(
     # obligatorios estan aceptados.
     EstadoAdmision.objects.create(nombre="Inicial")
     EstadoAdmision.objects.create(nombre="Avanzada")
-    tipo_convenio = TipoConvenio.objects.create(
-        pk=3, nombre="Personería Jurídica"
-    )
+    tipo_convenio = TipoConvenio.objects.create(pk=3, nombre="Personería Jurídica")
     comedor = Comedor.objects.create(
         nombre="Comedor afectado", organizacion=organizacion_con_documentos
     )
@@ -202,9 +195,7 @@ def test_cambio_tipo_entidad_materializa_archivos_en_admision_activa(
 
     client = Client()
     client.force_login(usuario)
-    url = reverse(
-        "organizacion_editar", kwargs={"pk": organizacion_con_documentos.pk}
-    )
+    url = reverse("organizacion_editar", kwargs={"pk": organizacion_con_documentos.pk})
 
     response = client.post(
         url, _post_payload(organizacion_con_documentos, tipos["eclesiastica"])
@@ -230,9 +221,7 @@ def test_cambio_tipo_entidad_no_materializa_en_admisiones_archivadas(
     """Admisiones ya enviadas a archivo no deben recibir clones — ya son
     historico inmutable."""
 
-    tipo_convenio = TipoConvenio.objects.create(
-        pk=3, nombre="Personería Jurídica"
-    )
+    tipo_convenio = TipoConvenio.objects.create(pk=3, nombre="Personería Jurídica")
     comedor = Comedor.objects.create(
         nombre="Comedor archivado", organizacion=organizacion_con_documentos
     )
@@ -246,14 +235,88 @@ def test_cambio_tipo_entidad_no_materializa_en_admisiones_archivadas(
 
     client = Client()
     client.force_login(usuario)
-    url = reverse(
-        "organizacion_editar", kwargs={"pk": organizacion_con_documentos.pk}
-    )
+    url = reverse("organizacion_editar", kwargs={"pk": organizacion_con_documentos.pk})
 
-    client.post(
-        url, _post_payload(organizacion_con_documentos, tipos["eclesiastica"])
-    )
+    client.post(url, _post_payload(organizacion_con_documentos, tipos["eclesiastica"]))
 
     assert (
         ArchivoAdmision.objects.filter(admision=admision).count() == 0
     ), "Una admision archivada no debe recibir clones materializados"
+
+
+def _setup_admision_para_materializacion(organizacion, tipos):
+    EstadoAdmision.objects.create(nombre="Inicial")
+    EstadoAdmision.objects.create(nombre="Avanzada")
+    tipo_convenio = TipoConvenio.objects.create(pk=3, nombre="Personería Jurídica")
+    comedor = Comedor.objects.create(nombre="Comedor GDE", organizacion=organizacion)
+    return Admision.objects.create(
+        comedor=comedor,
+        tipo_convenio=tipo_convenio,
+        tipo_entidad_origen=tipos["juridica"],
+        estado_admision="documentacion_en_proceso",
+    )
+
+
+def test_materializacion_preserva_numero_gde_desde_admision(
+    organizacion_con_documentos, tipos, usuario
+):
+    """Si el tecnico cargo un Numero de GDE desde la admision sobre un archivo
+    heredado, al materializarse el archivo en `ArchivoAdmision` el GDE debe
+    persistir en el campo `numero_gde` y el registro `NumeroGdeOrganizacion`
+    queda eliminado (deja de ser canonico)."""
+
+    admision = _setup_admision_para_materializacion(
+        organizacion_con_documentos, tipos
+    )
+    archivo_org_a = ArchivoOrganizacion.objects.filter(
+        organizacion=organizacion_con_documentos,
+        documentacion__nombre="Acta Constitutiva",
+    ).first()
+    NumeroGdeOrganizacion.objects.create(
+        admision=admision,
+        archivo_organizacion=archivo_org_a,
+        numero_gde="GDE-2026-PRESERVAR",
+    )
+
+    client = Client()
+    client.force_login(usuario)
+    url = reverse("organizacion_editar", kwargs={"pk": organizacion_con_documentos.pk})
+    client.post(url, _post_payload(organizacion_con_documentos, tipos["eclesiastica"]))
+
+    archivo_admision = ArchivoAdmision.objects.filter(
+        admision=admision, nombre_personalizado="Acta Constitutiva"
+    ).first()
+    assert archivo_admision is not None
+    assert archivo_admision.numero_gde == "GDE-2026-PRESERVAR"
+    assert (
+        NumeroGdeOrganizacion.objects.filter(admision=admision).count() == 0
+    ), "El registro de GDE en organizacion debe eliminarse tras la materializacion"
+
+
+def test_materializacion_fallback_a_numero_gde_legacy_de_archivo_organizacion(
+    organizacion_con_documentos, tipos, usuario
+):
+    """Si no hay `NumeroGdeOrganizacion` para la admision pero el
+    `ArchivoOrganizacion.numero_gde` (historico) tiene valor, al materializarse
+    se usa ese GDE como fallback."""
+
+    admision = _setup_admision_para_materializacion(
+        organizacion_con_documentos, tipos
+    )
+    archivo_org_a = ArchivoOrganizacion.objects.filter(
+        organizacion=organizacion_con_documentos,
+        documentacion__nombre="Acta Constitutiva",
+    ).first()
+    archivo_org_a.numero_gde = "GDE-LEGACY"
+    archivo_org_a.save(update_fields=["numero_gde"])
+
+    client = Client()
+    client.force_login(usuario)
+    url = reverse("organizacion_editar", kwargs={"pk": organizacion_con_documentos.pk})
+    client.post(url, _post_payload(organizacion_con_documentos, tipos["eclesiastica"]))
+
+    archivo_admision = ArchivoAdmision.objects.filter(
+        admision=admision, nombre_personalizado="Acta Constitutiva"
+    ).first()
+    assert archivo_admision is not None
+    assert archivo_admision.numero_gde == "GDE-LEGACY"


### PR DESCRIPTION
## Summary

PR independiente sobre [#1763](https://github.com/dsocial118/SISOC/pull/1763) (que abarca el grueso del issue #1605). Acá agrego solo el **bugfix reportado en QA**: al materializar archivos del legajo de Organización a la Admisión cuando cambia el `tipo_entidad`, el `numero_gde` se estaba perdiendo.

> Escenario del bug: tengo una Admisión y desde la Organización adjunto dos archivos con GDE cargado. Al cambiar el tipo de entidad en la Organización, elijo "Continuar operando con la Admisión actual" — los archivos quedan correctos pero el GDE asociado se borra. Debería persistir.

## Fix

`AdmisionService._crear_archivo_admision_desde_archivo_organizacion` ahora resuelve el `numero_gde` antes de crear el `ArchivoAdmision`, en este orden:

1. **`NumeroGdeOrganizacion(admision, archivo_organizacion)`** — el valor canónico actual cargado por el técnico desde la admisión.
2. **`ArchivoOrganizacion.numero_gde` (legacy)** — como fallback histórico.

Si se usó (1), también se elimina el registro de `NumeroGdeOrganizacion` (el GDE pasa a vivir en el `ArchivoAdmision` clonado → evita divergencia).

Helper extraído: `_resolver_numero_gde_para_clonado(admision, archivo_org)`.

## Cleanup adicional

Aplico `black` sobre los 4 archivos que el CI del PR de release ([#1749](https://github.com/dsocial118/SISOC/pull/1749)) flagged en su check de formato:

- `admisiones/models/admisiones.py`
- `admisiones/views/web_views.py`
- `admisiones/tests/test_numero_gde_organizacion.py`
- `organizaciones/test_update_view_tipo_entidad.py`

## Tests nuevos

```
docker compose exec -T django pytest organizaciones/test_update_view_tipo_entidad.py admisiones/tests/ --tb=short
46 passed in 11.53s
```

- `test_materializacion_preserva_numero_gde_desde_admision` — verifica que el GDE de `NumeroGdeOrganizacion` se traslada a `ArchivoAdmision.numero_gde` y el registro intermedio se elimina.
- `test_materializacion_fallback_a_numero_gde_legacy_de_archivo_organizacion` — verifica el camino de fallback al campo legacy.

## Test plan manual

- [ ] Crear admisión sobre un comedor con organización con `tipo_entidad` A.
- [ ] Desde la admisión, cargar el GDE para un archivo de la organización en estado Aceptado.
- [ ] Cambiar `tipo_entidad` de la organización a B → modal en la admisión.
- [ ] Elegir **"Continuar operando con la Admisión actual"** → confirmar.
- [ ] Verificar que el archivo sigue apareciendo en la admisión Y que el GDE persiste con el valor cargado.

## Dependencia

Este PR aplica sobre la rama del PR [#1763](https://github.com/dsocial118/SISOC/pull/1763) — incluye todos sus commits porque el bug solo se manifiesta en presencia de la lógica de materialización (que vive en ese PR).

Closes #1605 (junto a #1763)

🤖 Generated with [Claude Code](https://claude.com/claude-code)