### PR TITLE
fix(dispositivos): aplicar alcance territorial provincial (#1824)

### DIFF
--- a/celiaquia/tests/test_expediente_detail.py
+++ b/celiaquia/tests/test_expediente_detail.py
@@ -372,6 +372,7 @@ def test_expediente_detail_expone_motivo_rechazo_para_provincia(client):
         nombre="Lucia",
         fecha_nacimiento=date(2005, 5, 1),
         documento=33444555,
+        provincia=provincia,
     )
     legajo = ExpedienteCiudadano.objects.create(
         expediente=expediente,

--- a/dispositivos/forms.py
+++ b/dispositivos/forms.py
@@ -555,9 +555,12 @@ class DispositivoForm(forms.ModelForm):
                 "nombre"
             )
             if geo_scope is not None:
-                municipios_permitidos = geo_scope.get(provincia.pk)
-                if municipios_permitidos is not None:
-                    municipio_qs = municipio_qs.filter(pk__in=municipios_permitidos)
+                if provincia.pk not in geo_scope:
+                    # Provincia fuera del alcance del usuario: sin municipios válidos.
+                    municipio_qs = Municipio.objects.none()
+                elif geo_scope[provincia.pk] is not None:
+                    # Alcance limitado a municipios específicos de la provincia.
+                    municipio_qs = municipio_qs.filter(pk__in=geo_scope[provincia.pk])
             self.fields["municipio"].queryset = municipio_qs
         else:
             self.fields["municipio"].queryset = Municipio.objects.none()

--- a/dispositivos/forms.py
+++ b/dispositivos/forms.py
@@ -4,6 +4,7 @@ from django.core.exceptions import ValidationError
 from core.models import Municipio, Provincia
 
 from .models import Dispositivo
+from .services import get_dispositivos_geography_scope
 from .validators import DOCUMENTACION_ACCEPT_ATTR, DOCUMENTACION_UPLOAD_FIELDS
 
 
@@ -469,6 +470,7 @@ class DispositivoForm(forms.ModelForm):
         ]
 
     def __init__(self, *args, **kwargs):
+        self._form_user = kwargs.pop("user", None)
         super().__init__(*args, **kwargs)
         self._configure_geography_fields()
         self._apply_field_texts()
@@ -536,16 +538,27 @@ class DispositivoForm(forms.ModelForm):
         def parse_pk(value):
             return int(value) if value and str(value).isdigit() else None
 
+        geo_scope = get_dispositivos_geography_scope(self._form_user)
+
         provincia = Provincia.objects.filter(
             pk=parse_pk(self.data.get(self.add_prefix("provincia")))
         ).first() or getattr(self.instance, "provincia", None)
 
-        self.fields["provincia"].queryset = Provincia.objects.all().order_by("nombre")
+        provincia_qs = Provincia.objects.all().order_by("nombre")
+        if geo_scope is not None:
+            provincia_qs = provincia_qs.filter(pk__in=geo_scope.keys())
+        self.fields["provincia"].queryset = provincia_qs
+
         if provincia:
             self.fields["provincia"].initial = provincia
-            self.fields["municipio"].queryset = Municipio.objects.filter(
-                provincia=provincia
-            ).order_by("nombre")
+            municipio_qs = Municipio.objects.filter(provincia=provincia).order_by(
+                "nombre"
+            )
+            if geo_scope is not None:
+                municipios_permitidos = geo_scope.get(provincia.pk)
+                if municipios_permitidos is not None:
+                    municipio_qs = municipio_qs.filter(pk__in=municipios_permitidos)
+            self.fields["municipio"].queryset = municipio_qs
         else:
             self.fields["municipio"].queryset = Municipio.objects.none()
 

--- a/dispositivos/services.py
+++ b/dispositivos/services.py
@@ -1,4 +1,7 @@
+from django.db.models import Q
 from django.shortcuts import get_object_or_404
+
+from users.territorial_scope import get_effective_scopes, is_territorial_user
 
 from .models import Dispositivo
 
@@ -8,6 +11,62 @@ def get_dispositivos_queryset():
         "-created_at",
         "nombre_institucion",
     )
