### PR TITLE
fix(admisiones): 'Actualizar desde Legajo' dirigido, sin sobreescribir docs de la Admisión (#1799 feedback p1)

### DIFF
--- a/admisiones/services/admisiones_service/impl.py
+++ b/admisiones/services/admisiones_service/impl.py
@@ -1217,6 +1217,69 @@ class AdmisionService:
         )
         return True, "Continuara operando con la informacion actual de la admision."
 
+    @staticmethod
+    def actualizar_documentacion_desde_organizacion(admision, user=None):
+        """Issue #1799 (feedback punto 1): "Actualizar Informacion desde Legajo
+        Organizacion" DIRIGIDO. Refresca SOLO los documentos de origen
+        organizacional cuyo slot cambio (agregado / modificado / quitado),
+        preservando los documentos nativos de la admision (cargados admision-side)
+        y los de origen organizacional NO modificados. No resetea ``tipo_convenio``
+        ni ``estado`` (a diferencia de ``resync_admision_desde_organizacion``, que
+        aplica cuando cambio el Tipo de Entidad y reconstruye todo)."""
+        organizacion = getattr(getattr(admision, "comedor", None), "organizacion", None)
+        if not organizacion:
+            return False, "La admision no tiene organizacion asociada."
+
+        actuales = AdmisionService._tokens_org_actuales(admision)
+        snapshots = {
+            snap.slot_key: snap
+            for snap in AdmisionDocOrgSnapshot.objects.filter(admision=admision)
+        }
+        slots_a_refrescar = set()
+        for slot, data in actuales.items():
+            snap = snapshots.get(slot)
+            if snap is None or snap.token != data["token"]:
+                slots_a_refrescar.add(slot)  # agregado / modificado
+        for slot in snapshots:
+            if slot not in actuales:
+                slots_a_refrescar.add(slot)  # quitado del legajo
+
+        if not slots_a_refrescar:
+            AdmisionService.refrescar_snapshot_documentacion_organizacional(admision)
+            return True, "La documentacion ya estaba actualizada con el Legajo."
+
+        # Borrar SOLO los ArchivoAdmision de origen organizacional de los slots
+        # que cambiaron. Nunca se tocan los documentos nativos de la admision
+        # (sin archivo_organizacion_origen) ni los de origen organizacional no
+        # modificados.
+        borrados = 0
+        for archivo_adm in ArchivoAdmision.objects.filter(
+            admision=admision, archivo_organizacion_origen__isnull=False
+        ).select_related("archivo_organizacion_origen"):
+            origin = archivo_adm.archivo_organizacion_origen
+            if origin.documentacion_id:
+                slot = f"doc:{origin.documentacion_id}"
+            else:
+                slot = f"custom:{origin.id}"
+            if slot in slots_a_refrescar:
+                archivo_adm.delete()
+                borrados += 1
+
+        # Re-materializar (aditivo): re-crea desde el legajo los slots borrados que
+        # siguen vigentes; los quitados no se re-crean; preserva nativos y los no
+        # modificados (congelar saltea los que ya existen).
+        AdmisionService.congelar_documentacion_organizacional(admision, user)
+        AdmisionService.refrescar_snapshot_documentacion_organizacional(admision)
+        logger.info(
+            "Documentacion de admision actualizada (dirigida) desde la organizacion",
+            extra={
+                "admision_pk": admision.pk,
+                "slots_refrescados": sorted(slots_a_refrescar),
+                "archivos_borrados": borrados,
+            },
+        )
+        return True, "Documentacion actualizada desde el Legajo de la Organizacion."
+
     # ------------------------------------------------------------------
     # Issue #1799 Req 1: deteccion de cambios en la documentacion del legajo
     # ------------------------------------------------------------------

