### PR TITLE
chore(format): black reformat test_documentacion_desactualizada.py

### DIFF
--- a/admisiones/tests/test_documentacion_desactualizada.py
+++ b/admisiones/tests/test_documentacion_desactualizada.py
@@ -359,7 +359,8 @@ def test_confirmar_tipo_convenio_inicializa_snapshot_y_detecta_cambios_posterior
 ):
     """Bug A regresion: confirmar_tipo_convenio_desde_organizacion debe llamar a
     refrescar_snapshot, de lo contrario la primera modificacion del legajo DESPUES
-    de confirmar no dispara la advertencia (admision en estado 'convenio_seleccionado')."""
+    de confirmar no dispara la advertencia (admision en estado 'convenio_seleccionado').
+    """
     admision = setup_legajo_con_dos_docs["admision"]
     archivo_org_1 = setup_legajo_con_dos_docs["archivo_org_1"]
 
@@ -368,9 +369,9 @@ def test_confirmar_tipo_convenio_inicializa_snapshot_y_detecta_cambios_posterior
 
     # Snapshot debe existir (refrescar fue llamado por confirmar).
     snaps = list(AdmisionDocOrgSnapshot.objects.filter(admision=admision))
-    assert any(s.slot_key != "__init__" for s in snaps), (
-        "confirmar_tipo_convenio debe inicializar el snapshot con los docs del legajo"
-    )
+    assert any(
+        s.slot_key != "__init__" for s in snaps
+    ), "confirmar_tipo_convenio debe inicializar el snapshot con los docs del legajo"
 
     # Ahora se modifica el primer doc del legajo.
     archivo_org_1.estado = ArchivoOrganizacion.ESTADO_ACEPTADO


### PR DESCRIPTION
## Summary
- Desbloquea el job `black` del workflow "Formateo y linteo" que aparece rojo en el PR de predeploy [#1839](https://github.com/dsocial118/SISOC/pull/1839)
- Reformat puntual en `admisiones/tests/test_documentacion_desactualizada.py` (introducido en el PR #1799 mergeado el mismo día)
- Sin cambios funcionales — solo reflow de un docstring y de un `assert` multilínea

## Test plan
- [x] `python -m black --check admisiones/tests/test_documentacion_desactualizada.py` localmente
- [ ] Verificar `black` verde en CI tras merge a `development`
- [ ] Re-ejecutar el workflow en PR #1839 para que `deploy_guard` reintente (el primer intento timeoutéo esperando `release_sanity`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)