+
+
+def apply_dispositivos_scope(queryset, user):
+    """Acota el queryset de dispositivos al alcance territorial del usuario.
+
+    - Sin usuario autenticado: queryset vacío.
+    - Superusuario o usuario sin alcance provincial: sin restricción.
+    - Usuario provincial: provincia y, si corresponde, municipio.
+
+    El modelo ``Dispositivo`` no tiene localidad, por lo que un alcance a nivel
+    localidad se respeta hasta su municipio (la granularidad más fina posible).
+    Un usuario provincial sin alcances configurados no ve ningún registro.
+    """
+    if not user or not getattr(user, "is_authenticated", False):
+        return queryset.none()
+    if getattr(user, "is_superuser", False):
+        return queryset
+    if not is_territorial_user(user):
+        return queryset
+
+    scopes = get_effective_scopes(user)
+    if not scopes:
+        return queryset.none()
+
+    scope_q = Q()
+    for scope in scopes:
+        condiciones = {"provincia_id": scope.provincia_id}
+        if scope.municipio_id:
+            condiciones["municipio_id"] = scope.municipio_id
+        scope_q |= Q(**condiciones)
+    return queryset.filter(scope_q).distinct()
+
+
+def get_dispositivos_geography_scope(user):
+    """Mapa ``provincia_id -> set(municipio_id) | None`` para acotar el formulario.
+
+    Devuelve ``None`` si el usuario no tiene restricción territorial (sin usuario,
+    superusuario o usuario no provincial). Cuando el valor de una provincia es
+    ``None`` significa que se permite la provincia completa; un ``set`` limita a
+    esos municipios.
+    """
+    if not user or not getattr(user, "is_authenticated", False):
+        return None
+    if getattr(user, "is_superuser", False) or not is_territorial_user(user):
+        return None
+
+    restriccion = {}
+    for scope in get_effective_scopes(user):
+        provincia_id = scope.provincia_id
+        if provincia_id in restriccion and restriccion[provincia_id] is None:
+            continue
+        if scope.municipio_id is None:
+            restriccion[provincia_id] = None
+        else:
+            restriccion.setdefault(provincia_id, set()).add(scope.municipio_id)
+    return restriccion
 
 
 def get_dispositivo_or_404(pk):

--- a/dispositivos/services.py
+++ b/dispositivos/services.py
@@ -1,5 +1,4 @@
 from django.db.models import Q
-from django.shortcuts import get_object_or_404
 
 from users.territorial_scope import get_effective_scopes, is_territorial_user
 
@@ -67,10 +66,6 @@ def get_dispositivos_geography_scope(user):
         else:
             restriccion.setdefault(provincia_id, set()).add(scope.municipio_id)
     return restriccion
-
-
-def get_dispositivo_or_404(pk):
-    return get_object_or_404(get_dispositivos_queryset(), pk=pk)
 
 
 def save_dispositivo_from_form(form, *, instance=None):

--- a/dispositivos/tests/test_dispositivos_views.py
+++ b/dispositivos/tests/test_dispositivos_views.py
@@ -5,6 +5,7 @@ from django.urls import reverse
 
 from core.models import Municipio, Provincia
 from dispositivos.models import Dispositivo
+from users.models import Profile, ProfileTerritorialScope
 
 
 @pytest.fixture
@@ -442,3 +443,226 @@ def test_formulario_micro_ajustes_visibles(client, user_con_permisos):
     assert (
         'class="col-md-12"' in bloque_necesidades
     ), "Necesidades prioritarias debe estar en col-md-12"
