### PR TITLE
fix(celiaquia): provincia del expediente derivada del ciudadano (#1793)

### DIFF
--- a/celiaquia/models.py
+++ b/celiaquia/models.py
@@ -1,4 +1,5 @@
 from django.contrib.auth import get_user_model
+from django.core.exceptions import ObjectDoesNotExist
 from django.db import models
 
 from ciudadanos.models import Ciudadano
@@ -147,9 +148,23 @@ class Expediente(SoftDeleteModelMixin, models.Model):
 
     @property
     def provincia(self):
+        # La provincia del expediente se deriva del territorio de los ciudadanos
+        # cargados desde el Excel: un usuario puede tener varias provincias, por lo
+        # que ya no se puede inferir desde su perfil. Se toma la provincia del
+        # primer ciudadano con provincia asignada (los expedientes son homogeneos
+        # por provincia en el uso normal). Como respaldo, para un expediente sin
+        # legajos importados, se usa la provincia legacy del usuario creador.
+        provincia_id = (
+            self.expediente_ciudadanos.filter(ciudadano__provincia__isnull=False)
+            .order_by("ciudadano_id")
+            .values_list("ciudadano__provincia_id", flat=True)
+            .first()
+        )
+        if provincia_id:
+            return Provincia.objects.filter(pk=provincia_id).first()
         try:
             return self.usuario_provincia.profile.provincia
-        except Exception:
+        except (AttributeError, ObjectDoesNotExist):
             return None
 
 

--- a/celiaquia/services/cruce_service/impl.py
+++ b/celiaquia/services/cruce_service/impl.py
@@ -621,8 +621,15 @@ class CruceService:
                 "El expediente no está en un estado válido para realizar el cruce."
             )
 
+        provincia_expediente = expediente.provincia
+        if provincia_expediente is None:
+            raise ValidationError(
+                "No se pudo determinar la provincia del expediente a partir de los "
+                "ciudadanos cargados. Verifique que los legajos tengan municipio y "
+                "localidad antes de realizar el cruce con SINTYS."
+            )
         try:
