### PR TITLE
fix(celiaquia): corrige 404 al remover tecnico asignado al expediente

### DIFF
--- a/static/custom/js/celiaquia_list.js
+++ b/static/custom/js/celiaquia_list.js
@@ -322,7 +322,7 @@
         return;
       }
 
-      const url = `/expedientes/${expId}/asignar-tecnico/?tecnico_id=${tecnicoId}`;
+      const url = `/celiaquia/expedientes/${expId}/asignar-tecnico/?tecnico_id=${tecnicoId}`;
 
       const fetchPreviewMessage = async () => {
         try {


### PR DESCRIPTION
# Información de la Tarea

Vincular el #ISSUE — (sin número de issue asociado)

### **Resumen de la Solución:**
- En `/celiaquia/expedientes/`, al remover un técnico previamente asignado, el sistema mostraba una pantalla de error **404 (Page not found)**. La causa raíz: el handler `DELETE` del botón de remover técnico construía la URL **sin el prefijo `/celiaquia/`** bajo el que se monta la app (`config/urls.py:69`), por lo que la request caía en `/expedientes/<pk>/asignar-tecnico/`, una ruta inexistente.

### **Información Adicional:**
- El fallo era de **ruteo**, no de permisos. La vista `AsignarTecnicoView.delete()` (`celiaquia/views/expediente.py:1625`) ya autorizaba correctamente a **Admin** y **Coordinador**; la request simplemente nunca llegaba a la vista.
- El handler vecino de "eliminar expediente" (`celiaquia_list.js:414`) ya usaba el prefijo `/celiaquia/` correcto, lo que confirma que fue un olvido en este handler.

# Descripción de los Cambios

### **Cambios:**
- `static/custom/js/celiaquia_list.js` (línea ~325): se agrega el prefijo `/celiaquia/` a la URL del `DELETE` de remover técnico, dejándolo consistente con el resto del archivo.

```diff
- const url = `/expedientes/${expId}/asignar-tecnico/?tecnico_id=${tecnicoId}`;
+ const url = `/celiaquia/expedientes/${expId}/asignar-tecnico/?tecnico_id=${tecnicoId}`;
```

# Cómo Testear los Cambios

### **Pruebas Automáticas:**
- No hay infraestructura de tests JS en el repo. Los tests pytest existentes (`test_asignar_tecnico_post_and_delete_paths`) ejercitan la lógica de la vista directamente, no la construcción de URL en el cliente, por lo que no aplican a este fix.

### **Pruebas Manuales:**
- Ingresar a `/celiaquia/expedientes/` como **Admin** o **Coordinador**.
- En un expediente en estado `RECEPCIONADO`/`ASIGNADO` con un técnico asignado, hacer clic en la "✕" del badge del técnico.
- Confirmar el diálogo → debe responder *"Técnico removido correctamente"* y el badge desaparece (antes devolvía la pantalla 404).
- Si el deploy usa `collectstatic`, re-ejecutarlo para publicar el JS actualizado.

# Metadata para documentación automática

- Contexto funcional: Gestión de expedientes de Celiaquía — remoción de técnico asignado.
- Tipo de cambio: Bugfix
- Área principal: celiaquia (frontend / JS)
- Resumen para changelog: Corrige el error 404 al remover un técnico asignado a un expediente.
- Impacto usuario: Admin y Coordinador pueden volver a remover técnicos asignados sin error.
- Riesgos / rollback: Mínimo (cambio de un literal de string). Rollback = revertir el commit.

# Capturas de Pantalla

🤖 Generated with [Claude Code](https://claude.com/claude-code)
