### PR TITLE
refactor(ticketera): endpoint de alta a /auth/crear_usuario/

### DIFF
--- a/docs/registro/cambios/2026-05-29-ticketera-endpoint-crear-usuario.md
+++ b/docs/registro/cambios/2026-05-29-ticketera-endpoint-crear-usuario.md
@@ -1,0 +1,42 @@
+# 2026-05-29 - Ticketera: renombre del endpoint de alta a `/auth/crear_usuario/`
+
+## Contexto
+
+El endpoint de alta de usuarios de la integración con la Ticketera estaba en
+`POST /api/ticketera/usuarios/`. Se mueve bajo el prefijo `auth/`, junto a los
+otros dos endpoints de la integración (`verificar`, `cambiar-password`), que es
+donde la Ticketera espera consumir las tres operaciones.
+
+Decisión y contratos en
+[docs/registro/decisiones/2026-05-27-integracion-ticketera.md](../decisiones/2026-05-27-integracion-ticketera.md).
+
+## Cambios aplicados
+
+- **Endpoint:** `POST /api/ticketera/usuarios/` → `POST /api/ticketera/auth/crear_usuario/`.
+- **Name de URL:** `ticketera-usuarios` → `ticketera-auth-crear-usuario`
+  (`ticketera/api_urls.py`), alineado con `ticketera-auth-verificar` /
+  `ticketera-auth-cambiar-password`.
+- **Tests:** `ticketera/tests.py` (`reverse("ticketera-auth-crear-usuario")`) y
+  `tests/test_ticketera.py` (constante `CREAR_USUARIO_URL` con la nueva ruta).
+- **Docs:** ADR `2026-05-27-integracion-ticketera.md` actualizado (tabla de
+  contratos, sección de contrato y referencias al endpoint) + sección datada
+  con el motivo. Guía de integración externa `docs/integraciones/ticketera_api.md`.
+
+Solo cambia la ruta y el name de URL. El método, el payload, los códigos de
+respuesta (`201`/`200`/`400`/`409`/`503`) y los shapes se conservan.
+
+## Nota de estilo
+
+Se usa `crear_usuario` (guion bajo) por pedido explícito; el endpoint hermano
+`cambiar-password` usa guion medio. Inconsistencia menor, conocida y aceptada.
+
+## Validación
+
+- `black --check` sobre los archivos `.py` modificados.
+- `pytest ticketera/tests.py tests/test_ticketera.py` (ver nota de la corrida en
+  la entrega; el grafo de migraciones heredado puede requerir `--no-migrations`).
+
+## Rollback
+
+Revertir la ruta y el name en `ticketera/api_urls.py` (y las referencias en
+tests/docs). No hay migraciones ni cambios de modelo asociados.

--- a/docs/registro/decisiones/2026-05-27-integracion-ticketera.md
+++ b/docs/registro/decisiones/2026-05-27-integracion-ticketera.md
@@ -25,7 +25,7 @@ bajo el prefijo `/api/ticketera/`:
 
 | Método | Ruta | Función |
 |---|---|---|
-| POST | `/usuarios/` | Crea o reconcilia un usuario (idempotente con `source=ticketera`). |
+| POST | `/auth/crear_usuario/` | Crea o reconcilia un usuario (idempotente con `source=ticketera`). |
 | POST | `/auth/verificar/` | Verifica credenciales y reporta `must_change_password`. |
 | POST | `/auth/cambiar-password/` | Fija la contraseña definitiva y baja `must_change_password` (cierra el ciclo de la temporal). |
 
@@ -83,7 +83,7 @@ Migración: `users/migrations/0031_profile_source.py`.
 
 ## Contratos
 
-### POST `/api/ticketera/usuarios/`
+### POST `/api/ticketera/auth/crear_usuario/`
 
 Request:
 
@@ -202,10 +202,10 @@ una nueva (coherente con la decisión de no bloquear, abajo).
 
 ### Expiración de la temporal en el alta — DEFAULT: SÍ (aplicado)
 
