### PR TITLE
fix(centrodeinfancia): campo año de inicio CDI solo numérico

### DIFF
--- a/centrodeinfancia/forms.py
+++ b/centrodeinfancia/forms.py
@@ -112,11 +112,11 @@ class CentroDeInfanciaForm(forms.ModelForm):
     fecha_inicio = forms.CharField(
         required=False,
         label="Año de inicio de actividades del CDI",
-        widget=forms.TextInput(
+        widget=forms.NumberInput(
             attrs={
                 "placeholder": "AAAA",
-                "inputmode": "numeric",
-                "pattern": "\\d{4}",
+                "min": "1900",
+                "max": "2100",
                 "class": "form-control",
             }
         ),


### PR DESCRIPTION
## ¿Qué cambió?

El campo **Año de inicio de actividades del CDI** en `CentroDeInfanciaForm` usaba `TextInput` con atributos `inputmode`/`pattern` que solo sugerían comportamiento numérico pero no lo forzaban en el navegador.

Se cambió a `NumberInput`, lo que genera `type="number"` en el HTML y bloquea la entrada de caracteres no numéricos de forma nativa en el browser. Se agregaron `min="1900"` y `max="2100"` para limitar el rango de años válidos.

## Archivos modificados

- `centrodeinfancia/forms.py` — widget `TextInput` → `NumberInput`, `inputmode`/`pattern` → `min`/`max`

## Notas para el revisor

- La validación server-side existente en `forms.py:354` se mantiene sin cambios como respaldo.
- El `placeholder="AAAA"` se conserva.

🤖 Generated with [Claude Code](https://claude.com/claude-code)