+
+
+DISPOSITIVOS_PERMISOS = [
+    "add_dispositivo",
+    "change_dispositivo",
+    "delete_dispositivo",
+    "view_dispositivo",
+]
+
+
+def _agregar_permisos_dispositivos(user):
+    perms = Permission.objects.filter(
+        content_type__app_label="dispositivos",
+        codename__in=DISPOSITIVOS_PERMISOS,
+    )
+    user.user_permissions.add(*perms)
+
+
+def _crear_usuario_provincial(username, *, provincia, municipio=None):
+    user = User.objects.create_user(username=username, password="test1234")
+    _agregar_permisos_dispositivos(user)
+    profile, _ = Profile.objects.get_or_create(user=user)
+    profile.es_usuario_provincial = True
+    profile.save()
+    ProfileTerritorialScope.objects.create(
+        profile=profile, provincia=provincia, municipio=municipio
+    )
+    return user
+
+
+def _form_post_data(provincia, municipio, **overrides):
+    data = {
+        "nombre_institucion": "Dispositivo Scope",
+        "tipo_gestion": "estatal",
+        "cuit_institucion": "20123456789",
+        "provincia": provincia.id,
+        "municipio": municipio.id,
+        "calle": "Calle 1",
+        "altura": "123",
+        "telefono_prefijo": "221",
+        "telefono_numero": "1234567",
+        "responsable_nombre_completo": "Juan Perez",
+        "responsable_dni": "12345678",
+        "tipo_dispositivo": "refugio",
+        "modalidad_funcionamiento": "permanente",
+        "capacidad_total_plazas": "16_30",
+    }
+    data.update(overrides)
+    return data
+
+
+@pytest.fixture
+def dos_provincias(db):
+    provincia_a = Provincia.objects.create(nombre="Buenos Aires")
+    provincia_b = Provincia.objects.create(nombre="Cordoba")
+    municipio_a = Municipio.objects.create(nombre="La Plata", provincia=provincia_a)
+    municipio_b = Municipio.objects.create(nombre="Capital", provincia=provincia_b)
+    return provincia_a, municipio_a, provincia_b, municipio_b
+
+
+@pytest.mark.django_db
+def test_listado_usuario_provincial_ve_solo_su_provincia(client, dos_provincias):
+    provincia_a, municipio_a, provincia_b, municipio_b = dos_provincias
+    _crear_dispositivo(
+        provincia_a, municipio_a, indice=1, nombre_institucion="Disp Provincia A"
+    )
+    _crear_dispositivo(
+        provincia_b, municipio_b, indice=2, nombre_institucion="Disp Provincia B"
+    )
+    user = _crear_usuario_provincial("prov-a", provincia=provincia_a)
+
+    client.force_login(user)
+    response = client.get(reverse("dispositivos_listar"))
+
+    assert response.status_code == 200
+    contenido = response.content.decode("utf-8")
+    assert "Disp Provincia A" in contenido
+    assert "Disp Provincia B" not in contenido
+
+
+@pytest.mark.django_db
+def test_listado_usuario_provincial_con_municipio_ve_solo_su_municipio(
+    client, dos_provincias
+):
+    provincia_a, municipio_a, _provincia_b, _municipio_b = dos_provincias
+    otro_municipio = Municipio.objects.create(nombre="Quilmes", provincia=provincia_a)
+    _crear_dispositivo(
+        provincia_a, municipio_a, indice=3, nombre_institucion="Disp Municipio A1"
+    )
+    _crear_dispositivo(
+        provincia_a, otro_municipio, indice=4, nombre_institucion="Disp Municipio A2"
+    )
+    user = _crear_usuario_provincial(
+        "prov-a-muni", provincia=provincia_a, municipio=municipio_a
+    )
+
+    client.force_login(user)
+    response = client.get(reverse("dispositivos_listar"))
+
+    assert response.status_code == 200
+    contenido = response.content.decode("utf-8")
+    assert "Disp Municipio A1" in contenido
+    assert "Disp Municipio A2" not in contenido
+
+
+@pytest.mark.django_db
+def test_listado_usuario_sin_provincia_ve_todos(
+    client, user_con_permisos, dos_provincias
+):
+    provincia_a, municipio_a, provincia_b, municipio_b = dos_provincias
+    _crear_dispositivo(
+        provincia_a, municipio_a, indice=5, nombre_institucion="Disp Libre A"
+    )
+    _crear_dispositivo(
+        provincia_b, municipio_b, indice=6, nombre_institucion="Disp Libre B"
+    )
+
+    client.force_login(user_con_permisos)
+    response = client.get(reverse("dispositivos_listar"))
+
+    assert response.status_code == 200
+    contenido = response.content.decode("utf-8")
+    assert "Disp Libre A" in contenido
+    assert "Disp Libre B" in contenido
+
+
+@pytest.mark.django_db
+def test_listado_superusuario_ve_todos(client, dos_provincias):
+    provincia_a, municipio_a, provincia_b, municipio_b = dos_provincias
+    _crear_dispositivo(
+        provincia_a, municipio_a, indice=7, nombre_institucion="Disp Admin A"
+    )
+    _crear_dispositivo(
+        provincia_b, municipio_b, indice=8, nombre_institucion="Disp Admin B"
+    )
+    admin = User.objects.create_superuser(
+        username="admin-disp", password="test1234", email="admin@example.com"
+    )
+
+    client.force_login(admin)
+    response = client.get(reverse("dispositivos_listar"))
+
+    assert response.status_code == 200
+    contenido = response.content.decode("utf-8")
+    assert "Disp Admin A" in contenido
+    assert "Disp Admin B" in contenido
+
+
+@pytest.mark.django_db
+def test_detalle_usuario_provincial_accede_en_su_provincia(client, dos_provincias):
+    provincia_a, municipio_a, _provincia_b, _municipio_b = dos_provincias
+    dispositivo = _crear_dispositivo(provincia_a, municipio_a, indice=9)
+    user = _crear_usuario_provincial("prov-a-detalle", provincia=provincia_a)
+
+    client.force_login(user)
+    response = client.get(
+        reverse("dispositivos_detalle", kwargs={"pk": dispositivo.pk})
+    )
+
+    assert response.status_code == 200
+
+
+@pytest.mark.django_db
+def test_detalle_usuario_provincial_bloqueado_fuera_de_provincia(
+    client, dos_provincias
+):
+    provincia_a, _municipio_a, provincia_b, municipio_b = dos_provincias
+    dispositivo_b = _crear_dispositivo(provincia_b, municipio_b, indice=10)
+    user = _crear_usuario_provincial("prov-a-bloqueo", provincia=provincia_a)
+
+    client.force_login(user)
+    response = client.get(
+        reverse("dispositivos_detalle", kwargs={"pk": dispositivo_b.pk})
+    )
+
+    assert response.status_code == 404
+
+
+@pytest.mark.django_db
+def test_editar_usuario_provincial_bloqueado_fuera_de_provincia(client, dos_provincias):
+    provincia_a, _municipio_a, provincia_b, municipio_b = dos_provincias
+    dispositivo_b = _crear_dispositivo(provincia_b, municipio_b, indice=12)
+    user = _crear_usuario_provincial("prov-a-editar", provincia=provincia_a)
+
+    client.force_login(user)
+    response = client.get(
+        reverse("dispositivos_editar", kwargs={"pk": dispositivo_b.pk})
+    )
+
+    assert response.status_code == 404
+
+
+@pytest.mark.django_db
+def test_formulario_creacion_restringe_provincias(client, dos_provincias):
+    provincia_a, _municipio_a, provincia_b, _municipio_b = dos_provincias
+    user = _crear_usuario_provincial("prov-a-form", provincia=provincia_a)
+
+    client.force_login(user)
+    response = client.get(reverse("dispositivos_crear"))
+
+    assert response.status_code == 200
+    provincia_ids = set(
+        response.context["form"]
+        .fields["provincia"]
+        .queryset.values_list("id", flat=True)
+    )
+    assert provincia_a.id in provincia_ids
+    assert provincia_b.id not in provincia_ids
+
+
+@pytest.mark.django_db
+def test_creacion_rechaza_provincia_fuera_de_scope(client, dos_provincias):
+    provincia_a, _municipio_a, provincia_b, municipio_b = dos_provincias
+    user = _crear_usuario_provincial("prov-a-post", provincia=provincia_a)
+
+    client.force_login(user)
+    response = client.post(
+        reverse("dispositivos_crear"),
+        data=_form_post_data(provincia_b, municipio_b),
+    )
+
+    assert response.status_code == 200
+    assert not Dispositivo.objects.filter(provincia=provincia_b).exists()

