### PR TITLE
fix(celiaquia): aísla expedientes por provincia en carga y listado (#1793)

### DIFF
--- a/celiaquia/services/importacion_service/impl.py
+++ b/celiaquia/services/importacion_service/impl.py
@@ -269,6 +269,48 @@ def _obtener_provincia_usuario_id(usuario):
     return provincia_usuario_id
 
 
+def _obtener_provincias_permitidas_ids(usuario):
+    """Conjunto de ``provincia_id`` sobre las que el usuario puede cargar legajos.
+
+    Devuelve ``None`` cuando no hay restriccion provincial (superusuario o cualquier
+    usuario no territorial, p. ej. coordinador). Para un usuario territorial devuelve
+    el conjunto de provincias de su alcance (``ProfileTerritorialScope``); puede ser
+    vacio si no tiene alcance configurado, en cuyo caso no podra cargar ninguna.
+
+    A diferencia de ``_obtener_provincia_usuario_id`` (que solo resuelve cuando hay
+    una unica provincia), este conjunto soporta usuarios multi-provincia: cada
+    ciudadano se acepta solo si su provincia pertenece al alcance del usuario.
+    """
+    if getattr(usuario, "is_superuser", False):
+        return None
+    try:
+        from users.territorial_scope import get_effective_scopes, is_territorial_user
+
+        if not is_territorial_user(usuario):
+            return None
+        return {scope.provincia_id for scope in get_effective_scopes(usuario)}
+    except Exception as exc:  # pylint: disable=broad-exception-caught
+        logger.warning("No se pudo obtener el alcance provincial del usuario: %s", exc)
+        return None
+
+
+def _validar_provincia_permitida_importacion(payload, provincias_permitidas_ids):
+    """Rechaza un ciudadano cuya provincia quede fuera del alcance del usuario.
+
+    ``provincias_permitidas_ids=None`` significa sin restriccion (admin/coordinador).
+    Si la provincia no pudo inferirse (``None``), no se valida aca: la obligatoriedad
+    de municipio/localidad ya produce el error correspondiente.
+    """
+    if provincias_permitidas_ids is None:
+        return
+    provincia_id = payload.get("provincia")
+    if provincia_id and provincia_id not in provincias_permitidas_ids:
+        raise ValidationError(
+            "El ciudadano pertenece a una provincia fuera de su alcance territorial; "
+            "no puede cargar legajos de otra provincia."
+        )
+
+
 def _colectar_ids_y_nombres_importacion(df: pd.DataFrame):
     municipio_ids = set()
     localidad_ids = set()
@@ -1070,6 +1112,7 @@ def validar_y_normalizar_payloads_importacion(
     *,
     payload,
     provincia_usuario_id,
+    provincias_permitidas_ids=None,
     offset=0,
     municipios_cache=None,
     localidades_cache=None,
@@ -1115,6 +1158,9 @@ def validar_y_normalizar_payloads_importacion(
     _inferir_provincia_desde_municipio_importacion(
         payload_normalizado, municipio_provincia_map
     )
+    _validar_provincia_permitida_importacion(
+        payload_normalizado, provincias_permitidas_ids
+    )
     _validar_beneficiario_menor_con_responsable_importacion(payload_normalizado)
 
     responsable_payload = None
@@ -1132,6 +1178,11 @@ def validar_y_normalizar_payloads_importacion(
             add_warning=add_warning,
             add_error=add_error,
             validar_edad_responsable_fn=validar_edad_responsable,
+        )
+
+    if responsable_payload:
+        _validar_provincia_permitida_importacion(
+            responsable_payload, provincias_permitidas_ids
         )
 
     return payload_normalizado, responsable_payload, es_mismo_documento_resp
@@ -1723,6 +1774,7 @@ def _construir_payload_fila_importacion(
     offset,
     numeric_fields,
     provincia_usuario_id,
+    provincias_permitidas_ids,
     validar_documento,
     add_warning,
     to_date,
@@ -1753,6 +1805,7 @@ def _construir_payload_fila_importacion(
         paises_a_nacionalidad=paises_a_nacionalidad,
     )
     _inferir_provincia_desde_municipio_importacion(payload, municipio_provincia_map)
+    _validar_provincia_permitida_importacion(payload, provincias_permitidas_ids)
     _validar_beneficiario_menor_con_responsable_importacion(payload)
     return payload
 
@@ -1975,6 +2028,7 @@ def _procesar_beneficiario_desde_row_importacion(
     expediente,
     estado_id,
     provincia_usuario_id,
+    provincias_permitidas_ids,
     municipios_cache,
     localidades_cache,
     municipio_provincia_map,
@@ -1999,6 +2053,7 @@ def _procesar_beneficiario_desde_row_importacion(
         offset=offset,
         numeric_fields=IMPORTACION_NUMERIC_FIELDS,
         provincia_usuario_id=provincia_usuario_id,
+        provincias_permitidas_ids=provincias_permitidas_ids,
         validar_documento=validar_documento,
         add_warning=add_warning,
         to_date=to_date,
@@ -2025,6 +2080,11 @@ def _procesar_beneficiario_desde_row_importacion(
             add_warning=add_warning,
             add_error=add_error,
             validar_edad_responsable_fn=validar_edad_responsable,
+        )
+
+    if responsable_payload:
+        _validar_provincia_permitida_importacion(
+            responsable_payload, provincias_permitidas_ids
         )
 
     # Detectar doble rol: mismo documento O documento en lista de doble rol
@@ -2116,6 +2176,7 @@ def _procesar_fila_legajo_importacion(
     expediente,
     estado_id,
     provincia_usuario_id,
+    provincias_permitidas_ids,
     municipios_cache,
     localidades_cache,
     municipio_provincia_map,
@@ -2161,6 +2222,7 @@ def _procesar_fila_legajo_importacion(
                 expediente=expediente,
                 estado_id=estado_id,
                 provincia_usuario_id=provincia_usuario_id,
+                provincias_permitidas_ids=provincias_permitidas_ids,
                 municipios_cache=municipios_cache,
                 localidades_cache=localidades_cache,
                 municipio_provincia_map=municipio_provincia_map,
@@ -2261,6 +2323,7 @@ def _build_contexto_filas_importacion_legajos(
 ):
     estado_id = _estado_doc_pendiente_id()
     provincia_usuario_id = _obtener_provincia_usuario_id(usuario)
+    provincias_permitidas_ids = _obtener_provincias_permitidas_ids(usuario)
     existentes_ids, en_programa, abiertos = (
         _precargar_conflictos_y_existentes_importacion(expediente)
     )
@@ -2286,6 +2349,7 @@ def _build_contexto_filas_importacion_legajos(
         "expediente": expediente,
         "estado_id": estado_id,
         "provincia_usuario_id": provincia_usuario_id,
+        "provincias_permitidas_ids": provincias_permitidas_ids,
         "municipios_cache": precargas["municipios_cache"],
         "localidades_cache": precargas["localidades_cache"],
         "municipio_provincia_map": precargas["municipio_provincia_map"],

--- a/celiaquia/tests/test_provincia_scope.py
+++ b/celiaquia/tests/test_provincia_scope.py
@@ -1,0 +1,177 @@
+"""Tests del seguimiento del issue #1793: aislamiento territorial de expedientes.
+
+Tras derivar la provincia del ciudadano (PR #1814) quedaron expuestos dos huecos
+que este cambio cierra:
+
+1. **Listado**: un usuario provincial veia expedientes que el mismo habia cargado
+   aunque sus ciudadanos fueran de otra provincia (por ``include_own=True``).
+2. **Carga**: un usuario multi-provincia (o sin alcance resoluble a una unica
+   provincia) podia importar ciudadanos de cualquier provincia, porque el filtro
+   por provincia unica quedaba en ``None``.
+"""
+
+from datetime import date
+
+import pytest
+from django.contrib.auth.models import Permission, User
+from django.core.exceptions import ValidationError
+from django.urls import reverse
+
+from ciudadanos.models import Ciudadano
+from core.models import Localidad, Municipio, Provincia
+from users.models import Profile, ProfileTerritorialScope
+from celiaquia.models import (
+    Expediente,
+    ExpedienteCiudadano,
+    EstadoExpediente,
+    EstadoLegajo,
+)
+from celiaquia.services.importacion_service import (
+    _obtener_provincias_permitidas_ids,
+    _validar_provincia_permitida_importacion,
+)
+
+
+def _grant_view_expediente(user):
+    user.user_permissions.add(
+        Permission.objects.get(
+            content_type__app_label="celiaquia",
+            codename="view_expediente",
+        )
+    )
+
+
+def _provincial_user(username, *provincias):
+    user = User.objects.create_user(username=username, password="pass")
+    _grant_view_expediente(user)
+    profile, _ = Profile.objects.get_or_create(user=user)
+    profile.es_usuario_provincial = True
+    profile.save()
+    for provincia in provincias:
+        ProfileTerritorialScope.objects.create(profile=profile, provincia=provincia)
+    return user
+
+
+def _territorio(nombre):
+    provincia = Provincia.objects.create(nombre=f"{nombre} Prov")
+    municipio = Municipio.objects.create(nombre=f"{nombre} Mun", provincia=provincia)
+    localidad = Localidad.objects.create(nombre=f"{nombre} Loc", municipio=municipio)
+    return provincia, municipio, localidad
+
+
+def _expediente_con_ciudadano(
+    owner, estado, documento, provincia, municipio, localidad
+):
+    expediente = Expediente.objects.create(usuario_provincia=owner, estado=estado)
+    ciudadano = Ciudadano.objects.create(
+        apellido="Perez",
+        nombre=f"Ciudadano {documento}",
+        fecha_nacimiento=date(2010, 1, 1),
+        documento=documento,
+        provincia=provincia,
+        municipio=municipio,
+        localidad=localidad,
+    )
+    estado_legajo, _ = EstadoLegajo.objects.get_or_create(nombre="DOCUMENTO_PENDIENTE")
+    ExpedienteCiudadano.objects.create(
+        expediente=expediente, ciudadano=ciudadano, estado=estado_legajo
+    )
+    return expediente
+
+
+# --------------------------------------------------------------------------- #
+# Listado (ExpedienteListView -> _apply_provincial_expediente_scope)
+# --------------------------------------------------------------------------- #
+
+
+@pytest.mark.django_db
+def test_listado_oculta_expediente_propio_de_otra_provincia(client):
+    """El usuario NO ve un expediente que el mismo cargo si sus ciudadanos son de
+    una provincia fuera de su alcance (caso del Exped. #367 de Misiones)."""
+    prov_propia, mun_propio, loc_propia = _territorio("Buenos Aires")
+    prov_ajena, mun_ajeno, loc_ajena = _territorio("Misiones")
+    user = _provincial_user("prov-bsas", prov_propia)
+    estado = EstadoExpediente.objects.create(nombre="EN_ESPERA")
+
+    propio_en_alcance = _expediente_con_ciudadano(
+        user, estado, 501, prov_propia, mun_propio, loc_propia
+    )
+    propio_fuera_de_alcance = _expediente_con_ciudadano(
+        user, estado, 502, prov_ajena, mun_ajeno, loc_ajena
+    )
+    propio_sin_legajos = Expediente.objects.create(
+        usuario_provincia=user, estado=estado
+    )
+
+    client.force_login(user)
+    response = client.get(reverse("expediente_list"))
+    expedientes = list(response.context["expedientes"])
+
+    assert response.status_code == 200
+    assert propio_en_alcance in expedientes
+    assert propio_sin_legajos in expedientes  # recien creado, todavia sin provincia
+    assert propio_fuera_de_alcance not in expedientes
+
+
+@pytest.mark.django_db
+def test_detalle_de_expediente_de_otra_provincia_da_404(client):
+    """El detalle de un expediente fuera de alcance no debe ser accesible aunque
+    sea propio."""
+    prov_ajena, mun_ajeno, loc_ajena = _territorio("Salta")
+    prov_propia = Provincia.objects.create(nombre="Cordoba Scope")
+    user = _provincial_user("prov-cba", prov_propia)
+    estado = EstadoExpediente.objects.create(nombre="EN_ESPERA")
+    ajeno = _expediente_con_ciudadano(
+        user, estado, 601, prov_ajena, mun_ajeno, loc_ajena
+    )
+
+    client.force_login(user)
+    response = client.get(reverse("expediente_detail", args=[ajeno.pk]))
+
+    assert response.status_code == 404
+
+
+# --------------------------------------------------------------------------- #
+# Carga (_obtener_provincias_permitidas_ids / _validar_provincia_permitida_importacion)
+# --------------------------------------------------------------------------- #
+
+
+def test_validar_provincia_sin_restriccion_no_lanza():
+    # None => admin/coordinador, sin restriccion provincial.
+    _validar_provincia_permitida_importacion({"provincia": 99}, None)
+
+
+def test_validar_provincia_en_alcance_no_lanza():
+    _validar_provincia_permitida_importacion({"provincia": 5}, {5, 7})
+
+
+def test_validar_provincia_fuera_de_alcance_lanza():
+    with pytest.raises(ValidationError):
+        _validar_provincia_permitida_importacion({"provincia": 9}, {5, 7})
+
+
+def test_validar_provincia_no_inferida_no_lanza():
+    # Sin provincia resuelta no se valida aca (la obligatoriedad de municipio ya
+    # produce el error correspondiente).
+    _validar_provincia_permitida_importacion({"provincia": None}, {5})
+    _validar_provincia_permitida_importacion({}, {5})
+
+
+@pytest.mark.django_db
+def test_provincias_permitidas_superusuario_sin_restriccion():
+    admin = User.objects.create_superuser(username="admin-scope", password="pass")
+    assert _obtener_provincias_permitidas_ids(admin) is None
+
+
+@pytest.mark.django_db
+def test_provincias_permitidas_no_territorial_sin_restriccion():
+    user = User.objects.create_user(username="plain-scope", password="pass")
+    assert _obtener_provincias_permitidas_ids(user) is None
+
+
+@pytest.mark.django_db
+def test_provincias_permitidas_multiprovincia_devuelve_conjunto():
+    p1 = Provincia.objects.create(nombre="P1 Scope")
+    p2 = Provincia.objects.create(nombre="P2 Scope")
+    user = _provincial_user("multi-scope", p1, p2)
+    assert _obtener_provincias_permitidas_ids(user) == {p1.id, p2.id}

--- a/celiaquia/views/expediente.py
+++ b/celiaquia/views/expediente.py
@@ -49,6 +49,7 @@ from celiaquia.services.importacion_service import (
     _beneficiario_requiere_responsable_importacion,
     _cargar_nacionalidades_cache,
     _cargar_paises_a_nacionalidad_importacion,
+    _obtener_provincias_permitidas_ids,
     _precargar_conflictos_y_existentes_importacion,
     _resolver_nacionalidad_payload_importacion,
     validar_y_normalizar_payloads_importacion,
@@ -62,6 +63,7 @@ from core.soft_delete.preview import build_delete_preview
 from core.soft_delete.view_helpers import is_soft_deletable_instance
 from users.territorial_scope import (
     apply_territorial_scope,
+    build_territorial_scope_q,
     get_effective_scopes,
     get_single_full_province_scope_id,
     is_territorial_user,
@@ -485,10 +487,13 @@ def _formatear_observaciones_historial(observaciones):
     return "\n".join(partes) or observaciones
 
 
-def _validar_datos_registro_erroneo(payload, provincia_id, fila_excel=0):
+def _validar_datos_registro_erroneo(
+    payload, provincia_id, fila_excel=0, provincias_permitidas_ids=None
+):
     return validar_y_normalizar_payloads_importacion(
         payload=payload,
         provincia_usuario_id=provincia_id,
+        provincias_permitidas_ids=provincias_permitidas_ids,
         offset=fila_excel,
     )
 
@@ -532,19 +537,33 @@ def _user_scope_provincias(user):
 
 
 def _apply_provincial_expediente_scope(queryset, user):
+    if getattr(user, "is_superuser", False):
+        return queryset
     if not is_territorial_user(user):
         # Tiene role_provinciaceliaquia pero no scope territorial configurado;
         # restringir a expedientes propios.
         return queryset.filter(usuario_provincia=user).distinct()
-    return apply_territorial_scope(
-        queryset,
-        user,
+
+    # Un expediente es visible si tiene al menos un ciudadano dentro del alcance
+    # territorial del usuario. NO se incluyen los expedientes propios fuera de
+    # alcance (sin include_own): un expediente cargado por el usuario con
+    # ciudadanos de otra provincia no debe listarse (seguimiento del issue #1793).
+    scope_q = build_territorial_scope_q(
+        get_effective_scopes(user),
         provincia_lookup="expediente_ciudadanos__ciudadano__provincia_id",
         municipio_lookup="expediente_ciudadanos__ciudadano__municipio_id",
         localidad_lookup="expediente_ciudadanos__ciudadano__localidad_id",
-        own_lookup="usuario_provincia",
-        include_own=True,
     )
+    # Excepcion: sus propios expedientes recien creados, aun sin legajos
+    # importados (sin provincia derivable todavia), deben seguir siendo accesibles
+    # para poder cargar/procesar el Excel.
+    propios_sin_legajos_q = Q(
+        usuario_provincia=user, expediente_ciudadanos__isnull=True
+    )
+    combined_q = (
+        propios_sin_legajos_q if scope_q is None else scope_q | propios_sin_legajos_q
+    )
+    return queryset.filter(combined_q).distinct()
 
 
 def _get_provincial_expediente_or_404(user, pk):
@@ -2045,12 +2064,21 @@ class RevisarLegajoView(View):
 class ActualizarRegistroErroneoView(View):
     def post(self, request, pk, registro_id):
         user = request.user
-        expediente = get_object_or_404(Expediente, pk=pk)
 
         if not _can_manage_registros_erroneos(user):
             return JsonResponse(
                 {"success": False, "error": "Permiso denegado."}, status=403
             )
+
+        # Coordinador/admin gestionan cualquier expediente; el usuario provincial
+        # solo los de su alcance territorial (evita operar registros de otra
+        # provincia accediendo por pk directo).
+        if _is_admin(user) or _user_has_permission(
+            user, ROLE_COORDINADOR_CELIAQUIA_PERMISSION
+        ):
+            expediente = get_object_or_404(Expediente, pk=pk)
+        else:
+            expediente = _get_provincial_expediente_or_404(user, pk)
 
         from celiaquia.models import RegistroErroneo
 
@@ -2078,6 +2106,7 @@ class ActualizarRegistroErroneoView(View):
                 datos_normalizados,
                 provincia_id=provincia_id,
                 fila_excel=registro.fila_excel,
+                provincias_permitidas_ids=_obtener_provincias_permitidas_ids(user),
             )
             datos_limpios = _limpiar_datos_registro_erroneo(datos_normalizados)
             registro.datos_raw = datos_limpios
@@ -2113,12 +2142,20 @@ class ReprocesarRegistrosErroneosView(View):
     @transaction.atomic
     def post(self, request, pk):
         user = request.user
-        expediente = get_object_or_404(Expediente, pk=pk)
 
         if not _can_manage_registros_erroneos(user):
             return JsonResponse(
                 {"success": False, "error": "Permiso denegado."}, status=403
             )
+
+        # Coordinador/admin reprocesan cualquier expediente; el usuario provincial
+        # solo los de su alcance territorial.
+        if _is_admin(user) or _user_has_permission(
+            user, ROLE_COORDINADOR_CELIAQUIA_PERMISSION
+        ):
+            expediente = get_object_or_404(Expediente, pk=pk)
+        else:
+            expediente = _get_provincial_expediente_or_404(user, pk)
 
         registros = expediente.registros_erroneos.filter(procesado=False)
 
@@ -2152,6 +2189,8 @@ class ReprocesarRegistrosErroneosView(View):
                 status=400,
             )
 
+        provincias_permitidas_ids = _obtener_provincias_permitidas_ids(user)
+
         for registro in registros:
             datos = _aplicar_defaults_registro_erroneo(
                 _normalizar_datos_registro_erroneo(registro.datos_raw.copy())
@@ -2165,6 +2204,7 @@ class ReprocesarRegistrosErroneosView(View):
                     datos,
                     provincia_id=provincia_id,
                     fila_excel=registro.fila_excel,
+                    provincias_permitidas_ids=provincias_permitidas_ids,
                 )
 
                 with transaction.atomic():

--- a/celiaquia/views/reporter_provincias.py
+++ b/celiaquia/views/reporter_provincias.py
@@ -39,14 +39,16 @@ class ReporterProvinciasView(LoginRequiredMixin, TemplateView):
         )
 
         if es_usuario_provincial:
+            # Reporte restringido al alcance territorial real del usuario. No se
+            # incluyen legajos de expedientes propios fuera de alcance (sin
+            # include_own): no deben contabilizarse casos de otra provincia
+            # (seguimiento del issue #1793).
             queryset = apply_territorial_scope(
                 queryset,
                 user,
                 provincia_lookup="ciudadano__provincia_id",
                 municipio_lookup="ciudadano__municipio_id",
                 localidad_lookup="ciudadano__localidad_id",
-                own_lookup="expediente__usuario_provincia",
-                include_own=True,
             )
 
         # Aplicar filtros

--- a/docs/registro/cambios/2026-06-02-celiaquia-scope-provincial-carga-listado.md
+++ b/docs/registro/cambios/2026-06-02-celiaquia-scope-provincial-carga-listado.md
@@ -1,0 +1,104 @@
+# 2026-06-02 - Celiaquía: aislamiento territorial en carga y listado de expedientes
+
+## Contexto
+
+Seguimiento del issue [#1793](https://github.com/dsocial118/SISOC/issues/1793). El
+PR [#1814](https://github.com/dsocial118/SISOC/pull/1814) corrigió la derivación de
+la provincia del expediente (ahora se toma del ciudadano, no del perfil legacy del
+usuario). Al mostrarse la provincia correcta quedaron expuestos dos huecos de
+control de acceso que **no** eran nuevos pero que antes pasaban inadvertidos:
+
+1. **Carga**: un usuario provincial podía importar un Excel con ciudadanos de una
+   provincia fuera de su alcance. El filtro de importación dependía de
+   `_obtener_provincia_usuario_id`, que solo devuelve una provincia cuando el
+   usuario tiene **exactamente una** en su alcance; con multi-provincia (o sin
+   alcance resoluble) quedaba en `None` y se importaba **sin filtro provincial**.
+2. **Listado / detalle**: `_apply_provincial_expediente_scope` usaba
+   `include_own=True`, por lo que un usuario provincial veía y accedía a **todos
+   los expedientes que él mismo había cargado**, sin importar la provincia de sus
+   ciudadanos (caso reportado: Exped. #367 de Misiones, cargado por un usuario sin
+   alcance en Misiones).
+
+Esto era inconsistente con la regla de escritura ya existente en
+`celiaquia/permissions.py` (`_expediente_fully_in_territorial_scope`), que exige que
+todos los legajos estén dentro del alcance territorial del usuario.
+
+## Cambios aplicados
+
+### Listado y detalle (control de acceso de lectura)
+
+- **`_apply_provincial_expediente_scope`**
+  ([celiaquia/views/expediente.py](../../../celiaquia/views/expediente.py)): se quita
+  `include_own=True`. Un expediente es visible para un usuario provincial solo si
+  tiene **al menos un ciudadano dentro de su alcance territorial**. Se mantiene una
+  única excepción: los expedientes **propios aún sin legajos importados** (recién
+  creados, sin provincia derivable) siguen siendo accesibles para poder cargar y
+  procesar el Excel. Esto afecta de forma centralizada al listado, al detalle y a
+  todas las acciones que resuelven el expediente con
+  `_get_provincial_expediente_or_404` (procesar, importar, crear legajos, confirmar
+  envío).
+- **`ReporterProvinciasView`**
+  ([celiaquia/views/reporter_provincias.py](../../../celiaquia/views/reporter_provincias.py)):
+  mismo criterio; se elimina `include_own` para que el reporte no contabilice
+  legajos de otra provincia provenientes de expedientes propios.
+- **Vistas de registros erróneos** (`ActualizarRegistroErroneoView`,
+  `ReprocesarRegistrosErroneosView`): ahora resuelven el expediente con alcance
+  territorial para usuarios provinciales (coordinador/admin sin restricción), en
+  lugar de `get_object_or_404(Expediente, pk=pk)` directo.
+
+### Carga (control de acceso de escritura en la importación)
+
+- **`_obtener_provincias_permitidas_ids(usuario)`** (nuevo,
+  [importacion_service/impl.py](../../../celiaquia/services/importacion_service/impl.py)):
+  devuelve el **conjunto** de `provincia_id` del alcance del usuario (soporta
+  multi-provincia). `None` = sin restricción (superusuario / usuario no territorial,
+  p. ej. coordinador).
+- **`_validar_provincia_permitida_importacion(payload, provincias_permitidas_ids)`**
+  (nuevo): si hay restricción y la provincia inferida del ciudadano no pertenece al
+  conjunto, lanza `ValidationError`. La fila queda como **registro erróneo**
+  (consistente con el comportamiento actual de provincia única) y no se crea el
+  ciudadano; el resto del Excel se importa normalmente.
+- El gate se aplica al **beneficiario** y al **responsable** en las dos rutas de
+  validación: la importación masiva (`_construir_payload_fila_importacion`) y el
+  reproceso de registros erróneos (`validar_y_normalizar_payloads_importacion`).
+
+## Decisiones / supuestos
+
+- **Rechazo por fila, no de toda la carga**: las filas de otra provincia se marcan
+  como registros erróneos y se importan las válidas. Es lo menos disruptivo y
+  consistente con cómo ya se comporta la validación de provincia única. (Si el
+  negocio prefiere bloquear toda la importación, es un cambio acotado sobre el mismo
+  gate.)
+- **Datos existentes**: los expedientes cross-provincia ya cargados (p. ej. #367)
+  dejan de verse/accederse para usuarios provinciales. Admin y coordinador los
+  siguen viendo y pueden eliminarlos/reasignarlos. No se incluye migración ni script
+  de limpieza.
+- **Usuarios provinciales = territoriales**: el modelo documentado
+  (`Profile.es_usuario_provincial` + `ProfileTerritorialScope`) asume que los
+  usuarios provinciales son territoriales. Para un usuario con solo el permiso
+  `role_provinciaceliaquia` y sin alcance territorial, el listado/acceso sigue
+  restringido a sus propios expedientes (comportamiento previo) y la carga no aplica
+  filtro provincial; en la práctica estos usuarios no deberían existir.
+- **Granularidad**: la carga valida a nivel **provincia** (lo que pide el issue). El
+  listado conserva su granularidad existente (provincia/municipio/localidad) vía
+  `build_territorial_scope_q`.
+
+## Validación
+
+- `black --check`: OK sobre los archivos tocados.
+- `python -m py_compile`: OK.
+- **pytest no se pudo correr localmente**: el Python global del usuario tiene un
+  Django incompatible (`ImportError: punycode`) y Docker estaba apagado. Se delega
+  a la CI del PR (práctica habitual del repo). Tests nuevos en
+  `celiaquia/tests/test_provincia_scope.py` (listado oculta expediente propio de
+  otra provincia, detalle 404, validador de provincia en/ fuera de alcance, conjunto
+  de provincias permitidas).
+
+## Cómo probar manualmente
+
+1. Usuario provincial con alcance en provincia A (sin Misiones).
+2. Subir un Excel con ciudadanos de Misiones → esas filas quedan como registros
+   erróneos ("provincia fuera de su alcance"); las de A se importan.
+3. El expediente #367 (Misiones) ya no aparece en el listado ni es accesible por
+   detalle para ese usuario; sí lo ven admin/coordinador.
+4. Un usuario multi-provincia (A + B) puede cargar y ver expedientes de A y de B.


### PR DESCRIPTION
# Información de la Tarea
Seguimiento de #1793

### **Resumen de la Solución:**
- Al derivar la provincia del ciudadano (PR #1814) quedaron expuestos dos huecos de control de acceso territorial **preexistentes**. Se restringe la **carga** y el **listado/detalle** de expedientes al alcance provincial del usuario.

### **Información Adicional:**
- No son comportamientos nuevos "deseados": los huecos ya existían y se hicieron visibles al mostrarse por fin la provincia correcta.
- Queda consistente con la regla de escritura ya existente en `celiaquia/permissions.py` (`_expediente_fully_in_territorial_scope`).

# Descripción de los Cambios

### **Cambios:**
- **Carga** (`celiaquia/services/importacion_service/impl.py`): nuevos `_obtener_provincias_permitidas_ids` (conjunto de provincias del alcance; soporta multi‑provincia; `None` = sin restricción para admin/coordinador) y `_validar_provincia_permitida_importacion`. Un ciudadano de provincia fuera de alcance queda como **registro erróneo** y se importa el resto. Aplica a **beneficiario y responsable**, en importación masiva y en reproceso de registros erróneos.
- **Listado/detalle/acciones** (`celiaquia/views/expediente.py`): `_apply_provincial_expediente_scope` deja de usar `include_own=True`; un expediente es visible solo si tiene al menos un ciudadano en el alcance, con la única excepción de los **propios aún sin legajos** (recién creados, para poder cargar). Las vistas de registros erróneos resuelven el expediente con alcance territorial.
- **Reporte** (`celiaquia/views/reporter_provincias.py`): mismo criterio, sin `include_own`.

### **Decisiones (defaults, confirmables):**
- Rechazo **por fila** (registro erróneo), no de toda la carga.
- Datos cross‑provincia ya cargados: solo se **ocultan** a usuarios provinciales (admin/coordinador los siguen viendo para limpiar). Sin migración.

# Cómo Testear los Cambios

### **Pruebas Automáticas:**
- `celiaquia/tests/test_provincia_scope.py`: listado oculta expediente propio de otra provincia, detalle 404, validador de provincia en/fuera de alcance, conjunto de provincias permitidas.
- Locales: `black --check` y `py_compile` OK. `pytest` se deja a la CI (Python global con `ImportError: punycode` + Docker apagado).

### **Pruebas Manuales:**
- Usuario provincial con alcance en provincia A (sin Misiones): subir un Excel con ciudadanos de Misiones → esas filas quedan como registros erróneos ("provincia fuera de su alcance"); las de A se importan.
- El Exped. #367 (Misiones) ya no aparece en el listado ni es accesible por detalle para ese usuario; admin/coordinador sí lo ven.
- Usuario multi‑provincia (A + B) puede cargar y ver expedientes de A y de B.

# Metadata para documentación automática

- Contexto funcional: Celiaquía — aislamiento territorial (provincia) de expedientes.
- Tipo de cambio: fix (control de acceso / seguridad).
- Área principal: celiaquía (importación y listado de expedientes).
- Resumen para changelog: la carga y el listado de expedientes quedan restringidos al alcance provincial del usuario; ya no se pueden importar ni ver expedientes de otra provincia.
- Impacto usuario: usuarios provinciales solo cargan/ven expedientes de su(s) provincia(s); admin y coordinador sin cambios.
- Riesgos / rollback: cambio acotado a celiaquía; rollback = revertir el commit. Tests completos diferidos a CI.

# Capturas de Pantalla
N/A

🤖 Generated with [Claude Code](https://claude.com/claude-code)