### PR TITLE
fix(reporter-provincias): corregir escala de barras del gráfico de tendencia

### DIFF
--- a/static/custom/css/reporter_provincias.css
+++ b/static/custom/css/reporter_provincias.css
@@ -318,7 +318,7 @@
     background: linear-gradient(180deg, rgba(123, 199, 255, 0.94), rgba(44, 207, 157, 0.92));
     border-radius: 14px;
     display: flex;
-    height: calc(max(var(--size), 0.08) * 100%);
+    height: calc(max(var(--size), 8) * 1%);
     justify-content: center;
     padding-top: 0.55rem;
     position: relative;
@@ -408,7 +408,7 @@
     border-radius: inherit;
     display: block;
     height: 100%;
-    width: calc(max(var(--size), 0.04) * 100%);
+    width: calc(max(var(--size), 4) * 1%);
 }
 
 .province-ranking__meta,


### PR DESCRIPTION
## Problema

En `/reporter-provincias/`, las barras del gráfico de tendencia mensual y las barras de ranking de provincias/chips de estado cubrían toda la página, haciendo la UI inutilizable.

## Causa raíz

El backend calcula `size` como un porcentaje relativo al máximo (rango 0–100), por ejemplo `75.2` para el 75.2% del máximo. Pero el CSS usaba:

```css
height: calc(max(var(--size), 0.08) * 100%);
```

Esto esperaba un valor entre 0 y 1. Con `size = 75.2`, la altura resultaba en `7520%`.

## Solución

Dos líneas en `reporter_provincias.css` para que la fórmula trabaje con el rango 0–100 que envía el backend:

```css
/* antes */
height: calc(max(var(--size), 0.08) * 100%);
width:  calc(max(var(--size), 0.04) * 100%);

/* después */
height: calc(max(var(--size), 8) * 1%);
width:  calc(max(var(--size), 4) * 1%);
```

El comportamiento visual es el correcto: `size: 100` → `100%`, `size: 50` → `50%`, `size: 0` → mínimo visible.

## Archivos modificados

- `static/custom/css/reporter_provincias.css` — 2 líneas cambiadas

🤖 Generated with [Claude Code](https://claude.com/claude-code)