### PR TITLE
fix(ci): eliminar --workers de djlint (no soportada en 1.34.2)

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -81,22 +81,19 @@ jobs:
               run: |
                   python - <<'PY'
                   import json
-                  import multiprocessing
                   import os
                   import subprocess
 
                   templates = json.loads(
                       os.environ.get("TEMPLATE_FILES_JSON") or "[]"
                   )
-                  workers = max(1, multiprocessing.cpu_count())
-                  print("Running djlint --reformat on", len(templates), "template file(s) with", workers, "worker(s)")
+                  print("Running djlint --reformat on", len(templates), "template file(s)")
                   subprocess.run(
                       [
                           "djlint",
                           *templates,
                           "--reformat",
                           "--configuration=.djlintrc",
-                          f"--workers={workers}",
                       ],
                       check=True,
                   )


### PR DESCRIPTION
## Problema

El job `autofix` en `lint.yml` pasaba `--workers=4` a djlint, pero djlint 1.34.2 no tiene esa opción. El resultado era que el job reventaba con `No such option: --workers` antes de poder commitear el reformat, y dejaba todos los jobs downstream (`black`, `djlint`, `pylint`, `encoding_check`) en **skipping** para cada PR abierto contra development.

## Fix

Eliminar las 4 líneas que calculaban y pasaban `--workers`: el comando queda igual a como estaba antes de que se agregara ese flag.

## Test

El job `autofix` va a pasar en el próximo CI run de cualquier PR contra development.

🤖 Generated with [Claude Code](https://claude.com/claude-code)