-            metrics_iniciales = CupoService.metrics_por_provincia(expediente.provincia)
+            metrics_iniciales = CupoService.metrics_por_provincia(provincia_expediente)
         except CupoNoConfigurado as e:
             raise ValidationError(
                 f"No hay cupo configurado para la provincia del expediente. {e}"

--- a/celiaquia/services/cupo_service/impl.py
+++ b/celiaquia/services/cupo_service/impl.py
@@ -46,7 +46,7 @@ class CupoService:
         usados = int(pc.usados or 0)
         disponibles = max(total - usados, 0)
         fuera = ExpedienteCiudadano.objects.filter(
-            expediente__usuario_provincia__profile__provincia=provincia,
+            ciudadano__provincia=provincia,
             estado_cupo=EstadoCupo.FUERA,
             es_titular_activo=False,
             rol__in=[
@@ -67,7 +67,7 @@ class CupoService:
         Titulares activos que ocupan cupo.
         """
         return ExpedienteCiudadano.objects.filter(
-            expediente__usuario_provincia__profile__provincia=provincia,
+            ciudadano__provincia=provincia,
             revision_tecnico=RevisionTecnico.APROBADO,
             resultado_sintys=ResultadoSintys.MATCH,
             estado_cupo=EstadoCupo.DENTRO,
@@ -84,7 +84,7 @@ class CupoService:
         Titulares suspendidos: mantienen estado_cupo=DENTRO (cupo ocupado) pero es_titular_activo=False.
         """
         return ExpedienteCiudadano.objects.filter(
-            expediente__usuario_provincia__profile__provincia=provincia,
+            ciudadano__provincia=provincia,
             estado_cupo=EstadoCupo.DENTRO,
             es_titular_activo=False,
             rol__in=[
@@ -145,8 +145,8 @@ class CupoService:
             ExpedienteCiudadano.objects.select_for_update()
             .select_related(
                 "expediente",
-                "expediente__usuario_provincia",
-                "expediente__usuario_provincia__profile",
+                "ciudadano",
+                "ciudadano__provincia",
             )
             .get(pk=legajo.pk)
         )
@@ -174,13 +174,9 @@ class CupoService:
                 )
             return False
 
-        provincia = getattr(
-            legajo.expediente.usuario_provincia.profile, "provincia", None
-        )
+        provincia = legajo.ciudadano.provincia
         if not provincia:
-            raise ValidationError(
-                "El legajo no tiene provincia asociada al usuario del expediente."
-            )
+            raise ValidationError("El legajo no tiene provincia asociada al ciudadano.")
 
         try:
             pc = (
@@ -202,7 +198,7 @@ class CupoService:
         ya_ocupa = (
             ExpedienteCiudadano.objects.filter(
                 ciudadano_id=legajo.ciudadano_id,
-                expediente__usuario_provincia__profile__provincia=provincia,
+                ciudadano__provincia=provincia,
                 estado_cupo=EstadoCupo.DENTRO,
                 rol__in=[
                     ExpedienteCiudadano.ROLE_BENEFICIARIO,
@@ -286,18 +282,14 @@ class CupoService:
             ExpedienteCiudadano.objects.select_for_update()
             .select_related(
                 "expediente",
-                "expediente__usuario_provincia",
-                "expediente__usuario_provincia__profile",
+                "ciudadano",
+                "ciudadano__provincia",
             )
             .get(pk=legajo.pk)
         )
-        provincia = getattr(
-            legajo.expediente.usuario_provincia.profile, "provincia", None
-        )
+        provincia = legajo.ciudadano.provincia
         if not provincia:
-            raise ValidationError(
-                "El legajo no tiene provincia asociada al usuario del expediente."
-            )
+            raise ValidationError("El legajo no tiene provincia asociada al ciudadano.")
 
         # Sólo si tiene cupo DENTRO (activo o ya suspendido)
         if legajo.estado_cupo != EstadoCupo.DENTRO:
@@ -349,18 +341,14 @@ class CupoService:
             ExpedienteCiudadano.objects.select_for_update()
             .select_related(
                 "expediente",
-                "expediente__usuario_provincia",
-                "expediente__usuario_provincia__profile",
+                "ciudadano",
+                "ciudadano__provincia",
             )
             .get(pk=legajo.pk)
         )
-        provincia = getattr(
-            legajo.expediente.usuario_provincia.profile, "provincia", None
-        )
+        provincia = legajo.ciudadano.provincia
         if not provincia:
-            raise ValidationError(
-                "El legajo no tiene provincia asociada al usuario del expediente."
-            )
+            raise ValidationError("El legajo no tiene provincia asociada al ciudadano.")
 
         try:
             pc = (
@@ -438,18 +426,14 @@ class CupoService:
             ExpedienteCiudadano.objects.select_for_update()
             .select_related(
                 "expediente",
-                "expediente__usuario_provincia",
-                "expediente__usuario_provincia__profile",
+                "ciudadano",
+                "ciudadano__provincia",
             )
             .get(pk=legajo.pk)
         )
-        provincia = getattr(
-            legajo.expediente.usuario_provincia.profile, "provincia", None
-        )
+        provincia = legajo.ciudadano.provincia
         if not provincia:
-            raise ValidationError(
-                "El legajo no tiene provincia asociada al usuario del expediente."
-            )
+            raise ValidationError("El legajo no tiene provincia asociada al ciudadano.")
 
         # Debe estar dentro de cupo y NO activo
         if legajo.estado_cupo != EstadoCupo.DENTRO or legajo.es_titular_activo:

--- a/celiaquia/services/expediente_service/impl.py
+++ b/celiaquia/services/expediente_service/impl.py
@@ -166,14 +166,6 @@ class ExpedienteService:
         if excel_masivo:
             create_kwargs["excel_masivo_cargado_por"] = usuario_provincia
             create_kwargs["excel_masivo_cargado_en"] = timezone.now()
-        try:
-            if hasattr(Expediente, "provincia_id"):
-                create_kwargs["provincia_id"] = getattr(
-                    getattr(usuario_provincia, "profile", None), "provincia_id", None
-                )
-        except Exception:
-            pass
-
         expediente = Expediente.objects.create(**create_kwargs)
         logger.info(
             "Expediente creado por usuario_provincia=%s id=%s",

--- a/celiaquia/services/pago_service/impl.py
+++ b/celiaquia/services/pago_service/impl.py
@@ -64,7 +64,7 @@ class PagoService:
         return ExpedienteCiudadano.objects.select_related(
             "ciudadano", "expediente", "expediente__usuario_provincia"
         ).filter(
-            expediente__usuario_provincia__profile__provincia=provincia,
+            ciudadano__provincia=provincia,
             estado_cupo=EstadoCupo.DENTRO,
             es_titular_activo=True,
             revision_tecnico="APROBADO",

--- a/celiaquia/templates/celiaquia/expediente_detail.html
+++ b/celiaquia/templates/celiaquia/expediente_detail.html
@@ -84,7 +84,7 @@
                  style="background-color:#11202e;
                         color:#e0e0e0">
                 <div class="d-flex justify-content-between align-items-center">
-                    <h5 class="mb-3">Provincial de {{ expediente.usuario_provincia.profile.provincia|default:"-" }}</h5>
+                    <h5 class="mb-3">Provincial de {{ provincia_expediente|default:"-" }}</h5>
                 </div>
                 <div class="row g-3">
                     <div class="col-sm-6 col-lg-3">
@@ -181,7 +181,7 @@
                 </div>
                 <div class="col-md-6">
                     <p>
-                        <strong>Provincia:</strong> {{ expediente.usuario_provincia.profile.provincia|default:"-" }}
+                        <strong>Provincia:</strong> {{ provincia_expediente|default:"-" }}
                     </p>
                     <p>
                         <strong>Técnicos asignados:</strong>

--- a/celiaquia/templates/celiaquia/expediente_list.html
+++ b/celiaquia/templates/celiaquia/expediente_list.html
@@ -77,7 +77,7 @@
                             <td data-id="{{ exp.pk }}">{{ exp.pk }}</td>
                             <td data-numero="{{ exp.numero_expediente|default:'-' }}">{{ exp.numero_expediente|default:"-" }}</td>
                             <td data-fecha="{{ exp.fecha_creacion|date:'Y-m-d H:i' }}">{{ exp.fecha_creacion|date:"d/m/Y H:i" }}</td>
-                            <td data-provincia="{{ exp.provincia }}">{{ exp.provincia }}</td>
+                            <td data-provincia="{{ exp.provincia_derivada|default:'' }}">{{ exp.provincia_derivada|default:"-" }}</td>
                             <td data-estado="{{ exp.estado.display_name }}">
                                 <span class="badge {% if exp.estado.nombre == 'CREADO' %}bg-secondary {% elif exp.estado.nombre == 'EN_ESPERA' %}bg-info {% elif exp.estado.nombre == 'CONFIRMACION_DE_ENVIO' %}bg-warning {% elif exp.estado.nombre == 'RECEPCIONADO' %}bg-secondary {% elif exp.estado.nombre == 'ASIGNADO' %}bg-primary {% elif exp.estado.nombre == 'PROCESO_DE_CRUCE' %}bg-dark {% elif exp.estado.nombre == 'CRUCE_FINALIZADO' %}bg-success {% else %}bg-body-tertiary text-body{% endif %}">
                                     {{ exp.estado.display_name }}

--- a/celiaquia/templates/celiaquia/pdf_prd_cruce.html
+++ b/celiaquia/templates/celiaquia/pdf_prd_cruce.html
@@ -264,7 +264,7 @@
                 </div>
                 <div class="info-item">
                     <div class="info-label">Provincia:</div>
-                    <div class="info-value">{{ expediente.usuario_provincia.profile.provincia|default:"No especificada" }}</div>
+                    <div class="info-value">{{ expediente.provincia|default:"No especificada" }}</div>
                 </div>
             </div>
         </div>

--- a/celiaquia/tests/test_provincia_derivada.py
+++ b/celiaquia/tests/test_provincia_derivada.py
@@ -5,7 +5,7 @@ provincias o un municipio especifico y dejar el campo legacy vacio)."""
 from datetime import date
 
 import pytest
-from django.contrib.auth.models import Permission, User
+from django.contrib.auth.models import User
 from django.core.exceptions import ValidationError
 from django.core.files.uploadedfile import SimpleUploadedFile
 from django.urls import reverse
@@ -46,22 +46,28 @@ def _legajo(expediente, ciudadano, estado_legajo, **kwargs):
     )
 
 
+def _perfil_provincial(creador, provincia):
+    profile, _ = Profile.objects.get_or_create(user=creador)
+    profile.es_usuario_provincial = True
+    profile.provincia = provincia
+    profile.save()
+    return profile
+
+
 @pytest.mark.django_db
 def test_provincia_property_deriva_del_ciudadano():
     """Sin provincia en el perfil (usuario multi-provincia), la provincia se toma
     del ciudadano cargado."""
     provincia = Provincia.objects.create(nombre="Cordoba")
     creador = User.objects.create_user(username="prov_multi", password="pass")
-    profile, _ = Profile.objects.get_or_create(user=creador)
-    profile.es_usuario_provincial = True
-    profile.provincia = None  # legacy vacio: el usuario maneja varias provincias
-    profile.save()
+    _perfil_provincial(creador, None)  # legacy vacio: maneja varias provincias
 
     estado = EstadoExpediente.objects.create(nombre="EN_ESPERA")
     estado_legajo, _ = EstadoLegajo.objects.get_or_create(nombre="VALIDO")
     expediente = Expediente.objects.create(usuario_provincia=creador, estado=estado)
     _legajo(expediente, _ciudadano(1001, provincia), estado_legajo)
 
+    expediente = Expediente.objects.get(pk=expediente.pk)
     assert expediente.provincia == provincia
 
 
@@ -70,14 +76,12 @@ def test_provincia_property_fallback_legacy_sin_ciudadanos():
     """Un expediente sin legajos importados cae al valor legacy del perfil."""
     provincia = Provincia.objects.create(nombre="Salta")
     creador = User.objects.create_user(username="prov_legacy", password="pass")
-    profile, _ = Profile.objects.get_or_create(user=creador)
-    profile.es_usuario_provincial = True
-    profile.provincia = provincia
-    profile.save()
+    _perfil_provincial(creador, provincia)
 
     estado = EstadoExpediente.objects.create(nombre="CREADO")
     expediente = Expediente.objects.create(usuario_provincia=creador, estado=estado)
 
+    expediente = Expediente.objects.get(pk=expediente.pk)
     assert expediente.provincia == provincia
 
 
@@ -85,14 +89,12 @@ def test_provincia_property_fallback_legacy_sin_ciudadanos():
 def test_provincia_property_none_sin_datos():
     """Sin ciudadanos ni provincia legacy, la provincia es None (sin estallar)."""
     creador = User.objects.create_user(username="prov_sin_datos", password="pass")
-    profile, _ = Profile.objects.get_or_create(user=creador)
-    profile.es_usuario_provincial = True
-    profile.provincia = None
-    profile.save()
+    _perfil_provincial(creador, None)
 
     estado = EstadoExpediente.objects.create(nombre="CREADO")
     expediente = Expediente.objects.create(usuario_provincia=creador, estado=estado)
 
+    expediente = Expediente.objects.get(pk=expediente.pk)
     assert expediente.provincia is None
 
 
@@ -101,10 +103,7 @@ def test_grilla_muestra_provincia_derivada_para_usuario_multi_provincia(client):
     """La grilla muestra la provincia del ciudadano aunque el perfil no la tenga."""
     provincia = Provincia.objects.create(nombre="Mendoza")
     creador = User.objects.create_user(username="prov_grilla", password="pass")
-    profile, _ = Profile.objects.get_or_create(user=creador)
-    profile.es_usuario_provincial = True
-    profile.provincia = None
-    profile.save()
+    _perfil_provincial(creador, None)
 
     estado = EstadoExpediente.objects.create(nombre="EN_ESPERA")
     estado_legajo, _ = EstadoLegajo.objects.get_or_create(nombre="VALIDO")
@@ -129,10 +128,7 @@ def test_cupo_lista_ocupados_por_provincia_del_ciudadano():
     ProvinciaCupo.objects.create(provincia=provincia, total_asignado=10)
 
     creador = User.objects.create_user(username="prov_cupo", password="pass")
-    profile, _ = Profile.objects.get_or_create(user=creador)
-    profile.es_usuario_provincial = True
-    profile.provincia = None  # sin provincia legacy
-    profile.save()
+    _perfil_provincial(creador, None)  # sin provincia legacy
 
     estado = EstadoExpediente.objects.create(nombre="CRUCE_FINALIZADO")
     estado_legajo, _ = EstadoLegajo.objects.get_or_create(nombre="VALIDO")
@@ -159,10 +155,7 @@ def test_cupo_metrics_cuenta_fuera_por_provincia_del_ciudadano():
     ProvinciaCupo.objects.create(provincia=provincia, total_asignado=0)
 
     creador = User.objects.create_user(username="prov_fuera", password="pass")
-    profile, _ = Profile.objects.get_or_create(user=creador)
-    profile.es_usuario_provincial = True
-    profile.provincia = None
-    profile.save()
+    _perfil_provincial(creador, None)
 
     estado = EstadoExpediente.objects.create(nombre="CRUCE_FINALIZADO")
     estado_legajo, _ = EstadoLegajo.objects.get_or_create(nombre="VALIDO")
@@ -189,10 +182,7 @@ def test_cruce_sin_provincia_derivable_da_error_claro():
     from celiaquia.services.cruce_service import CruceService
 
     creador = User.objects.create_user(username="prov_cruce", password="pass")
-    profile, _ = Profile.objects.get_or_create(user=creador)
-    profile.es_usuario_provincial = True
-    profile.provincia = None
-    profile.save()
+    _perfil_provincial(creador, None)
 
     estado = EstadoExpediente.objects.create(nombre="ASIGNADO")
     expediente = Expediente.objects.create(usuario_provincia=creador, estado=estado)

--- a/celiaquia/tests/test_provincia_derivada.py
+++ b/celiaquia/tests/test_provincia_derivada.py
@@ -1,0 +1,204 @@
+"""Tests del fix #1793: la provincia del expediente y los cupos se derivan del
+territorio de los ciudadanos (no del perfil del usuario, que puede tener varias
+provincias o un municipio especifico y dejar el campo legacy vacio)."""
+
+from datetime import date
+
+import pytest
+from django.contrib.auth.models import Permission, User
+from django.core.exceptions import ValidationError
+from django.core.files.uploadedfile import SimpleUploadedFile
+from django.urls import reverse
+
+from ciudadanos.models import Ciudadano
+from core.models import Provincia
+from users.models import Profile
+from celiaquia.models import (
+    EstadoCupo,
+    EstadoExpediente,
+    EstadoLegajo,
+    Expediente,
+    ExpedienteCiudadano,
+    ProvinciaCupo,
+    ResultadoSintys,
+    RevisionTecnico,
+)
+from celiaquia.services.cupo_service import CupoService
+
+
+def _ciudadano(documento, provincia=None):
+    return Ciudadano.objects.create(
+        apellido="Perez",
+        nombre=f"Ciudadano {documento}",
+        fecha_nacimiento=date(2000, 1, 1),
+        documento=documento,
+        tipo_documento=Ciudadano.DOCUMENTO_DNI,
+        provincia=provincia,
+    )
+
+
+def _legajo(expediente, ciudadano, estado_legajo, **kwargs):
+    return ExpedienteCiudadano.objects.create(
+        expediente=expediente,
+        ciudadano=ciudadano,
+        estado=estado_legajo,
+        **kwargs,
+    )
+
+
+@pytest.mark.django_db
+def test_provincia_property_deriva_del_ciudadano():
+    """Sin provincia en el perfil (usuario multi-provincia), la provincia se toma
+    del ciudadano cargado."""
+    provincia = Provincia.objects.create(nombre="Cordoba")
+    creador = User.objects.create_user(username="prov_multi", password="pass")
+    profile, _ = Profile.objects.get_or_create(user=creador)
+    profile.es_usuario_provincial = True
+    profile.provincia = None  # legacy vacio: el usuario maneja varias provincias
+    profile.save()
+
+    estado = EstadoExpediente.objects.create(nombre="EN_ESPERA")
+    estado_legajo, _ = EstadoLegajo.objects.get_or_create(nombre="VALIDO")
+    expediente = Expediente.objects.create(usuario_provincia=creador, estado=estado)
+    _legajo(expediente, _ciudadano(1001, provincia), estado_legajo)
+
+    assert expediente.provincia == provincia
+
+
+@pytest.mark.django_db
+def test_provincia_property_fallback_legacy_sin_ciudadanos():
+    """Un expediente sin legajos importados cae al valor legacy del perfil."""
+    provincia = Provincia.objects.create(nombre="Salta")
+    creador = User.objects.create_user(username="prov_legacy", password="pass")
+    profile, _ = Profile.objects.get_or_create(user=creador)
+    profile.es_usuario_provincial = True
+    profile.provincia = provincia
+    profile.save()
+
+    estado = EstadoExpediente.objects.create(nombre="CREADO")
+    expediente = Expediente.objects.create(usuario_provincia=creador, estado=estado)
+
+    assert expediente.provincia == provincia
+
+
+@pytest.mark.django_db
+def test_provincia_property_none_sin_datos():
+    """Sin ciudadanos ni provincia legacy, la provincia es None (sin estallar)."""
+    creador = User.objects.create_user(username="prov_sin_datos", password="pass")
+    profile, _ = Profile.objects.get_or_create(user=creador)
+    profile.es_usuario_provincial = True
+    profile.provincia = None
+    profile.save()
+
+    estado = EstadoExpediente.objects.create(nombre="CREADO")
+    expediente = Expediente.objects.create(usuario_provincia=creador, estado=estado)
+
+    assert expediente.provincia is None
+
+
+@pytest.mark.django_db
+def test_grilla_muestra_provincia_derivada_para_usuario_multi_provincia(client):
+    """La grilla muestra la provincia del ciudadano aunque el perfil no la tenga."""
+    provincia = Provincia.objects.create(nombre="Mendoza")
+    creador = User.objects.create_user(username="prov_grilla", password="pass")
+    profile, _ = Profile.objects.get_or_create(user=creador)
+    profile.es_usuario_provincial = True
+    profile.provincia = None
+    profile.save()
+
+    estado = EstadoExpediente.objects.create(nombre="EN_ESPERA")
+    estado_legajo, _ = EstadoLegajo.objects.get_or_create(nombre="VALIDO")
+    expediente = Expediente.objects.create(usuario_provincia=creador, estado=estado)
+    _legajo(expediente, _ciudadano(1100, provincia), estado_legajo)
+
+    admin = User.objects.create_superuser(username="admin_grilla", password="pass")
+    client.force_login(admin)
+    response = client.get(reverse("expediente_list"))
+
+    assert response.status_code == 200
+    content = response.content.decode()
+    assert str(expediente.pk) in content
+    assert provincia.nombre in content
+
+
+@pytest.mark.django_db
+def test_cupo_lista_ocupados_por_provincia_del_ciudadano():
+    """Los titulares que ocupan cupo se cuentan por la provincia del ciudadano,
+    no por la del perfil del usuario creador."""
+    provincia = Provincia.objects.create(nombre="Jujuy")
+    ProvinciaCupo.objects.create(provincia=provincia, total_asignado=10)
+
+    creador = User.objects.create_user(username="prov_cupo", password="pass")
+    profile, _ = Profile.objects.get_or_create(user=creador)
+    profile.es_usuario_provincial = True
+    profile.provincia = None  # sin provincia legacy
+    profile.save()
+
+    estado = EstadoExpediente.objects.create(nombre="CRUCE_FINALIZADO")
+    estado_legajo, _ = EstadoLegajo.objects.get_or_create(nombre="VALIDO")
+    expediente = Expediente.objects.create(usuario_provincia=creador, estado=estado)
+    legajo = _legajo(
+        expediente,
+        _ciudadano(1200, provincia),
+        estado_legajo,
+        revision_tecnico=RevisionTecnico.APROBADO,
+        resultado_sintys=ResultadoSintys.MATCH,
+        estado_cupo=EstadoCupo.DENTRO,
+        es_titular_activo=True,
+        rol=ExpedienteCiudadano.ROLE_BENEFICIARIO,
+    )
+
+    ocupados = list(CupoService.lista_ocupados_por_provincia(provincia))
+    assert legajo in ocupados
+
+
+@pytest.mark.django_db
+def test_cupo_metrics_cuenta_fuera_por_provincia_del_ciudadano():
+    """La lista de espera (fuera de cupo) se cuenta por provincia del ciudadano."""
+    provincia = Provincia.objects.create(nombre="La Rioja")
+    ProvinciaCupo.objects.create(provincia=provincia, total_asignado=0)
+
+    creador = User.objects.create_user(username="prov_fuera", password="pass")
+    profile, _ = Profile.objects.get_or_create(user=creador)
+    profile.es_usuario_provincial = True
+    profile.provincia = None
+    profile.save()
+
+    estado = EstadoExpediente.objects.create(nombre="CRUCE_FINALIZADO")
+    estado_legajo, _ = EstadoLegajo.objects.get_or_create(nombre="VALIDO")
+    expediente = Expediente.objects.create(usuario_provincia=creador, estado=estado)
+    _legajo(
+        expediente,
+        _ciudadano(1300, provincia),
+        estado_legajo,
+        revision_tecnico=RevisionTecnico.APROBADO,
+        resultado_sintys=ResultadoSintys.MATCH,
+        estado_cupo=EstadoCupo.FUERA,
+        es_titular_activo=False,
+        rol=ExpedienteCiudadano.ROLE_BENEFICIARIO,
+    )
+
+    metrics = CupoService.metrics_por_provincia(provincia)
+    assert metrics["fuera"] == 1
+
+
+@pytest.mark.django_db
+def test_cruce_sin_provincia_derivable_da_error_claro():
+    """Si no se puede determinar la provincia (sin ciudadanos con territorio), el
+    cruce SINTYS falla con un mensaje claro, no con 'no hay cupo'."""
+    from celiaquia.services.cruce_service import CruceService
+
+    creador = User.objects.create_user(username="prov_cruce", password="pass")
+    profile, _ = Profile.objects.get_or_create(user=creador)
+    profile.es_usuario_provincial = True
+    profile.provincia = None
+    profile.save()
+
+    estado = EstadoExpediente.objects.create(nombre="ASIGNADO")
+    expediente = Expediente.objects.create(usuario_provincia=creador, estado=estado)
+
+    archivo = SimpleUploadedFile("cruce.csv", b"cuit\n20123456789")
+    with pytest.raises(ValidationError) as exc:
+        CruceService.procesar_cruce_por_cuit(expediente, archivo, creador)
+
+    assert "no se pudo determinar la provincia" in str(exc.value).lower()

--- a/celiaquia/views/cupo.py
+++ b/celiaquia/views/cupo.py
@@ -87,7 +87,7 @@ class CupoProvinciaDetailView(View):
         suspendidos_qs = ExpedienteCiudadano.objects.select_related(
             "ciudadano", "expediente", "expediente__usuario_provincia"
         ).filter(
-            expediente__usuario_provincia__profile__provincia=provincia,
+            ciudadano__provincia=provincia,
             estado_cupo=EstadoCupo.DENTRO,
             es_titular_activo=False,
         )
@@ -96,7 +96,7 @@ class CupoProvinciaDetailView(View):
         lista_espera_qs = ExpedienteCiudadano.objects.select_related(
             "ciudadano", "expediente", "expediente__usuario_provincia"
         ).filter(
-            expediente__usuario_provincia__profile__provincia=provincia,
+            ciudadano__provincia=provincia,
             estado_cupo=EstadoCupo.FUERA,
         )
 
@@ -109,7 +109,7 @@ class CupoProvinciaDetailView(View):
                 Q(provincia=provincia)
                 | Q(
                     provincia__isnull=True,
-                    expediente__usuario_provincia__profile__provincia=provincia,
+                    legajo__ciudadano__provincia=provincia,
                 )
             )
             .order_by("-creado_en")
@@ -183,15 +183,12 @@ class _BaseAccionLegajo(View):
         provincia = get_object_or_404(Provincia, pk=provincia_id)
         legajo = get_object_or_404(
             ExpedienteCiudadano.objects.select_related(
-                "expediente",
-                "expediente__usuario_provincia",
-                "expediente__usuario_provincia__profile",
+                "ciudadano",
+                "ciudadano__provincia",
             ),
             pk=legajo_id,
         )
-        leg_prov = getattr(
-            legajo.expediente.usuario_provincia.profile, "provincia", None
-        )
+        leg_prov = legajo.ciudadano.provincia
         if not leg_prov or leg_prov.id != provincia.id:
             raise ValidationError("El legajo no pertenece a la provincia indicada.")
         return legajo

--- a/celiaquia/views/expediente.py
+++ b/celiaquia/views/expediente.py
@@ -21,7 +21,8 @@ from django.core.exceptions import ObjectDoesNotExist, ValidationError, Permissi
 from django.conf import settings
 from django.utils.decorators import method_decorator
 from django.contrib.auth.models import User
-from django.db.models import Q, Count, OuterRef, Subquery
+from django.db.models import Q, Count, OuterRef, Subquery, F, CharField
+from django.db.models.functions import Coalesce
 from django.core.paginator import Paginator
 from iam.services import user_has_permission_code
 
@@ -595,20 +596,20 @@ class LocalidadesLookupView(View):
 
         localidades = Localidad.objects.select_related("municipio__provincia")
 
-        # Filtrar por provincia del usuario solo si es provincial Y NO es coordinador
+        # Restringir por el alcance territorial real del usuario (provincia,
+        # municipio y/o localidad). Coordinador y admin no tienen restriccion.
+        # Antes se filtraba por la provincia unica del perfil, que queda vacia
+        # cuando el usuario tiene varias provincias o un municipio especifico,
+        # ocultando las localidades de su municipio.
         is_coord = _user_has_permission(user, ROLE_COORDINADOR_CELIAQUIA_PERMISSION)
         if _is_provincial(user) and not is_coord and not _is_admin(user):
-            prov = _user_provincia(user)
-            if prov:
-                localidades = localidades.filter(municipio__provincia=prov)
-            else:
-                localidades = apply_territorial_scope(
-                    localidades,
-                    user,
-                    provincia_lookup="municipio__provincia_id",
-                    municipio_lookup="municipio_id",
-                    localidad_lookup="id",
-                )
+            localidades = apply_territorial_scope(
+                localidades,
+                user,
+                provincia_lookup="municipio__provincia_id",
+                municipio_lookup="municipio_id",
+                localidad_lookup="id",
+            )
 
         if provincia_id:
             localidades = localidades.filter(municipio__provincia_id=provincia_id)
@@ -683,6 +684,27 @@ class ExpedienteListView(ListView):
                 "excel_masivo_procesado_en",
             )
         )
+
+        # Provincia mostrada en la grilla: se deriva del territorio de los
+        # ciudadanos del expediente (un usuario puede tener varias provincias y el
+        # perfil legacy queda vacio). Se anota con Subquery para evitar N+1 y se
+        # cae al valor legacy del perfil para expedientes aun sin legajos.
+        provincia_derivada_sq = (
+            ExpedienteCiudadano.objects.filter(
+                expediente=OuterRef("pk"),
+                ciudadano__provincia__isnull=False,
+            )
+            .order_by("ciudadano_id")
+            .values("ciudadano__provincia__nombre")[:1]
+        )
+        qs = qs.annotate(
+            provincia_derivada=Coalesce(
+                Subquery(provincia_derivada_sq),
+                F("usuario_provincia__profile__provincia__nombre"),
+                output_field=CharField(),
+            )
+        )
+
         if _is_admin(user):
             qs = qs.order_by("-fecha_creacion")
         elif _is_provincial(user):
@@ -708,6 +730,9 @@ class ExpedienteListView(ListView):
                 | Q(estado__nombre__icontains=search_query)
                 | Q(
                     usuario_provincia__profile__provincia__nombre__icontains=search_query
+                )
+                | Q(
+                    expediente_ciudadanos__ciudadano__provincia__nombre__icontains=search_query
                 )
                 | Q(asignaciones_tecnicos__tecnico__first_name__icontains=search_query)
                 | Q(asignaciones_tecnicos__tecnico__last_name__icontains=search_query)
@@ -1243,7 +1268,10 @@ class ExpedienteDetailView(DetailView):
             except CupoNoConfigurado:
                 cupo_error = "La provincia no tiene cupo configurado."
         else:
-            cupo_error = "No se pudo determinar la provincia del expediente."
+            # Sin provincia determinable aun (p. ej. expediente sin legajos
+            # importados). No corresponde a ninguna accion del usuario, por lo que
+            # no se muestra un error al abrir el expediente.
+            cupo_error = None
 
         fuera_count = expediente.expediente_ciudadanos.filter(
             estado_cupo="FUERA"
@@ -1392,6 +1420,7 @@ class ExpedienteDetailView(DetailView):
                 "cupo": cupo,  # para el template actual
                 "cupo_metrics": cupo_metrics,  # compat si lo usas en JS/otros templates
                 "cupo_error": cupo_error,
+                "provincia_expediente": prov,
                 "fuera_count": fuera_count,
                 "total_responsables": len(estructura_familiar.get("responsables", {})),
                 "total_hijos_sin_responsable": len(

--- a/docs/plans/2026-06-01-issue-1793-celiaquia-provincia-design.md
+++ b/docs/plans/2026-06-01-issue-1793-celiaquia-provincia-design.md
@@ -1,0 +1,304 @@
+# Plan — Issue #1793 "Fixes Celiaquia - Provincia"
+
+Rama propuesta: `codex/issue-1793-celiaquia-provincia`
+Fecha: 2026-06-01
+Estado: pendiente de aprobacion.
+Autor del issue: jcamiloparra. Asignado: juanikitro.
+
+## Contexto
+
+El issue [#1793](https://github.com/dsocial118/SISOC/issues/1793) reporta 5 sintomas
+en el modulo `celiaquia`, todos derivados de **una unica causa raiz**: el codigo
+asume "una provincia por usuario", pero se introdujo la capacidad de asignar
+**multiples provincias (y municipios) por usuario** via `ProfileTerritorialScope`
+(migracion `users/0030`). El campo legacy `Profile.provincia` dejo de poblarse en
+esos casos y toda la cadena `expediente.usuario_provincia.profile.provincia`
+devuelve `None`.
+
+## Causa raiz
+
+`Expediente` no tiene provincia propia: la expone como property derivada del
+perfil del usuario creador.
+
+```python
+# celiaquia/models.py:148-153
+@property
+def provincia(self):
+    try:
+        return self.usuario_provincia.profile.provincia  # FK legacy
+    except Exception:
+        return None
+```
+
+El legacy `Profile.provincia` solo se rellena cuando el usuario tiene
+**exactamente 1 scope territorial sin municipio**:
+
+```python
+# users/territorial_scope.py:261-266
+legacy_provincia_id = None
+if len(scopes_data) == 1 and not scopes_data[0]["municipio_id"]:
+    legacy_provincia_id = scopes_data[0]["provincia_id"]
+...
+profile.provincia_id = legacy_provincia_id
+```
+
+Por lo tanto, con 2+ provincias **o** con 1 provincia + municipio especifico,
+`Profile.provincia = None` -> `expediente.provincia = None`. Ese `None` se propaga
+a la grilla, el detalle, el cruce SINTYS y los filtros de cupo/pago.
+
+**La fuente de verdad correcta ya existe**: cada `Ciudadano` guarda `provincia`,
+`municipio` y `localidad` propios cargados desde el Excel del expediente
+([ciudadano_service/impl.py:193-195](../../celiaquia/services/ciudadano_service/impl.py)),
+y el codigo **ya tiene el patron** para derivar territorio desde el ciudadano en
+`_apply_provincial_expediente_scope`
+([expediente.py:533-546](../../celiaquia/views/expediente.py)), que filtra por
+`expediente_ciudadanos__ciudadano__provincia_id` / `municipio_id` / `localidad_id`.
+Los lugares rotos simplemente nunca se migraron a ese patron.
+
+## Hallazgos previos clave
+
+- `Expediente.usuario_provincia` -> FK a `User` (creador). No hay FK a provincia
+  ([models.py:87-89](../../celiaquia/models.py)).
+- Property rota: [models.py:148-153](../../celiaquia/models.py).
+- `Ciudadano.provincia/municipio/localidad` -> FK directas
+  (ciudadanos/models.py). Cadena: `Localidad.municipio.provincia`.
+- `ExpedienteCiudadano.ciudadano` -> FK; related_name del expediente:
+  `expediente_ciudadanos` ([models.py:204-208](../../celiaquia/models.py)).
+- Patron correcto ya existente: `apply_territorial_scope` y
+  `_apply_provincial_expediente_scope`
+  ([expediente.py:533-546](../../celiaquia/views/expediente.py),
+  [users/territorial_scope.py:318-346](../../users/territorial_scope.py)).
+- Codigo muerto que anticipa la solucion denormalizada:
+  `if hasattr(Expediente, "provincia_id")` en
+  [expediente_service/impl.py:170-175](../../celiaquia/services/expediente_service/impl.py)
+  (hoy nunca entra: `Expediente` no tiene campo `provincia_id`).
+
+### Mapa sintoma -> codigo
+
+| # | Sintoma | Ubicacion |
+|---|---|---|
+| 1 | Provincia "none" en grilla y detalle | property [models.py:148](../../celiaquia/models.py); queryset [expediente.py:648-685](../../celiaquia/views/expediente.py); [expediente_list.html:80](../../celiaquia/templates/celiaquia/expediente_list.html); [expediente_detail.html:87,184](../../celiaquia/templates/celiaquia/expediente_detail.html) |
+| 2 | Modal "Buscar Localidades": municipio del usuario no se ve bien | `LocalidadesLookupView` [expediente.py:588-635](../../celiaquia/views/expediente.py); resolucion fragil `_user_provincia` [expediente.py:509-523](../../celiaquia/views/expediente.py); modal [expediente_form.html:68-140](../../celiaquia/templates/celiaquia/expediente_form.html) |
+| 3 | SINTYS bloquea el cruce | [cruce_service/impl.py:624-629](../../celiaquia/services/cruce_service/impl.py) (usa `expediente.provincia`); `metrics_por_provincia` [cupo_service/impl.py:37-44](../../celiaquia/services/cupo_service/impl.py) |
+| 4 | "Error al cargar expediente" sin accion | [expediente.py:1238-1246](../../celiaquia/views/expediente.py) (`cupo_error` espurio) |
+| 5 | Otras referencias a `profile.provincia` | cupo_service 49,70,87,178,205,295,358,447; cupo.py 90,99,112,193; pago_service 67; expediente.py 340,511; pdf_prd_cruce.html 267 |
+
+## Decision de diseno
+
+Hay dos caminos. Este plan **recomienda el Enfoque A** y deja el B documentado
+como evolucion futura.
+
+- **Enfoque A (recomendado): derivar del ciudadano, sin migracion.**
+  La provincia del expediente y los filtros se calculan desde el territorio de los
+  ciudadanos importados. Es lo que pide literalmente el issue ("derivar del
+  Municipio y/o Localidad del Excel"), es consistente con
+  `_apply_provincial_expediente_scope`, y respeta AGENTS.md (cambios chicos,
+  locales, sin migracion ni backfill).
+
+- **Enfoque B (alternativa): denormalizar `Expediente.provincia` como FK real**,
+  poblada en import desde el territorio de los ciudadanos, con migracion +
+  backfill, y repuntar todos los filtros a `expediente__provincia`. Resuelve el
+  N+1 de la grilla de forma natural y el codigo muerto de
+  [expediente_service:170](../../celiaquia/services/expediente_service/impl.py)
+  ya lo anticipaba. Mayor alcance; recomendado solo si se necesita performance o
+  consistencia fuerte mas adelante.
+
+**Regla multi-provincia (supuesto a confirmar):** un expediente puede, en teoria,
+tener ciudadanos de mas de una provincia. Para mostrar/validar se usa la
+**provincia dominante** (la mas frecuente entre sus ciudadanos). Alternativa mas
+estricta: validar homogeneidad al importar y rechazar mezclas. Ver Supuestos.
+
+## Seccion 0 — Helper de derivacion (nucleo compartido)
+
+Nuevo helper, idealmente en `celiaquia/services/expediente_service/impl.py` (o
+`celiaquia/utils.py`):
+
+- `provincias_de_expediente(expediente) -> set[int]`: ids distintos de
+  `expediente.expediente_ciudadanos.values_list("ciudadano__provincia_id", flat=True)`
+  (excluyendo `None`).
+- `provincia_principal_de_expediente(expediente) -> Provincia | None`: la dominante
+  (o la unica). `None` si el expediente no tiene ciudadanos con provincia.
+
+Todos los puntos siguientes consumen este helper, para que la regla viva en un
+solo lugar.
+
+## Seccion 1 — Grilla y detalle (puntos 1 y 4)
+
+### Property
+
+Reescribir `Expediente.provincia` ([models.py:148](../../celiaquia/models.py)) para
+delegar en `provincia_principal_de_expediente(self)` con fallback al legacy
+`usuario_provincia.profile.provincia` (compatibilidad hacia atras). Quitar el
+`except Exception` mudo (acotar a las excepciones reales).
+
+### Grilla (evitar N+1)
+
+En `ExpedienteListView.get_queryset`
+([expediente.py:647-685](../../celiaquia/views/expediente.py)) **no** depender de la
+property por fila. Anotar la provincia derivada con un `Subquery` sobre
+`ExpedienteCiudadano` (primer/maximo `ciudadano__provincia__nombre`) y exponerla al
+template. Actualizar [expediente_list.html:80](../../celiaquia/templates/celiaquia/expediente_list.html)
+para leer la anotacion en vez de `exp.provincia`.
+
+### Detalle / cupo_error espurio
+
+En el detalle ([expediente.py:1234-1246](../../celiaquia/views/expediente.py)),
+resolver `prov` con el helper. Si sigue siendo `None` por falta de ciudadanos
+cargados, **no** mostrar "No se pudo determinar la provincia del expediente" como
+error visible en la carga inicial: degradar a estado neutro (sin cupo aun) y
+mostrar el aviso solo cuando corresponda. Corregir
+[expediente_detail.html:87,184](../../celiaquia/templates/celiaquia/expediente_detail.html)
+y [pdf_prd_cruce.html:267](../../celiaquia/templates/celiaquia/pdf_prd_cruce.html)
+para usar la provincia derivada.
+
+## Seccion 2 — Modal "Buscar Localidades" (punto 2)
+
+El modal sirve para que el usuario vea los **codigos** (ids) de
+provincia/municipio/localidad y los cargue en el Excel
+([expediente_form.html:68-140](../../celiaquia/templates/celiaquia/expediente_form.html)).
+Lo alimenta `LocalidadesLookupView`
+([expediente.py:588-635](../../celiaquia/views/expediente.py)).
+
+Problema: para un usuario provincial con municipio configurado,
+`_user_provincia(user)` ([expediente.py:509-523](../../celiaquia/views/expediente.py))
+es fragil. Devuelve la provincia solo si hay `Profile.provincia` o un unico scope
+de provincia **completa**; con municipio especifico devuelve `None` y cae al
+fallback `apply_territorial_scope`, y en escenarios mixtos (un scope full-province
++ otro con municipio) puede cortocircuitar y filtrar por una sola provincia,
+perdiendo el resto. El resultado es que el municipio del usuario no se refleja bien
+en el listado.
+
+Cambios:
+
+1. Reemplazar la rama `if prov: ... else: ...`
+   ([expediente.py:600-611](../../celiaquia/views/expediente.py)) por **siempre**
+   `apply_territorial_scope` con los lookups del propio modelo `Localidad`
+   (`municipio__provincia_id`, `municipio_id`, `id`). Asi un usuario con municipio
+   ve exactamente las localidades de su(s) municipio(s) y uno con provincia
+   completa ve toda la provincia; coordinador/admin siguen sin restriccion.
+2. Verificar el JS del modal (en `static/`, buscar el fetch a
+   `expediente_localidades_lookup`) para confirmar que la columna/selector de
+   municipio se renderiza desde `municipio_nombre`/`municipio_id` del JSON.
+3. Confirmar el comportamiento esperado contra las capturas del issue (si el
+   municipio debe pre-seleccionarse o solo filtrarse).
+
+## Seccion 3 — Cupo y Pago (filtros)
+
+Repuntar los filtros que cuelgan del perfil del usuario hacia el territorio del
+ciudadano (consistente con `_apply_provincial_expediente_scope`):
+
+- `cupo_service/impl.py` lineas 49, 70, 87:
+  `expediente__usuario_provincia__profile__provincia=provincia`
+  -> `ciudadano__provincia=provincia` (el queryset ya es sobre
+  `ExpedienteCiudadano`, que tiene FK directa a `ciudadano`).
+- `cupo.py` lineas 90, 99, 112: idem.
+- `pago_service/impl.py` linea 67: idem.
+- Revisar los `getattr(legajo.expediente.usuario_provincia.profile, "provincia", None)`
+  (cupo_service 178, 295, 358, 447) y `_get_legajo_validado`
+  ([cupo.py:192-196](../../celiaquia/views/cupo.py)): la validacion "el legajo
+  pertenece a la provincia" debe compararse contra `legajo.ciudadano.provincia_id`,
+  no contra el perfil del creador.
+
+Nota: el cupo es por provincia de **residencia del beneficiario**, por lo que
+filtrar por `ciudadano.provincia` es ademas semanticamente mas correcto que por la
+provincia del usuario creador.
+
+## Seccion 4 — Cruce SINTYS (punto 3, el mas critico: bloquea el resto del flujo)
+
+En `procesar_cruce_por_cuit`
+([cruce_service/impl.py:624-629](../../celiaquia/services/cruce_service/impl.py)):
+
+- Resolver la provincia con `provincia_principal_de_expediente(expediente)` (helper
+  Seccion 0) en vez de `expediente.provincia` legacy.
+- Si el expediente abarca varias provincias, validar cupo por cada provincia
+  involucrada (o por la dominante, segun la regla confirmada).
+- Mejorar el mensaje: distinguir "no se pudo determinar la provincia del
+  expediente" (no hay ciudadanos con territorio) de "la provincia X no tiene cupo
+  configurado". El mensaje actual ("No hay cupo configurado...") es enganoso cuando
+  el problema real es la provincia `None`.
+- Aplicar el mismo criterio a la segunda llamada
+  ([cruce_service/impl.py:~832](../../celiaquia/services/cruce_service/impl.py)).
+
+## Seccion 5 — Barrido de referencias (punto 5)
+
+Punto 5 del issue: corregir toda referencia a la provincia derivada del usuario.
+Ademas de lo anterior:
+
+- `expediente.py:340` (`_resolver_provincia_id_registro_erroneo`) y `expediente.py:511`
+  (`_user_provincia`): unificar con el helper / scopes.
+- Limpiar el codigo muerto `hasattr(Expediente, "provincia_id")` en
+  [expediente_service/impl.py:170-175](../../celiaquia/services/expediente_service/impl.py)
+  (eliminar si se va por Enfoque A; convertir en asignacion real si se va por B).
+- `grep` de cierre por `profile__provincia` y `profile.provincia` en `celiaquia/`
+  para no dejar rutas sin migrar.
+
+## Orden de implementacion
+
+1. **Seccion 0** (helper) — base sin breaking changes.
+2. **Seccion 4** (SINTYS) — desbloquea el flujo completo, habilita pruebas E2E.
+3. **Seccion 3** (cupo/pago) — repunte de filtros.
+4. **Seccion 1** (grilla/detalle) — UI + anotacion anti N+1.
+5. **Seccion 2** (modal localidades) — independiente; cerrar al final.
+6. **Seccion 5** (barrido) — limpieza y verificacion de que no queden referencias.
+
+Cada seccion = 1 commit revisable. Si el alcance crece (p. ej. si se elige
+Enfoque B), separar la migracion + backfill en su propio commit.
+
+## Archivos clave
+
+| Archivo | Cambio |
+|---|---|
+| `celiaquia/services/expediente_service/impl.py` | + helper de derivacion; limpiar codigo muerto |
+| `celiaquia/models.py` | reescribir property `Expediente.provincia` |
+| `celiaquia/views/expediente.py` | queryset grilla (anotacion), `LocalidadesLookupView`, detalle/cupo_error, `_user_provincia`, `_resolver_provincia_id_registro_erroneo` |
+| `celiaquia/services/cruce_service/impl.py` | derivar provincia para SINTYS + mensajes |
+| `celiaquia/services/cupo_service/impl.py` | repuntar filtros a `ciudadano__provincia` |
+| `celiaquia/views/cupo.py` | repuntar filtros + `_get_legajo_validado` |
+| `celiaquia/services/pago_service/impl.py` | repuntar filtro de nomina |
+| `celiaquia/templates/celiaquia/expediente_list.html` | leer provincia anotada |
+| `celiaquia/templates/celiaquia/expediente_detail.html` | provincia derivada |
+| `celiaquia/templates/celiaquia/pdf_prd_cruce.html` | provincia derivada |
+| `static/.../*localidades*.js` (a ubicar) | render municipio en el modal |
+
+## Validacion
+
+Manual (post-cambio), idealmente con un usuario provincial multi-provincia y otro
+con municipio especifico:
+
+1. **Punto 1**: grilla `/celiaquia/expedientes/` muestra la provincia derivada del
+   Excel (no "none"); el detalle muestra la misma provincia.
+2. **Punto 3/4**: abrir un expediente como `/celiaquia/expedientes/<id>/` no muestra
+   el cartel de provincia espurio; el cruce SINTYS procede (no se bloquea con "no
+   hay cupo").
+3. **Punto 2**: con usuario de municipio especifico, el modal "Buscar Localidades"
+   lista las localidades del municipio correcto y muestra el municipio.
+4. **Cupo/Pago**: el detalle de cupo por provincia y la nomina muestran los legajos
+   esperados para usuarios multi-provincia.
+
+Automatizada (extender, hoy asumen `profile.provincia` unico):
+- `celiaquia/tests/test_expediente_list.py`, `test_expediente_detail.py`,
+  `test_cruce_service.py`, `test_pago_expediente_list.py`,
+  `test_localidades_lookup.py` — agregar casos multi-provincia y municipio.
+- `powershell -ExecutionPolicy Bypass -File scripts/ai/codex_run.ps1 validate`
+
+## Registro
+
+Al cerrar la PR:
+- `docs/registro/cambios/2026-06-01-issue-1793-celiaquia-provincia.md`
+- Si se adopta el Enfoque B (FK + migracion):
+  `docs/registro/decisiones/2026-06-01-expediente-provincia-denormalizada.md`
+
+## Supuestos
+
+1. **Provincia dominante** para expedientes con ciudadanos de varias provincias.
+   Si el negocio exige que un expediente sea de una sola provincia, cambiar a
+   validacion de homogeneidad en import (rechazar mezclas) — decision a confirmar
+   con el equipo funcional.
+2. `Ciudadano.provincia_id` esta poblado en la importacion (lo setea
+   `ciudadano_service`). Si hubiera ciudadanos sin provincia, usar
+   `ciudadano__municipio__provincia` como fuente secundaria.
+3. El sintoma exacto del punto 2 (municipio "no se visualiza correctamente") se
+   confirma contra las capturas del issue; la correccion propuesta (filtrar el
+   lookup por scopes territoriales completos) cubre las variantes conocidas.
+4. Se prioriza el Enfoque A (sin migracion). El Enfoque B queda como evolucion si
+   se requiere performance/consistencia fuerte.

--- a/docs/registro/cambios/2026-06-01-issue-1793-celiaquia-provincia.md
+++ b/docs/registro/cambios/2026-06-01-issue-1793-celiaquia-provincia.md
@@ -1,0 +1,71 @@
+# 2026-06-01 - Celiaquía: la provincia del expediente se deriva del ciudadano
+
+## Contexto
+
+Issue [#1793](https://github.com/dsocial118/SISOC/issues/1793). Al introducirse la
+asignación de múltiples provincias por usuario (`ProfileTerritorialScope`,
+`users/0030`), el campo legacy `Profile.provincia` dejó de poblarse cuando el
+usuario tiene 2+ provincias o un municipio específico. El módulo `celiaquia`
+derivaba la provincia del expediente desde `usuario_provincia.profile.provincia`,
+que quedaba en `None`, rompiendo 5 flujos: grilla de expedientes, detalle, cruce
+SINTYS, cupos y el modal "Buscar Localidades".
+
+Diseño en
+[docs/plans/2026-06-01-issue-1793-celiaquia-provincia-design.md](../../plans/2026-06-01-issue-1793-celiaquia-provincia-design.md)
+(enfoque A: derivar del territorio del ciudadano, sin migración).
+
+## Cambios aplicados
+
+- **`Expediente.provincia`** ([celiaquia/models.py](../../../celiaquia/models.py)):
+  la property ahora deriva la provincia del primer ciudadano del expediente con
+  provincia asignada (`expediente_ciudadanos → ciudadano → provincia`), con
+  respaldo al valor legacy del perfil para expedientes aún sin legajos.
+- **Grilla de expedientes**
+  ([celiaquia/views/expediente.py](../../../celiaquia/views/expediente.py)): el
+  queryset anota `provincia_derivada` con `Subquery` (sin N+1) usando
+  `Coalesce(provincia del ciudadano, provincia legacy del perfil)`. El buscador
+  también matchea por la provincia del ciudadano. Template
+  `expediente_list.html` actualizado.
+- **Detalle**: el detalle pasa `provincia_expediente` al contexto; los templates
+  `expediente_detail.html` y `pdf_prd_cruce.html` lo usan en vez del perfil. Se
+  elimina el cartel espurio "No se pudo determinar la provincia del expediente"
+  al abrir un expediente sin legajos (punto 4 del issue).
+- **Cruce SINTYS**
+  ([cruce_service/impl.py](../../../celiaquia/services/cruce_service/impl.py)):
+  si no se puede determinar la provincia, el error es explícito en vez del
+  engañoso "no hay cupo configurado".
+- **Cupos y pagos**
+  ([cupo_service/impl.py](../../../celiaquia/services/cupo_service/impl.py),
+  [views/cupo.py](../../../celiaquia/views/cupo.py),
+  [pago_service/impl.py](../../../celiaquia/services/pago_service/impl.py)): los
+  filtros `expediente__usuario_provincia__profile__provincia` pasan a
+  `ciudadano__provincia` (y `legajo__ciudadano__provincia` para
+  `CupoMovimiento`). Las operaciones de cupo (reservar/suspender/liberar/
+  reactivar) y la validación de pertenencia toman la provincia del ciudadano.
+- **Modal "Buscar Localidades"** (`LocalidadesLookupView`): se filtra siempre por
+  el alcance territorial real del usuario (`apply_territorial_scope`), en lugar de
+  la provincia única del perfil, para que un usuario con municipio específico vea
+  las localidades de su municipio (punto 2 del issue).
+- **Limpieza**: se elimina código muerto en `expediente_service.create_expediente`
+  (`hasattr(Expediente, "provincia_id")`, campo inexistente en el enfoque A).
+- **Tests**: nuevo `celiaquia/tests/test_provincia_derivada.py` (property derivada
+  y fallback, grilla multi-provincia, cupos por provincia del ciudadano, error
+  claro de SINTYS sin provincia).
+
+## Validación
+
+- `black --check` sobre los archivos tocados: OK.
+- `python -m py_compile` de los módulos modificados: OK.
+- **pytest no se pudo correr localmente**: el Python global del usuario tiene un
+  Django incompatible (`ImportError: punycode`) y Docker Desktop estaba apagado.
+  La corrida de `pytest`/`migrations_check`/`smoke` queda delegada a la CI del PR
+  (práctica habitual del repo cuando Docker no está disponible).
+
+## Notas
+
+- Enfoque A no agrega campo `provincia` al modelo (sin migración). Si se necesita
+  performance/consistencia fuerte, el enfoque B (FK denormalizada) queda
+  documentado en el plan.
+- Supuesto pendiente de confirmación funcional: para un expediente con ciudadanos
+  de más de una provincia se usa la del primer ciudadano (los expedientes son
+  homogéneos por provincia en el uso normal).

--- a/tests/test_celiaquia_expediente_view_helpers_unit.py
+++ b/tests/test_celiaquia_expediente_view_helpers_unit.py
@@ -232,7 +232,8 @@ def test_localidades_lookup_view_filters_and_returns_json(mocker):
 
     mocker.patch("celiaquia.views.expediente._user_has_permission", return_value=False)
     mocker.patch("celiaquia.views.expediente._is_provincial", return_value=True)
-    mocker.patch("celiaquia.views.expediente._user_provincia", return_value="prov_obj")
+    # El lookup ahora restringe por el alcance territorial real del usuario.
+    mocker.patch("celiaquia.views.expediente.apply_territorial_scope", return_value=qs)
 
     request = SimpleNamespace(
         user=SimpleNamespace(),
@@ -243,7 +244,8 @@ def test_localidades_lookup_view_filters_and_returns_json(mocker):
 
     assert isinstance(response, JsonResponse)
     assert response.status_code == 200
-    assert qs.filter.call_count >= 3
+    # Filtros por provincia y municipio de los parametros GET.
+    assert qs.filter.call_count >= 2
 
 
 def test_expediente_preview_excel_view_error_and_success(mocker):

--- a/tests/test_cupo_service_unit.py
+++ b/tests/test_cupo_service_unit.py
@@ -133,6 +133,7 @@ def test_suspender_liberar_reactivar_basic_branches(mocker):
         estado_cupo=module.EstadoCupo.DENTRO,
         es_titular_activo=True,
         expediente=exp,
+        ciudadano=SimpleNamespace(provincia=provincia),
         save=mocker.Mock(),
     )
     mocker.patch(
@@ -148,6 +149,7 @@ def test_suspender_liberar_reactivar_basic_branches(mocker):
         estado_cupo=module.EstadoCupo.DENTRO,
         es_titular_activo=False,
         expediente=exp,
+        ciudadano=SimpleNamespace(provincia=provincia),
         save=mocker.Mock(),
     )
     mocker.patch(
@@ -164,6 +166,7 @@ def test_suspender_liberar_reactivar_basic_branches(mocker):
         estado_cupo=module.EstadoCupo.DENTRO,
         es_titular_activo=True,
         expediente=exp,
+        ciudadano=SimpleNamespace(provincia=provincia),
         save=mocker.Mock(),
     )
     mocker.patch(

--- a/tests/test_expediente_service_unit.py
+++ b/tests/test_expediente_service_unit.py
@@ -115,9 +115,7 @@ def test_create_expediente_and_provincia_guard(mocker):
     created = SimpleNamespace(pk=7)
 
     create_mock = mocker.Mock(return_value=created)
-    expediente_stub = SimpleNamespace(
-        provincia_id=True, objects=SimpleNamespace(create=create_mock)
-    )
+    expediente_stub = SimpleNamespace(objects=SimpleNamespace(create=create_mock))
     mocker.patch("celiaquia.services.expediente_service.Expediente", expediente_stub)
 
     user = SimpleNamespace(username="usr", profile=SimpleNamespace(provincia_id=12))
@@ -127,7 +125,11 @@ def test_create_expediente_and_provincia_guard(mocker):
         excel_masivo="f.xlsx",
     )
     assert out is created
-    assert create_mock.call_args.kwargs["provincia_id"] == 12
+    # La provincia ya no se denormaliza en el expediente (se deriva del ciudadano):
+    # create_expediente no debe pasar provincia_id.
+    kwargs = create_mock.call_args.kwargs
+    assert "provincia_id" not in kwargs
+    assert kwargs["usuario_provincia"] is user
 
 
 def test_procesar_expediente_validations_and_success(mocker):


### PR DESCRIPTION
## Resumen

Corrige los 5 síntomas del issue #1793 en el módulo `celiaquia`, todos con una única causa raíz: al introducirse la asignación de **múltiples provincias por usuario** (`ProfileTerritorialScope`, `users/0030`), el campo legacy `Profile.provincia` quedó en `None` para usuarios con 2+ provincias o un municipio específico. `celiaquia` derivaba la provincia del expediente desde `usuario_provincia.profile.provincia`, propagando ese `None` a la grilla, el detalle, el cruce SINTYS, los cupos y el modal de localidades.

**Enfoque A** (ver [plan](docs/plans/2026-06-01-issue-1793-celiaquia-provincia-design.md)): derivar la provincia del **territorio de los ciudadanos** cargados desde el Excel, sin migración, reutilizando el patrón ya existente en `_apply_provincial_expediente_scope`.

## Cambios por punto del issue

1. **Provincia "none" en grilla y detalle** — `Expediente.provincia` ahora deriva del primer ciudadano con provincia (fallback legacy). La grilla anota `provincia_derivada` con `Subquery`+`Coalesce` (sin N+1); el detalle pasa `provincia_expediente` al contexto. Templates actualizados.
2. **Modal "Buscar Localidades"** — `LocalidadesLookupView` filtra siempre por el alcance territorial real del usuario (`apply_territorial_scope`), para que un usuario con municipio específico vea las localidades de su municipio.
3. **Cruce SINTYS** — ya no se bloquea por `provincia=None`; si realmente no se puede determinar, el mensaje es explícito en vez del engañoso "no hay cupo configurado".
4. **"Error al cargar expediente"** — se elimina el cartel espurio "No se pudo determinar la provincia del expediente" al abrir un expediente sin legajos.
5. **Barrido (otras referencias)** — filtros de cupo/pago (`cupo_service`, `cupo.py`, `pago_service`) pasan de `expediente__usuario_provincia__profile__provincia` a `ciudadano__provincia` (y `legajo__ciudadano__provincia` para `CupoMovimiento`); operaciones de cupo y validación de pertenencia toman la provincia del ciudadano; se limpia código muerto en `expediente_service.create_expediente`.

## Tests

Nuevo `celiaquia/tests/test_provincia_derivada.py`: property derivada y fallback, grilla multi-provincia, cupos por provincia del ciudadano, y error claro de SINTYS sin provincia.

## Validación

- `black --check` sobre los archivos tocados: OK.
- `py_compile` de los módulos modificados: OK.
- ⚠️ **pytest no se pudo correr localmente**: el Python global tiene un Django incompatible (`ImportError: punycode`) y Docker estaba apagado. La corrida de `pytest`/`migrations_check`/`smoke` queda **delegada a la CI de este PR** (práctica habitual del repo cuando Docker no está disponible).

## Nota / supuesto a confirmar

Para un expediente con ciudadanos de **más de una provincia** se usa la del primer ciudadano (los expedientes son homogéneos por provincia en el uso normal). Si el negocio exige validar homogeneidad al importar, se ajusta en un cambio aparte.

Closes #1793

🤖 Generated with [Claude Code](https://claude.com/claude-code)