--- a/dispositivos/tests/test_dispositivos_views.py
+++ b/dispositivos/tests/test_dispositivos_views.py
@@ -4,6 +4,7 @@ from django.core.files.uploadedfile import SimpleUploadedFile
 from django.urls import reverse
 
 from core.models import Localidad, Municipio, Provincia
+from dispositivos.forms import DispositivoForm
 from dispositivos.models import Dispositivo
 from users.models import Profile, ProfileTerritorialScope
 
@@ -769,3 +770,18 @@ def test_eliminar_usuario_provincial_bloqueado_fuera_de_provincia(
 
     assert response.status_code == 404
     assert Dispositivo.objects.filter(pk=dispositivo_b.pk).exists()
+
+
+@pytest.mark.django_db
+def test_form_municipio_vacio_para_provincia_fuera_de_alcance(dos_provincias):
+    # Defensa en profundidad: aunque el campo provincia ya rechaza una provincia
+    # fuera de alcance, el queryset de municipio no debe ofrecer opciones de esa
+    # provincia.
+    provincia_a, municipio_a, provincia_b, _municipio_b = dos_provincias
+    user = _crear_usuario_provincial(
+        "prov-a-form-hard", provincia=provincia_a, municipio=municipio_a
+    )
+
+    form = DispositivoForm(data={"provincia": provincia_b.id}, user=user)
+
+    assert not form.fields["municipio"].queryset.exists()

--- a/dispositivos/tests/test_dispositivos_views.py
+++ b/dispositivos/tests/test_dispositivos_views.py
@@ -3,7 +3,7 @@ from django.contrib.auth.models import Permission, User
 from django.core.files.uploadedfile import SimpleUploadedFile
 from django.urls import reverse
 
-from core.models import Municipio, Provincia
+from core.models import Localidad, Municipio, Provincia
 from dispositivos.models import Dispositivo
 from users.models import Profile, ProfileTerritorialScope
 
@@ -461,15 +461,28 @@ def _agregar_permisos_dispositivos(user):
     user.user_permissions.add(*perms)
 
 
-def _crear_usuario_provincial(username, *, provincia, municipio=None):
+def _crear_usuario_provincial(
+    username, *, provincia, municipio=None, localidad=None, scopes_extra=None
+):
     user = User.objects.create_user(username=username, password="test1234")
     _agregar_permisos_dispositivos(user)
     profile, _ = Profile.objects.get_or_create(user=user)
     profile.es_usuario_provincial = True
     profile.save()
     ProfileTerritorialScope.objects.create(
-        profile=profile, provincia=provincia, municipio=municipio
+        profile=profile, provincia=provincia, municipio=municipio, localidad=localidad
     )
+    for extra in scopes_extra or []:
+        ProfileTerritorialScope.objects.create(profile=profile, **extra)
+    return user
+
+
+def _crear_usuario_provincial_sin_alcance(username):
+    user = User.objects.create_user(username=username, password="test1234")
+    _agregar_permisos_dispositivos(user)
+    profile, _ = Profile.objects.get_or_create(user=user)
+    profile.es_usuario_provincial = True
+    profile.save()
     return user
 
 
@@ -666,3 +679,93 @@ def test_creacion_rechaza_provincia_fuera_de_scope(client, dos_provincias):
 
     assert response.status_code == 200
     assert not Dispositivo.objects.filter(provincia=provincia_b).exists()
+
+
+@pytest.mark.django_db
+def test_listado_usuario_con_alcance_localidad_ve_su_municipio(client, dos_provincias):
+    # El modelo Dispositivo no tiene localidad: un alcance a nivel localidad
+    # debe respetarse hasta su municipio (decisión de diseño del fix #1824).
+    provincia_a, municipio_a, _provincia_b, _municipio_b = dos_provincias
+    otro_municipio = Municipio.objects.create(nombre="Berisso", provincia=provincia_a)
+    localidad = Localidad.objects.create(nombre="Centro", municipio=municipio_a)
+    _crear_dispositivo(
+        provincia_a, municipio_a, indice=13, nombre_institucion="Disp Loc Municipio"
+    )
+    _crear_dispositivo(
+        provincia_a, otro_municipio, indice=14, nombre_institucion="Disp Otro Municipio"
+    )
+    user = _crear_usuario_provincial(
+        "prov-a-loc",
+        provincia=provincia_a,
+        municipio=municipio_a,
+        localidad=localidad,
+    )
+
+    client.force_login(user)
+    response = client.get(reverse("dispositivos_listar"))
+
+    assert response.status_code == 200
+    contenido = response.content.decode("utf-8")
+    assert "Disp Loc Municipio" in contenido
+    assert "Disp Otro Municipio" not in contenido
+
+
+@pytest.mark.django_db
+def test_listado_usuario_multiprovincia_ve_ambas(client, dos_provincias):
+    provincia_a, municipio_a, provincia_b, municipio_b = dos_provincias
+    _crear_dispositivo(
+        provincia_a, municipio_a, indice=15, nombre_institucion="Disp Multi A"
+    )
+    _crear_dispositivo(
+        provincia_b, municipio_b, indice=16, nombre_institucion="Disp Multi B"
+    )
+    user = _crear_usuario_provincial(
+        "prov-multi",
+        provincia=provincia_a,
+        scopes_extra=[{"provincia": provincia_b}],
+    )
+
+    client.force_login(user)
+    response = client.get(reverse("dispositivos_listar"))
+
+    assert response.status_code == 200
+    contenido = response.content.decode("utf-8")
+    assert "Disp Multi A" in contenido
+    assert "Disp Multi B" in contenido
+
+
+@pytest.mark.django_db
+def test_listado_usuario_provincial_sin_alcance_no_ve_nada(client, dos_provincias):
+    provincia_a, municipio_a, provincia_b, municipio_b = dos_provincias
+    _crear_dispositivo(
+        provincia_a, municipio_a, indice=17, nombre_institucion="Disp Sin Alcance A"
+    )
+    _crear_dispositivo(
+        provincia_b, municipio_b, indice=18, nombre_institucion="Disp Sin Alcance B"
+    )
+    user = _crear_usuario_provincial_sin_alcance("prov-sin-alcance")
+
+    client.force_login(user)
+    response = client.get(reverse("dispositivos_listar"))
+
+    assert response.status_code == 200
+    contenido = response.content.decode("utf-8")
+    assert "Disp Sin Alcance A" not in contenido
+    assert "Disp Sin Alcance B" not in contenido
+
+
+@pytest.mark.django_db
+def test_eliminar_usuario_provincial_bloqueado_fuera_de_provincia(
+    client, dos_provincias
+):
+    provincia_a, _municipio_a, provincia_b, municipio_b = dos_provincias
+    dispositivo_b = _crear_dispositivo(provincia_b, municipio_b, indice=19)
+    user = _crear_usuario_provincial("prov-a-eliminar", provincia=provincia_a)
+
+    client.force_login(user)
+    response = client.post(
+        reverse("dispositivos_eliminar", kwargs={"pk": dispositivo_b.pk})
+    )
+
+    assert response.status_code == 404
+    assert Dispositivo.objects.filter(pk=dispositivo_b.pk).exists()

--- a/dispositivos/views.py
+++ b/dispositivos/views.py
@@ -26,6 +26,7 @@ from .dispositivos_filter_config import (
 from .forms import DispositivoForm
 from .models import Dispositivo
 from .services import (
+    apply_dispositivos_scope,
     delete_dispositivo,
     get_dispositivos_queryset,
     save_dispositivo_from_form,
@@ -73,6 +74,7 @@ class DispositivoListView(LoginRequiredMixin, ListView):
 
     def get_queryset(self):
         queryset = get_dispositivos_queryset()
+        queryset = apply_dispositivos_scope(queryset, self.request.user)
         queryset = DISPOSITIVOS_ADVANCED_FILTER.filter_queryset(queryset, self.request)
 
         query = (self.request.GET.get("busqueda") or "").strip()
@@ -107,7 +109,7 @@ class DispositivoDetailView(LoginRequiredMixin, DetailView):
     context_object_name = "dispositivo"
 
     def get_queryset(self):
-        return get_dispositivos_queryset()
+        return apply_dispositivos_scope(get_dispositivos_queryset(), self.request.user)
 
     def get_context_data(self, **kwargs):
         context = super().get_context_data(**kwargs)
@@ -501,6 +503,11 @@ class DispositivoCreateView(LoginRequiredMixin, CreateView):
     form_class = DispositivoForm
     template_name = "dispositivos_form.html"
 
+    def get_form_kwargs(self):
+        kwargs = super().get_form_kwargs()
+        kwargs["user"] = self.request.user
+        return kwargs
+
     def get_context_data(self, **kwargs):
         context = super().get_context_data(**kwargs)
         context["breadcrumb_items"] = [
@@ -524,7 +531,12 @@ class DispositivoUpdateView(LoginRequiredMixin, UpdateView):
     template_name = "dispositivos_form.html"
 
     def get_queryset(self):
-        return get_dispositivos_queryset()
+        return apply_dispositivos_scope(get_dispositivos_queryset(), self.request.user)
+
+    def get_form_kwargs(self):
+        kwargs = super().get_form_kwargs()
+        kwargs["user"] = self.request.user
+        return kwargs
 
     def get_context_data(self, **kwargs):
         context = super().get_context_data(**kwargs)
@@ -553,7 +565,7 @@ class DispositivoDeleteView(LoginRequiredMixin, DeleteView):
     context_object_name = "dispositivo"
 
     def get_queryset(self):
-        return get_dispositivos_queryset()
+        return apply_dispositivos_scope(get_dispositivos_queryset(), self.request.user)
 
     def form_valid(self, form):
         self.object = self.get_object()

--- a/docs/registro/cambios/2026-06-03-cleanup-tests-celiaquia-scope-1793.md
+++ b/docs/registro/cambios/2026-06-03-cleanup-tests-celiaquia-scope-1793.md
@@ -1,0 +1,28 @@
+# 2026-06-03 - Cleanup: tests de celiaquía rotos por el scope territorial (#1793)
+
+## Contexto
+
+El commit `31ed6d93` (`fix(celiaquia): aisla expedientes por provincia en carga y listado (#1793)`, 2026-06-02, ya en `development`) endureció el scope de expedientes: removió `include_own` de `_apply_provincial_expediente_scope` e introdujo `_get_provincial_expediente_or_404`. Dejó **2 tests desactualizados** que el job `pytest` (solo en PRs) recién flagueó al abrir un PR nuevo (deuda heredada, no causada por el PR que la expone — ver [[reference-sisoc-validation]]).
+
+El código de producción es **correcto**; los tests no se habían adaptado al nuevo comportamiento.
+
+## Fallas y fix
+
+1. **`celiaquia/tests/test_expediente_detail.py::test_expediente_detail_expone_motivo_rechazo_para_provincia`**
+   — fallaba con `assert 404 == 200`. El usuario provincial (Buenos Aires) ya no ve el
+   expediente porque su único ciudadano no tenía provincia, y el nuevo scope exige que
+   al menos un ciudadano caiga dentro del alcance. **Fix:** el `Ciudadano` del legajo se
+   crea con `provincia=provincia` (la del usuario), reflejando el comportamiento real.
+
+2. **`tests/test_celiaquia_expediente_view_helpers_unit.py::test_reprocesar_registros_erroneos_convierte_conflicto_en_excluido`**
+   — fallaba con `TypeError: Field 'id' expected a number but got namespace()`. El test
+   mockeaba `get_object_or_404`, pero la rama provincial de `ReprocesarRegistrosErroneosView.post`
+   ahora resuelve el expediente con `_get_provincial_expediente_or_404`, que aplica
+   `.filter(usuario_provincia=user)` sobre el `SimpleNamespace` de prueba. **Fix:** se
+   mockea también `_get_provincial_expediente_or_404` para devolver el expediente simulado.
+
+## Validación
+
+- `pytest celiaquia/tests/test_expediente_detail.py tests/test_celiaquia_expediente_view_helpers_unit.py`: **36 passed** (Docker one-off, SQLite, `--no-migrations`). Antes: 2 failed / 34 passed.
+- `black`: sin cambios. `pylint`: exit 0 (sin mensajes).
+- Cambio **solo de tests**; sin tocar código de producción, modelos ni migraciones.

--- a/docs/registro/cambios/2026-06-03-issue-1824-dispositivos-scope-provincial.md
+++ b/docs/registro/cambios/2026-06-03-issue-1824-dispositivos-scope-provincial.md
@@ -1,0 +1,90 @@
+# 2026-06-03 - Dispositivos (Data Calle): alcance territorial provincial
+
+## Contexto
+
+HOTFIX del issue [#1824](https://github.com/dsocial118/SISOC/issues/1824). El módulo
+`dispositivos/` (rutas `/dispositivos/` y `/dispositivos/crear`) **no** aplicaba el
+alcance territorial del usuario: las cuatro vistas CRUD usaban
+`get_dispositivos_queryset()` sin filtrar, y el formulario ofrecía todas las
+provincias/municipios. Un usuario provincial podía listar, ver, editar y crear
+dispositivos de cualquier provincia.
+
+Regla pedida:
+
+1. Usuario con provincia asignada: solo lista/ve/edita/crea dispositivos dentro de su
+   provincia.
+2. Si además tiene municipio (y/o localidad) configurado, se restringe a esa selección.
+3. Usuario sin provincia asignada y/o admin: interactúa con todos los registros.
+
+## Cambios aplicados
+
+### Lógica de alcance (nueva, centralizada en `services.py`)
+
+- **`apply_dispositivos_scope(queryset, user)`**
+  ([dispositivos/services.py](../../../dispositivos/services.py)): acota el queryset al
+  alcance del usuario. No autenticado → vacío; superusuario o usuario no provincial →
+  sin restricción; usuario provincial → `provincia` (+ `municipio` cuando el alcance lo
+  precisa). Un usuario provincial sin alcances configurados no ve nada.
+- **`get_dispositivos_geography_scope(user)`** (nueva): devuelve el mapa
+  `provincia_id -> set(municipio_id) | None` que usa el formulario para limitar los
+  desplegables. `None` = sin restricción.
+
+### Vistas (control de acceso de lectura y escritura)
+
+- **`DispositivoListView`**: aplica `apply_dispositivos_scope` antes de los filtros
+  avanzados y la búsqueda libre.
+- **`DispositivoDetailView` / `DispositivoUpdateView` / `DispositivoDeleteView`**:
+  `get_queryset()` devuelve el queryset acotado, por lo que un pk fuera de alcance
+  responde **404** (también vía POST directo).
+- **`DispositivoCreateView` / `DispositivoUpdateView`**: `get_form_kwargs()` pasa el
+  usuario al formulario.
+
+### Formulario (control de acceso en alta/edición)
+
+- **`DispositivoForm`** ([dispositivos/forms.py](../../../dispositivos/forms.py)): toma
+  `user` por kwarg; `_configure_geography_fields()` restringe el `queryset` de
+  `provincia` y `municipio` al alcance. Como `ModelChoiceField` valida contra su
+  `queryset`, un POST con una provincia/municipio fuera de alcance es rechazado por la
+  propia validación del form (defensa server-side, no solo UI).
+
+## Decisiones / supuestos
+
+- **Localidad → municipio**: el modelo `Dispositivo` tiene `provincia` y `municipio`,
+  **no** `localidad`. Un alcance a nivel localidad se respeta hasta su **municipio** (la
+  granularidad más fina que admite el modelo). Por eso no se reutiliza directamente
+  `apply_territorial_scope` con `localidad_lookup`, que descartaría esos alcances
+  (`build_territorial_scope_q` hace `continue`) y dejaría sin acceso al usuario; se
+  construye el `Q` a medida.
+- **Delete acotado**: el issue menciona listar/ver/editar/crear; se incluye también
+  `DispositivoDeleteView` para no dejar un hueco (borrado fuera de provincia por POST
+  directo).
+- **Usuarios provinciales = territoriales**: se asume el modelo documentado
+  (`Profile.es_usuario_provincial` + `ProfileTerritorialScope`), consistente con
+  celiaquía y centrodeinfancia. Un usuario provincial sin alcances no ve ni puede crear
+  dispositivos.
+- **Sin migración**: no se tocan modelos; el cambio es de vistas/servicios/formulario.
+- **Compatibilidad**: `DispositivoForm` sin `user` (instanciación directa, p. ej. tests
+  legacy) conserva el comportamiento previo sin restricción.
+
+## Validación
+
+- `black --check`: OK sobre los archivos tocados.
+- `pylint` (archivos cambiados): 10.00/10.
+- `manage.py check`: sin issues (wiring/imports, sin import circular).
+- `pytest dispositivos/tests/`: **38 passed** (Docker one-off, SQLite). 9 tests nuevos
+  en [test_dispositivos_views.py](../../../dispositivos/tests/test_dispositivos_views.py):
+  listado por provincia y por municipio, admin/superusuario y usuario sin provincia ven
+  todo, detalle 200 dentro / 404 fuera, editar 404 fuera, el form de alta restringe
+  provincias y rechaza el POST fuera de alcance.
+- `makemigrations --check` / `djlint`: N/A (sin cambios de modelo/migración ni
+  templates).
+
+## Cómo probar manualmente
+
+1. Usuario provincial con alcance en provincia A.
+2. `/dispositivos/` muestra solo dispositivos de A; los de otra provincia no aparecen.
+3. Abrir el detalle/editar de un dispositivo de otra provincia por URL directa → 404.
+4. `/dispositivos/crear`: el desplegable de provincia solo ofrece A (y municipio, los de
+   A o el municipio configurado). Forzar por POST otra provincia → el form no valida.
+5. Usuario con municipio configurado: solo ve/crea dentro de ese municipio.
+6. Admin / usuario sin provincia: ve y opera sobre todos los dispositivos.

--- a/docs/registro/cambios/2026-06-03-issue-1824-dispositivos-scope-provincial.md
+++ b/docs/registro/cambios/2026-06-03-issue-1824-dispositivos-scope-provincial.md
@@ -45,7 +45,15 @@ Regla pedida:
   `user` por kwarg; `_configure_geography_fields()` restringe el `queryset` de
   `provincia` y `municipio` al alcance. Como `ModelChoiceField` valida contra su
   `queryset`, un POST con una provincia/municipio fuera de alcance es rechazado por la
-  propia validación del form (defensa server-side, no solo UI).
+  propia validación del form (defensa server-side, no solo UI). Si en el `data` llega una
+  provincia fuera del alcance, el `queryset` de `municipio` queda vacío (no ofrece
+  municipios de esa provincia), además del rechazo del campo `provincia`.
+
+### Limpieza
+
+- Se elimina `get_dispositivo_or_404` de `services.py`: estaba **sin uso** y devolvía un
+  objeto sin acotar por alcance (footgun si se cableaba a una vista). Las vistas resuelven
+  el objeto vía `get_queryset()` acotado.
 
 ## Decisiones / supuestos
 
@@ -71,11 +79,13 @@ Regla pedida:
 - `black --check`: OK sobre los archivos tocados.
 - `pylint` (archivos cambiados): 10.00/10.
 - `manage.py check`: sin issues (wiring/imports, sin import circular).
-- `pytest dispositivos/tests/`: **38 passed** (Docker one-off, SQLite). 9 tests nuevos
+- `pytest dispositivos/tests/`: **43 passed** (Docker one-off, SQLite). 14 tests nuevos
   en [test_dispositivos_views.py](../../../dispositivos/tests/test_dispositivos_views.py):
-  listado por provincia y por municipio, admin/superusuario y usuario sin provincia ven
-  todo, detalle 200 dentro / 404 fuera, editar 404 fuera, el form de alta restringe
-  provincias y rechaza el POST fuera de alcance.
+  listado por provincia y por municipio, alcance localidad → municipio, multi-provincia,
+  admin/superusuario y usuario sin provincia ven todo, usuario provincial sin alcance no
+  ve nada, detalle 200 dentro / 404 fuera, editar y eliminar 404 fuera, el form de alta
+  restringe provincias, rechaza el POST fuera de alcance y deja vacío el municipio de una
+  provincia fuera de alcance.
 - `makemigrations --check` / `djlint`: N/A (sin cambios de modelo/migración ni
   templates).
 

--- a/tests/test_celiaquia_expediente_view_helpers_unit.py
+++ b/tests/test_celiaquia_expediente_view_helpers_unit.py
@@ -1081,6 +1081,10 @@ def test_reprocesar_registros_erroneos_convierte_conflicto_en_excluido(mocker):
         "celiaquia.views.expediente.get_object_or_404", return_value=expediente
     )
     mocker.patch(
+        "celiaquia.views.expediente._get_provincial_expediente_or_404",
+        return_value=expediente,
+    )
+    mocker.patch(
         "celiaquia.views.expediente._can_manage_registros_erroneos", return_value=True
     )
     mocker.patch(


### PR DESCRIPTION
## Issue

Cierra #1824 (HOTFIX). El módulo `dispositivos/` (Data Calle, rutas `/dispositivos/` y `/dispositivos/crear`) no aplicaba el alcance territorial del usuario: un usuario provincial podía listar, ver, editar y crear dispositivos de **cualquier** provincia.

## Comportamiento esperado (del issue)

- Usuario con provincia asignada → solo lista/ve/edita/crea dispositivos **dentro de su provincia**.
- Si además tiene municipio (y/o localidad) configurado → se restringe a esa selección.
- Usuario sin provincia y/o admin → interactúa con **todos** los registros.

## Cambios

**`dispositivos/services.py`**
- `apply_dispositivos_scope(queryset, user)`: acota el queryset al alcance del usuario. No autenticado → vacío; superusuario o usuario no provincial → sin restricción; provincial → `provincia` (+ `municipio` cuando aplica).
- `get_dispositivos_geography_scope(user)`: mapa `provincia_id -> set(municipio_id) | None` que consume el formulario.

**`dispositivos/views.py`**
- Scope en `get_queryset()` de `List`/`Detail`/`Update`/`Delete` → un pk fuera de alcance responde **404** (también por POST directo).
- `get_form_kwargs()` pasa el `user` al formulario en `Create`/`Update`.

**`dispositivos/forms.py`**
- Restringe los `queryset` de `provincia` y `municipio` al alcance. Como `ModelChoiceField` valida contra su `queryset`, un POST con provincia/municipio fuera de alcance es rechazado por la propia validación (defensa server-side, no solo UI).

## Decisión de diseño

`Dispositivo` tiene `provincia` + `municipio` pero **no** `localidad`. Por eso construyo el `Q` a medida en `apply_dispositivos_scope` en lugar de reusar `apply_territorial_scope` con `localidad_lookup`: ese helper **descarta** los alcances de nivel localidad cuando el modelo no tiene ese campo (`build_territorial_scope_q` hace `continue`), lo que dejaría sin acceso al usuario. Aquí un alcance a nivel localidad se respeta hasta su **municipio** (la granularidad más fina del modelo).

También se acotó `DeleteView` (no estaba explícito en el issue) para no dejar un hueco de borrado cross-provincia por POST directo.

## Validación

- **pytest** `dispositivos/tests/`: **38 passed** (29 previos + 9 nuevos), Docker/SQLite.
- **pylint** (archivos tocados): **10.00/10**.
- **manage.py check**: sin issues (sin import circular en `forms → services → users.territorial_scope`).
- **black**: limpio. `makemigrations`/`djlint`: N/A (sin cambios de modelo/migración ni templates).

Tests nuevos: listado por provincia y por municipio, admin/superusuario y usuario sin provincia ven todo, detalle 200 dentro / 404 fuera, editar 404 fuera, el form de alta restringe provincias y rechaza el POST fuera de alcance.

## Notas

- Asume el modelo `Profile.es_usuario_provincial` + `ProfileTerritorialScope` (consistente con celiaquía/centrodeinfancia). Un usuario provincial **sin** alcances no ve ni crea nada.
- Datos existentes cross-provincia dejan de verse para usuarios provinciales; admin los sigue viendo. Sin script de limpieza.
- Sin migraciones.

Doc: `docs/registro/cambios/2026-06-03-issue-1824-dispositivos-scope-provincial.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
