### PR TITLE
fix(pwa): tests de nómina robustos al borde de mes

### DIFF
--- a/docs/registro/cambios/2026-06-01-pwa-tests-nomina-borde-mes.md
+++ b/docs/registro/cambios/2026-06-01-pwa-tests-nomina-borde-mes.md
@@ -1,0 +1,68 @@
+# 2026-06-01 - Tests de nómina PWA robustos al borde de mes
+
+## Contexto
+
+Tres tests de `tests/test_pwa_nomina_api.py` dependían del día real de
+ejecución y fallaban según la fecha:
+
+- `test_nomina_list_includes_monthly_attendance_history`
+- `test_nomina_register_attendance_current_month_is_idempotent`
+- `test_nomina_bulk_attendance_alimentaria_syncs_current_period`
+
+Solo es un cambio de **tests**: no se modifica comportamiento de producto
+(`pwa/` queda intacto).
+
+## Causa raíz
+
+El "período mensual actual" y la habilitación de la carga de asistencia derivan
+de `timezone.localdate()` en `pwa/services/nomina_service.py`:
+
+- `get_periodo_mensual_actual()` ya quedó simplificado a
+  `timezone.localdate().replace(day=1)` (commit `190db7aa`), por lo que el
+  desfase de período en el borde de mes (días 1-10 apuntando al mes anterior)
+  **ya no ocurre**: el test de historial mensual pasa cualquier día.
+- Pero `asistencia_nomina_habilitada()` mantiene la ventana de carga real
+  (`día >= 25 or día <= 10`). Los endpoints de alta (`registrar-asistencia/`,
+  `asistencia-alimentaria/`) llaman a `validar_asistencia_nomina_habilitada()`,
+  así que **entre el día 11 y el 24 devuelven `400`** y los dos tests que hacen
+  `POST` fallaban (`assert 400 == 200`).
+
+Verificado empíricamente congelando `timezone.localdate` al día 15: el test de
+historial pasa, pero los dos `POST` fallan con `400`.
+
+## Decisión
+
+Arreglar los **tests** (no el código): la ventana cruzada de mes es
+comportamiento intencional del producto, no un bug. Construir fechas relativas
+no alcanza porque no abre la ventana; hay que controlar "hoy".
+
+No hay `freezegun`/`time_machine` en `requirements/`, así que se usa el patrón
+ya establecido en el repo con `pytest-mock`: una fixture `fecha_fija_en_ventana`
+que parchea `django.utils.timezone.localdate` a una fecha fija **día 1**
+(`2026-06-01`).
+
+El día 1 mantiene la ventana abierta (`día <= 10`) y, además, reproduce el borde
+de mes: si alguien reintrodujera el cálculo de período desfasado de los primeros
+días, el test de historial volvería a romper (sirve de guarda de regresión).
+
+## Cambios aplicados
+
+- `tests/test_pwa_nomina_api.py`:
+  - Nueva constante `_FECHA_FIJA_VENTANA = date(2026, 6, 1)` + fixture
+    `fecha_fija_en_ventana` (parchea `timezone.localdate`).
+  - Se inyecta la fixture en los 3 tests afectados. Los cuerpos no cambian: las
+    expresiones `timezone.localdate().replace(day=1)` ahora resuelven a la fecha
+    congelada de forma determinista.
+
+## Validación
+
+- `black --check tests/test_pwa_nomina_api.py`: OK.
+- Imagen Docker del repo con `USE_SQLITE_FOR_TESTS=1` y `--no-migrations`
+  (SQLite):
+  - `tests/test_pwa_nomina_api.py`: **10 passed** (con la fecha fija en día 1).
+  - Resto de la suite PWA (`test_pwa_actividades_*`, `auditoria_auth`,
+    `colaboradores`, `comedores`, `formacion`, `mensajes`, `push`,
+    `signals_unit`): **71 passed**.
+  - Demostración previa con la fecha fija en día 15 (ventana cerrada): el test de
+    historial pasa y los dos `POST` fallan con `400`, confirmando la causa raíz.
+- La corrida con migraciones queda delegada a la CI del PR.

--- a/tests/test_pwa_nomina_api.py
+++ b/tests/test_pwa_nomina_api.py
@@ -70,6 +70,22 @@ def _auth_client_for_user(user):
     return client
 
 
