### PR TITLE
fix(admisiones): el N° de GDE aparece al aceptar documentos sin recargar (#1799 feedback p4)

### DIFF
--- a/admisiones/services/admisiones_service/impl.py
+++ b/admisiones/services/admisiones_service/impl.py
@@ -1663,21 +1663,28 @@ class AdmisionService:
     @staticmethod
     def _render_celda_gde_html(archivo, request):
         """Renderiza el interior de la celda GDE de un ArchivoAdmision para
-        inyectarlo via AJAX. Devuelve None si no hay request (la celda se
-        renderiza server-side en el render completo)."""
+        inyectarlo via AJAX. Devuelve None si no hay request o si el render falla:
+        el re-render es auxiliar y NUNCA debe romper la actualizacion de estado."""
         if request is None or archivo is None:
             return None
-        if archivo.documentacion_id:
-            doc = AdmisionService._serialize_documentacion(
-                archivo.documentacion, archivo
+        try:
+            if archivo.documentacion_id:
+                doc = AdmisionService._serialize_documentacion(
+                    archivo.documentacion, archivo
+                )
+            else:
+                doc = AdmisionService.serialize_documento_personalizado(archivo)
+            return render_to_string(
+                "admisiones/includes/gde_cell.html",
+                {"doc": doc, "admision": archivo.admision},
+                request=request,
             )
-        else:
-            doc = AdmisionService.serialize_documento_personalizado(archivo)
-        return render_to_string(
-            "admisiones/includes/gde_cell.html",
-            {"doc": doc, "admision": archivo.admision},
-            request=request,
-        )
+        except Exception:
+            logger.exception(
+                "No se pudo renderizar la celda GDE para el re-render AJAX",
+                extra={"archivo_pk": getattr(archivo, "pk", None)},
+            )
+            return None
 
     @staticmethod
     def _resolver_estado_y_observacion_actualizar_estado_ajax(request):

--- a/admisiones/services/admisiones_service/impl.py
+++ b/admisiones/services/admisiones_service/impl.py
@@ -6,6 +6,7 @@ from django.conf import settings
 from django.db import models
 from django.db import transaction
 from django.shortcuts import get_object_or_404
+from django.template.loader import render_to_string
 from django.urls import reverse
 from django.core.files.base import ContentFile
 from io import BytesIO
@@ -1646,14 +1647,37 @@ class AdmisionService:
 
     @staticmethod
     def _build_success_actualizar_estado_ajax_response(
-        archivo, display_objetivo, grupo_usuario
+        archivo, display_objetivo, grupo_usuario, request=None
     ):
         return {
             "success": True,
             "nuevo_estado": display_objetivo,
             "grupo_usuario": grupo_usuario,
             "observaciones": archivo.observaciones,
+            # Re-render de la celda "Número de GDE": al cambiar el estado del
+            # documento (p.ej. -> Aceptado) debe aparecer/ocultarse el campo GDE
+            # sin recargar la pagina (issue #1799, feedback punto 4).
+            "gde_html": AdmisionService._render_celda_gde_html(archivo, request),
         }
+
+    @staticmethod
+    def _render_celda_gde_html(archivo, request):
+        """Renderiza el interior de la celda GDE de un ArchivoAdmision para
+        inyectarlo via AJAX. Devuelve None si no hay request (la celda se
+        renderiza server-side en el render completo)."""
+        if request is None or archivo is None:
+            return None
+        if archivo.documentacion_id:
+            doc = AdmisionService._serialize_documentacion(
+                archivo.documentacion, archivo
+            )
+        else:
+            doc = AdmisionService.serialize_documento_personalizado(archivo)
+        return render_to_string(
+            "admisiones/includes/gde_cell.html",
+            {"doc": doc, "admision": archivo.admision},
+            request=request,
+        )
 
     @staticmethod
     def _resolver_estado_y_observacion_actualizar_estado_ajax(request):
@@ -1753,6 +1777,7 @@ class AdmisionService:
                 archivo=archivo,
                 display_objetivo=display_objetivo,
                 grupo_usuario=grupo_usuario,
+                request=request,
             )
 
         except Exception as e:

--- a/admisiones/templates/admisiones/includes/documento_row.html
+++ b/admisiones/templates/admisiones/includes/documento_row.html
@@ -114,75 +114,7 @@
             {% endif %}
         {% endif %}
     </td>
-    <td id="gde-{{ doc.id }}">
-        {% if doc.estado == "Aceptado" %}
-            {% if doc.es_origen_organizacion %}
-                <!-- Documento de origen organizacional: el N de GDE se gestiona
-                     desde el Legajo de la Organizacion y se replica aqui (#1799 Req 3) -->
-                {% if doc.numero_gde %}
-                    <span class="text-success fw-bold">{{ doc.numero_gde }}</span>
-                {% else %}
-                    <span class="text-muted">Sin número GDE</span>
-                {% endif %}
-                <i class="bi bi-info-circle ms-1 text-muted"
-                   title="El número de GDE se gestiona desde el Legajo de la Organización"></i>
-            {% elif doc.archivo_id and request.user.is_superuser or doc.archivo_id and request.user|has_any_perm:"comedores.view_comedor,admisiones.view_admision,acompanamientos.view_informacionrelevante" or doc.archivo_id and request.user|has_perm_code:"auth.role_tecnico_comedor" or doc.archivo_id and request.user|has_any_group:"Tecnico Comedor" %}
-                <!-- Modo vista (por defecto) -->
-                <div id="gde-display-{{ doc.id }}"
-                     class="gde-display"
-                     data-call-click="activarEdicionGDE"
-                     data-call-args="[{{ doc.id }}]">
-                    {% if doc.numero_gde %}
-                        <span class="text-success fw-bold">{{ doc.numero_gde }}</span>
-                        <i class="bi bi-pencil-square ms-2 text-muted"
-                           style="cursor: pointer"
-                           title="Editar número GDE"></i>
-                    {% else %}
-                        <span class="text-muted">Sin número GDE</span>
-                        <i class="bi bi-plus-circle ms-2 text-primary"
-                           style="cursor: pointer"
-                           title="Agregar número GDE"></i>
-                    {% endif %}
-                </div>
-                <!-- Modo edición (oculto por defecto) -->
-                <div id="gde-edit-{{ doc.id }}" class="gde-edit d-none">
-                    <div class="d-flex align-items-center">
-                        <input type="text"
-                               class="form-control form-control-sm me-2"
-                               id="gde-input-{{ doc.id }}"
-                               value="{{ doc.numero_gde|default_if_none:'' }}"
-                               placeholder="Ingrese número GDE"
-                               maxlength="50"
-                               style="max-width: 150px" />
-                        <button class="btn btn-success btn-sm me-1"
-                                data-call-click="guardarNumeroGDE"
-                                data-call-args="[{{ doc.id }}]"
-                                title="Guardar">
-                            <i class="bi bi-check"></i>
-                        </button>
-                        <button class="btn btn-secondary btn-sm"
-                                data-call-click="cancelarEdicionGDE"
-                                data-call-args="[{{ doc.id }}]"
-                                title="Cancelar">
-                            <i class="bi bi-x"></i>
-                        </button>
-                    </div>
-                </div>
-            {% else %}
-                {% if doc.numero_gde %}
-                    <span class="text-success fw-bold">{{ doc.numero_gde }}</span>
-                {% else %}
-                    <span class="text-muted">-</span>
-                {% endif %}
-            {% endif %}
-        {% else %}
-            {% if doc.numero_gde %}
-                <span class="text-success fw-bold">{{ doc.numero_gde }}</span>
-            {% else %}
-                <span class="text-muted">-</span>
-            {% endif %}
-        {% endif %}
-    </td>
+    <td id="gde-{{ doc.id }}">{% include "admisiones/includes/gde_cell.html" %}</td>
 </tr>
 {% if doc.observaciones %}
     <tr id="fila-obs-{{ doc.archivo_id|default:doc.row_id }}"

--- a/admisiones/templates/admisiones/includes/gde_cell.html
+++ b/admisiones/templates/admisiones/includes/gde_cell.html
@@ -1,0 +1,75 @@
+{% load custom_filters %}
+{% comment %}
+Contenido de la celda "Número de GDE" de un documento de la Admisión.
+Se extrae a un partial para poder re-renderizarlo desde el endpoint
+`actualizar_estado_archivo` (issue #1799 / feedback punto 4): al aceptar un
+documento via AJAX el campo GDE debe aparecer sin recargar la página.
+Contexto esperado: `doc` (dict serializado), `admision`, `request`.
+{% endcomment %}
+{% if doc.estado == "Aceptado" %}
+    {% if doc.es_origen_organizacion %}
+        <!-- Documento de origen organizacional: el N de GDE se gestiona
+             desde el Legajo de la Organizacion y se replica aqui (#1799 Req 3) -->
+        {% if doc.numero_gde %}
+            <span class="text-success fw-bold">{{ doc.numero_gde }}</span>
+        {% else %}
+            <span class="text-muted">Sin número GDE</span>
+        {% endif %}
+        <i class="bi bi-info-circle ms-1 text-muted"
+           title="El número de GDE se gestiona desde el Legajo de la Organización"></i>
+    {% elif doc.archivo_id and request.user.is_superuser or doc.archivo_id and request.user|has_any_perm:"comedores.view_comedor,admisiones.view_admision,acompanamientos.view_informacionrelevante" or doc.archivo_id and request.user|has_perm_code:"auth.role_tecnico_comedor" or doc.archivo_id and request.user|has_any_group:"Tecnico Comedor" %}
+        <!-- Modo vista (por defecto) -->
+        <div id="gde-display-{{ doc.id }}"
+             class="gde-display"
+             data-call-click="activarEdicionGDE"
+             data-call-args="[{{ doc.id }}]">
+            {% if doc.numero_gde %}
+                <span class="text-success fw-bold">{{ doc.numero_gde }}</span>
+                <i class="bi bi-pencil-square ms-2 text-muted"
+                   style="cursor: pointer"
+                   title="Editar número GDE"></i>
+            {% else %}
+                <span class="text-muted">Sin número GDE</span>
+                <i class="bi bi-plus-circle ms-2 text-primary"
+                   style="cursor: pointer"
+                   title="Agregar número GDE"></i>
+            {% endif %}
+        </div>
+        <!-- Modo edición (oculto por defecto) -->
+        <div id="gde-edit-{{ doc.id }}" class="gde-edit d-none">
+            <div class="d-flex align-items-center">
+                <input type="text"
+                       class="form-control form-control-sm me-2"
+                       id="gde-input-{{ doc.id }}"
+                       value="{{ doc.numero_gde|default_if_none:'' }}"
+                       placeholder="Ingrese número GDE"
+                       maxlength="50"
+                       style="max-width: 150px" />
+                <button class="btn btn-success btn-sm me-1"
+                        data-call-click="guardarNumeroGDE"
+                        data-call-args="[{{ doc.id }}]"
+                        title="Guardar">
+                    <i class="bi bi-check"></i>
+                </button>
+                <button class="btn btn-secondary btn-sm"
+                        data-call-click="cancelarEdicionGDE"
+                        data-call-args="[{{ doc.id }}]"
+                        title="Cancelar">
+                    <i class="bi bi-x"></i>
+                </button>
+            </div>
+        </div>
+    {% else %}
+        {% if doc.numero_gde %}
+            <span class="text-success fw-bold">{{ doc.numero_gde }}</span>
+        {% else %}
+            <span class="text-muted">-</span>
+        {% endif %}
+    {% endif %}
+{% else %}
+    {% if doc.numero_gde %}
+        <span class="text-success fw-bold">{{ doc.numero_gde }}</span>
+    {% else %}
+        <span class="text-muted">-</span>
+    {% endif %}
+{% endif %}

--- a/admisiones/tests/test_gde_cell_ajax.py
+++ b/admisiones/tests/test_gde_cell_ajax.py
@@ -1,0 +1,140 @@
+"""Issue #1799 (feedback punto 4): al cambiar el estado de un documento via AJAX,
+la celda "Número de GDE" se re-renderiza para que el campo aparezca/oculte sin
+recargar. Antes, aceptar un documento nativo de la Admisión dejaba la celda con el
+"-" del render previo (Pendiente). Tests del re-render server-side de la celda."""
+
+import pytest
+from django.contrib.auth import get_user_model
+from django.test import RequestFactory
+
+from admisiones.models.admisiones import (
+    Admision,
+    ArchivoAdmision,
+    Documentacion,
+    EstadoAdmision,
+    TipoConvenio,
+)
+from admisiones.services.admisiones_service import AdmisionService
+from comedores.models import Comedor
+from organizaciones.models import (
+    ArchivoOrganizacion,
+    DocumentacionOrganizacion,
+    Organizacion,
+    TipoEntidad,
+)
+
+
+pytestmark = pytest.mark.django_db
+User = get_user_model()
+
+
+@pytest.fixture
+def setup():
+    tipo = TipoEntidad.objects.create(nombre="Personería Jurídica")
+    organizacion = Organizacion.objects.create(nombre="Org GDE", tipo_entidad=tipo)
+    comedor = Comedor.objects.create(nombre="Comedor GDE", organizacion=organizacion)
+    EstadoAdmision.objects.create(pk=1, nombre="Pendiente")
+    tipo_convenio = TipoConvenio.objects.create(pk=3, nombre="Personería Jurídica")
+    admision = Admision.objects.create(
+        comedor=comedor,
+        tipo_convenio=tipo_convenio,
+        tipo_entidad_origen=tipo,
+        estado_admision="documentacion_en_proceso",
+    )
+    documentacion = Documentacion.objects.create(
+        nombre="Nota de Solicitud e Inclusión al Programa", obligatorio=True
+    )
+    return {
+        "organizacion": organizacion,
+        "admision": admision,
+        "documentacion": documentacion,
+    }
+
+
+def _request(user):
+    request = RequestFactory().post("/ajax/actualizar-estado-archivo/")
+    request.user = user
+    return request
+
+
+def test_doc_nativo_aceptado_devuelve_campo_gde_editable(setup):
+    """Un documento NATIVO de la admisión aceptado debe exponer el campo GDE
+    editable (no un '-'), que es justo lo que faltaba al aceptar via AJAX."""
+    superuser = User.objects.create_superuser(username="su", password="pwd")
+    archivo = ArchivoAdmision.objects.create(
+        admision=setup["admision"],
+        documentacion=setup["documentacion"],
+        archivo="admisiones/nota.pdf",
+        estado="aceptado",
+    )
+
+    resultado = AdmisionService._build_success_actualizar_estado_ajax_response(
+        archivo=archivo,
+        display_objetivo="Aceptado",
+        grupo_usuario="Abogado Dupla",
+        request=_request(superuser),
+    )
+
+    html = resultado["gde_html"]
+    # Widget GDE editable presente (vista + edición): esto es lo que faltaba.
+    assert f"gde-display-{archivo.id}" in html
+    assert f"gde-input-{archivo.id}" in html
+    assert "Sin número GDE" in html
+
+
+def test_doc_origen_organizacion_aceptado_es_solo_lectura(setup):
+    """Un documento de origen organizacional sigue siendo solo lectura admisión-side
+    (el GDE se gestiona desde el Legajo, #1799 Req 3): sin input de edición."""
+    superuser = User.objects.create_superuser(username="su2", password="pwd")
+    doc_org = DocumentacionOrganizacion.objects.create(
+        nombre="DNI del Presidente",
+        categoria=DocumentacionOrganizacion.CATEGORIA_PERSONERIA,
+        obligatorio=True,
+    )
+    archivo_org = ArchivoOrganizacion.objects.create(
+        organizacion=setup["organizacion"],
+        documentacion=doc_org,
+        archivo="organizaciones/dni.pdf",
+        estado=ArchivoOrganizacion.ESTADO_ACEPTADO,
+    )
+    archivo = ArchivoAdmision.objects.create(
+        admision=setup["admision"],
+        documentacion=setup["documentacion"],
+        archivo="admisiones/dni.pdf",
+        estado="aceptado",
+        archivo_organizacion_origen=archivo_org,
+    )
+
+    html = AdmisionService._render_celda_gde_html(archivo, _request(superuser))
+
+    assert f"gde-input-{archivo.id}" not in html
+    assert "bi-info-circle" in html
+    assert "Sin número GDE" in html
+
+
+def test_doc_no_aceptado_no_muestra_campo_gde(setup):
+    """Un documento no aceptado muestra '-' (sin campo GDE)."""
+    superuser = User.objects.create_superuser(username="su3", password="pwd")
+    archivo = ArchivoAdmision.objects.create(
+        admision=setup["admision"],
+        documentacion=setup["documentacion"],
+        archivo="admisiones/nota.pdf",
+        estado="pendiente",
+    )
+
+    html = AdmisionService._render_celda_gde_html(archivo, _request(superuser))
+
+    # Ni editable ni solo-lectura-org: cae en la rama del guion "-".
+    assert f"gde-display-{archivo.id}" not in html
+    assert "Sin número GDE" not in html
+    assert "bi-info-circle" not in html
+
+
+def test_render_celda_gde_sin_request_devuelve_none(setup):
+    archivo = ArchivoAdmision.objects.create(
+        admision=setup["admision"],
+        documentacion=setup["documentacion"],
+        archivo="admisiones/nota.pdf",
+        estado="aceptado",
+    )
+    assert AdmisionService._render_celda_gde_html(archivo, None) is None

--- a/admisiones/views/web_views.py
+++ b/admisiones/views/web_views.py
@@ -617,6 +617,7 @@ def actualizar_estado_archivo(request):
                 "grupo_usuario": resultado.get("grupo_usuario"),
                 "mostrar_select": resultado.get("mostrar_select", False),
                 "opciones": resultado.get("opciones", []),
+                "gde_html": resultado.get("gde_html"),
             }
         )
     else:

