### PR TITLE
fix(admisiones): destrabar grafo de migraciones squasheado (quitar replaces de 0014)

### DIFF
--- a/admisiones/migrations/0014_squashed_0020_complementary_flow.py
+++ b/admisiones/migrations/0014_squashed_0020_complementary_flow.py
@@ -8,19 +8,6 @@ import django.db.models.deletion
 
 class Migration(migrations.Migration):
 
-    replaces = [
-        ("admisiones", "0014_alter_admision_estado_legales"),
-        ("admisiones", "0015_admision_complementario_solicitado"),
-        ("admisiones", "0016_alter_admision_estado_legales"),
-        ("admisiones", "0017_informecomplementario_estado_and_more"),
-        ("admisiones", "0018_alter_admision_estado_legales_and_more"),
-        ("admisiones", "0019_informetecnico_solicitudes_almuerzo_domingo_and_more"),
-        (
-            "admisiones",
-            "0020_remove_informetecnico_prestaciones_almuerzo_letras_and_more",
-        ),
-    ]
-
     dependencies = [
         ("admisiones", "0013_alter_admision_comedor"),
     ]


### PR DESCRIPTION
## Qué arregla

La CI de **todos** los PRs abiertos contra `development` estaba roja en los jobs `migrations_check`, `pytest` y `mysql_compat` porque el grafo de migraciones de `admisiones` no construye:

```
django.db.migrations.exceptions.NodeNotFoundError: Unable to find replacement node
('admisiones', '0014_squashed_0020_complementary_flow').
```

## Causa raíz (squash anidado)

- `admisiones/migrations/0001_squashed_0058.py` (squash maestro) lista en su `replaces` a `0014_squashed_0020_complementary_flow`.
- Pero `0014_squashed_0020_complementary_flow.py` **todavía declaraba su propio `replaces=[]`** (0014–0020) y seguía en disco.

Django no soporta un squash que reemplace a otro squash que aún conserva `replaces` y está en disco → `build_graph()` falla con `NodeNotFoundError`. Como los push directos a `development` solo corren `smoke` (que arma el schema desde los modelos sin recorrer el grafo), no se detectó al mergear.

## El cambio

Se elimina el bloque `replaces` de `0014_squashed_0020_complementary_flow.py` (transición a migración normal), exactamente como ya se había hecho con su gemelo `0007_anexo_barrio_squashed_0008`. **No se toca** `dependencies`, `operations` ni nada más.

### Verificaciones de seguridad
- Las migraciones originales `0014`–`0020` ya **no existen** como archivos sueltos en `admisiones/migrations/` (el directorio salta de `0013` a `0021`).
- `0001_squashed_0058.py` **sigue listando** `0014_squashed_0020_complementary_flow` en su `replaces`, así que la transición de DBs ya migradas queda cubierta.
- **El esquema final NO cambia**: este fix es puramente del grafo de migraciones (metadata), no agrega ni quita columnas/índices.

## Validación (Docker, local)

| Check | Antes | Después |
|---|---|---|
| `makemigrations --check --dry-run` | `NodeNotFoundError` (exit 1) | `No changes detected` (exit 0) |
| `manage check` | — | `System check identified no issues` |
| `pytest -n auto --cov=. --cov-fail-under=75` | no llegaba a correr | **2389 passed, 1 skipped**, coverage **81.81%** |

## Impacto en otros PRs

Esto destraba la CI de los PRs abiertos contra `development` (p. ej. #1794, #1789, #1795, entre otros). Una vez mergeado, esos PRs deberán **re-sincronizar con `development` y re-correr la CI** para que sus jobs `migrations_check`/`pytest`/`mysql_compat` pasen.

🤖 Generated with [Claude Code](https://claude.com/claude-code)