### PR TITLE
fix(ci): black + pylint para desbloquear PR #1749

### DIFF
--- a/admisiones/migrations/0060_numero_gde_organizacion.py
+++ b/admisiones/migrations/0060_numero_gde_organizacion.py
@@ -93,9 +93,7 @@ class Migration(migrations.Migration):
                 ),
             ],
             options={
-                "verbose_name": (
-                    "Numero GDE de archivo de organizacion por admision"
-                ),
+                "verbose_name": ("Numero GDE de archivo de organizacion por admision"),
                 "verbose_name_plural": (
                     "Numeros GDE de archivos de organizacion por admision"
                 ),

--- a/organizaciones/views.py
+++ b/organizaciones/views.py
@@ -683,7 +683,7 @@ class OrganizacionUpdateView(LoginRequiredMixin, UpdateView):
             # Información desde Legajo Organización", el reset posterior los
             # destruira igualmente.
             from admisiones.models.admisiones import Admision
-            from admisiones.services.admisiones_service import AdmisionService
+            from admisiones.services.admisiones_service.impl import AdmisionService
 
             admisiones_afectadas = Admision.objects.filter(
                 comedor__organizacion=self.object,


### PR DESCRIPTION
## Resumen

Dos fixes de CI para desbloquear [PR #1749](https://github.com/dsocial118/SISOC/pull/1749) (`development → main`):

- **autofix (black)**: `admisiones/migrations/0060_numero_gde_organizacion.py` — `verbose_name` cabe en una sola línea; black forzaba el collapse y el autofix no podía pushear a `development` por branch protection.
- **pylint (E0611)**: `organizaciones/views.py:686` — import lazy de `AdmisionService` desde el paquete `admisiones_service` (cuyo `__init__.py` usa el truco `sys.modules`) genera `no-name-in-module`; corregido importando directamente desde `.impl`.

## Plan de verificación

- [ ] `pylint` pasa en CI (score 10.00, sin E0611)
- [ ] `autofix` pasa en CI (black no encuentra cambios)
- [ ] `deploy_guard` pasa en PR #1749 una vez que development esté verde