--- a/docs/registro/cambios/2026-06-02-issue-1799-fix-gde-ajax.md
+++ b/docs/registro/cambios/2026-06-02-issue-1799-fix-gde-ajax.md
@@ -1,0 +1,58 @@
+# 2026-06-02 — Issue #1799 (feedback punto 4): el campo "Número de GDE" no aparecía en docs de la Admisión
+
+Rama: `claude/issue-1799-fix-gde-ajax-render`
+Issue: [#1799](https://github.com/dsocial118/SISOC/issues/1799) (comentario 2026-06-02, punto 4)
+
+## Problema
+
+El revisor reportó que el campo `Número de GDE` se visualiza para los documentos
+de la Organización pero **no para los documentos de la Admisión**.
+
+**Causa raíz (client-side):** el render server-side ya era correcto
+(`documento_row.html` muestra un campo GDE editable para documentos nativos en
+estado `Aceptado`). El problema aparecía al **aceptar un documento en la misma
+sesión** vía el `<select>` inline: `actualizarEstado()`
+([static/custom/js/admisionesactualizarestado.js](../../../static/custom/js/admisionesactualizarestado.js))
+re-renderizaba **solo** la celda de estado (`displayState`) y **nunca tocaba la
+celda GDE** (`gde-{id}`). Resultado: el badge pasaba a "Aceptado" pero la celda
+GDE conservaba el `-` renderizado cuando el documento estaba `Pendiente`; el campo
+recién aparecía al recargar la página. Los documentos de la Organización "se ven"
+porque llegan ya `Aceptado` desde el Legajo (render server-side).
+
+## Solución
+
+Re-renderizar la celda GDE en el mismo flujo AJAX, reusando la lógica server-side
+(sin duplicar permisos/origen en JS):
+
+- **Partial** [admisiones/templates/admisiones/includes/gde_cell.html](../../../admisiones/templates/admisiones/includes/gde_cell.html):
+  se extrae el interior del `<td id="gde-...">` a un include reutilizable.
+  `documento_row.html` ahora lo incluye (sin cambio visual).
+- **Servicio** `AdmisionService._render_celda_gde_html(archivo, request)` +
+  `gde_html` en `_build_success_actualizar_estado_ajax_response`
+  ([admisiones/services/admisiones_service/impl.py](../../../admisiones/services/admisiones_service/impl.py)):
+  serializa el `ArchivoAdmision` (`_serialize_documentacion` o
+  `serialize_documento_personalizado`) y renderiza el partial con `render_to_string`.
+- **Vista** `actualizar_estado_archivo`
+  ([admisiones/views/web_views.py](../../../admisiones/views/web_views.py)):
+  reenvía `gde_html` en el JSON de éxito.
+- **JS**: al recibir la respuesta, si viene `gde_html` se inyecta en
+  `#gde-{documentoId}`. Los `data-call-click` del widget funcionan por delegación
+  de eventos ([base.js](../../../static/custom/js/base.js)), así que el campo queda
+  operativo sin re-binding.
+
+Documentos de origen organizacional siguen en **solo lectura** admisión-side
+(el GDE se gestiona desde el Legajo, #1799 Req 3).
+
+## Validación
+
+Entorno local Windows (Docker apagado, ver memoria de validación):
+
+- `python -m py_compile` sobre impl.py / web_views.py / test → OK.
+- `python -m black --check` sobre los .py → sin cambios.
+- `python -m djlint --reformat` sobre los templates → canónicos.
+- Tests nuevos: [admisiones/tests/test_gde_cell_ajax.py](../../../admisiones/tests/test_gde_cell_ajax.py)
+  (doc nativo aceptado → campo editable; doc origen-org → solo lectura; no aceptado
+  → `-`). Corren en la CI del PR (pytest local requiere Docker).
+
+Manual: aceptar un documento nativo de la admisión → el campo `Número de GDE`
+aparece sin recargar la página.

--- a/static/custom/js/admisionesactualizarestado.js
+++ b/static/custom/js/admisionesactualizarestado.js
@@ -241,6 +241,16 @@ function actualizarEstado(selectElement, observacionForzada = null) {
                 selectElement.dataset.currentValue = nuevoEstado;
             }
 
+            // Re-render de la celda "Número de GDE": al cambiar el estado del
+            // documento (p.ej. -> Aceptado) el campo GDE debe aparecer/ocultarse
+            // sin recargar la pagina (issue #1799, feedback punto 4).
+            if (data.gde_html !== undefined && data.gde_html !== null) {
+                const gdeCell = document.getElementById(`gde-${documentoId}`);
+                if (gdeCell) {
+                    gdeCell.innerHTML = data.gde_html;
+                }
+            }
+
             const toastEl = document.getElementById("toastEstadoExito");
             if (toastEl) {
                 new bootstrap.Toast(toastEl).show();


### PR DESCRIPTION
## Contexto

Feedback del issue #1799 (comentario 2026-06-02), **punto 4**: "Se visualiza correctamente el campo `Número de GDE` para los documentos de la Organización pero no para los documentos de la Admisión".

## Causa raíz (client-side)

El render server-side ya era correcto. El problema aparecía al **aceptar un documento en la misma sesión** vía el `<select>` inline: `actualizarEstado()` re-renderizaba **solo** la celda de estado y **nunca la celda GDE** (`gde-{id}`), que quedaba con el `-` del render previo (`Pendiente`). El campo recién aparecía al recargar. Los documentos de la Organización "se ven" porque llegan ya `Aceptado` desde el Legajo.

## Solución

Re-renderizar la celda GDE en el mismo flujo AJAX, reusando la lógica server-side (sin duplicar permisos/origen en JS):

- Nuevo partial `admisiones/includes/gde_cell.html` (extraído del `<td id="gde-...">`); `documento_row.html` lo incluye (sin cambio visual).
- `AdmisionService._render_celda_gde_html` + `gde_html` en la respuesta de `actualizar_estado_archivo`.
- El JS inyecta `gde_html` en `#gde-{id}`; los `data-call-click` funcionan por delegación de eventos (`base.js`), sin re-binding.

Los documentos de **origen organizacional** siguen en solo lectura admisión-side (el GDE se gestiona desde el Legajo — #1799 Req 3).

## Tests

`admisiones/tests/test_gde_cell_ajax.py`: doc nativo aceptado → campo editable; doc origen-org → solo lectura; no aceptado → `-`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)