### PR TITLE
fix: corrige 3 problemas detectados en revisión del PR #1826

### DIFF
--- a/VAT/forms.py
+++ b/VAT/forms.py
@@ -93,15 +93,18 @@ def _normalize_curso_tipo_value(nombre):
     return normalized
 
 
-def _collect_curso_tipo_values_from_existing_courses():
+def _collect_curso_tipo_values_from_existing_courses(centro_id=None):
+    qs = Curso.objects.values_list("tipo", flat=True)
+    if centro_id:
+        qs = qs.filter(centro_id=centro_id)
     values = []
-    for tipo_list in Curso.objects.values_list("tipo", flat=True):
+    for tipo_list in qs:
         if isinstance(tipo_list, list):
             values.extend(tipo_list)
     return _normalize_related_ids(values)
 
 
-def build_curso_tipo_choices(include_values=None):
+def build_curso_tipo_choices(include_values=None, centro_id=None):
     include_values = _normalize_related_ids(include_values)
     choices = []
     seen_values = set()
@@ -116,7 +119,7 @@ def build_curso_tipo_choices(include_values=None):
         seen_values.add(value)
 
     include_values = _normalize_related_ids(
-        [*_collect_curso_tipo_values_from_existing_courses(), *include_values]
+        [*_collect_curso_tipo_values_from_existing_courses(centro_id=centro_id), *include_values]
     )
 
     for value in include_values:
@@ -1708,6 +1711,7 @@ class CursoForm(forms.ModelForm):
         )
         self.fields["tipo"].choices = build_curso_tipo_choices(
             include_values=current_tipo_values,
+            centro_id=centro_id,
         )
 
     def clean(self):

--- a/VAT/views/oferta_institucional.py
+++ b/VAT/views/oferta_institucional.py
@@ -47,6 +47,7 @@ from VAT.services.access_scope import (
     filter_sesiones_queryset_for_management,
     filter_sesiones_queryset_for_user,
 )
+from VAT.services.sesion_comision_service.impl import SesionComisionService
 
 logger = logging.getLogger("django")
 
@@ -523,8 +524,6 @@ class ComisionUpdateView(LoginRequiredMixin, UpdateView):
         return form
 
     def form_valid(self, form):
-        from VAT.services.sesion_comision_service.impl import SesionComisionService
-
         fechas_cambiaron = bool({"fecha_inicio", "fecha_fin"} & set(form.changed_data))
         messages.success(self.request, "Comisión actualizada exitosamente.")
         response = super().form_valid(form)


### PR DESCRIPTION
## Resumen

Correcciones para los problemas encontrados en la revisión del [PR #1826](https://github.com/dsocial118/SISOC/pull/1826).

- **Migración faltante** — se agrega `0048_remove_comisioncurso_modalidad.py` para eliminar `ComisionCurso.modalidad` de la base de datos. Sin esta migración el PR no puede desplegarse (Django SystemCheckError + CI falla).
- **Query sin acotar en `build_curso_tipo_choices`** — `_collect_curso_tipo_values_from_existing_courses` cargaba los tipos de **todos** los cursos de la DB. Ahora acepta `centro_id` y filtra por centro, lo que es la semántica correcta: los choices históricos relevantes son los del mismo centro.
- **Import dentro de método** — `SesionComisionService` se importaba dentro de `ComisionUpdateView.form_valid`. Movido al tope del módulo.

## Test plan

- [ ] Verificar que `python manage.py migrate` corre sin errores en el entorno de dev
- [ ] Abrir el modal de Nuevo/Editar Curso en un centro: el selector de Tipo muestra solo los tipos activos + los previamente usados por cursos del mismo centro
- [ ] Editar una `Comision` cambiando fecha de inicio/fin: las sesiones se regeneran correctamente

🤖 Generated with [Claude Code](https://claude.com/claude-code)