### PR TITLE
fix(celiaquia): mensaje legible al fallar la baja de tecnico asignado (#1801)

### DIFF
--- a/static/custom/js/celiaquia_list.js
+++ b/static/custom/js/celiaquia_list.js
@@ -376,10 +376,24 @@
             });
             
             if (!ok) {
-              const msg = (data && data.error) || text || `HTTP ${status}`;
+              // No mostramos el cuerpo crudo (text): ante un 404/500/redirect sería el
+              // HTML de la página de error de Django. Damos un mensaje legible por status.
+              if (text) {
+                console.error('Remover técnico (respuesta no-JSON):', text.slice(0, 200));
+              }
+              let msg = data && data.error;
+              if (!msg) {
+                if (status === 404) {
+                  msg = 'La asignación no existe o ya fue removida.';
+                } else if (status === 403) {
+                  msg = 'No tenés permisos para remover el técnico.';
+                } else {
+                  msg = `No se pudo completar la operación (HTTP ${status}).`;
+                }
+              }
               throw new Error(msg);
             }
-            
+
             showAlert('success', 'Técnico removido correctamente.');
             
             // Remover el badge del DOM


### PR DESCRIPTION
# Información de la Tarea
Relacionado con #1801

### **Resumen de la Solución:**
- El handler JS de "remover técnico asignado" mostraba el cuerpo crudo de la respuesta como mensaje de error. Ante un 404/500/redirect eso era el HTML de la página de error de Django (`<!DOCTYPE html>...`) sin parsear. Ahora arma un mensaje legible según el status.

### **Información Adicional:**
- La **causa raíz** del 404 del issue (URL del `DELETE` sin el prefijo `/celiaquia/`) ya fue corregida en `development` por el commit `ba122c62`. Este PR es **complementario**: blinda el manejo de error para que nunca se muestre HTML crudo.
- Para que el fix llegue a un entorno desplegado (ej. `10.80.9.15`) hay que correr `collectstatic` tras el deploy: el proyecto usa `ManifestStaticFilesStorage`, así que el JS no se actualiza solo.

# Descripción de los Cambios

### **Cambios:**
- `static/custom/js/celiaquia_list.js` → `attachRemoveTecnicoHandlers`: ante una respuesta **no-JSON** ya no se usa el cuerpo crudo (`text`). Si no hay un error JSON, se arma un mensaje por status:
  - `404` → "La asignación no existe o ya fue removida."
  - `403` → "No tenés permisos para remover el técnico."
  - otro → "No se pudo completar la operación (HTTP N)."
  - El HTML solo se loguea **truncado** en consola para depuración.

# Cómo Testear los Cambios

### **Pruebas Automáticas:**
- `node tests/test_escape_html.js` → verde (el cambio no afecta `escapeHtml`).
- `node --check static/custom/js/celiaquia_list.js` → sintaxis válida.

### **Prubeas Manuales:**
- Como **Admin** o **Coordinador**, en la lista de expedientes de Celiaquía: asignar un técnico y luego removerlo con la ✕ del badge → debe removerse y mostrar "Técnico removido correctamente."
- Para validar el blindaje: provocar un error (p. ej. técnico ya removido) y verificar que el mensaje sea legible y **no** muestre HTML.

# Metadata para documentación automática

- Contexto funcional: Celiaquía — asignación/baja de técnicos en expedientes
- Tipo de cambio: Fix (frontend / UX de errores)
- Área principal: `celiaquia` (`static/custom/js/celiaquia_list.js`)
- Resumen para changelog: Mensaje de error legible al fallar la baja de un técnico asignado (ya no se muestra el HTML crudo del 404).
- Impacto usuario: Coordinadores/Admin ven un mensaje claro en vez del HTML de la página de error; sin cambios en el flujo exitoso.
- Riesgos / rollback: Bajo. Cambio acotado al manejo de error de un handler JS. Rollback = revertir el commit.

# Capturas de Pantalla
_No aplica._

🤖 Generated with [Claude Code](https://claude.com/claude-code)
