### PR TITLE
test: cleanup de 7 tests heredados que dejan pytest en rojo en development

### DIFF
--- a/VAT/tests.py
+++ b/VAT/tests.py
@@ -1,7 +1,7 @@
 import importlib
 from io import BytesIO
 from types import SimpleNamespace
-from datetime import date, time
+from datetime import date, time, timedelta
 import json
 
 import pytest
@@ -14,6 +14,7 @@ from django.core.exceptions import ValidationError
 from django.core.management import call_command
 from django.test import RequestFactory, override_settings
 from django.urls import reverse
+from django.utils import timezone
 from openpyxl import load_workbook
 from rest_framework.test import APIClient
 from rest_framework_api_key.models import APIKey
@@ -8336,14 +8337,20 @@ def _wizard_url(wizard_setup):
 
 
 def _step1_data(wizard_setup):
+    # La validacion del paso 1 exige fecha_inicio >= hoy. Derivar las fechas de
+    # la fecha actual evita que el dato quede en el pasado con el correr del
+    # tiempo (antes estaba hardcodeado "2026-06-01" y rompia a partir del dia
+    # siguiente, dejando el wizard atascado en el paso "info").
+    fecha_inicio = timezone.localdate() + timedelta(days=1)
+    fecha_fin = fecha_inicio + timedelta(days=180)
     return {
         f"{_WIZARD_PREFIX}-current_step": "info",
         "info-ubicacion": str(wizard_setup.ubicacion.pk),
         "info-modalidad": str(wizard_setup.curso.modalidad_id),
         "info-cupo_total": "20",
         "info-estado": "planificada",
-        "info-fecha_inicio": "2026-06-01",
-        "info-fecha_fin": "2026-12-31",
+        "info-fecha_inicio": fecha_inicio.isoformat(),
+        "info-fecha_fin": fecha_fin.isoformat(),
         "info-observaciones": "",
     }
 

