### PR TITLE
fix(admisiones): Bug A — confirmar_tipo_convenio no inicializaba snap…

### DIFF
--- a/admisiones/services/admisiones_service/impl.py
+++ b/admisiones/services/admisiones_service/impl.py
@@ -1520,6 +1520,9 @@ class AdmisionService:
         admision.estado_admision = "convenio_seleccionado"
         admision.save(update_fields=["tipo_convenio", "estado_admision"])
         AdmisionService.congelar_documentacion_organizacional(admision)
+        # Sincronizar snapshot tras materializar docs: sin este paso la primera
+        # modificacion en el legajo no dispararia la advertencia (Bug A #1799).
+        AdmisionService.refrescar_snapshot_documentacion_organizacional(admision)
         return True, "Tipo de convenio precargado desde la organización."
 
     @staticmethod

--- a/admisiones/tests/test_documentacion_desactualizada.py
+++ b/admisiones/tests/test_documentacion_desactualizada.py
@@ -242,6 +242,9 @@ def setup_legajo_con_dos_docs():
         nombre="Org Multi Doc", tipo_entidad=tipo
     )
     comedor = Comedor.objects.create(nombre="Comedor Multi", organizacion=organizacion)
+    # EstadoAdmision necesarios para que _sincronizar_estado_documental no rompa FK.
+    EstadoAdmision.objects.create(pk=1, nombre="Pendiente")
+    EstadoAdmision.objects.create(pk=2, nombre="Doc en proceso")
     # pk=3 mapea a CATEGORIA_PERSONERIA en CATEGORIA_ORGANIZACIONAL_POR_TIPO_CONVENIO.
     tipo_convenio = TipoConvenio.objects.create(pk=3, nombre="Personería Jurídica")
     doc_org_1 = DocumentacionOrganizacion.objects.create(
@@ -344,3 +347,40 @@ def test_sin_cambios_no_dispara_advertencia_con_legajo_con_docs(
     )
     assert desactualizada is False
     assert labels == []
+
+
+# ---------------------------------------------------------------------------
+# Regresion Bug A path: confirmar_tipo_convenio_desde_organizacion (#1799)
+# ---------------------------------------------------------------------------
+
+
+def test_confirmar_tipo_convenio_inicializa_snapshot_y_detecta_cambios_posteriores(
+    setup_legajo_con_dos_docs,
+):
+    """Bug A regresion: confirmar_tipo_convenio_desde_organizacion debe llamar a
+    refrescar_snapshot, de lo contrario la primera modificacion del legajo DESPUES
+    de confirmar no dispara la advertencia (admision en estado 'convenio_seleccionado')."""
+    admision = setup_legajo_con_dos_docs["admision"]
+    archivo_org_1 = setup_legajo_con_dos_docs["archivo_org_1"]
+
+    # Simular el click en "Confirmar tipo de convenio" en la vista de edicion.
+    AdmisionService.confirmar_tipo_convenio_desde_organizacion(admision)
+
+    # Snapshot debe existir (refrescar fue llamado por confirmar).
+    snaps = list(AdmisionDocOrgSnapshot.objects.filter(admision=admision))
+    assert any(s.slot_key != "__init__" for s in snaps), (
+        "confirmar_tipo_convenio debe inicializar el snapshot con los docs del legajo"
+    )
+
+    # Ahora se modifica el primer doc del legajo.
+    archivo_org_1.estado = ArchivoOrganizacion.ESTADO_ACEPTADO
+    archivo_org_1.save(update_fields=["estado"])
+
+    desactualizada, labels = AdmisionService.admision_documentacion_desactualizada(
+        admision
+    )
+    assert desactualizada is True, (
+        "Tras confirmar_tipo_convenio, la primera modificacion del legajo "
+        "debe disparar la advertencia"
+    )
+    assert "DNI del Presidente" in labels


### PR DESCRIPTION
…shot (#1799)

confirmar_tipo_convenio_desde_organizacion llamaba a congelar_documentacion_organizacional pero no a refrescar_snapshot_documentacion_organizacional. Esto dejaba el snapshot en el estado pre-confirmacion: la primera modificacion en el legajo despues de confirmar el tipo de convenio (admision en estado 'convenio_seleccionado') no disparaba la advertencia porque el baseline no reflejaba los docs del legajo al momento de la confirmacion.

Fix: agregar refrescar_snapshot al final de confirmar_tipo_convenio_desde_organizacion.

Test anadido: test_confirmar_tipo_convenio_inicializa_snapshot_y_detecta_cambios_posteriores

# Información de la Tarea
Vincular el #ISSUE

### **Resumen de la Solución:** 
-

### **Información Adicional:**
-

# Descripción de los Cambios

### **Cambios:**
-

# Cómo Testear los Cambios

### **Pruebas Automáticas:**
-

### **Prubeas Manuales:**
-

# Metadata para documentación automática

- Contexto funcional:
- Tipo de cambio:
- Área principal:
- Resumen para changelog:
- Impacto usuario:
- Riesgos / rollback:

# Capturas de Pantalla