--- a/admisiones/tests/test_actualizar_documentacion_dirigido.py
+++ b/admisiones/tests/test_actualizar_documentacion_dirigido.py
@@ -1,0 +1,145 @@
+"""Issue #1799 (feedback punto 1): "Actualizar Información desde Legajo Organización"
+DIRIGIDO. Debe refrescar solo los documentos org cuyo slot cambió y PRESERVAR los
+documentos nativos de la admisión (cargados admisión-side) y los org no modificados,
+sin resetear tipo_convenio ni estado. Antes borraba TODOS los ArchivoAdmision."""
+
+import pytest
+
+from admisiones.models.admisiones import (
+    Admision,
+    ArchivoAdmision,
+    Documentacion,
+    EstadoAdmision,
+    TipoConvenio,
+)
+from admisiones.services.admisiones_service import AdmisionService
+from comedores.models import Comedor
+from organizaciones.models import (
+    ArchivoOrganizacion,
+    DocumentacionOrganizacion,
+    Organizacion,
+    TipoEntidad,
+)
+
+
+pytestmark = pytest.mark.django_db
+
+
+@pytest.fixture
+def setup():
+    tipo = TipoEntidad.objects.create(nombre="Personería Jurídica")
+    organizacion = Organizacion.objects.create(nombre="Org Dir", tipo_entidad=tipo)
+    comedor = Comedor.objects.create(nombre="Comedor Dir", organizacion=organizacion)
+    EstadoAdmision.objects.create(pk=1, nombre="Pendiente")
+    tipo_convenio = TipoConvenio.objects.create(pk=3, nombre="Personería Jurídica")
+    admision = Admision.objects.create(
+        comedor=comedor,
+        tipo_convenio=tipo_convenio,
+        tipo_entidad_origen=tipo,
+        estado_admision="documentacion_en_proceso",
+    )
+
+    # Documento de catálogo de la Organización + su par aliasado en la Admisión.
+    doc_org = DocumentacionOrganizacion.objects.create(
+        nombre="DNI del Presidente",
+        categoria=DocumentacionOrganizacion.CATEGORIA_PERSONERIA,
+        obligatorio=True,
+    )
+    archivo_org = ArchivoOrganizacion.objects.create(
+        organizacion=organizacion,
+        documentacion=doc_org,
+        archivo="organizaciones/dni.pdf",
+        estado=ArchivoOrganizacion.ESTADO_PENDIENTE,
+    )
+    doc_adm = Documentacion.objects.create(nombre="DNI Presidente", obligatorio=True)
+    doc_adm.convenios.add(tipo_convenio)
+
+    # Materializar (org -> admisión) y dejar el snapshot en sync.
+    AdmisionService.congelar_documentacion_organizacional(admision)
+    AdmisionService.refrescar_snapshot_documentacion_organizacional(admision)
+
+    # Documento NATIVO de la admisión (cargado admisión-side): debe preservarse.
+    doc_nativo = Documentacion.objects.create(nombre="Memo PNUD", obligatorio=True)
+    doc_nativo.convenios.add(tipo_convenio)
+    archivo_nativo = ArchivoAdmision.objects.create(
+        admision=admision,
+        documentacion=doc_nativo,
+        archivo="admisiones/memo.pdf",
+        estado="aceptado",
+        numero_gde="GDE-NATIVO-1",
+    )
+
+    return {
+        "admision": admision,
+        "archivo_org": archivo_org,
+        "doc_adm": doc_adm,
+        "archivo_nativo": archivo_nativo,
+    }
+
+
+def _archivo_org_materializado(admision, doc_adm):
+    return ArchivoAdmision.objects.filter(
+        admision=admision, documentacion=doc_adm
+    ).first()
+
+
+def test_actualizar_refresca_doc_cambiado_y_preserva_nativo(setup):
+    admision = setup["admision"]
+    materializado_previo = _archivo_org_materializado(admision, setup["doc_adm"])
+    assert materializado_previo is not None
+    assert materializado_previo.archivo_organizacion_origen_id is not None
+    convenio_previo = admision.tipo_convenio_id
+    estado_admision_previo = admision.estado_admision
+
+    # Cambio SOLO de documentación: el doc org pasa Pendiente -> Aceptado.
+    setup["archivo_org"].estado = ArchivoOrganizacion.ESTADO_ACEPTADO
+    setup["archivo_org"].save(update_fields=["estado"])
+
+    ok, _ = AdmisionService.actualizar_documentacion_desde_organizacion(admision)
+    assert ok is True
+
+    # El doc org materializado se refrescó al nuevo estado.
+    materializado = _archivo_org_materializado(admision, setup["doc_adm"])
+    assert materializado is not None
+    assert materializado.estado == ArchivoOrganizacion.ESTADO_ACEPTADO
+
+    # El doc NATIVO se preservó intacto (mismo registro, mismo GDE).
+    nativo = ArchivoAdmision.objects.get(pk=setup["archivo_nativo"].pk)
+    assert nativo.estado == "aceptado"
+    assert nativo.numero_gde == "GDE-NATIVO-1"
+    assert nativo.archivo_organizacion_origen_id is None
+
+    # No se reseteó convenio ni estado de la admisión.
+    admision.refresh_from_db()
+    assert admision.tipo_convenio_id == convenio_previo
+    assert admision.estado_admision == estado_admision_previo
+
+
+def test_actualizar_sin_cambios_no_toca_nada(setup):
+    admision = setup["admision"]
+    materializado_previo = _archivo_org_materializado(admision, setup["doc_adm"])
+    nativo_previo_pk = setup["archivo_nativo"].pk
+
+    ok, mensaje = AdmisionService.actualizar_documentacion_desde_organizacion(admision)
+
+    assert ok is True
+    # El doc org materializado sigue siendo el mismo registro (no se recreó).
+    materializado = _archivo_org_materializado(admision, setup["doc_adm"])
+    assert materializado.pk == materializado_previo.pk
+    assert ArchivoAdmision.objects.filter(pk=nativo_previo_pk).exists()
+
+
+def test_actualizar_quita_doc_removido_del_legajo_y_preserva_nativo(setup):
+    admision = setup["admision"]
+
+    # El documento se quita del legajo (pierde su archivo => deja de estar vigente).
+    setup["archivo_org"].archivo = ""
+    setup["archivo_org"].save(update_fields=["archivo"])
+
+    ok, _ = AdmisionService.actualizar_documentacion_desde_organizacion(admision)
+    assert ok is True
+
+    # El ArchivoAdmision de origen organizacional se quitó.
+    assert _archivo_org_materializado(admision, setup["doc_adm"]) is None
+    # El doc nativo se preservó.
+    assert ArchivoAdmision.objects.filter(pk=setup["archivo_nativo"].pk).exists()