+# Día fijo dentro de la ventana de carga de asistencia (día <= 10). El período
+# mensual "actual" y la habilitación de la ventana derivan de
+# ``timezone.localdate()``; sin congelarla los tests dependen del día real de
+# ejecución (la ventana solo está abierta entre el 25 y el 10 del mes
+# siguiente). Fijar la fecha en el día 1 reproduce el borde de mes de forma
+# determinista y mantiene la ventana abierta.
+_FECHA_FIJA_VENTANA = date(2026, 6, 1)
+
+
+@pytest.fixture
+def fecha_fija_en_ventana(mocker):
+    """Congela ``timezone.localdate`` en ``_FECHA_FIJA_VENTANA`` para todo el test."""
+    mocker.patch("django.utils.timezone.localdate", return_value=_FECHA_FIJA_VENTANA)
+    return _FECHA_FIJA_VENTANA
+
+
 @pytest.mark.django_db
 def test_nomina_list_stats_and_tabs(comedor, admision, sexo_f, sexo_m, dia):
     representante = _create_representante(comedor=comedor, username="rep_nomina_tabs")
@@ -281,7 +297,9 @@ def test_nomina_delete_is_logical(comedor, admision, sexo_m, dia):
 
 
 @pytest.mark.django_db
-def test_nomina_list_includes_monthly_attendance_history(comedor, admision, sexo_f):
+def test_nomina_list_includes_monthly_attendance_history(
+    comedor, admision, sexo_f, fecha_fija_en_ventana
+):
     representante = _create_representante(comedor=comedor, username="rep_nomina_hist")
     client = _auth_client_for_user(representante)
 
@@ -417,7 +435,7 @@ def test_nomina_detail_endpoint_returns_linked_activities(
 
 @pytest.mark.django_db
 def test_nomina_register_attendance_current_month_is_idempotent(
-    comedor, admision, sexo_m
+    comedor, admision, sexo_m, fecha_fija_en_ventana
 ):
     representante = _create_representante(comedor=comedor, username="rep_nomina_asis")
     client = _auth_client_for_user(representante)
@@ -461,7 +479,7 @@ def test_nomina_register_attendance_current_month_is_idempotent(
 
 @pytest.mark.django_db
 def test_nomina_bulk_attendance_alimentaria_syncs_current_period(
-    comedor, admision, sexo_f, sexo_m
+    comedor, admision, sexo_f, sexo_m, fecha_fija_en_ventana
 ):
     representante = _create_representante(
         comedor=comedor, username="rep_nomina_bulk_alimentaria"


### PR DESCRIPTION
## Problema

Tres tests de `tests/test_pwa_nomina_api.py` dependían del día real de ejecución y fallaban según la fecha:

- `test_nomina_list_includes_monthly_attendance_history`
- `test_nomina_register_attendance_current_month_is_idempotent`
- `test_nomina_bulk_attendance_alimentaria_syncs_current_period`

## Causa raíz

El período mensual y la habilitación de la carga de asistencia derivan de `timezone.localdate()` en `pwa/services/nomina_service.py`:

- `get_periodo_mensual_actual()` ya quedó simplificado a `timezone.localdate().replace(day=1)` (commit `190db7aa`), así que el **desfase de período** del borde de mes (días 1-10 apuntando al mes anterior) ya no ocurre y el test de historial pasa cualquier día.
- Pero `asistencia_nomina_habilitada()` mantiene la ventana real de carga (`día >= 25 or día <= 10`). Los endpoints `registrar-asistencia/` y `asistencia-alimentaria/` validan esa ventana, por lo que **entre el día 11 y el 24 devuelven `400`** y los dos tests con `POST` fallaban (`assert 400 == 200`).

Verificado congelando `timezone.localdate` al día 15: el test de historial pasa y los dos `POST` fallan con `400`.

## Decisión

Arreglar los **tests**, no el código: la ventana de carga cruzada de mes es comportamiento intencional del producto. Construir fechas relativas no alcanza (no abre la ventana), así que hay que controlar "hoy".

No hay `freezegun`/`time_machine` en `requirements/`; se usa el patrón ya presente en el repo con `pytest-mock`: una fixture `fecha_fija_en_ventana` que parchea `django.utils.timezone.localdate` a una fecha fija de **día 1** (`2026-06-01`). El día 1 mantiene la ventana abierta y reproduce el borde de mes, de modo que sirve de **guarda de regresión**: si se reintrodujera el cálculo de período desfasado de los primeros días, el test de historial volvería a romper.

Cambio acotado a `tests/` (no se toca `pwa/`). Los cuerpos de los tests no cambian; las expresiones `timezone.localdate().replace(day=1)` ahora resuelven a la fecha congelada.

## Validación

Imagen Docker del repo con `USE_SQLITE_FOR_TESTS=1` y `--no-migrations` (SQLite):

- `tests/test_pwa_nomina_api.py`: **10 passed** (fecha fija día 1).
- Resto de la suite PWA (actividades, auditoría/auth, colaboradores, comedores, formación, mensajes, push, signals): **71 passed**.
- `black --check tests/test_pwa_nomina_api.py`: OK.

Corrida con migraciones delegada a la CI.

Detalle en `docs/registro/cambios/2026-06-01-pwa-tests-nomina-borde-mes.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)