### PR TITLE
feat: registrar modelos faltantes en Django admin

### DIFF
--- a/centrodefamilia/admin.py
+++ b/centrodefamilia/admin.py
@@ -99,3 +99,5 @@ class InformeCabalRegistroAdmin(admin.ModelAdmin):
     list_filter = ("no_coincidente",)
     search_fields = ("nro_comercio", "razon_social", "nro_tarjeta")
     raw_id_fields = ("archivo", "centro")
+    date_hierarchy = "fecha_trx"
+    list_per_page = 50

--- a/centrodefamilia/admin.py
+++ b/centrodefamilia/admin.py
@@ -1,5 +1,16 @@
 from django.contrib import admin
-from .models import Centro, Actividad, ParticipanteActividad, Categoria
+
+from .models import (
+    Actividad,
+    AccesoCDF,
+    Beneficiario,
+    CabalArchivo,
+    Categoria,
+    Centro,
+    InformeCabalRegistro,
+    ParticipanteActividad,
+    Responsable,
+)
 
 
 @admin.register(Centro)
@@ -45,3 +56,46 @@ class ParticipanteActividadAdmin(admin.ModelAdmin):
     list_display = ("actividad_centro", "ciudadano", "fecha_registro")
     search_fields = ("ciudadano__apellido", "ciudadano__nombre", "ciudadano__documento")
     list_filter = ("actividad_centro__centro",)
+
+
+@admin.register(Responsable)
+class ResponsableAdmin(admin.ModelAdmin):
+    list_display = ("apellido", "nombre", "dni", "cuil", "vinculo_parental", "genero")
+    list_filter = ("vinculo_parental", "genero", "provincia")
+    search_fields = ("apellido", "nombre", "dni", "cuil")
+    raw_id_fields = ("creado_por",)
+    readonly_fields = ("fecha_creado", "fecha_modificado")
+
+
+@admin.register(Beneficiario)
+class BeneficiarioAdmin(admin.ModelAdmin):
+    list_display = ("apellido", "nombre", "dni", "cuil", "genero", "maximo_nivel_educativo")
+    list_filter = ("genero", "maximo_nivel_educativo", "estado_academico")
+    search_fields = ("apellido", "nombre", "dni", "cuil")
+    raw_id_fields = ("responsable", "creado_por")
+    readonly_fields = ("actividad_preferida", "fecha_creado", "fecha_modificado")
+
+
+@admin.register(AccesoCDF)
+class AccesoCDFAdmin(admin.ModelAdmin):
+    list_display = ("user", "centro", "activo", "fecha_creacion")
+    list_filter = ("activo",)
+    search_fields = ("user__username", "user__email", "centro__nombre")
+    raw_id_fields = ("user", "creado_por")
+    readonly_fields = ("fecha_creacion", "fecha_baja")
+
+
+@admin.register(CabalArchivo)
+class CabalArchivoAdmin(admin.ModelAdmin):
+    list_display = ("nombre_original", "usuario", "fecha_subida", "total_filas", "total_validas", "total_invalidas")
+    search_fields = ("nombre_original",)
+    raw_id_fields = ("usuario",)
+    readonly_fields = ("fecha_subida", "total_filas", "total_validas", "total_invalidas")
+
+
+@admin.register(InformeCabalRegistro)
+class InformeCabalRegistroAdmin(admin.ModelAdmin):
+    list_display = ("archivo", "centro", "nro_comercio", "razon_social", "importe", "fecha_trx", "no_coincidente")
+    list_filter = ("no_coincidente",)
+    search_fields = ("nro_comercio", "razon_social", "nro_tarjeta")
+    raw_id_fields = ("archivo", "centro")

