### PR TITLE
fix(admisiones): refrescar adjunto org Aceptado al sincronizar desde el legajo

### DIFF
--- a/admisiones/services/admisiones_service/impl.py
+++ b/admisiones/services/admisiones_service/impl.py
@@ -1255,27 +1255,49 @@ class AdmisionService:
             AdmisionService.refrescar_snapshot_documentacion_organizacional(admision)
             return True, "La documentacion ya estaba actualizada con el Legajo."
 
+        # Mapa slot -> nombre del archivo vigente en el legajo. Permite distinguir
+        # un cambio REAL de archivo (la organizacion subio un adjunto nuevo, hay
+        # que refrescar) de un cambio de metadatos como estado/observaciones (no
+        # debe pisar una validacion admision-side).
+        nombres_org_por_slot = {}
+        for archivo in AdmisionService._org_archivos_relevantes(admision):
+            if not archivo.archivo:
+                continue
+            if archivo.es_personalizado:
+                slot_org = f"custom:{archivo.id}"
+            else:
+                slot_org = f"doc:{archivo.documentacion_id}"
+            nombres_org_por_slot[slot_org] = getattr(archivo.archivo, "name", "") or ""
+
         # Borrar SOLO los ArchivoAdmision de origen organizacional de los slots
         # que cambiaron. Nunca se tocan los documentos nativos de la admision
         # (sin archivo_organizacion_origen) ni los de origen organizacional no
         # modificados.
-        # Tampoco se eliminan los que esten en estado "Aceptado": un documento
-        # validado debe preservarse aunque el legajo haya cambiado
-        # (fix Bug #1799 - docs validados en admision no deben pisarse).
         borrados = 0
         for archivo_adm in ArchivoAdmision.objects.filter(
             admision=admision, archivo_organizacion_origen__isnull=False
         ).select_related("archivo_organizacion_origen"):
-            if archivo_adm.estado == "Aceptado":
-                continue
             origin = archivo_adm.archivo_organizacion_origen
             if origin.documentacion_id:
                 slot = f"doc:{origin.documentacion_id}"
             else:
                 slot = f"custom:{origin.id}"
-            if slot in slots_a_refrescar:
-                archivo_adm.delete()
-                borrados += 1
+            if slot not in slots_a_refrescar:
+                continue
+            # Un documento validado ("Aceptado") en la admision se preserva, PERO
+            # solo si el archivo del legajo no cambio: si la organizacion subio un
+            # adjunto nuevo, la validacion quedo obsoleta y debe refrescarse para
+            # no seguir mostrando el adjunto viejo en la admision. Un cambio que
+            # solo toca metadatos (estado/observaciones/vencimiento) preserva la
+            # validacion (fix Bug #1799 - docs validados no deben pisarse por
+            # cambios de metadatos).
+            if archivo_adm.estado == "Aceptado":
+                nombre_legajo = nombres_org_por_slot.get(slot)
+                nombre_copia = getattr(archivo_adm.archivo, "name", "") or ""
+                if nombre_legajo is None or nombre_legajo == nombre_copia:
+                    continue
+            archivo_adm.delete()
+            borrados += 1
 
         # Re-materializar (aditivo): re-crea desde el legajo los slots borrados que
         # siguen vigentes; los quitados no se re-crean; preserva nativos y los no

--- a/admisiones/tests/test_actualizar_documentacion_dirigido.py
+++ b/admisiones/tests/test_actualizar_documentacion_dirigido.py
@@ -183,3 +183,40 @@ def test_actualizar_preserva_doc_aceptado_de_origen_org(setup):
     )
     conservado = ArchivoAdmision.objects.get(pk=pk_aceptado)
     assert conservado.estado == "Aceptado"
+
+
+def test_actualizar_refresca_doc_aceptado_cuando_cambia_el_archivo(setup):
+    """Bug sincronizacion de adjuntos: si el archivo del legajo cambia realmente
+    (la organizacion sube un adjunto nuevo), el documento de origen organizacional
+    debe refrescarse en la admision AUNQUE su copia este "Aceptado" — de lo
+    contrario la admision sigue mostrando el adjunto viejo. Solo los cambios de
+    metadatos (estado/observaciones) preservan la validacion."""
+    admision = setup["admision"]
+    doc_adm = setup["doc_adm"]
+    organizacion = admision.comedor.organizacion
+
+    # La copia materializada en la admision quedo validada (Aceptado) sobre el
+    # archivo viejo del legajo.
+    materializado = _archivo_org_materializado(admision, doc_adm)
+    assert materializado is not None
+    nombre_viejo = materializado.archivo.name
+    materializado.estado = "Aceptado"
+    materializado.save(update_fields=["estado"])
+
+    # La organizacion sube un ADJUNTO NUEVO: como el doc estaba Aceptado, el flujo
+    # real crea una nueva version (nueva fila ArchivoOrganizacion vigente).
+    ArchivoOrganizacion.objects.create(
+        organizacion=organizacion,
+        documentacion=setup["archivo_org"].documentacion,
+        archivo="organizaciones/dni_v2.pdf",
+        estado=ArchivoOrganizacion.ESTADO_ADJUNTO,
+    )
+
+    ok, _ = AdmisionService.actualizar_documentacion_desde_organizacion(admision)
+    assert ok is True
+
+    # La admision debe mostrar AHORA el archivo nuevo, no el viejo.
+    refrescado = _archivo_org_materializado(admision, doc_adm)
+    assert refrescado is not None
+    assert refrescado.archivo.name == "organizaciones/dni_v2.pdf"
+    assert refrescado.archivo.name != nombre_viejo

