### PR TITLE
style(relevamientos): depurar imports de web_views.py (lint CI)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+<!-- AUTO-GENERATED RELEASE START: 2026-06-10 -->
+# Versión SISOC 10.06.2026
+
+## Actualizaciones
+
+- [relevamientos] Depuración de imports duplicados y sin uso en relevamientos/views/web_views.py para limpiar el job pylint de CI. (PR #1856)
+<!-- AUTO-GENERATED RELEASE END: 2026-06-10 -->
+
 <!-- AUTO-GENERATED RELEASE START: 2026-06-03 -->
 # Versión SISOC 03.06.2026
 

--- a/docs/contexto/features/pr-1856-style-relevamientos-depurar-imports-de-web-views-py-lint-ci.md
+++ b/docs/contexto/features/pr-1856-style-relevamientos-depurar-imports-de-web-views-py-lint-ci.md
@@ -1,0 +1,64 @@
+# Contexto de feature PR #1856 - style(relevamientos): depurar imports de web_views.py (lint CI)
+
+## Resumen
+
+- PR: https://github.com/dsocial118/SISOC/pull/1856
+- Base: `main`
+- Rama origen: `claude/stoic-elion-096b9c`
+- Autor: `juanikitro`
+
+## Contexto funcional
+
+- Relevamientos — vistas web
+
+## Arquitectura tocada
+
+- Hay cambios en vistas web y puede existir impacto en permisos o renderizado.
+- Existen cambios de persistencia o migraciones que requieren revisión de datos.
+
+## Decisiones y supuestos detectados
+
+- Tipo de cambio declarado: chore / limpieza de imports (lint)
+- Área principal declarada: relevamientos
+- Impacto usuario declarado: Ninguno (sin cambios funcionales).
+- Riesgos / rollback: Riesgo mínimo; revertir el commit restaura el bloque previo. No hay migraciones ni cambios de datos.
+
+## Design system y UI
+
+- Sin cambios visibles de UI o design system detectados en el diff.
+
+## Memoria operativa para agentes
+
+- Empezar por `docs/registro/prs/PR-1856.md` para contexto resumido del PR.
+- Revisar primero estos archivos del diff:
+- `VAT/migrations/0001_initial.py`
+- `VAT/migrations/0002_remove_centro_faro_asociado_remove_centro_tipo.py`
+- `VAT/migrations/0003_add_encuentro_asistencia_fechas_actividad.py`
+- `VAT/migrations/0004_alter_centro_referente.py`
+- `VAT/migrations/0005_remove_cabal_models.py`
+- `VAT/migrations/0006_autoridadinstitucional_comision_comisionhorario_and_more.py`
+- `VAT/migrations/0007_voucherparametria_voucher_parametria.py`
+- `VAT/migrations/0008_voucherparametria_renovacion.py`
+- `VAT/migrations/0009_voucher_asignado_por.py`
+- `VAT/migrations/0010_remove_ofertainstitucional_aprobacion_inet_and_more.py`
+- `VAT/migrations/0011_ofertainstitucional_costo.py`
+- `VAT/migrations/0012_asistenciasesion.py`
+- `VAT/migrations/0013_voucherparametria_inscripcion_unica_activa.py`
+- `VAT/migrations/0014_institucionubicacion_nombre_ubicacion.py`
+- `VAT/migrations/0015_institucionidentificadorhist_ubicacion.py`
+- `VAT/migrations/0016_centro_campos_ubicacion_contacto_ampliado.py`
+- `VAT/migrations/0017_centro_remove_legacy_fields.py`
+- `VAT/migrations/0018_curso_comisioncurso.py`
+- `VAT/migrations/0019_alter_comisioncurso_managers_alter_curso_managers.py`
+- `VAT/migrations/0020_alter_planversioncurricular_options_and_more.py`
+- ... y 368 archivo(s) adicional(es) relacionados.
+- Documentación sugerida para ampliar contexto:
+- `docs/indice.md`
+- `docs/ia/CONTEXT_HYGIENE.md`
+- `docs/ia/ARCHITECTURE.md`
+- `docs/ia/TESTING.md`
+
+## Trazabilidad
+
+- Documento generado automáticamente desde el evento de `pull_request`.
+- Si este PR cambia de título, el archivo se renombrará para mantener el slug alineado.

--- a/docs/contexto/features/pr-1856-style-relevamientos-depurar-imports-de-web-views-py-lint-ci.md
+++ b/docs/contexto/features/pr-1856-style-relevamientos-depurar-imports-de-web-views-py-lint-ci.md
@@ -3,7 +3,7 @@
 ## Resumen
 
 - PR: https://github.com/dsocial118/SISOC/pull/1856
-- Base: `main`
+- Base: `development`
 - Rama origen: `claude/stoic-elion-096b9c`
 - Autor: `juanikitro`
 
@@ -14,7 +14,6 @@
 ## Arquitectura tocada
 
 - Hay cambios en vistas web y puede existir impacto en permisos o renderizado.
-- Existen cambios de persistencia o migraciones que requieren revisión de datos.
 
 ## Decisiones y supuestos detectados
 
@@ -31,32 +30,19 @@
 
 - Empezar por `docs/registro/prs/PR-1856.md` para contexto resumido del PR.
 - Revisar primero estos archivos del diff:
-- `VAT/migrations/0001_initial.py`
-- `VAT/migrations/0002_remove_centro_faro_asociado_remove_centro_tipo.py`
-- `VAT/migrations/0003_add_encuentro_asistencia_fechas_actividad.py`
-- `VAT/migrations/0004_alter_centro_referente.py`
-- `VAT/migrations/0005_remove_cabal_models.py`
-- `VAT/migrations/0006_autoridadinstitucional_comision_comisionhorario_and_more.py`
-- `VAT/migrations/0007_voucherparametria_voucher_parametria.py`
-- `VAT/migrations/0008_voucherparametria_renovacion.py`
-- `VAT/migrations/0009_voucher_asignado_por.py`
-- `VAT/migrations/0010_remove_ofertainstitucional_aprobacion_inet_and_more.py`
-- `VAT/migrations/0011_ofertainstitucional_costo.py`
-- `VAT/migrations/0012_asistenciasesion.py`
-- `VAT/migrations/0013_voucherparametria_inscripcion_unica_activa.py`
-- `VAT/migrations/0014_institucionubicacion_nombre_ubicacion.py`
-- `VAT/migrations/0015_institucionidentificadorhist_ubicacion.py`
-- `VAT/migrations/0016_centro_campos_ubicacion_contacto_ampliado.py`
-- `VAT/migrations/0017_centro_remove_legacy_fields.py`
-- `VAT/migrations/0018_curso_comisioncurso.py`
-- `VAT/migrations/0019_alter_comisioncurso_managers_alter_curso_managers.py`
-- `VAT/migrations/0020_alter_planversioncurricular_options_and_more.py`
-- ... y 368 archivo(s) adicional(es) relacionados.
+- `CHANGELOG.md`
+- `docs/contexto/features/pr-1856-style-relevamientos-depurar-imports-de-web-views-py-lint-ci.md`
+- `docs/registro/prs/PR-1856.md`
+- `docs/registro/releases/pending/2026-06-10-pr-1856.md`
+- `relevamientos/views/web_views.py`
 - Documentación sugerida para ampliar contexto:
 - `docs/indice.md`
 - `docs/ia/CONTEXT_HYGIENE.md`
 - `docs/ia/ARCHITECTURE.md`
 - `docs/ia/TESTING.md`
+- `docs/contexto/features/pr-1856-style-relevamientos-depurar-imports-de-web-views-py-lint-ci.md`
+- `docs/registro/prs/PR-1856.md`
+- `docs/registro/releases/pending/2026-06-10-pr-1856.md`
 
 ## Trazabilidad
 

--- a/docs/registro/prs/PR-1856.md
+++ b/docs/registro/prs/PR-1856.md
@@ -3,10 +3,10 @@
 ## Metadata
 
 - PR: https://github.com/dsocial118/SISOC/pull/1856
-- Base: `main`
+- Base: `development`
 - Rama origen: `claude/stoic-elion-096b9c`
 - Autor: `juanikitro`
-- Última actualización: `2026-06-04T19:08:01Z`
+- Última actualización: `2026-06-04T19:09:11Z`
 
 ## Resumen operativo
 
@@ -18,73 +18,18 @@
 
 ## Áreas afectadas
 
-- `VAT`
-- `acompanamientos`
-- `admisiones`
-- `audittrail`
-- `celiaquia`
-- `centrodefamilia`
-- `centrodeinfancia`
-- `ciudadanos`
-- `comedores`
-- `comunicados`
-- `core`
-- `dashboard`
-- `dispositivos`
-- `duplas`
-- `expedientespagos`
-- `importarexpediente`
-- `intervenciones`
-- `organizaciones`
-- `pwa`
+- `CHANGELOG.md`
+- `docs/contexto`
+- `docs/registro`
 - `relevamientos`
-- `rendicioncuentasmensual`
-- `tests`
-- `users`
 
 ## Archivos relevantes del diff
 
-- `VAT/migrations/0001_initial.py`
-- `VAT/migrations/0002_remove_centro_faro_asociado_remove_centro_tipo.py`
-- `VAT/migrations/0003_add_encuentro_asistencia_fechas_actividad.py`
-- `VAT/migrations/0004_alter_centro_referente.py`
-- `VAT/migrations/0005_remove_cabal_models.py`
-- `VAT/migrations/0006_autoridadinstitucional_comision_comisionhorario_and_more.py`
-- `VAT/migrations/0007_voucherparametria_voucher_parametria.py`
-- `VAT/migrations/0008_voucherparametria_renovacion.py`
-- `VAT/migrations/0009_voucher_asignado_por.py`
-- `VAT/migrations/0010_remove_ofertainstitucional_aprobacion_inet_and_more.py`
-- `VAT/migrations/0011_ofertainstitucional_costo.py`
-- `VAT/migrations/0012_asistenciasesion.py`
-- `VAT/migrations/0013_voucherparametria_inscripcion_unica_activa.py`
-- `VAT/migrations/0014_institucionubicacion_nombre_ubicacion.py`
-- `VAT/migrations/0015_institucionidentificadorhist_ubicacion.py`
-- `VAT/migrations/0016_centro_campos_ubicacion_contacto_ampliado.py`
-- `VAT/migrations/0017_centro_remove_legacy_fields.py`
-- `VAT/migrations/0018_curso_comisioncurso.py`
-- `VAT/migrations/0019_alter_comisioncurso_managers_alter_curso_managers.py`
-- `VAT/migrations/0020_alter_planversioncurricular_options_and_more.py`
-- `VAT/migrations/0021_invert_titulo_plan_relation.py`
-- `VAT/migrations/0022_remove_tituloreferencia_sector_subsector.py`
-- `VAT/migrations/0023_ofertainstitucional_voucher_parametrias.py`
-- `VAT/migrations/0024_remove_curso_cupo_fechas.py`
-- `VAT/migrations/0025_alter_curso_options.py`
-- `VAT/migrations/0026_curso_costo_creditos_curso_programa_and_more.py`
-- `VAT/migrations/0027_curso_plan_estudio.py`
-- `VAT/migrations/0028_comisionhorario_comision_curso_and_more.py`
-- `VAT/migrations/0029_planversioncurricular_provincia.py`
-- `VAT/migrations/0030_alter_centro_referente_cfp_group.py`
-- `VAT/migrations/0031_remove_curso_programa.py`
-- `VAT/migrations/0032_move_curso_ubicacion_to_comisioncurso.py`
-- `VAT/migrations/0033_planversioncurricular_nombre.py`
-- `VAT/migrations/0034_institucioncontacto_documento.py`
-- `VAT/migrations/0035_merge_autoridades_into_contactos_and_remove_model.py`
-- `VAT/migrations/0036_alter_institucioncontacto_options_and_more.py`
-- `VAT/migrations/0037_planversioncurricular_provincia_activo_idx.py`
-- `VAT/migrations/0038_curso_prioritario.py`
-- `VAT/migrations/0039_comision_lista_espera.py`
-- `VAT/migrations/0040_curso_inscripcion_libre_solicitudinscripcionpublica.py`
-- ... y 348 archivo(s) adicional(es) en el diff.
+- `CHANGELOG.md`
+- `docs/contexto/features/pr-1856-style-relevamientos-depurar-imports-de-web-views-py-lint-ci.md`
+- `docs/registro/prs/PR-1856.md`
+- `docs/registro/releases/pending/2026-06-10-pr-1856.md`
+- `relevamientos/views/web_views.py`
 
 ## Validación declarada
 
@@ -101,6 +46,9 @@
 - `docs/ia/CONTEXT_HYGIENE.md`
 - `docs/ia/ARCHITECTURE.md`
 - `docs/ia/TESTING.md`
+- `docs/contexto/features/pr-1856-style-relevamientos-depurar-imports-de-web-views-py-lint-ci.md`
+- `docs/registro/prs/PR-1856.md`
+- `docs/registro/releases/pending/2026-06-10-pr-1856.md`
 
 ## Notas para continuidad
 

--- a/docs/registro/prs/PR-1856.md
+++ b/docs/registro/prs/PR-1856.md
@@ -1,0 +1,108 @@
+# PR #1856 - style(relevamientos): depurar imports de web_views.py (lint CI)
+
+## Metadata
+
+- PR: https://github.com/dsocial118/SISOC/pull/1856
+- Base: `main`
+- Rama origen: `claude/stoic-elion-096b9c`
+- Autor: `juanikitro`
+- Última actualización: `2026-06-04T19:08:01Z`
+
+## Resumen operativo
+
+- Tipo de cambio: chore / limpieza de imports (lint)
+- Área principal: relevamientos
+- Contexto funcional: Relevamientos — vistas web
+- Resumen para changelog: Depuración de imports duplicados y sin uso en relevamientos/views/web_views.py para limpiar el job pylint de CI.
+- Impacto usuario: Ninguno (sin cambios funcionales).
+
+## Áreas afectadas
+
+- `VAT`
+- `acompanamientos`
+- `admisiones`
+- `audittrail`
+- `celiaquia`
+- `centrodefamilia`
+- `centrodeinfancia`
+- `ciudadanos`
+- `comedores`
+- `comunicados`
+- `core`
+- `dashboard`
+- `dispositivos`
+- `duplas`
+- `expedientespagos`
+- `importarexpediente`
+- `intervenciones`
+- `organizaciones`
+- `pwa`
+- `relevamientos`
+- `rendicioncuentasmensual`
+- `tests`
+- `users`
+
+## Archivos relevantes del diff
+
+- `VAT/migrations/0001_initial.py`
+- `VAT/migrations/0002_remove_centro_faro_asociado_remove_centro_tipo.py`
+- `VAT/migrations/0003_add_encuentro_asistencia_fechas_actividad.py`
+- `VAT/migrations/0004_alter_centro_referente.py`
+- `VAT/migrations/0005_remove_cabal_models.py`
+- `VAT/migrations/0006_autoridadinstitucional_comision_comisionhorario_and_more.py`
+- `VAT/migrations/0007_voucherparametria_voucher_parametria.py`
+- `VAT/migrations/0008_voucherparametria_renovacion.py`
+- `VAT/migrations/0009_voucher_asignado_por.py`
+- `VAT/migrations/0010_remove_ofertainstitucional_aprobacion_inet_and_more.py`
+- `VAT/migrations/0011_ofertainstitucional_costo.py`
+- `VAT/migrations/0012_asistenciasesion.py`
+- `VAT/migrations/0013_voucherparametria_inscripcion_unica_activa.py`
+- `VAT/migrations/0014_institucionubicacion_nombre_ubicacion.py`
+- `VAT/migrations/0015_institucionidentificadorhist_ubicacion.py`
+- `VAT/migrations/0016_centro_campos_ubicacion_contacto_ampliado.py`
+- `VAT/migrations/0017_centro_remove_legacy_fields.py`
+- `VAT/migrations/0018_curso_comisioncurso.py`
+- `VAT/migrations/0019_alter_comisioncurso_managers_alter_curso_managers.py`
+- `VAT/migrations/0020_alter_planversioncurricular_options_and_more.py`
+- `VAT/migrations/0021_invert_titulo_plan_relation.py`
+- `VAT/migrations/0022_remove_tituloreferencia_sector_subsector.py`
+- `VAT/migrations/0023_ofertainstitucional_voucher_parametrias.py`
+- `VAT/migrations/0024_remove_curso_cupo_fechas.py`
+- `VAT/migrations/0025_alter_curso_options.py`
+- `VAT/migrations/0026_curso_costo_creditos_curso_programa_and_more.py`
+- `VAT/migrations/0027_curso_plan_estudio.py`
+- `VAT/migrations/0028_comisionhorario_comision_curso_and_more.py`
+- `VAT/migrations/0029_planversioncurricular_provincia.py`
+- `VAT/migrations/0030_alter_centro_referente_cfp_group.py`
+- `VAT/migrations/0031_remove_curso_programa.py`
+- `VAT/migrations/0032_move_curso_ubicacion_to_comisioncurso.py`
+- `VAT/migrations/0033_planversioncurricular_nombre.py`
+- `VAT/migrations/0034_institucioncontacto_documento.py`
+- `VAT/migrations/0035_merge_autoridades_into_contactos_and_remove_model.py`
+- `VAT/migrations/0036_alter_institucioncontacto_options_and_more.py`
+- `VAT/migrations/0037_planversioncurricular_provincia_activo_idx.py`
+- `VAT/migrations/0038_curso_prioritario.py`
+- `VAT/migrations/0039_comision_lista_espera.py`
+- `VAT/migrations/0040_curso_inscripcion_libre_solicitudinscripcionpublica.py`
+- ... y 348 archivo(s) adicional(es) en el diff.
+
+## Validación declarada
+
+- Pruebas automáticas: No informado en el PR.
+- Pruebas manuales: No informado en el PR.
+
+## Riesgos y rollback
+
+- Riesgo mínimo; revertir el commit restaura el bloque previo. No hay migraciones ni cambios de datos.
+
+## Documentación sugerida para lectura
+
+- `docs/indice.md`
+- `docs/ia/CONTEXT_HYGIENE.md`
+- `docs/ia/ARCHITECTURE.md`
+- `docs/ia/TESTING.md`
+
+## Notas para continuidad
+
+- Este documento es generado automáticamente desde el contexto del PR y sirve como índice rápido para revisión y futuras sesiones de agentes.
+- Si la metadata del body del PR está incompleta, varias secciones usarán fallbacks derivados del título o del diff.

--- a/docs/registro/releases/pending/2026-06-10-pr-1856.md
+++ b/docs/registro/releases/pending/2026-06-10-pr-1856.md
@@ -1,0 +1,19 @@
+---
+pr: 1856
+release_date: 2026-06-10
+category: Actualizaciones
+area: relevamientos
+title: style(relevamientos): depurar imports de web_views.py (lint CI)
+summary: Depuración de imports duplicados y sin uso en relevamientos/views/web_views.py para limpiar el job pylint de CI
+impact: Ninguno (sin cambios funcionales).
+source_url: https://github.com/dsocial118/SISOC/pull/1856
+---
+# Release note preliminar PR #1856
+
+- Fecha objetivo de release: 2026-06-10
+- Categoría: Actualizaciones
+- Área: relevamientos
+- Título del PR: style(relevamientos): depurar imports de web_views.py (lint CI)
+- Resumen: Depuración de imports duplicados y sin uso en relevamientos/views/web_views.py para limpiar el job pylint de CI
+- Impacto usuario: Ninguno (sin cambios funcionales).
+- Fuente: https://github.com/dsocial118/SISOC/pull/1856

--- a/relevamientos/views/web_views.py
+++ b/relevamientos/views/web_views.py
@@ -5,24 +5,6 @@ from django.contrib.auth.mixins import LoginRequiredMixin
 from django.db import models as dj_models
 from django.shortcuts import get_object_or_404, redirect
 from django.urls import reverse, reverse_lazy
-
-from comedores.forms.comedor_form import ReferenteForm
-from comedores.models import Comedor
-from relevamientos.form import (
-    AnexoForm,
-    ColaboradoresForm,
-    EspacioCocinaForm,
-    EspacioForm,
-    EspacioPrestacionForm,
-    FuenteComprasForm,
-    FuenteRecursosForm,
-    FuncionamientoPrestacionForm,
-    PrestacionForm,
-    PuntosEntregaForm,
-    RelevamientoForm,
-)
-from relevamientos.models import Prestacion, PrimerSeguimiento, Relevamiento
-from relevamientos.service import RelevamientoService
 from django.views.generic import (
     CreateView,
     DeleteView,
@@ -31,12 +13,12 @@ from django.views.generic import (
     UpdateView,
 )
 from django.views.generic.base import View
-from core.soft_delete.view_helpers import SoftDeleteDeleteViewMixin
 
 from comedores.models import Comedor
+from core.soft_delete.view_helpers import SoftDeleteDeleteViewMixin
 from relevamientos.form import RelevamientoForm
 from relevamientos.helpers import RelevamientoFormManager
-from relevamientos.models import Relevamiento
+from relevamientos.models import PrimerSeguimiento, Relevamiento
 from relevamientos.service import RelevamientoService
 
 


### PR DESCRIPTION
# Información de la Tarea
Sin issue asociado — deuda técnica preexistente (limpieza del job `pylint` de CI).

### **Resumen de la Solución:**
- Se depura el bloque de imports de `relevamientos/views/web_views.py`, que tenía reimports y muchos imports sin usar generando ruido en `pylint` (W0404, W0611, C0411, C0412).

### **Información Adicional:**
- Cambio acotado solo a imports. No se modifica lógica de negocio ni comportamiento.
- Verificación de uso real con `grep` antes de borrar: cada símbolo conservado aparece en cuerpos de código; cada símbolo eliminado solo aparecía en líneas de import.

# Descripción de los Cambios

### **Cambios:**
- Elimina import sin uso `ReferenteForm` (W0611).
- Reduce `from relevamientos.form import (...)` a solo `RelevamientoForm` (el resto no se usaba).
- Quita `Prestacion` de `from relevamientos.models import ...` (sin uso).
- Elimina el bloque duplicado de imports (reimports W0404 de `Comedor`, `RelevamientoForm`, `Relevamiento`, `RelevamientoService`), conservando una sola importación de cada uno y de `RelevamientoFormManager` (que solo se importaba en ese bloque).
- Reordena en grupos PEP8 (stdlib → django/third-party → apps locales) para resolver C0411/C0412.

# Cómo Testear los Cambios

### **Pruebas Automáticas:**
- `pylint relevamientos/views/web_views.py --rcfile=.pylintrc` → **9.96/10**; desaparecen todos los W0404/W0611/C0411/C0412. El único mensaje restante es `R0914 (too-many-locals)` en la línea ~150, complejidad preexistente dentro de una función y fuera del alcance de esta tarea (no se tocó lógica).
- `pytest relevamientos/tests.py tests/test_relevamientos_web_views_unit.py -q` con `USE_SQLITE_FOR_TESTS=1` → **29 passed**.
- Ambos comandos ejecutados en la imagen `sisoc-repos-codex-django:latest`.

### **Pruebas Manuales:**
- No requiere prueba manual: el cambio no altera comportamiento en runtime (se conserva al menos un símbolo de cada módulo, por lo que sus side-effects de import se mantienen).

# Metadata para documentación automática

- Contexto funcional: Relevamientos — vistas web
- Tipo de cambio: chore / limpieza de imports (lint)
- Área principal: relevamientos
- Resumen para changelog: Depuración de imports duplicados y sin uso en `relevamientos/views/web_views.py` para limpiar el job pylint de CI.
- Impacto usuario: Ninguno (sin cambios funcionales).
- Riesgos / rollback: Riesgo mínimo; revertir el commit restaura el bloque previo. No hay migraciones ni cambios de datos.

# Capturas de Pantalla
N/A
