### PR TITLE
fix(celiaquia): provincia del expediente se deriva del municipio importado

### DIFF
--- a/celiaquia/services/importacion_service/impl.py
+++ b/celiaquia/services/importacion_service/impl.py
@@ -310,6 +310,15 @@ def _cargar_municipios_cache(municipio_ids, provincia_usuario_id):
     return municipios_cache
 
 
+def _cargar_municipio_provincia_map(municipio_ids):
+    if not municipio_ids:
+        return {}
+    return {
+        m.pk: m.provincia_id
+        for m in Municipio.objects.filter(pk__in=municipio_ids).only("pk", "provincia_id")
+    }
+
+
 def _cargar_localidades_cache(localidad_ids):
     localidades_cache = {}
     if not localidad_ids:
@@ -376,6 +385,9 @@ def _precargar_datos_importacion(df: pd.DataFrame, provincia_usuario_id):
     return {
         "municipios_cache": _cargar_municipios_cache(
             lookup_values["municipio_ids"], provincia_usuario_id
+        ),
+        "municipio_provincia_map": _cargar_municipio_provincia_map(
+            lookup_values["municipio_ids"]
         ),
         "localidades_cache": _cargar_localidades_cache(lookup_values["localidad_ids"]),
         "sexos_cache": _cargar_sexos_cache(),
@@ -715,11 +727,8 @@ def validar_campos_obligatorios_importacion(
         raise ValidationError(f"Faltan campos obligatorios: {', '.join(faltantes)}")
 
 
-def _aplicar_defaults_y_validar_payload_importacion(payload, provincia_usuario_id):
+def _aplicar_defaults_y_validar_payload_importacion(payload):
     payload["tipo_documento"] = _get_tipo_documento(payload.get("documento", ""))
-
-    if provincia_usuario_id:
-        payload["provincia"] = provincia_usuario_id
 
     validar_campos_obligatorios_importacion(
         payload,
@@ -731,6 +740,22 @@ def _aplicar_defaults_y_validar_payload_importacion(payload, provincia_usuario_i
         raise ValidationError("Documento es obligatorio")
     if not str(doc).isdigit():
         raise ValidationError("Documento debe contener sólo dígitos")
+
+
+def _inferir_provincia_desde_municipio_importacion(payload, municipio_provincia_map=None):
+    municipio_id = payload.get("municipio")
+    if municipio_id is None:
+        return
+    if municipio_provincia_map is not None:
+        provincia_id = municipio_provincia_map.get(municipio_id)
+    else:
+        provincia_id = (
+            Municipio.objects.filter(pk=municipio_id)
+            .values_list("provincia_id", flat=True)
+            .first()
+        )
+    if provincia_id:
+        payload["provincia"] = provincia_id
 
 
 def _validar_beneficiario_menor_con_responsable_importacion(payload):
@@ -973,7 +998,7 @@ def _build_lookup_caches_payload_importacion(payload, provincia_usuario_id):
 def _build_responsable_payload_importacion(
     payload, provincia_usuario_id, offset, add_error
 ):
-    del offset, add_error
+    del provincia_usuario_id, offset, add_error
     validar_campos_obligatorios_importacion(
         payload=payload,
         required_fields=IMPORTACION_RESPONSABLE_REQUIRED_FIELDS,
@@ -987,7 +1012,6 @@ def _build_responsable_payload_importacion(
         "email": payload.get("email_responsable"),
         "documento": payload.get("documento_responsable"),
         "tipo_documento": _get_tipo_documento(payload.get("documento_responsable", "")),
-        "provincia": provincia_usuario_id,
     }
 
 
@@ -1045,6 +1069,7 @@ def validar_y_normalizar_payloads_importacion(
     offset=0,
     municipios_cache=None,
     localidades_cache=None,
+    municipio_provincia_map=None,
     nacionalidades_cache=None,
     paises_a_nacionalidad=None,
     normalizar_sexo=None,
@@ -1071,9 +1096,7 @@ def validar_y_normalizar_payloads_importacion(
     if paises_a_nacionalidad is None:
         paises_a_nacionalidad = _cargar_paises_a_nacionalidad_importacion()
 
-    _aplicar_defaults_y_validar_payload_importacion(
-        payload_normalizado, provincia_usuario_id
-    )
+    _aplicar_defaults_y_validar_payload_importacion(payload_normalizado)
     _normalizar_enriquecer_payload_importacion(
         payload=payload_normalizado,
         offset=offset,
@@ -1085,6 +1108,7 @@ def validar_y_normalizar_payloads_importacion(
         nacionalidades_cache=nacionalidades_cache,
         paises_a_nacionalidad=paises_a_nacionalidad,
     )
+    _inferir_provincia_desde_municipio_importacion(payload_normalizado, municipio_provincia_map)
     _validar_beneficiario_menor_con_responsable_importacion(payload_normalizado)
 
     responsable_payload = None
@@ -1202,6 +1226,8 @@ def _resolver_localidad_responsable_payload_importacion(
                 localidad_obj = coincidencias[0]
                 responsable_payload["localidad"] = localidad_obj.pk
                 responsable_payload["municipio"] = localidad_obj.municipio.pk
+                if localidad_obj.municipio.provincia_id:
+                    responsable_payload["provincia"] = localidad_obj.municipio.provincia_id
                 return
             if len(coincidencias) > 1:
                 raise ValidationError(
@@ -1694,6 +1720,7 @@ def _construir_payload_fila_importacion(
     to_date,
     municipios_cache,
     localidades_cache,
+    municipio_provincia_map,
     normalizar_sexo,
     nacionalidades_cache,
     paises_a_nacionalidad,
@@ -1705,10 +1732,7 @@ def _construir_payload_fila_importacion(
         validar_documento=validar_documento,
         add_warning=add_warning,
     )
-    _aplicar_defaults_y_validar_payload_importacion(
-        payload=payload,
-        provincia_usuario_id=provincia_usuario_id,
-    )
+    _aplicar_defaults_y_validar_payload_importacion(payload)
     _normalizar_enriquecer_payload_importacion(
         payload=payload,
         offset=offset,
@@ -1720,6 +1744,7 @@ def _construir_payload_fila_importacion(
         nacionalidades_cache=nacionalidades_cache,
         paises_a_nacionalidad=paises_a_nacionalidad,
     )
+    _inferir_provincia_desde_municipio_importacion(payload, municipio_provincia_map)
     _validar_beneficiario_menor_con_responsable_importacion(payload)
     return payload
 
@@ -1944,6 +1969,7 @@ def _procesar_beneficiario_desde_row_importacion(
     provincia_usuario_id,
     municipios_cache,
     localidades_cache,
+    municipio_provincia_map,
     nacionalidades_cache,
     paises_a_nacionalidad,
     validar_documento,
@@ -1970,6 +1996,7 @@ def _procesar_beneficiario_desde_row_importacion(
         to_date=to_date,
         municipios_cache=municipios_cache,
         localidades_cache=localidades_cache,
+        municipio_provincia_map=municipio_provincia_map,
         normalizar_sexo=normalizar_sexo,
         nacionalidades_cache=nacionalidades_cache,
         paises_a_nacionalidad=paises_a_nacionalidad,
@@ -2083,6 +2110,7 @@ def _procesar_fila_legajo_importacion(
     provincia_usuario_id,
     municipios_cache,
     localidades_cache,
+    municipio_provincia_map,
     nacionalidades_cache,
     paises_a_nacionalidad,
     validar_documento,
@@ -2127,6 +2155,7 @@ def _procesar_fila_legajo_importacion(
                 provincia_usuario_id=provincia_usuario_id,
                 municipios_cache=municipios_cache,
                 localidades_cache=localidades_cache,
+                municipio_provincia_map=municipio_provincia_map,
                 nacionalidades_cache=nacionalidades_cache,
                 paises_a_nacionalidad=paises_a_nacionalidad,
                 validar_documento=validar_documento,
@@ -2251,6 +2280,7 @@ def _build_contexto_filas_importacion_legajos(
         "provincia_usuario_id": provincia_usuario_id,
         "municipios_cache": precargas["municipios_cache"],
         "localidades_cache": precargas["localidades_cache"],
+        "municipio_provincia_map": precargas["municipio_provincia_map"],
         "nacionalidades_cache": nacionalidades_cache,
         "paises_a_nacionalidad": paises_a_nacionalidad,
         "validar_documento": _validar_documento_importacion,

--- a/tests/test_importacion_service_helpers_unit.py
+++ b/tests/test_importacion_service_helpers_unit.py
@@ -208,6 +208,9 @@ def test_importacion_helpers_normalizan_dataframe_y_precargas(mocker):
                 return self
             return [x for x in self if x.provincia_id == provincia_id]
 
+        def only(self, *_fields):
+            return self
+
     mocker.patch(
         "celiaquia.services.importacion_service.Municipio.objects.filter",
         return_value=_FakeMunicipiosQS(
@@ -231,6 +234,7 @@ def test_importacion_helpers_normalizan_dataframe_y_precargas(mocker):
 
     precargas = module._precargar_datos_importacion(out, provincia_usuario_id=7)
     assert precargas["municipios_cache"] == {1: 1}
+    assert precargas["municipio_provincia_map"] == {1: 7, 3: 8}
     assert precargas["localidades_cache"] == {2: 2}
     assert precargas["sexos_cache"]["masculino"] == 1
     assert precargas["sexos_cache"]["f"] == 2
@@ -416,15 +420,12 @@ def test_importacion_helpers_payload_row_and_defaults_validation():
         }
     )
 
-    module._aplicar_defaults_y_validar_payload_importacion(
-        payload, provincia_usuario_id=7
-    )
-    assert payload["provincia"] == 7
+    module._aplicar_defaults_y_validar_payload_importacion(payload)
     assert payload["tipo_documento"] == module.Ciudadano.DOCUMENTO_CUIT
 
     with pytest.raises(ValidationError):
         module._aplicar_defaults_y_validar_payload_importacion(
-            {"nombre": "Ana", "documento": "123"}, provincia_usuario_id=None
+            {"nombre": "Ana", "documento": "123"}
         )
 
 
@@ -582,7 +583,7 @@ def test_importacion_helpers_responsable_payload_and_same_document():
     )
 
     assert responsable_payload["tipo_documento"] == module.Ciudadano.DOCUMENTO_CUIT
-    assert responsable_payload["provincia"] == 7
+    assert "provincia" not in responsable_payload
     assert responsable_payload["sexo"] == 2
     assert module._es_mismo_documento_responsable_importacion(payload) is True
 
@@ -606,9 +607,17 @@ def test_importacion_helpers_responsable_enriquecimiento_y_relacion(mocker):
             if "municipio__provincia_id" in kwargs:
                 return self
             if kwargs == {"nombre__iexact": "Rosario"}:
-                return [SimpleNamespace(pk=11, municipio=SimpleNamespace(pk=22))]
+                return [
+                    SimpleNamespace(
+                        pk=11, municipio=SimpleNamespace(pk=22, provincia_id=7)
+                    )
+                ]
             if kwargs == {"nombre__icontains": "Rosario"}:
-                return [SimpleNamespace(pk=11, municipio=SimpleNamespace(pk=22))]
+                return [
+                    SimpleNamespace(
+                        pk=11, municipio=SimpleNamespace(pk=22, provincia_id=7)
+                    )
+                ]
             return []
 
     mocker.patch(
@@ -635,6 +644,7 @@ def test_importacion_helpers_responsable_enriquecimiento_y_relacion(mocker):
     assert responsable_payload["altura"] == "1234"
     assert responsable_payload["localidad"] == 11
     assert responsable_payload["municipio"] == 22
+    assert responsable_payload["provincia"] == 7
     assert responsable_payload["fecha_nacimiento"] == date(2001, 2, 3)
     assert warnings == []
 
@@ -670,7 +680,11 @@ def test_importacion_helpers_resuelve_localidad_responsable_con_parentesis(mocke
             if "municipio__provincia_id" in kwargs:
                 return self
             if kwargs == {"nombre__iexact": "Rosario"}:
-                return [SimpleNamespace(pk=44, municipio=SimpleNamespace(pk=55))]
+                return [
+                    SimpleNamespace(
+                        pk=44, municipio=SimpleNamespace(pk=55, provincia_id=7)
+                    )
+                ]
             return []
 
     mocker.patch(
@@ -690,6 +704,7 @@ def test_importacion_helpers_resuelve_localidad_responsable_con_parentesis(mocke
 
     assert responsable_payload["localidad"] == 44
     assert responsable_payload["municipio"] == 55
+    assert responsable_payload["provincia"] == 7
 
 
 def test_importacion_helpers_crear_responsable_y_legajo(mocker):


### PR DESCRIPTION
## Resumen

- La provincia del expediente/ciudadano ya no se toma del usuario importador sino del municipio del registro importado.
- Cuando el usuario tiene múltiples provincias, `provincia_usuario_id` es `None` y la provincia quedaba sin asignar. Ahora se deriva correctamente del municipio.

## Cambios

**`celiaquia/services/importacion_service/impl.py`**
- `_cargar_municipio_provincia_map`: nueva función que pre-carga `{municipio_pk → provincia_id}` para todos los municipios del lote (sin filtrar por usuario).
- `_inferir_provincia_desde_municipio_importacion`: nuevo helper que asigna `payload["provincia"]` desde el mapa pre-cargado. Si no hay mapa (ruta de validación de registros erróneos), hace una consulta DB como fallback.
- `_aplicar_defaults_y_validar_payload_importacion`: eliminado parámetro `provincia_usuario_id` y el bloque de asignación `payload["provincia"] = provincia_usuario_id`.
- `_build_responsable_payload_importacion`: eliminado `"provincia": provincia_usuario_id` del payload del responsable.
- `_resolver_localidad_responsable_payload_importacion`: al resolver la localidad del responsable, ahora también asigna `responsable_payload["provincia"]` desde `localidad_obj.municipio.provincia_id`.
- Cadena batch (`_construir_payload_fila_importacion`, `_procesar_beneficiario_desde_row_importacion`, `_procesar_fila_legajo_importacion`, `_build_contexto_filas_importacion_legajos`): propagado `municipio_provincia_map`.

**`tests/test_importacion_service_helpers_unit.py`**
- Tests actualizados para reflejar la nueva lógica: mocks de municipio incluyen `provincia_id`, nuevas aserciones de provincia desde municipio, removidas aserciones de provincia desde usuario.

## Notas para el revisor

- El filtro de municipios válidos por provincia del usuario se **mantiene sin cambios** (solo afecta validación, no asignación).
- Si `Municipio.provincia_id` es `None`, la provincia queda sin asignar (igual que antes cuando el usuario tenía múltiples provincias).
- Continuación lógica del PR #1781 que corrigió que la importación no falle cuando el usuario tiene múltiples provincias.

## Cómo probar

1. Crear usuario con múltiples provincias.
2. Importar un expediente de celiaquía con municipio de una provincia específica.
3. Verificar que el ciudadano creado tenga la provincia del municipio importado, no la del usuario.

🤖 Generated with [Claude Code](https://claude.com/claude-code)