### PR TITLE
fix(migrations): agregar migración faltante para choices de categoria en DocumentacionAdjunta

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+<!-- AUTO-GENERATED RELEASE START: 2026-05-27 -->
+# Versión SISOC 27.05.2026
+
+## Actualizaciones
+
+- [sin-area] fix(migrations): agregar migración faltante para choices de categoria en DocumentacionAdjunta. (PR #1783)
+<!-- AUTO-GENERATED RELEASE END: 2026-05-27 -->
+
 <!-- AUTO-GENERATED RELEASE START: 2026-05-20 -->
 # Versión SISOC 20.05.2026
 

--- a/docs/contexto/features/pr-1783-fix-migrations-agregar-migracion-faltante-para-choices-de-categoria-en-documentacionadjunta.md
+++ b/docs/contexto/features/pr-1783-fix-migrations-agregar-migracion-faltante-para-choices-de-categoria-en-documentacionadjunta.md
@@ -1,0 +1,43 @@
+# Contexto de feature PR #1783 - fix(migrations): agregar migración faltante para choices de categoria en DocumentacionAdjunta
+
+## Resumen
+
+- PR: https://github.com/dsocial118/SISOC/pull/1783
+- Base: `main`
+- Rama origen: `claude/priceless-mirzakhani-6d1846`
+- Autor: `juanikitro`
+
+## Contexto funcional
+
+- No informado explícitamente; inferir desde el título del PR y el diff.
+
+## Arquitectura tocada
+
+- Existen cambios de persistencia o migraciones que requieren revisión de datos.
+
+## Decisiones y supuestos detectados
+
+- Tipo de cambio declarado: No informado
+- Área principal declarada: No informada
+- Impacto usuario declarado: No informado
+- Riesgos / rollback: No informado
+
+## Design system y UI
+
+- Sin cambios visibles de UI o design system detectados en el diff.
+
+## Memoria operativa para agentes
+
+- Empezar por `docs/registro/prs/PR-1783.md` para contexto resumido del PR.
+- Revisar primero estos archivos del diff:
+- `rendicioncuentasmensual/migrations/0013_alter_documentacionadjunta_categoria_choices.py`
+- Documentación sugerida para ampliar contexto:
+- `docs/indice.md`
+- `docs/ia/CONTEXT_HYGIENE.md`
+- `docs/ia/ARCHITECTURE.md`
+- `docs/ia/TESTING.md`
+
+## Trazabilidad
+
+- Documento generado automáticamente desde el evento de `pull_request`.
+- Si este PR cambia de título, el archivo se renombrará para mantener el slug alineado.

--- a/docs/registro/prs/PR-1783.md
+++ b/docs/registro/prs/PR-1783.md
@@ -1,0 +1,46 @@
+# PR #1783 - fix(migrations): agregar migración faltante para choices de categoria en DocumentacionAdjunta
+
+## Metadata
+
+- PR: https://github.com/dsocial118/SISOC/pull/1783
+- Base: `main`
+- Rama origen: `claude/priceless-mirzakhani-6d1846`
+- Autor: `juanikitro`
+- Última actualización: `2026-05-26T15:45:15Z`
+
+## Resumen operativo
+
+- Tipo de cambio: No informado
+- Área principal: No informada
+- Contexto funcional: No informado explícitamente; revisar título, diff y documentación relacionada.
+- Resumen para changelog: No informado
+- Impacto usuario: No informado
+
+## Áreas afectadas
+
+- `rendicioncuentasmensual`
+
+## Archivos relevantes del diff
+
+- `rendicioncuentasmensual/migrations/0013_alter_documentacionadjunta_categoria_choices.py`
+
+## Validación declarada
+
+- Pruebas automáticas: No informado en el PR.
+- Pruebas manuales: No informado en el PR.
+
+## Riesgos y rollback
+
+- No informado explícitamente en el PR.
+
+## Documentación sugerida para lectura
+
+- `docs/indice.md`
+- `docs/ia/CONTEXT_HYGIENE.md`
+- `docs/ia/ARCHITECTURE.md`
+- `docs/ia/TESTING.md`
+
+## Notas para continuidad
+
+- Este documento es generado automáticamente desde el contexto del PR y sirve como índice rápido para revisión y futuras sesiones de agentes.
+- Si la metadata del body del PR está incompleta, varias secciones usarán fallbacks derivados del título o del diff.

--- a/docs/registro/releases/pending/2026-05-27-pr-1783.md
+++ b/docs/registro/releases/pending/2026-05-27-pr-1783.md
@@ -1,0 +1,19 @@
+---
+pr: 1783
+release_date: 2026-05-27
+category: Actualizaciones
+area: sin-area
+title: fix(migrations): agregar migración faltante para choices de categoria en DocumentacionAdjunta
+summary: fix(migrations): agregar migración faltante para choices de categoria en DocumentacionAdjunta
+impact: No informado
+source_url: https://github.com/dsocial118/SISOC/pull/1783
+---
+# Release note preliminar PR #1783
+
+- Fecha objetivo de release: 2026-05-27
+- Categoría: Actualizaciones
+- Área: sin-area
+- Título del PR: fix(migrations): agregar migración faltante para choices de categoria en DocumentacionAdjunta
+- Resumen: fix(migrations): agregar migración faltante para choices de categoria en DocumentacionAdjunta
+- Impacto usuario: No informado
+- Fuente: https://github.com/dsocial118/SISOC/pull/1783

--- a/rendicioncuentasmensual/migrations/0013_alter_documentacionadjunta_categoria_choices.py
+++ b/rendicioncuentasmensual/migrations/0013_alter_documentacionadjunta_categoria_choices.py
@@ -1,0 +1,53 @@
+# Generated manually 2026-05-26
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ("rendicioncuentasmensual", "0012_alter_rendicioncuentamensual_options_and_more"),
+    ]
+
+    operations = [
+        migrations.AlterField(
+            model_name="documentacionadjunta",
+            name="categoria",
+            field=models.CharField(
+                choices=[
+                    ("formulario_i", "Formulario I - Certificación de Cuenta Bancaria"),
+                    ("formulario_ii", "Formulario II - Resumen"),
+                    (
+                        "formulario_iii",
+                        "Formulario III - Desagregado por Facturas Prestación Alimentaria",
+                    ),
+                    (
+                        "formulario_iii_alimentario",
+                        "Formulario III - Desagregado por Facturas Prestación Alimentaria",
+                    ),
+                    (
+                        "formulario_iii_siph",
+                        "Formulario III - Desagregado por Facturas SIPH",
+                    ),
+                    ("formulario_iv", "Formulario IV - Recibo de Fondos"),
+                    (
+                        "formulario_v",
+                        "Formulario V - Certificación de Prestaciones Alimentarias",
+                    ),
+                    (
+                        "formulario_v_alimentario",
+                        "Formulario V - Certificación de Prestaciones Alimentarias",
+                    ),
+                    ("formulario_v_siph", "Formulario V - Certificación de SIPH"),
+                    ("formulario_vi", "Formulario VI - Planilla de Pagos"),
+                    ("extracto_bancario", "Extracto Bancario"),
+                    ("comprobantes", "Comprobante/s"),
+                    ("planilla_seguros", "Planilla de Seguros"),
+                    ("otros", "Documentación Adicional"),
+                ],
+                default="comprobantes",
+                max_length=40,
+                verbose_name="Categoría",
+            ),
+        ),
+    ]


### PR DESCRIPTION
## Summary

- La migración 0012 tenía labels cortos en `CATEGORIA_CHOICES` (ej. `"Formulario I"`) pero el modelo actual usa labels completos (ej. `"Formulario I - Certificación de Cuenta Bancaria"`)
- Django detectaba la discrepancia y arrojaba error al correr `makemigrations --check`
- Se agrega migración `0013` con `AlterField` que sincroniza los choices del campo `categoria` de `DocumentacionAdjunta` con el estado actual del modelo

## Test plan

- [ ] `python manage.py migrate` corre sin errores
- [ ] `python manage.py makemigrations --check --dry-run` pasa sin detectar cambios pendientes

🤖 Generated with [Claude Code](https://claude.com/claude-code)