--- a/docs/registro/cambios/2026-06-03-fix-sync-adjunto-aceptado-org-admision.md
+++ b/docs/registro/cambios/2026-06-03-fix-sync-adjunto-aceptado-org-admision.md
@@ -1,0 +1,53 @@
+# 2026-06-03 — Fix: "Actualizar desde Legajo" no refrescaba el adjunto cuando el doc estaba Aceptado
+
+Issue relacionado: [#1799](https://github.com/dsocial118/SISOC/issues/1799) (seguimiento de la
+sincronización de documentación Organización → Admisión).
+
+## Problema
+
+Al **actualizar un archivo adjunto en la Organización** y luego pedir "Actualizar
+Información desde Legajo Organización" en la Admisión, la admisión **seguía
+mostrando el adjunto viejo**.
+
+Causa raíz en
+[`AdmisionService.actualizar_documentacion_desde_organizacion`](../../../admisiones/services/admisiones_service/impl.py)
+(actualización dirigida del #1799 feedback punto 1): el bucle de borrado **saltaba
+incondicionalmente** todo `ArchivoAdmision` de origen organizacional con estado
+`"Aceptado"`. Ese salto existía para no pisar una validación admisión-side ante
+cambios de metadatos (estado/observaciones). Pero un documento organizacional
+validado se clona en la admisión **con estado `Aceptado`**, y cuando la
+organización sube un adjunto nuevo sobre un doc Aceptado el flujo real crea una
+**nueva versión** (`ArchivoOrganizacion` vigente,
+[`organizaciones/views.py:subir_documento_organizacion`](../../../organizaciones/views.py)).
+Resultado: el cambio se detectaba (el token difería) pero la copia Aceptada no se
+borraba, y `congelar_documentacion_organizacional` no la re-creaba (ya existía) →
+adjunto viejo persistente.
+
+## Solución
+
+Preservar el documento Aceptado **solo si el archivo del legajo no cambió**. Si la
+organización subió un adjunto nuevo (cambió el nombre del archivo vigente respecto
+de la copia materializada), la validación quedó obsoleta y el documento se
+refresca. Los cambios que solo tocan metadatos (estado/observaciones/vencimiento)
+siguen preservando la validación.
+
+- Se construye un mapa `slot -> nombre de archivo vigente` del legajo y se compara
+  contra el `archivo.name` de la copia materializada. Es un discriminante seguro:
+  los documentos de origen organizacional son **solo lectura admisión-side**
+  (ver `admisiones/tests/test_gde_cell_ajax.py::test_doc_origen_organizacion_aceptado_es_solo_lectura`),
+  así que el nombre de archivo de la copia refleja el archivo del legajo al momento
+  del clonado.
+
+## Tests
+
+[admisiones/tests/test_actualizar_documentacion_dirigido.py](../../../admisiones/tests/test_actualizar_documentacion_dirigido.py)
+
+- **Nuevo** `test_actualizar_refresca_doc_aceptado_cuando_cambia_el_archivo`: doc
+  org Aceptado en la admisión + la organización sube un adjunto nuevo (nueva
+  versión vigente) → la admisión muestra ahora el archivo nuevo.
+- Regresión `test_actualizar_preserva_doc_aceptado_de_origen_org` (cambio de solo
+  metadatos preserva la validación) sigue verde.
+
+Validación local (Docker, SQLite): `test_actualizar_documentacion_dirigido.py`
+5 passed; suite de doc-sync de admisiones (resync + desactualizada +
+archivo_organizacion_origen + gde_cell + dirigido) 30 passed; `black --check` OK.


### PR DESCRIPTION
@
## Problema

Al **actualizar un archivo adjunto en la Organización** y luego pedir "Actualizar Información desde Legajo Organización" en la Admisión, la admisión **seguía mostrando el adjunto viejo** (reportado por el usuario con video).

Causa raíz en la actualización dirigida del #1799 (`AdmisionService.actualizar_documentacion_desde_organizacion`): el borrado/recreación **saltaba incondicionalmente** toda copia de origen organizacional con estado `Aceptado`. Pero un documento organizacional validado se clona en la admisión **como `Aceptado`**, y cuando la organización sube un adjunto nuevo sobre un doc Aceptado el flujo real crea una **nueva versión** (`organizaciones/views.py:subir_documento_organizacion`). El cambio se detectaba (el token difería) pero la copia Aceptada no se borraba y `congelar` no la re-creaba → adjunto viejo persistente.

## Solución

Preservar el documento Aceptado **solo si el archivo del legajo no cambió**. Se compara el nombre del archivo vigente en el legajo contra el de la copia materializada:

- **Cambió el archivo** (la org subió un adjunto nuevo) → se refresca, aunque esté Aceptado (la validación quedó obsoleta).
- **Solo metadatos** (estado/observaciones/vencimiento) → se preserva la validación (comportamiento previo intacto).

Discriminante seguro: los documentos de origen organizacional son **solo lectura admisión-side**, así que el `archivo.name` de la copia refleja el archivo del legajo al momento del clonado.

## Tests

- **Nuevo** `test_actualizar_refresca_doc_aceptado_cuando_cambia_el_archivo`: doc org Aceptado en la admisión + la organización sube un adjunto nuevo → la admisión muestra el archivo nuevo.
- Regresión `test_actualizar_preserva_doc_aceptado_de_origen_org` (cambio de solo metadatos preserva la validación) sigue verde.

Validación local (Docker, SQLite): suite de doc-sync de admisiones **30 passed**; `black --check` OK.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
@