--- a/centrodeinfancia/admin.py
+++ b/centrodeinfancia/admin.py
@@ -1,6 +1,7 @@
 from django.contrib import admin
 
 from centrodeinfancia.models import (
+    AccesoCDI,
     CentroDeInfancia,
     DepartamentoIpi,
     FormularioCDI,
@@ -10,6 +11,7 @@ from centrodeinfancia.models import (
     IntervencionCentroInfancia,
     NominaCentroInfancia,
     ObservacionCentroInfancia,
+    OfertaServicio,
     Trabajador,
 )
 
@@ -109,3 +111,18 @@ class FormularioCDIWaitlistByAgeGroupAdmin(admin.ModelAdmin):
 class FormularioCDIArticulationFrequencyAdmin(admin.ModelAdmin):
     list_display = ("id", "formulario", "tipo_institucion", "frecuencia")
     list_filter = ("frecuencia",)
+
+
+@admin.register(AccesoCDI)
+class AccesoCDIAdmin(admin.ModelAdmin):
+    list_display = ("user", "centro", "activo", "fecha_creacion")
+    list_filter = ("activo",)
+    search_fields = ("user__username", "user__email", "centro__nombre")
+    raw_id_fields = ("user", "creado_por")
+    readonly_fields = ("fecha_creacion", "fecha_baja")
+
+
+@admin.register(OfertaServicio)
+class OfertaServicioAdmin(admin.ModelAdmin):
+    list_display = ("codigo", "orden")
+    search_fields = ("codigo",)

--- a/ciudadanos/admin.py
+++ b/ciudadanos/admin.py
@@ -2,10 +2,12 @@ from django.contrib import admin
 
 from ciudadanos.models import (
     Ciudadano,
+    CiudadanosImportJob,
+    CiudadanosImportJobRow,
     GrupoFamiliar,
-    ProgramaTransferencia,
     HistorialTransferencia,
     Interaccion,
+    ProgramaTransferencia,
 )
 
 
@@ -70,3 +72,42 @@ class InteraccionAdmin(admin.ModelAdmin):
     list_filter = ("estado", "fecha")
     autocomplete_fields = ("ciudadano", "responsable")
     readonly_fields = ("creado", "modificado")
+
+
+@admin.register(CiudadanosImportJob)
+class CiudadanosImportJobAdmin(admin.ModelAdmin):
+    list_display = ("id", "requested_by", "original_filename", "status", "total_rows", "processed_rows", "requested_at")
+    list_filter = ("status",)
+    search_fields = ("original_filename", "requested_by__username")
+    raw_id_fields = ("requested_by",)
+    readonly_fields = (
+        "requested_by", "original_filename", "archivo", "status",
+        "total_rows", "processed_rows", "created_rows", "existing_rows", "failed_rows",
+        "pending_rows", "next_row_index", "last_successful_row", "last_successful_documento",
+        "last_attempted_row", "last_attempted_documento", "last_error_message", "last_error_type",
+        "last_error_at", "resume_count", "requested_at", "started_at", "finished_at", "last_activity_at",
+    )
+
+    def has_add_permission(self, request):
+        return False
+
+    def has_change_permission(self, request, obj=None):
+        return False
+
+
+@admin.register(CiudadanosImportJobRow)
+class CiudadanosImportJobRowAdmin(admin.ModelAdmin):
+    list_display = ("job", "fila", "documento_raw", "status", "processed_at")
+    list_filter = ("status",)
+    search_fields = ("documento_raw", "dni", "cuil")
+    raw_id_fields = ("job", "ciudadano")
+    readonly_fields = (
+        "job", "fila", "documento_raw", "dni", "cuil", "sexo", "sexos_intentados",
+        "status", "ciudadano", "mensaje", "error_type", "attempts", "processed_at",
+    )
+
+    def has_add_permission(self, request):
+        return False
+
+    def has_change_permission(self, request, obj=None):
+        return False

--- a/ciudadanos/admin.py
+++ b/ciudadanos/admin.py
@@ -79,7 +79,6 @@ class CiudadanosImportJobAdmin(admin.ModelAdmin):
     list_display = ("id", "requested_by", "original_filename", "status", "total_rows", "processed_rows", "requested_at")
     list_filter = ("status",)
     search_fields = ("original_filename", "requested_by__username")
-    raw_id_fields = ("requested_by",)
     readonly_fields = (
         "requested_by", "original_filename", "archivo", "status",
         "total_rows", "processed_rows", "created_rows", "existing_rows", "failed_rows",

--- a/comedores/admin.py
+++ b/comedores/admin.py
@@ -1,15 +1,18 @@
 from django.contrib import admin
 
 from comedores.models import (
+    CapacitacionComedorCertificado,
+    ComedorDatosConvenioPnud,
+    ColaboradorEspacio,
     Comedor,
+    HistorialValidacion,
+    ImagenComedor,
+    Nomina,
     Observacion,
+    Programas,
+    Referente,
     TipoDeComedor,
     ValorComida,
-    Programas,
-    Nomina,
-    Referente,
-    ImagenComedor,
-    HistorialValidacion,
 )
 
 
@@ -46,3 +49,29 @@ admin.site.register(Programas)
 admin.site.register(Nomina)
 admin.site.register(Referente)
 admin.site.register(ImagenComedor)
+
+
+@admin.register(ComedorDatosConvenioPnud)
+class ComedorDatosConvenioPnudAdmin(admin.ModelAdmin):
+    list_display = ("comedor", "nro_convenio", "monto_total_conveniado", "personas_conveniadas", "actualizado_en")
+    search_fields = ("comedor__nombre", "nro_convenio")
+    raw_id_fields = ("comedor",)
+    readonly_fields = ("actualizado_en",)
+
+
+@admin.register(ColaboradorEspacio)
+class ColaboradorEspacioAdmin(admin.ModelAdmin):
+    list_display = ("ciudadano", "comedor", "genero", "fecha_alta", "fecha_baja")
+    list_filter = ("genero",)
+    search_fields = ("ciudadano__apellido", "ciudadano__nombre", "ciudadano__documento", "comedor__nombre")
+    raw_id_fields = ("comedor", "ciudadano", "creado_por", "modificado_por")
+    readonly_fields = ("fecha_creado", "fecha_modificado")
+
+
+@admin.register(CapacitacionComedorCertificado)
+class CapacitacionComedorCertificadoAdmin(admin.ModelAdmin):
+    list_display = ("comedor", "capacitacion", "estado", "fecha_presentacion", "fecha_revision")
+    list_filter = ("estado", "capacitacion")
+    search_fields = ("comedor__nombre",)
+    raw_id_fields = ("comedor", "presentado_por", "revisado_por")
+    readonly_fields = ("observacion", "creado", "modificado")

--- a/core/admin.py
+++ b/core/admin.py
@@ -8,6 +8,9 @@ from core.models import (
     Mes,
     Dia,
     Turno,
+    Programa,
+    Nacionalidad,
+    MontoPrestacionPrograma,
 )
 
 admin.site.register(Provincia)
@@ -16,6 +19,28 @@ admin.site.register(Sexo)
 admin.site.register(Mes)
 admin.site.register(Dia)
 admin.site.register(Turno)
+
+
+@admin.register(Programa)
+class ProgramaAdmin(admin.ModelAdmin):
+    list_display = ("nombre", "estado", "organismo")
+    list_filter = ("estado",)
+    search_fields = ("nombre",)
+    readonly_fields = ("descripcion",)
+
+
+@admin.register(Nacionalidad)
+class NacionalidadAdmin(admin.ModelAdmin):
+    list_display = ("nacionalidad",)
+    search_fields = ("nacionalidad",)
+
+
+@admin.register(MontoPrestacionPrograma)
+class MontoPrestacionProgramaAdmin(admin.ModelAdmin):
+    list_display = ("programa", "desayuno_valor", "almuerzo_valor", "merienda_valor", "cena_valor", "fecha_creacion")
+    list_filter = ("programa",)
+    raw_id_fields = ("usuario_creador",)
+    readonly_fields = ("fecha_creacion", "fecha_modificacion")
 
 
 @admin.register(Localidad)

--- a/core/admin.py
+++ b/core/admin.py
@@ -26,7 +26,6 @@ class ProgramaAdmin(admin.ModelAdmin):
     list_display = ("nombre", "estado", "organismo")
     list_filter = ("estado",)
     search_fields = ("nombre",)
-    readonly_fields = ("descripcion",)
 
 
 @admin.register(Nacionalidad)

--- a/users/admin.py
+++ b/users/admin.py
@@ -1,0 +1,12 @@
+from django.contrib import admin
+
+from users.models import Profile
+
+
+@admin.register(Profile)
+class ProfileAdmin(admin.ModelAdmin):
+    list_display = ("user", "source", "must_change_password", "initial_password_expires_at")
+    list_filter = ("must_change_password", "source")
+    search_fields = ("user__username", "user__email")
+    raw_id_fields = ("user",)
+    readonly_fields = ("fecha_creacion",)


### PR DESCRIPTION
## ¿Qué cambia?

Registra en el Django admin los modelos que tenían valor operativo real pero no estaban accesibles desde el panel.

### Prioridad alta

| App | Modelos agregados |
|---|---|
| `users` | `Profile` |
| `core` | `Programa`, `Nacionalidad`, `MontoPrestacionPrograma` |
| `centrodefamilia` | `Responsable`, `Beneficiario`, `AccesoCDF` |
| `centrodeinfancia` | `AccesoCDI`, `OfertaServicio` |
| `ciudadanos` | `CiudadanosImportJob`, `CiudadanosImportJobRow` (solo lectura) |

### Prioridad media

| App | Modelos agregados |
|---|---|
| `centrodefamilia` | `CabalArchivo`, `InformeCabalRegistro` |
| `comedores` | `ComedorDatosConvenioPnud`, `ColaboradorEspacio`, `CapacitacionComedorCertificado` |

## Criterios aplicados

- Todos usan `@admin.register()` (no `admin.site.register()`)
- `raw_id_fields` en toda FK a `User` o `Ciudadano` para no romper performance
- `readonly_fields` en `JSONField`, campos `auto_now`/`auto_now_add` y datos sistema
- `CiudadanosImportJob` / `CiudadanosImportJobRow`: `has_add_permission` y `has_change_permission` devuelven `False` (debug only)
- No se tocaron ni duplicaron modelos ya registrados

## Test plan

- [ ] `python manage.py check` sin errores
- [ ] Login en `/admin/` y verificar que los nuevos modelos aparecen en sus respectivas apps
- [ ] Verificar que la lista de `Profile` filtra por `must_change_password` y `source`
- [ ] Verificar que `CiudadanosImportJob` no muestra botón "Agregar" ni permite editar
- [ ] Verificar que `raw_id_fields` funciona en `Beneficiario` (lookup de responsable/ciudadano)

🤖 Generated with [Claude Code](https://claude.com/claude-code)