--- a/admisiones/views/web_views.py
+++ b/admisiones/views/web_views.py
@@ -671,7 +671,16 @@ def resync_convenio_admision(request, admision_pk):
     )
 
     if accion == "actualizar":
-        ok, mensaje = AdmisionService.resync_admision_desde_organizacion(admision)
+        # Si cambio el Tipo de Entidad, el convenio (y su set documental) cambia:
+        # se reconstruye todo (#1605). Si solo cambio la documentacion del legajo,
+        # la actualizacion es DIRIGIDA: refresca lo que cambio y preserva el resto,
+        # sin borrar los documentos cargados admision-side (#1799 feedback punto 1).
+        if AdmisionService.admision_desincronizada(admision):
+            ok, mensaje = AdmisionService.resync_admision_desde_organizacion(admision)
+        else:
+            ok, mensaje = AdmisionService.actualizar_documentacion_desde_organizacion(
+                admision, request.user
+            )
     elif accion == "continuar":
         ok, mensaje = AdmisionService.aceptar_desincronizacion_admision(admision)
     else:

--- a/docs/registro/cambios/2026-06-02-issue-1799-fix-actualizar-dirigido.md
+++ b/docs/registro/cambios/2026-06-02-issue-1799-fix-actualizar-dirigido.md
@@ -1,0 +1,52 @@
+# 2026-06-02 — Issue #1799 (feedback punto 1): "Actualizar desde Legajo" dirigido (no sobreescribir)
+
+Rama: `claude/issue-1799-fix-actualizar-dirigido`
+Issue: [#1799](https://github.com/dsocial118/SISOC/issues/1799) (comentario 2026-06-02, punto 1)
+
+## Problema
+
+El revisor pidió que la alerta y la decisión del Req 1 funcionen para todas las
+admisiones que conviven hoy —incluidas las legacy con 100% de la documentación
+cargada admisión-side, en cualquier estado— **cuidando no sobreescribir la info que
+ya opera en el sistema**.
+
+La opción **"Actualizar Información desde Legajo Organización"** llamaba a
+[resync_admision_desde_organizacion](../../../admisiones/services/admisiones_service/impl.py),
+que hace un **reset total**: cambia `tipo_convenio`, resetea `estado` y **borra
+TODOS los `ArchivoAdmision`** antes de re-materializar. Eso es correcto cuando
+cambia el **Tipo de Entidad** (el convenio y su set documental cambian, #1605),
+pero para un cambio **solo de documentación** destruye los documentos nativos /
+cargados admisión-side que no tienen contraparte en la organización.
+
+## Solución (decisión de producto: actualización DIRIGIDA)
+
+- **Nuevo** `AdmisionService.actualizar_documentacion_desde_organizacion(admision, user)`:
+  calcula el diff entre el snapshot (`AdmisionDocOrgSnapshot`) y el estado actual
+  del legajo (reusa `_tokens_org_actuales`), y refresca **solo** los slots que
+  cambiaron (agregados / modificados / quitados):
+  - borra únicamente los `ArchivoAdmision` **de origen organizacional**
+    (`archivo_organizacion_origen` no nulo) de esos slots;
+  - re-materializa con `congelar_documentacion_organizacional` (aditivo: re-crea los
+    borrados que siguen vigentes, saltea los que ya existen);
+  - **preserva** los documentos nativos de la admisión y los de origen
+    organizacional no modificados;
+  - **no** toca `tipo_convenio` ni `estado`; refresca el snapshot al final.
+- **Routing** en [resync_convenio_admision](../../../admisiones/views/web_views.py)
+  (`accion == "actualizar"`): si cambió el Tipo de Entidad
+  (`admision_desincronizada`) → reset total (comportamiento #1605); si solo cambió
+  la documentación (`documentacion_desactualizada`) → actualización dirigida.
+- `accion == "continuar"` sigue igual (ya preservaba via
+  `aceptar_desincronizacion_admision`).
+
+## Validación
+
+Entorno local Windows (Docker apagado, ver memoria de validación):
+
+- `python -m py_compile` + `python -m black --check` sobre impl.py / web_views.py /
+  test → OK.
+- Tests nuevos: [admisiones/tests/test_actualizar_documentacion_dirigido.py](../../../admisiones/tests/test_actualizar_documentacion_dirigido.py)
+  - doc org cambiado (Pendiente→Aceptado) → se refresca y el doc nativo se preserva;
+    `tipo_convenio`/`estado` intactos;
+  - sin cambios → no se recrea nada;
+  - doc org quitado del legajo → se elimina solo ese, el nativo se preserva.
+  Corren en la CI del PR (pytest local requiere Docker).


### PR DESCRIPTION
## Contexto

Feedback del issue #1799 (comentario 2026-06-02), **punto 1**: la alerta y la decisión deben funcionar para todas las admisiones que conviven hoy (incluidas las legacy con 100% de docs cargados admisión-side, en cualquier estado), **cuidando no sobreescribir la info que ya opera**.

## Causa raíz

"Actualizar Información desde Legajo Organización" llamaba a `resync_admision_desde_organizacion`, que hace un **reset total**: cambia `tipo_convenio`, resetea `estado` y **borra TODOS los `ArchivoAdmision`** antes de re-materializar. Correcto para un cambio de **Tipo de Entidad** (#1605), pero para un cambio **solo de documentación** destruye los documentos nativos/legacy de la admisión que no tienen contraparte en la organización.

## Solución (decisión de producto: actualización DIRIGIDA)

- Nuevo `AdmisionService.actualizar_documentacion_desde_organizacion(admision, user)`: diff del snapshot (`AdmisionDocOrgSnapshot`) vs estado actual del legajo y refresca **solo** los slots que cambiaron:
  - borra únicamente los `ArchivoAdmision` **de origen organizacional** de esos slots;
  - re-materializa con `congelar_documentacion_organizacional` (aditivo);
  - **preserva** los documentos nativos y los org no modificados;
  - **no** toca `tipo_convenio` ni `estado`; refresca el snapshot.
- Routing en `resync_convenio_admision` (`accion == "actualizar"`): reset total si cambió el Tipo de Entidad; dirigido si solo cambió la documentación.
- `"continuar"` sin cambios (ya preservaba).

## Tests

`admisiones/tests/test_actualizar_documentacion_dirigido.py`: doc org cambiado → se refresca y el nativo se preserva (convenio/estado intactos); sin cambios → no recrea nada; doc org quitado → se elimina solo ese, el nativo se preserva.

🤖 Generated with [Claude Code](https://claude.com/claude-code)