### PR TITLE
fix(celiaquia): evitar 500 en reporter-provincias por CONVERT_TZ sin tz tables

### DIFF
--- a/celiaquia/views/reporter_provincias.py
+++ b/celiaquia/views/reporter_provincias.py
@@ -1,10 +1,10 @@
+from collections import Counter
 from datetime import timedelta
 from urllib.parse import urlencode
 
 from django.contrib.auth.mixins import LoginRequiredMixin
 from django.core.paginator import Paginator
 from django.db.models import Count
-from django.db.models.functions import TruncMonth
 from django.utils import timezone
 from django.views.generic import TemplateView
 
@@ -127,29 +127,35 @@ def _build_metricas_principales(
 
 
 def _build_tendencia_mensual(queryset):
+    # El agrupado mensual se hace en Python en lugar de delegar en TruncMonth.
+    # En MySQL, Trunc*/Extract* sobre DateTimeField con USE_TZ=True emiten
+    # CONVERT_TZ(..., 'UTC', settings.TIME_ZONE), que devuelve NULL si la base no
+    # tiene cargadas/activas las tablas mysql.time_zone* (el caso de produccion).
+    # Ver docs/registro/decisiones/2026-06-04-tendencia-mensual-sin-convert-tz.md.
     cutoff = timezone.now() - timedelta(days=180)
-    monthly = list(
-        queryset.filter(creado_en__gte=cutoff)
-        .annotate(periodo=TruncMonth("creado_en"))
-        .values("periodo")
-        .annotate(count=Count("id"))
-        .order_by("periodo")
-    )
+    fechas = queryset.filter(creado_en__gte=cutoff).values_list("creado_en", flat=True)
 
-    max_count = max((row["count"] for row in monthly), default=0)
-    tendencia = []
-
-    for row in monthly:
-        count = row["count"]
-        tendencia.append(
-            {
-                "label": row["periodo"].strftime("%m/%Y"),
-                "count": count,
-                "size": round((count / max_count) * 100, 1) if max_count else 0.0,
-            }
+    buckets = Counter()
+    for creado_en in fechas:
+        if creado_en is None:
+            continue
+        local = (
+            timezone.localtime(creado_en) if timezone.is_aware(creado_en) else creado_en
         )
+        buckets[(local.year, local.month)] += 1
 
-    return tendencia
+    if not buckets:
+        return []
+
+    max_count = max(buckets.values())
+    return [
+        {
+            "label": f"{month:02d}/{year}",
+            "count": count,
+            "size": round((count / max_count) * 100, 1) if max_count else 0.0,
+        }
+        for (year, month), count in sorted(buckets.items())
+    ]
 
 
 def _build_expedientes_por_provincia(queryset, total_cases):

--- a/docs/registro/decisiones/2026-06-04-tendencia-mensual-sin-convert-tz.md
+++ b/docs/registro/decisiones/2026-06-04-tendencia-mensual-sin-convert-tz.md
@@ -1,0 +1,63 @@
+# 2026-06-04 — Decision: la tendencia mensual del Reporter de Provincias se agrupa en Python, no con TruncMonth
+
+Contexto: error 500 en `/reporter-provincias/` reportado por el usuario.
+
+## Sintoma
+
+`GET /reporter-provincias/` levantaba `ValueError: Database returned an invalid
+datetime value. Are time zone definitions for your database installed?`, con el
+traceback terminando en `_build_tendencia_mensual`
+(`celiaquia/views/reporter_provincias.py`).
+
+## Causa raiz
+
+`_build_tendencia_mensual` agrupaba los casos por mes con
+`annotate(periodo=TruncMonth("creado_en"))`. En MySQL, cualquier `Trunc*`/`Extract*`
+sobre un `DateTimeField` con `USE_TZ=True` y `TIME_ZONE` distinto de UTC se traduce
+a `CONVERT_TZ(creado_en, 'UTC', 'America/Argentina/Buenos_Aires')`. Esa funcion
+devuelve `NULL` cuando la base **no tiene cargadas/activas** las tablas
+`mysql.time_zone*`, y Django convierte ese `NULL` en el `ValueError` de arriba.
+
+La base de produccion (`Produccion-vieja`, `10.80.5.46:3306`) no las tiene activas.
+
+## Alternativas evaluadas
+
+1. **Cargar `mysql.time_zone*` en produccion** (`mysql_tzinfo_to_sql`): es la
+   solucion "de plataforma", pero requiere permisos de escritura sobre el schema
+   `mysql` y, sobre todo, un **restart de `mysqld`** para que el server active las
+   zonas nombradas (es un flag que MySQL fija al arrancar; no hay `FLUSH` que lo
+   fuerce). No tenemos acceso a reiniciar el servicio productivo.
+2. **Usar offset fijo `-03:00`** en vez de la zona nombrada: valido (Argentina es
+   UTC-3 constante desde 2009, sin horario de verano) y no necesita las tablas,
+   pero obliga a tocar la config de conexion de Django y deja una convencion
+   implicita facil de romper.
+3. **Agrupar en Python** (elegida): se traen las fechas ya filtradas y se bucketea
+   por `(anio, mes)` en memoria, sin delegar la truncacion temporal a la base.
+
+## Decision
+
+Se adopta la opcion 3. `_build_tendencia_mensual` deja de usar `TruncMonth` y agrupa
+en Python usando `timezone.localtime` para respetar `settings.TIME_ZONE`. Asi el
+reporte funciona en cualquier entorno (produccion sin tz tables, CI con SQLite,
+local) sin depender del estado de `mysql.time_zone*` ni de un restart del server.
+
+## Implementacion
+
+- `celiaquia/views/reporter_provincias.py`: se elimina el import y el uso de
+  `django.db.models.functions.TruncMonth`; el conteo mensual se hace con un
+  `collections.Counter` sobre `creado_en` (ya acotado a 180 dias). Se conserva el
+  contrato de salida (`label` `MM/AAAA`, `count`, `size`) que consume
+  `celiaquia/templates/celiaquia/reporter_provincias.html`.
+
+## Consecuencias
+
+- **El reporte deja de depender de las tz tables de la base**: red de seguridad
+  permanente, no solo para produccion.
+- **Costo**: el agrupado pasa de la base a la app. El volumen esta acotado por el
+  filtro `creado_en >= hoy - 180 dias` y por el scope territorial del usuario, asi
+  que el set materializado es chico; el impacto es despreciable.
+- **Carga de `mysql.time_zone*` en produccion**: queda como tarea de plataforma de
+  baja prioridad (requiere restart de `mysqld`, coordinable por Infra). No es
+  bloqueante. Mientras tanto, cualquier consulta futura que necesite conversion de
+  zona del lado de la base deberia usar el offset fijo `-03:00` en vez de la zona
+  nombrada, o resolver el agrupado en Python como aca.


### PR DESCRIPTION
# Información de la Tarea

Sin issue vinculado (error 500 reportado directamente en sesión).

### **Resumen de la Solución:**
- `/reporter-provincias/` tiraba 500 al construir la tendencia mensual. Se elimina la dependencia de `CONVERT_TZ` de MySQL agrupando los meses en Python.

### **Información Adicional:**
- La base de producción (`Produccion-vieja`) no tiene activas las tablas `mysql.time_zone*` y activarlas requiere un restart de `mysqld` al que no tenemos acceso. Por eso se resuelve a nivel código en vez de a nivel base.

# Descripción de los Cambios

### **Cambios:**
- `celiaquia/views/reporter_provincias.py`: `_build_tendencia_mensual` deja de usar `TruncMonth("creado_en")` (que en MySQL con `USE_TZ=True` emite `CONVERT_TZ(..., "UTC", settings.TIME_ZONE)` → `NULL` sin tz tables → `ValueError`). Ahora agrupa por `(año, mes)` con `collections.Counter`, respetando `settings.TIME_ZONE` vía `timezone.localtime`. Se conserva el contrato de salida (`label` `MM/AAAA`, `count`, `size`) que consume el template.
- `docs/registro/decisiones/2026-06-04-tendencia-mensual-sin-convert-tz.md`: ADR liviana con causa raíz, alternativas evaluadas, decisión y consecuencias.

# Cómo Testear los Cambios

### **Pruebas Automáticas:**
- AST/parse OK; `black --check` conforme; sin imports muertos (`TruncMonth` eliminado del import).

### **Prubeas Manuales:**
- Entrar a `/reporter-provincias/` (con la base productiva sin tz tables) y verificar que ya no aparece el `ValueError: Database returned an invalid datetime value`, y que el bloque de tendencia mensual muestra las barras `MM/AAAA` con los conteos esperados.

# Metadata para documentación automática

- Contexto funcional: Reporter de Provincias (Celiaquía) — panel de tendencia mensual de casos.
- Tipo de cambio: fix
- Área principal: celiaquia
- Resumen para changelog: Se corrige un error 500 en el Reporter de Provincias al calcular la tendencia mensual en bases MySQL sin definiciones de zona horaria cargadas.
- Impacto usuario: La pantalla `/reporter-provincias/` vuelve a cargar correctamente; antes fallaba con error 500.
- Riesgos / rollback: Bajo. El agrupado pasa de la base a la app sobre un set acotado (180 días + scope territorial). Rollback = revertir el commit; reaparecería el 500 mientras la base no tenga las tz tables activas.

# Capturas de Pantalla

N/A

🤖 Generated with [Claude Code](https://claude.com/claude-code)