--- a/docs/registro/cambios/2026-06-02-cleanup-tests-heredados-pytest.md
+++ b/docs/registro/cambios/2026-06-02-cleanup-tests-heredados-pytest.md
@@ -1,0 +1,82 @@
+# 2026-06-02 — Cleanup de tests heredados que dejaban `pytest` en rojo en `development`
+
+Rama: `chore/cleanup-tests-heredados-pytest` (base: `development`)
+
+## Contexto
+
+El job `pytest` de la CI estaba ROJO en `development` con 7 fallos que **no**
+pertenecían a ningún PR de feature: eran tests desactualizados respecto de código ya
+mergeado (Issue #1799) y un test con fecha hardcodeada que venció con el paso del
+tiempo. Como el job `pytest` solo corre en `pull_request` (no en `push` a
+`development`), estos tests se mergearon rotos y reaparecían en **cualquier** PR
+abierto contra `development` (p.ej. #1822, #1823), bloqueando el deploy guard.
+
+Triaje (confirmado corriendo la suite completa): los 7 son **tests viejos**, no
+regresiones de producción. No se tocó lógica de negocio.
+
+## Cambios aplicados
+
+Solo archivos de test (+ este registro).
+
+### `tests/test_admisiones_service_helpers_unit.py`
+
+- `test_actualizar_numero_gde_ajax_validations`: el mock `SimpleNamespace` del
+  `archivo` no tenía `archivo_organizacion_origen_id`. La producción
+  (`AdmisionService.actualizar_numero_gde_ajax`) consulta ese atributo desde
+  **#1799 Req 3** (commit `fbbe2976`) para bloquear la edición del GDE de documentos de
+  origen organizacional; al faltar saltaba `AttributeError`, se lo capturaba el
+  `try/except` del método y `success` quedaba `False`. Fix: agregar
+  `archivo_organizacion_origen_id=None` al mock.
+- `test_contextos_create_admision_y_instancia_paths`: `create_admision` llama a
+  `congelar_documentacion_organizacional` (#1605) y, desde **#1799 Req 1**
+  (commit `3b6de805`), también a `refrescar_snapshot_documentacion_organizacional`.
+  Este último lee `admision.pk` directamente (`congelar_*` no fallaba porque usa
+  `getattr` y corta temprano si la admisión mock no tiene `comedor`/`organizacion`).
+  El objeto devuelto por el mock de `Admision.objects.create` era
+  `SimpleNamespace(id=99)` sin `pk` → `AttributeError` → `create_admision` devolvía
+  `None`. Fix: mockear ambos helpers (igual que el test vecino
+  `test_get_admision_update_context_*` ya mockea `congelar_*`), aislando la
+  orquestación de `create_admision` de la lógica de snapshot/freeze, que tiene sus
+  propios tests.
+
+### `VAT/tests.py`
+
+- Helper `_step1_data` del wizard de comisión de curso: tenía
+  `info-fecha_inicio = "2026-06-01"` hardcodeado (introducido el 2026-05-26, commit
+  `0b16e237`, cuando era fecha futura). `ComisionCursoWizardStep1Form.clean()` exige
+  `fecha_inicio >= hoy`; al pasar el 2026-06-01 la fecha quedó en el pasado, el paso 1
+  dejó de validar y el wizard quedaba atascado en el step `info`. Eso rompía los 5
+  tests que dependen de avanzar de step: `test_wizard_step2_duracion_menor_45min_es_rechazada`,
+  `test_wizard_step2_duracion_mayor_4h_es_rechazada`,
+  `test_wizard_step2_total_semanal_menor_2h_es_rechazado`,
+  `test_wizard_step2_dias_duplicados_son_rechazados` y
+  `test_wizard_flujo_completo_crea_comision_y_horario` (los AttributeError
+  `'ComisionCursoWizardStep1Form' object has no attribute 'forms'/'non_form_errors'` y
+  el `assert 'info' == 'horarios'` eran síntomas de eso). Fix: derivar
+  `fecha_inicio = timezone.localdate() + 1 día` y `fecha_fin = fecha_inicio + 180 días`
+  (imports `timedelta` y `django.utils.timezone`), eliminando la dependencia del reloj.
+  Los tests vecinos que prueban fechas inválidas (`..._fecha_inicio_pasada`,
+  `..._fecha_fin_igual_a_inicio`) ya sobreescriben las fechas y siguen pasando.
+
+## Impacto esperado
+
+- Ningún cambio de comportamiento de producción (cambios solo en tests).
+- El job `pytest` pasa de 7 fallos a 0.
+
+## Validación
+
+Docker one-off contra el checkout, SQLite en memoria con migraciones (igual que el job
+`pytest` de CI: `USE_SQLITE_FOR_TESTS=1`), `pytest -n auto`:
+
+- Baseline (sin fix): `7 failed, 2558 passed, 1 skipped` — exactamente los 7 reportados
+  por CI, ni uno más.
+- Post-fix (suite completa): `2565 passed, 1 skipped, 0 failed` (exit 0).
+- `python -m black --check` sobre los dos archivos tocados → limpio.
+
+## Riesgos y rollback
+
+- Riesgo a nivel producto: nulo (no se tocó código de producción).
+- `_step1_data` ahora depende de `timezone.localdate()`; si en el futuro se agrega una
+  validación de duración máxima entre `fecha_inicio` y `fecha_fin`, revisar el offset de
+  180 días.
+- Rollback: revertir el commit del PR.

--- a/tests/test_admisiones_service_helpers_unit.py
+++ b/tests/test_admisiones_service_helpers_unit.py
@@ -661,6 +661,9 @@ def test_actualizar_numero_gde_ajax_validations(mocker):
     archivo = SimpleNamespace(
         estado="Aceptado",
         numero_gde="OLD",
+        # Issue #1799 Req 3: la produccion ahora consulta este atributo para
+        # bloquear la edicion del GDE de documentos de origen organizacional.
+        archivo_organizacion_origen_id=None,
         admision=SimpleNamespace(comedor=SimpleNamespace()),
         save=mocker.Mock(),
     )
@@ -1162,6 +1165,14 @@ def test_contextos_create_admision_y_instancia_paths(mocker):
     create_mock = mocker.patch(
         "admisiones.services.admisiones_service.Admision.objects.create",
         return_value=admision,
+    )
+    # Issue #1799 Req 1 / #1605: create_admision congela y refresca el snapshot
+    # de documentacion organizacional de la admision recien creada. Esos helpers
+    # leen admision.pk y consultan la BD; aca probamos la orquestacion de
+    # create_admision (que llama a create y devuelve la admision), no su logica.
+    mocker.patch.object(module.AdmisionService, "congelar_documentacion_organizacional")
+    mocker.patch.object(
+        module.AdmisionService, "refrescar_snapshot_documentacion_organizacional"
     )
     mocker.patch(
         "admisiones.services.admisiones_service.TipoConvenio.objects.exclude",


### PR DESCRIPTION
## Qué

Cleanup chico: deja el job `pytest` de la CI en verde en `development` (7 → 0 fallos).
**Solo se tocan tests**; no se cambia comportamiento de producción.

## Por qué

Los 7 fallos no pertenecen a ningún PR de feature: son tests desactualizados respecto de
código ya mergeado (Issue #1799) y un test con fecha hardcodeada que venció con el paso
del tiempo. Como el job `pytest` solo corre en `pull_request` (no en `push` a
`development`), se mergearon rotos y reaparecen en **cualquier** PR contra `development`
(p.ej. #1822, #1823, que no tocan estas áreas y los reproducen igual), bloqueando el
deploy guard.

## Triaje (los 7 son tests viejos, no regresiones)

**`tests/test_admisiones_service_helpers_unit.py`**
- `test_actualizar_numero_gde_ajax_validations`: la producción lee
  `archivo.archivo_organizacion_origen_id` desde **#1799 Req 3** (`fbbe2976`); el mock no
  lo tenía → `AttributeError` → `success=False`. Fix: `archivo_organizacion_origen_id=None`
  en el mock.
- `test_contextos_create_admision_y_instancia_paths`: `create_admision` llama a
  `refrescar_snapshot_documentacion_organizacional` desde **#1799 Req 1** (`3b6de805`), que
  lee `admision.pk`; el objeto del mock de `Admision.objects.create` no lo tenía →
  `create_admision` devolvía `None`. Fix: mockear
  `congelar_`/`refrescar_snapshot_documentacion_organizacional` (igual que el test vecino
  `test_get_admision_update_context_*` ya mockea `congelar_`).

**`VAT/tests.py`** (5 tests del wizard de comisión de curso: 8442/8455/8468/8494/8505)
- `_step1_data` tenía `fecha_inicio = "2026-06-01"` hardcodeada (commit `0b16e237`, era
  futura cuando se escribió). `ComisionCursoWizardStep1Form.clean()` exige
  `fecha_inicio >= hoy`; al vencer, el paso 1 dejó de validar y el wizard quedaba atascado
  en el step `info`. Los errores `'ComisionCursoWizardStep1Form' object has no attribute
  'forms'/'non_form_errors'` y el `assert 'info' == 'horarios'` eran síntomas de eso. Fix:
  derivar la fecha dinámicamente (`timezone.localdate() + 1d`, fin +180d).

## Validación

Docker one-off contra el checkout, SQLite en memoria **con migraciones** (igual que el job
`pytest` de CI: `USE_SQLITE_FOR_TESTS=1`), `pytest -n auto`:
- **Baseline (sin fix):** `7 failed, 2558 passed, 1 skipped` — exactamente los 7 de CI, ni uno más.
- **Post-fix (suite completa):** `2565 passed, 1 skipped, 0 failed`.
- `python -m black --check` sobre los dos archivos tocados → limpio.

Registro: `docs/registro/cambios/2026-06-02-cleanup-tests-heredados-pytest.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
