### PR TITLE
fix(ci): autofix tolera exit 1 de djlint --reformat

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -83,20 +83,25 @@ jobs:
                   import json
                   import os
                   import subprocess
+                  import sys
 
                   templates = json.loads(
                       os.environ.get("TEMPLATE_FILES_JSON") or "[]"
                   )
                   print("Running djlint --reformat on", len(templates), "template file(s)")
-                  subprocess.run(
+                  result = subprocess.run(
                       [
                           "djlint",
                           *templates,
                           "--reformat",
                           "--configuration=.djlintrc",
                       ],
-                      check=True,
+                      check=False,
                   )
+                  # djlint --reformat devuelve 1 cuando reformatea archivos (comportamiento normal).
+                  # Solo fallar ante errores reales (>=2). El paso djlint posterior valida el resultado.
+                  if result.returncode >= 2:
+                      sys.exit(result.returncode)
                   PY
               env:
                   TEMPLATE_FILES_JSON: ${{ steps.detect-changed-templates.outputs.files }}


### PR DESCRIPTION
## Summary
- El job `autofix` del workflow "Formateo y linteo" estaba crónicamente rojo cuando había templates por reformatear ([memoria: project_ci_lint_development_red](memory)).
- Causa raíz: `djlint --reformat` devuelve exit code 1 cuando reformatea archivos exitosamente (mismo patrón que `black --check`). El script lo invocaba con `subprocess.run(..., check=True)`, lo que disparaba `CalledProcessError` aunque el autoformateo hubiese funcionado.
- Fix: usar `check=False` y solo abortar ante exit code >= 2 (errores reales). El paso `djlint` posterior (`--check`) sigue validando el output.

## Contexto
- Aparece rojo crónicamente en `development` y bloqueó el predeploy [#1839](https://github.com/dsocial118/SISOC/pull/1839).
- Sin cambios funcionales en el código de la app.

## Test plan
- [ ] Tras merge, abrir cualquier PR con templates afectados y verificar que `autofix` finaliza verde + commitea los reformateos.
- [ ] Verificar que un error real de djlint (exit >= 2) sí hace fallar el job.

🤖 Generated with [Claude Code](https://claude.com/claude-code)