### PR TITLE
Fix 15 tests heredados rotos en development + pytest en push

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -98,7 +98,6 @@ jobs:
               run: docker compose down -v
 
     pytest:
-        if: github.event_name == 'pull_request'
         runs-on: ubuntu-latest
 
         steps:

--- a/VAT/tests.py
+++ b/VAT/tests.py
@@ -1923,7 +1923,8 @@ def test_centro_detail_muestra_referentes_plural_sin_exponer_revisores(
 
     content = response.content.decode("utf-8")
     assert response.status_code == 200
-    assert "Referente/s del Centro" in content
+    # Refactor 4f1f2241 renombró la sección a "Referente del centro" (singular)
+    assert "Referente del centro" in content
     assert "ref-detalle-1" in content
     assert "ref-detalle-2" in content
     assert "revisor-detalle" not in content

--- a/VAT/tests.py
+++ b/VAT/tests.py
@@ -5910,7 +5910,9 @@ def test_centro_cursos_panel_renderiza_selector_de_planes_en_modal_nuevo_curso(
     assert response.status_code == 200
     assert 'data-panel-rendered="1"' in content
     assert "Planes Curriculares" not in content
-    assert 'title="Nuevo Curso"' in content
+    # El refactor reemplazó el botón title="Nuevo Curso" por un modal con
+    # heading "Nuevo Curso" (h5) y un botón "Agregar curso".
+    assert ">Nuevo Curso<" in content
     assert 'id="planEstudioSeleccionadoInfo"' in content
     assert 'id="modalPlanCurricularSelector"' in content
     assert 'id="openPlanCurricularSelector"' in content

--- a/VAT/tests.py
+++ b/VAT/tests.py
@@ -5815,11 +5815,14 @@ def test_centro_cursos_panel_renderiza_marcadores_para_filtrar_comisiones_por_cu
     )
     assert "<td>Plan Industrial Inicial</td>" in content
     assert 'id="tablaComisionesCursoCentro"' in content
-    assert "<th>Código</th>" in content
+    # Refactor 4f1f2241 reordenó las columnas: Curso, Comisión, Ubicación,
+    # Fecha Inicio, Fecha Fin, Cupo, Acciones.
+    assert "<th>Curso</th>" in content
+    assert "<th>Comisión</th>" in content
     assert "<th>Ubicación</th>" in content
     assert "<th>Fecha Inicio</th>" in content
     assert "<th>Fecha Fin</th>" in content
-    assert "<th>Observaciones</th>" in content
+    assert "<th>Cupo</th>" in content
     assert "FIL-01" in content
     assert "Comisión Filtrable" in content
     assert 'id="comisionesFilterSearch"' in content
@@ -5830,7 +5833,8 @@ def test_centro_cursos_panel_renderiza_marcadores_para_filtrar_comisiones_por_cu
     assert 'id="comisionesFilterClear"' in content
     assert 'class="comision-curso-row"' in content
     assert reverse("vat_comision_curso_detail", kwargs={"pk": comision.pk}) in content
-    assert 'title="Gestionar Comisión"' in content
+    # El refactor reemplazó el title="Gestionar Comisión" por un botón "Ver"
+    assert "sisoc-btn--view" in content
     assert comisiones_filter_curso is not None
     assert "select2" in comisiones_filter_curso.get("class", [])
     assert comisiones_filter_curso.get("data-width") == "100%"

--- a/VAT/tests.py
+++ b/VAT/tests.py
@@ -452,14 +452,15 @@ def test_centro_update_renderiza_mismo_formulario_extendido_que_alta(
     content = response.content.decode("utf-8")
     assert response.status_code == 200
     assert "contactos-TOTAL_FORMS" in content
-    assert "3.2 Contactos de la institución" in content
+    # Refactor 4f1f2241 renombró las secciones removiendo prefijos numéricos
+    assert "Contactos adicionales" in content
     assert "4. Autoridades" not in content
     assert 'name="contactos-0-documento"' in content
     assert 'name="save_continue"' not in content
     assert 'for="id_provincia"' not in content
     assert 'name="provincia"' in content
     assert 'name="activo_present"' in content
-    assert "4. Estado de la sede" in content
+    assert "Estado de Centro de Formación Profesional" in content
 
 
 @pytest.mark.django_db

--- a/VAT/tests.py
+++ b/VAT/tests.py
@@ -1886,11 +1886,13 @@ def test_centro_detail_muestra_boton_editar_para_referente_cfp(client, vat_geo_d
     assert response.status_code == 200
     assert reverse("vat_centro_update", kwargs={"pk": centro.pk}) in content
     assert "Editar" in content
-    assert "Datos del Establecimiento" in content
+    # Refactor 4f1f2241 renombró secciones: ahora hay tabs "Información general",
+    # "Ubicaciones adicionales" y modal "Agregar Identificador".
+    assert "Información general" in content
     assert "CUE" in content
     assert "Estructura Institucional" not in content
-    assert "Ubicacion Principal" in content
-    assert "Identificadores" in content
+    assert "Ubicaciones adicionales" in content
+    assert "Identificador" in content
 
 
 @pytest.mark.django_db

--- a/centrodeinfancia/tests/test_centrodeinfancia_form.py
+++ b/centrodeinfancia/tests/test_centrodeinfancia_form.py
@@ -495,8 +495,9 @@ def test_form_precarga_fecha_inicio_en_input_date():
 
     form = CentroDeInfanciaForm(instance=centro)
 
-    # fecha_inicio se redefinió como CharField (año solo, AAAA) — usa TextInput
-    assert form.fields["fecha_inicio"].widget.input_type == "text"
+    # fecha_inicio es CharField (año AAAA) con NumberInput para forzar entrada
+    # numérica desde el navegador (commit f156641a).
+    assert form.fields["fecha_inicio"].widget.input_type == "number"
     assert 'value="2024-05-04"' in str(form["fecha_inicio"])
 
 

--- a/tests/test_celiaquia_expediente_view_helpers_unit.py
+++ b/tests/test_celiaquia_expediente_view_helpers_unit.py
@@ -306,9 +306,7 @@ def test_expediente_create_view_context_by_user_type(mocker):
 
     mocker.patch("celiaquia.views.expediente._is_provincial", return_value=True)
     mocker.patch("celiaquia.views.expediente._is_admin", return_value=False)
-    mocker.patch(
-        "celiaquia.views.expediente.is_territorial_user", return_value=True
-    )
+    mocker.patch("celiaquia.views.expediente.is_territorial_user", return_value=True)
     mocker.patch(
         "celiaquia.views.expediente._user_scope_provincias",
         return_value=["prov"],

--- a/tests/test_celiaquia_expediente_view_helpers_unit.py
+++ b/tests/test_celiaquia_expediente_view_helpers_unit.py
@@ -296,13 +296,23 @@ def test_expediente_plantilla_excel_view_download(mocker):
 
 
 def test_expediente_create_view_context_by_user_type(mocker):
+    # Commit 18e87c53 introdujo scopes territoriales: ahora la rama provincial
+    # requiere además _is_admin=False + is_territorial_user=True y delega en
+    # _user_scope_provincias en lugar de _user_provincia.
     view = module.ExpedienteCreateView()
     mocker.patch(
         "django.views.generic.edit.ModelFormMixin.get_context_data", return_value={}
     )
 
     mocker.patch("celiaquia.views.expediente._is_provincial", return_value=True)
-    mocker.patch("celiaquia.views.expediente._user_provincia", return_value="prov")
+    mocker.patch("celiaquia.views.expediente._is_admin", return_value=False)
+    mocker.patch(
+        "celiaquia.views.expediente.is_territorial_user", return_value=True
+    )
+    mocker.patch(
+        "celiaquia.views.expediente._user_scope_provincias",
+        return_value=["prov"],
+    )
     view.request = SimpleNamespace(user=SimpleNamespace())
     ctx = view.get_context_data()
     assert ctx["provincias"] == ["prov"]

--- a/tests/test_ciudadano_service_unit.py
+++ b/tests/test_ciudadano_service_unit.py
@@ -72,6 +72,13 @@ def test_resolver_ubicacion_paths(mocker):
     with pytest.raises(ValidationError):
         module.CiudadanoService._resolver_provincia("abc")
 
+    # Commit 38a81093 cambió _resolver_municipio(provincia=None) para que
+    # busque por ID sin la restricción provincial. Si Municipio no existe,
+    # todavía se levanta ValidationError; si existe, se devuelve.
+    mocker.patch(
+        "celiaquia.services.ciudadano_service.Municipio.objects.filter",
+        return_value=_FirstResult(None),
+    )
     with pytest.raises(ValidationError):
         module.CiudadanoService._resolver_municipio("20", None)
 

--- a/tests/test_importacion_service_helpers_unit.py
+++ b/tests/test_importacion_service_helpers_unit.py
@@ -1477,6 +1477,7 @@ def test_importar_legajos_orquesta_loop_principal_y_postprocesos(mocker):
         return_value={
             "municipios_cache": {},
             "localidades_cache": {},
+            "municipio_provincia_map": {},
             "sexos_cache": {},
             "nacionalidades_cache": {},
             "paises_a_nacionalidad": {},

--- a/tests/test_importacion_service_helpers_unit.py
+++ b/tests/test_importacion_service_helpers_unit.py
@@ -1375,6 +1375,7 @@ def test_importar_legajos_acumula_warnings_emitidos_por_callbacks(mocker):
         return_value={
             "municipios_cache": {},
             "localidades_cache": {},
+            "municipio_provincia_map": {},
             "sexos_cache": {},
             "nacionalidades_cache": {},
             "paises_a_nacionalidad": {},

--- a/tests/test_importacion_service_helpers_unit.py
+++ b/tests/test_importacion_service_helpers_unit.py
@@ -1630,6 +1630,7 @@ def test_importar_legajos_registra_error_si_falla_responsable_tras_beneficiario(
         return_value={
             "municipios_cache": {},
             "localidades_cache": {},
+            "municipio_provincia_map": {},
             "sexos_cache": {},
             "nacionalidades_cache": {},
             "paises_a_nacionalidad": {},

--- a/tests/test_pwa_comedores_api.py
+++ b/tests/test_pwa_comedores_api.py
@@ -817,10 +817,15 @@ def test_adjuntar_y_presentar_rendicion(comedores, settings, tmp_path):
     )
     assert present_without_docs_response.status_code == 400
 
+    # El commit a4636912 actualizó CATEGORIAS_CONFIG: agregó Formulario I y
+    # dividió Formulario III/V en _ALIMENTARIO/_SIPH como obligatorios mobile.
     categorias_obligatorias = [
+        DocumentacionAdjunta.CATEGORIA_FORMULARIO_I,
         DocumentacionAdjunta.CATEGORIA_FORMULARIO_II,
-        DocumentacionAdjunta.CATEGORIA_FORMULARIO_III,
-        DocumentacionAdjunta.CATEGORIA_FORMULARIO_V,
+        DocumentacionAdjunta.CATEGORIA_FORMULARIO_III_ALIMENTARIO,
+        DocumentacionAdjunta.CATEGORIA_FORMULARIO_III_SIPH,
+        DocumentacionAdjunta.CATEGORIA_FORMULARIO_V_ALIMENTARIO,
+        DocumentacionAdjunta.CATEGORIA_FORMULARIO_V_SIPH,
         DocumentacionAdjunta.CATEGORIA_EXTRACTO_BANCARIO,
         DocumentacionAdjunta.CATEGORIA_COMPROBANTES,
     ]
@@ -841,13 +846,15 @@ def test_adjuntar_y_presentar_rendicion(comedores, settings, tmp_path):
         f"/api/comedores/{comedor_1.id}/rendiciones/{rendicion.id}/",
     )
     assert detail_response.status_code == 200
-    assert len(detail_response.data["documentacion"]) == 9
+    # CATEGORIAS_CONFIG ahora trae 12 items (Form I + III/V divididos +
+    # Form IV/VI + Extracto + Comprobantes + Planilla Seguros + Otros).
+    assert len(detail_response.data["documentacion"]) == 12
     categoria_extra = next(
         item
         for item in detail_response.data["documentacion"]
         if item["codigo"] == DocumentacionAdjunta.CATEGORIA_OTROS
     )
-    assert categoria_extra["label"] == "Documentación Extra"
+    assert categoria_extra["label"] == "Documentación Adicional"
 
     present_response = client.post(
         f"/api/comedores/{comedor_1.id}/rendiciones/{rendicion.id}/presentar/",

--- a/tests/test_pwa_mensajes_api.py
+++ b/tests/test_pwa_mensajes_api.py
@@ -483,10 +483,15 @@ def test_mensaje_de_rendicion_se_archiva_cuando_la_subsanacion_se_reenvia(
         periodo_fin=timezone.now().date(),
         estado=RendicionCuentaMensual.ESTADO_SUBSANAR,
     )
+    # El commit a4636912 dividió Formulario III y V en _ALIMENTARIO/_SIPH y
+    # agregó Formulario I (Cuenta Bancaria) como obligatorios mobile.
     for categoria in (
+        DocumentacionAdjunta.CATEGORIA_FORMULARIO_I,
         DocumentacionAdjunta.CATEGORIA_FORMULARIO_II,
-        DocumentacionAdjunta.CATEGORIA_FORMULARIO_III,
-        DocumentacionAdjunta.CATEGORIA_FORMULARIO_V,
+        DocumentacionAdjunta.CATEGORIA_FORMULARIO_III_ALIMENTARIO,
+        DocumentacionAdjunta.CATEGORIA_FORMULARIO_III_SIPH,
+        DocumentacionAdjunta.CATEGORIA_FORMULARIO_V_ALIMENTARIO,
+        DocumentacionAdjunta.CATEGORIA_FORMULARIO_V_SIPH,
         DocumentacionAdjunta.CATEGORIA_EXTRACTO_BANCARIO,
     ):
         DocumentacionAdjunta.objects.create(

--- a/tests/test_rendicioncuentasmensual_services_unit.py
+++ b/tests/test_rendicioncuentasmensual_services_unit.py
@@ -293,9 +293,11 @@ def test_obtener_documentacion_para_detalle_mantiene_vigente_reemplazo_categoria
 ):
     settings.MEDIA_ROOT = str(tmp_path)
     rendicion = RendicionCuentaMensual.objects.create(mes=4, anio=2026)
+    # Commit a4636912 dividió Formulario III en _ALIMENTARIO/_SIPH;
+    # usamos la variante actual para cubrir el caso "categoría única".
     observado = DocumentacionAdjunta.objects.create(
         nombre="formulario-iii-v1.pdf",
-        categoria=DocumentacionAdjunta.CATEGORIA_FORMULARIO_III,
+        categoria=DocumentacionAdjunta.CATEGORIA_FORMULARIO_III_ALIMENTARIO,
         estado=DocumentacionAdjunta.ESTADO_SUBSANAR,
         rendicion_cuenta_mensual=rendicion,
         archivo=SimpleUploadedFile(
@@ -307,7 +309,7 @@ def test_obtener_documentacion_para_detalle_mantiene_vigente_reemplazo_categoria
     observado.delete()
     reemplazo = DocumentacionAdjunta.objects.create(
         nombre="formulario-iii-v2.pdf",
-        categoria=DocumentacionAdjunta.CATEGORIA_FORMULARIO_III,
+        categoria=DocumentacionAdjunta.CATEGORIA_FORMULARIO_III_ALIMENTARIO,
         estado=DocumentacionAdjunta.ESTADO_VALIDADO,
         rendicion_cuenta_mensual=rendicion,
         documento_subsanado=observado,
@@ -325,7 +327,7 @@ def test_obtener_documentacion_para_detalle_mantiene_vigente_reemplazo_categoria
     formularios = next(
         item
         for item in categorias
-        if item["codigo"] == DocumentacionAdjunta.CATEGORIA_FORMULARIO_III
+        if item["codigo"] == DocumentacionAdjunta.CATEGORIA_FORMULARIO_III_ALIMENTARIO
     )
     assert [item.id for item in formularios["archivos"]] == [reemplazo.id]
     assert getattr(formularios["archivos"][0], "subsanaciones_historial", []) == []

--- a/tests/test_vat_centro_form_state_unit.py
+++ b/tests/test_vat_centro_form_state_unit.py
@@ -155,4 +155,6 @@ def test_template_centro_create_form_incluye_switch_activo():
     content = template_path.read_text(encoding="utf-8")
 
     assert 'name="activo_present"' in content
-    assert "4. Estado de la sede" in content
+    # Refactor 4f1f2241 renombró el header "4. Estado de la sede" a
+    # "Estado de Centro de Formación Profesional".
+    assert "Estado de Centro de Formación Profesional" in content


### PR DESCRIPTION
## Resumen

Arregla 15 tests que estaban rotos en `development` pero que CI no los flaggeaba porque el job `pytest` solo se ejecutaba en `pull_request`. Los descubrimos al abrir [#1643](https://github.com/dsocial118/SISOC/pull/1643) y [#1789](https://github.com/dsocial118/SISOC/pull/1789); este PR los desbloquea.

Cada test rotos recibió su commit propio (15 commits) + un commit final que habilita `pytest` también en push a `development`/`main` para que la deuda no se repita.

## Causas raíz por test

### `centro_create_form.html` refactorizado (commit `4f1f2241`)
- `VAT/tests.py::test_centro_update_renderiza_mismo_formulario_extendido_que_alta` — sección "3.2 Contactos de la institución" pasó a "Contactos adicionales"; "4. Estado de la sede" a "Estado de Centro de Formación Profesional".
- `VAT/tests.py::test_centro_detail_muestra_boton_editar_para_referente_cfp` — secciones del detalle reestructuradas en tabs ("Información general", "Ubicaciones adicionales").
- `VAT/tests.py::test_centro_detail_muestra_referentes_plural_sin_exponer_revisores` — "Referente/s del Centro" → "Referente del centro" (singular).
- `VAT/tests.py::test_centro_cursos_panel_renderiza_marcadores_para_filtrar_comisiones_por_curso` — columnas reordenadas (Curso/Comisión/Cupo en vez de Código/Observaciones); botón `title="Gestionar Comisión"` reemplazado por botón "Ver" (`sisoc-btn--view`).
- `VAT/tests.py::test_centro_cursos_panel_renderiza_selector_de_planes_en_modal_nuevo_curso` — botón `title="Nuevo Curso"` reemplazado por modal con `<h5>Nuevo Curso</h5>`.
- `tests/test_vat_centro_form_state_unit.py::test_template_centro_create_form_incluye_switch_activo` — misma rename de "4. Estado de la sede".

### Widget de `fecha_inicio` cambió a `NumberInput` (commit `f156641a`)
- `centrodeinfancia/tests/test_centrodeinfancia_form.py::test_form_precarga_fecha_inicio_en_input_date` — el test esperaba `input_type="text"` pero ahora es `"number"`.

### `_precargar_datos_importacion` agrega clave `municipio_provincia_map` (commit `be773716`)
- `tests/test_importacion_service_helpers_unit.py::test_importar_legajos_acumula_warnings_emitidos_por_callbacks`
- `tests/test_importacion_service_helpers_unit.py::test_importar_legajos_orquesta_loop_principal_y_postprocesos`
- `tests/test_importacion_service_helpers_unit.py::test_importar_legajos_registra_error_si_falla_responsable_tras_beneficiario`

Los tres mockean ese helper pero el dict de retorno no traía la nueva clave, así que `_build_contexto_filas_importacion_legajos` rompía con `KeyError`.

### `CATEGORIAS_CONFIG` de rendiciones expandido (commit `a4636912`)
- `tests/test_pwa_mensajes_api.py::test_mensaje_de_rendicion_se_archiva_cuando_la_subsanacion_se_reenvia`
- `tests/test_pwa_comedores_api.py::test_adjuntar_y_presentar_rendicion`
- `tests/test_rendicioncuentasmensual_services_unit.py::test_obtener_documentacion_para_detalle_mantiene_vigente_reemplazo_categoria_unica`

Se agregó `CATEGORIA_FORMULARIO_I` (Cuenta Bancaria) y se dividió Formulario III/V en `_ALIMENTARIO`/`_SIPH`. Los tests usaban las constantes legacy (`CATEGORIA_FORMULARIO_III`, `CATEGORIA_FORMULARIO_V`) que aún existen pero ya no aparecen en `CATEGORIAS_CONFIG`. Además, `CATEGORIA_OTROS` pasó de "Documentación Extra" a "Documentación Adicional" y `len(documentacion)` pasó de 9 a 12.

### Scopes territoriales en ExpedienteCreateView (commit `18e87c53`)
- `tests/test_celiaquia_expediente_view_helpers_unit.py::test_expediente_create_view_context_by_user_type` — la rama provincial ahora exige `_is_admin=False` + `is_territorial_user=True` y delega en `_user_scope_provincias`. Mockear solo `_is_provincial` + `_user_provincia` ya no alcanzaba.

### `_resolver_municipio` con `provincia=None` cambió (commit `38a81093`)
- `tests/test_ciudadano_service_unit.py::test_resolver_ubicacion_paths` — antes levantaba `ValidationError` incondicionalmente cuando `provincia=None`; ahora busca por ID via `Municipio.objects.filter`. El test necesita mockear ese filter (devolviendo `None`) para que la aserción de error se cumpla sin tocar la DB.

## CI

El último commit (`ci(tests): correr pytest también en push a development`) elimina el `if: github.event_name == 'pull_request'` del job `pytest`. La suite completa con coverage gate ya correrá también en pushes/merges a `development`/`main`, evitando que vuelvan a colarse tests rotos.

## Test plan

- [x] `pytest -n auto` corre completo en local (`2385 passed, 1 skipped` en 158s vía Docker / SQLite).
- [x] Los 15 tests originalmente rotos pasan individualmente y agrupados.
- [ ] CI: smoke, pytest, mysql_compat, migrations_check verdes contra `development`.
- [ ] Verificar que el job pytest ahora aparezca también en push a esta branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)