-El alta (`/usuarios/`) ahora setea
+El alta (`/auth/crear_usuario/`) ahora setea
 `initial_password_expires_at = now + timedelta(hours=INITIAL_PASSWORD_MAX_AGE_HOURS)`,
 para que la temporal de Ticketera expire igual que en el flujo PWA/web (ver
-`generate_temporary_password_for_user`). **El contrato de `/usuarios/` no
+`generate_temporary_password_for_user`). **El contrato de `/auth/crear_usuario/` no
 cambia** (sigue respondiendo `{ id, username, email }`).
 
 - **Interacción conocida:** `initial_password_expires_at` se **enforcea en el
@@ -278,9 +278,32 @@ Cuatro correcciones sobre los endpoints **sin cambiar los contratos existentes**
 
 ### Contrato afectado
 
-- `POST /usuarios/` agrega `400 Bad Request` por contraseña débil:
+- `POST /auth/crear_usuario/` agrega `400 Bad Request` por contraseña débil:
   `{ "password": ["<motivo 1>", ...] }`. (El `400` por payload inválido del
   serializer ya existía; este reutiliza ese mismo status.)
+
+---
+
+## Renombre del endpoint de alta → `/auth/crear_usuario/` (2026-05-29)
+
+El endpoint de alta pasa de `POST /api/ticketera/usuarios/` a
+`POST /api/ticketera/auth/crear_usuario/`. Motivo: agrupar las tres operaciones
+de la integración bajo el prefijo `auth/` (junto a `verificar` y
+`cambiar-password`), que es donde la Ticketera espera consumirlas.
+
+- **Solo cambia la ruta.** El método, el payload, los códigos de respuesta
+  (`201`/`200`/`400`/`409`/`503`) y los shapes se conservan.
+- **Name de URL:** `ticketera-usuarios` → `ticketera-auth-crear-usuario`
+  (alineado con `ticketera-auth-verificar` / `ticketera-auth-cambiar-password`).
+- **Nota de estilo:** se usa `crear_usuario` (guion bajo) por pedido explícito;
+  el endpoint hermano `cambiar-password` usa guion medio. Inconsistencia menor,
+  conocida y aceptada.
+- Cambio asociado:
+  [docs/registro/cambios/2026-05-29-ticketera-endpoint-crear-usuario.md](../cambios/2026-05-29-ticketera-endpoint-crear-usuario.md).
+
+> El registro `2026-05-28-ticketera-rename-app-endpoints.md` documenta la ruta
+> `/api/ticketera/usuarios/` como resultado del renombre `integracion → ticketera`
+> de esa fecha; esta sección la supersede.
 
 ---
 

--- a/tests/test_ticketera.py
+++ b/tests/test_ticketera.py
@@ -1,7 +1,7 @@
 """Tests de la API server-to-server con la Ticketera.
 
 Cubre los tres endpoints protegidos por API Key:
-- POST /api/ticketera/usuarios/              (alta / reconciliación)
+- POST /api/ticketera/auth/crear_usuario/    (alta / reconciliación)
 - POST /api/ticketera/auth/verificar/        (verificación de credenciales)
 - POST /api/ticketera/auth/cambiar-password/ (cambio de contraseña temporal)
 
@@ -19,7 +19,7 @@ from auditlog.models import LogEntry
 from audittrail.models import AuditEntryMeta
 
 
-USUARIOS_URL = "/api/ticketera/usuarios/"
+CREAR_USUARIO_URL = "/api/ticketera/auth/crear_usuario/"
 VERIFICAR_URL = "/api/ticketera/auth/verificar/"
 CAMBIAR_PASSWORD_URL = "/api/ticketera/auth/cambiar-password/"
 AUDIT_SOURCE = "ticketera"
@@ -56,7 +56,7 @@ def _crear_usuario(
 
 
 # --------------------------------------------------------------------------- #
-# POST /usuarios/  (alta / reconciliación)
+# POST /auth/crear_usuario/  (alta / reconciliación)
 # --------------------------------------------------------------------------- #
 
 
@@ -70,7 +70,7 @@ def test_usuarios_alta_nueva_devuelve_201_y_setea_profile(api_client):
         "password": "ContraseñaTemporal1!",
     }
 
-    response = api_client.post(USUARIOS_URL, payload, format="json")
+    response = api_client.post(CREAR_USUARIO_URL, payload, format="json")
 
     assert response.status_code == status.HTTP_201_CREATED
     user = User.objects.get(username="juan.perez")
@@ -95,7 +95,7 @@ def test_usuarios_alta_respeta_source_del_body(api_client):
         "source": "ticketera-qa",
     }
 
-    response = api_client.post(USUARIOS_URL, payload, format="json")
+    response = api_client.post(CREAR_USUARIO_URL, payload, format="json")
 
     assert response.status_code == status.HTTP_201_CREATED
     assert User.objects.get(username="ana.gomez").profile.source == "ticketera-qa"
@@ -111,7 +111,7 @@ def test_usuarios_idempotente_devuelve_200_sin_duplicar(api_client):
         "email": "otro-mail@ejemplo.gob.ar",
         "password": "OtraClave1!",
     }
-    response = api_client.post(USUARIOS_URL, payload, format="json")
+    response = api_client.post(CREAR_USUARIO_URL, payload, format="json")
 
     assert response.status_code == status.HTTP_200_OK
     assert response.data == {
@@ -132,7 +132,7 @@ def test_usuarios_username_tomado_por_otro_source_devuelve_409(api_client):
         "email": "nuevo@ejemplo.gob.ar",
         "password": "Clave1!",
     }
-    response = api_client.post(USUARIOS_URL, payload, format="json")
+    response = api_client.post(CREAR_USUARIO_URL, payload, format="json")
 
     assert response.status_code == status.HTTP_409_CONFLICT
     assert response.data["error"] == "username_taken"
@@ -162,7 +162,7 @@ def test_usuarios_username_tomado_por_otro_source_devuelve_409(api_client):
     ],
 )
 def test_usuarios_payload_invalido_devuelve_400(api_client, payload):
-    response = api_client.post(USUARIOS_URL, payload, format="json")
+    response = api_client.post(CREAR_USUARIO_URL, payload, format="json")
 
     assert response.status_code == status.HTTP_400_BAD_REQUEST
     assert not User.objects.filter(username=payload["username"]).exists()
@@ -496,7 +496,9 @@ def test_cambiar_password_registra_auditoria_con_source_ticketera(api_client):
 
 
 @pytest.mark.django_db
-@pytest.mark.parametrize("url", [USUARIOS_URL, VERIFICAR_URL, CAMBIAR_PASSWORD_URL])
+@pytest.mark.parametrize(
+    "url", [CREAR_USUARIO_URL, VERIFICAR_URL, CAMBIAR_PASSWORD_URL]
+)
 def test_sin_api_key_rechaza(url):
     client = APIClient()  # sin header Authorization: Api-Key
 
@@ -528,7 +530,7 @@ def test_alta_registra_auditoria_con_source_ticketera(api_client):
         "email": "auditado@ejemplo.gob.ar",
         "password": "ContraseñaTemporal1!",
     }
-    response = api_client.post(USUARIOS_URL, payload, format="json")
+    response = api_client.post(CREAR_USUARIO_URL, payload, format="json")
     assert response.status_code == status.HTTP_201_CREATED
 
     metas = AuditEntryMeta.objects.filter(source=AUDIT_SOURCE)

--- a/ticketera/api_urls.py
+++ b/ticketera/api_urls.py
@@ -11,9 +11,9 @@ from ticketera.api_views import (
 
 urlpatterns = [
     path(
-        "usuarios/",
+        "auth/crear_usuario/",
         TicketeraUsuarioCreateView.as_view(),
-        name="ticketera-usuarios",
+        name="ticketera-auth-crear-usuario",
     ),
     path(
         "auth/verificar/",

--- a/ticketera/tests.py
+++ b/ticketera/tests.py
@@ -68,7 +68,7 @@ def _crear_usuario(username, *, source, password=STRONG_PASSWORD, email=None):
 @override_settings(TICKETERA_ENABLED=False)
 def test_usuarios_responde_503_con_flag_deshabilitado(api_client):
     response = api_client.post(
-        reverse("ticketera-usuarios"),
+        reverse("ticketera-auth-crear-usuario"),
         {
             "username": "juan.perez",
             "email": "juan.perez@ejemplo.gob.ar",
@@ -118,7 +118,7 @@ def test_cambiar_password_responde_503_con_flag_deshabilitado(api_client):
 @override_settings(TICKETERA_ENABLED=True)
 def test_usuarios_opera_con_flag_habilitado(api_client):
     response = api_client.post(
-        reverse("ticketera-usuarios"),
+        reverse("ticketera-auth-crear-usuario"),
         {
             "username": "juan.perez",
             "email": "juan.perez@ejemplo.gob.ar",
@@ -142,7 +142,7 @@ def test_usuarios_idempotente_case_insensitive_200(api_client):
     _crear_usuario("juan.perez", source="ticketera")
 
     response = api_client.post(
-        reverse("ticketera-usuarios"),
+        reverse("ticketera-auth-crear-usuario"),
         {
             "username": "Juan.Perez",
             "email": "otro@ejemplo.gob.ar",
@@ -162,7 +162,7 @@ def test_usuarios_conflicto_case_insensitive_409(api_client):
     _crear_usuario("ana.gomez", source="sisoc")
 
     response = api_client.post(
-        reverse("ticketera-usuarios"),
+        reverse("ticketera-auth-crear-usuario"),
         {
             "username": "ANA.GOMEZ",
             "email": "ana@ejemplo.gob.ar",
@@ -183,7 +183,7 @@ def test_usuarios_idempotente_con_source_variante_ticketera_200(api_client):
     _crear_usuario("qa.user", source="ticketera-qa")
 
     response = api_client.post(
-        reverse("ticketera-usuarios"),
+        reverse("ticketera-auth-crear-usuario"),
         {
             "username": "qa.user",
             "email": "otro@ejemplo.gob.ar",
@@ -205,7 +205,7 @@ def test_usuarios_idempotente_con_source_variante_ticketera_200(api_client):
 @override_settings(TICKETERA_ENABLED=True)
 def test_usuarios_password_debil_400_sin_crear(api_client):
     response = api_client.post(
-        reverse("ticketera-usuarios"),
+        reverse("ticketera-auth-crear-usuario"),
         {
             "username": "debil.user",
             "email": "debil@ejemplo.gob.ar",
@@ -238,7 +238,7 @@ def test_usuarios_carrera_resuelve_200_si_ganador_es_ticketera(api_client):
         patch.object(User.objects, "create_user", side_effect=IntegrityError("dup")),
     ):
         response = api_client.post(
-            reverse("ticketera-usuarios"),
+            reverse("ticketera-auth-crear-usuario"),
             {
                 "username": "race.user",
                 "email": "race@ejemplo.gob.ar",
@@ -264,7 +264,7 @@ def test_usuarios_carrera_resuelve_409_si_ganador_es_otro_source(api_client):
         patch.object(User.objects, "create_user", side_effect=IntegrityError("dup")),
     ):
         response = api_client.post(
-            reverse("ticketera-usuarios"),
+            reverse("ticketera-auth-crear-usuario"),
             {
                 "username": "race.other",
                 "email": "race.other@ejemplo.gob.ar",


### PR DESCRIPTION
## Summary
- Renombra el endpoint de alta de la integracion con la Ticketera: `POST /api/ticketera/usuarios/` -> `POST /api/ticketera/auth/crear_usuario/`, para agrupar las tres operaciones bajo el prefijo `auth/`.
- Renombra el name de URL `ticketera-usuarios` -> `ticketera-auth-crear-usuario` (consistente con `ticketera-auth-verificar` / `ticketera-auth-cambiar-password`).
- Actualiza tests (`ticketera/tests.py`, `tests/test_ticketera.py`), el ADR `2026-05-27-integracion-ticketera.md` (tabla de contratos + seccion datada) y agrega `docs/registro/cambios/2026-05-29-ticketera-endpoint-crear-usuario.md`.
- **Solo cambia la ruta y el name de URL**: metodo, payload y codigos de respuesta (`201`/`200`/`400`/`409`/`503`) se conservan.

## Base
Apunta a `codex/integracion-ticketera` (PR #1795), **no** a development: la app `ticketera/` todavia no esta en development.

## Nota de estilo
Se usa `crear_usuario` (guion bajo) por pedido explicito; el hermano `cambiar-password` usa guion medio. Inconsistencia menor, conocida y aceptada.

## Test plan
- [ ] `black --check` OK (verificado local en los 3 .py).
- [ ] CI: `pytest ticketera/tests.py tests/test_ticketera.py` verde con el rename.
- [ ] `reverse("ticketera-auth-crear-usuario")` resuelve a `/api/ticketera/auth/crear_usuario/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)