### PR TITLE
fix(primer-seguimiento): que la sincronizacion con GESTIONAR funcione + UI del listado

### DIFF
--- a/comedores/tests.py
+++ b/comedores/tests.py
@@ -961,6 +961,39 @@ def test_relevamiento_create_edit_ajax_crea_primer_seguimiento(
 
 
 @pytest.mark.django_db
+def test_relevamiento_create_edit_ajax_primer_seguimiento_reenvia_relevamiento_id(
+    client_logged_fixture, comedor_fixture, monkeypatch
+):
+    """El alta desde el boton de una fila puntual reenvia su relevamiento_id."""
+    relevamiento_mock = mock.Mock()
+    relevamiento_mock.pk = 1002
+    relevamiento_mock.comedor = mock.Mock()
+    relevamiento_mock.comedor.pk = comedor_fixture.pk
+    seguimiento_mock = mock.Mock()
+    seguimiento_mock.id_relevamiento = relevamiento_mock
+    create_mock = mock.Mock(return_value=seguimiento_mock)
+
+    monkeypatch.setattr(
+        "comedores.views.relevamientos.PrimerSeguimientoService.create_asignado",
+        create_mock,
+    )
+
+    url = reverse("relevamiento_create_edit_ajax", kwargs={"pk": comedor_fixture.pk})
+    response = client_logged_fixture.post(
+        url,
+        {
+            "tipo_relevamiento": "primer_seguimiento",
+            "territorial": '{"gestionar_uid":"uid-1","nombre":"Territorial Norte"}',
+            "relevamiento_id": "777",
+        },
+        HTTP_X_REQUESTED_WITH="XMLHttpRequest",
+    )
+
+    assert response.status_code == 200
+    assert create_mock.call_args.kwargs["relevamiento_id"] == "777"
+
+
+@pytest.mark.django_db
 def test_relevamiento_create_edit_ajax_rechaza_segundo_seguimiento(
     client_logged_fixture, comedor_fixture
 ):

--- a/comedores/views/relevamientos.py
+++ b/comedores/views/relevamientos.py
@@ -76,6 +76,7 @@ def _handle_create_primer_seguimiento(request, comedor, is_ajax):
     seguimiento = PrimerSeguimientoService.create_asignado(
         comedor.id,
         request.POST.get("territorial"),
+        relevamiento_id=request.POST.get("relevamiento_id"),
     )
     return _success_response(
         request,
@@ -170,7 +171,7 @@ def relevamiento_crear_editar_ajax(request, pk):
     try:
         comedor = _resolve_scoped_comedor_from_pk(pk, request.user)
 
-        if "territorial" in request.POST:
+        if "tipo_relevamiento" in request.POST or "territorial" in request.POST:
             response = _handle_create_with_tipo(request, comedor, is_ajax)
         elif "territorial_editar" in request.POST:
             response = _handle_update_territorial(request, comedor, is_ajax)

--- a/docs/flujos/relevamiento_sync.md
+++ b/docs/flujos/relevamiento_sync.md
@@ -20,12 +20,12 @@ Registrar el relevamiento inicial de comedores y crear el primer seguimiento aso
 
 ## Primer seguimiento
 
-1. `PrimerSeguimientoService` valida el territorial usando el mismo parser del relevamiento inicial.
-2. Busca el ultimo `Relevamiento` del comedor que no este eliminado y cuyo estado no sea `Finalizado` ni `Finalizado/Excepciones`.
-3. Si no existe ancla activa, crea un `Relevamiento` local con `_skip_gestionar_sync=True`. Ese ancla no envia un relevamiento inicial a GESTIONAR.
-4. Crea `PrimerSeguimiento` en estado `Asignado`, guarda el tecnico externo en `tecnico` y lo vincula por `id_relevamiento`.
-5. Envia el alta con `AsyncSendPrimerSeguimientoToGestionar` usando `GESTIONAR_API_CREAR_PRIMER_SEGUIMIENTO`. El payload contiene `{"ID_Seguimiento1": "<pk>", "Id_Relevamiento": "<id>", "Id_SISOC": "<pk>"}`; `ID_Seguimiento1` viaja con el PK de SISOC para que ambos sistemas usen el mismo identificador. SISOC persiste lo que GESTIONAR devuelve en `Rows[0].ID_Seguimiento1` en `PrimerSeguimiento.gestionar_id` (en el flujo normal coincide con el sisoc_id; si GESTIONAR responde con otra cosa, queda registrado).
-6. La baja usa `AsyncRemovePrimerSeguimientoToGestionar` y `GESTIONAR_API_BORRAR_PRIMER_SEGUIMIENTO`, enviando el `gestionar_id` guardado. Si el seguimiento no tiene `gestionar_id` (por ejemplo el alta nunca llego a GESTIONAR), la baja se omite con un log informativo.
+1. `PrimerSeguimientoService.create_asignado` resuelve el `Relevamiento` ancla y el territorial del seguimiento:
+   - si llega `relevamiento_id` (alta desde el boton de una fila puntual del listado) o ya existe un relevamiento activo (no eliminado y cuyo estado no sea `Finalizado` ni `Finalizado/Excepciones`), usa ese relevamiento y **hereda** su `territorial_uid` como `tecnico` del seguimiento;
+   - si no hay relevamiento previo, valida el territorial del formulario (mismo parser del relevamiento inicial) y crea un `Relevamiento` ancla **asignado** (estado `Visita pendiente`, con ese territorial) que **SI** se sincroniza con GESTIONAR. El seguimiento referencia ese relevamiento por `Id_Relevamiento`, asi que GESTIONAR necesita conocerlo para poder enlazar la fila de `Seguimientos1erVisita`.
+2. Crea `PrimerSeguimiento` en estado `Asignado`, guarda el tecnico (heredado o del formulario) en `tecnico` y lo vincula por `id_relevamiento`.
+3. Envia el alta con `AsyncSendPrimerSeguimientoToGestionar` usando `GESTIONAR_API_CREAR_PRIMER_SEGUIMIENTO`. El payload contiene `{"ID_Seguimiento1": "<pk>", "Id_Relevamiento": "<id>", "Id_SISOC": "<pk>"}`; `ID_Seguimiento1` viaja con el PK de SISOC para que ambos sistemas usen el mismo identificador. SISOC persiste lo que GESTIONAR devuelve en `Rows[0].ID_Seguimiento1` en `PrimerSeguimiento.gestionar_id` (en el flujo normal coincide con el sisoc_id; si GESTIONAR responde con otra cosa, queda registrado).
+4. La baja usa `AsyncRemovePrimerSeguimientoToGestionar` y `GESTIONAR_API_BORRAR_PRIMER_SEGUIMIENTO`, enviando el `gestionar_id` guardado. Si el seguimiento no tiene `gestionar_id` (por ejemplo el alta nunca llego a GESTIONAR), la baja se omite con un log informativo.
 
 ## API externa
 
@@ -47,7 +47,10 @@ Respuestas esperadas:
 
 ## Estado de sincronizacion
 
-Tanto `Relevamiento` como `PrimerSeguimiento` exponen el booleano `sincronizado_gestionar` (default `False`). Cada `PATCH` exitoso desde GESTIONAR lo marca en `True` via `update()` (sin disparar signals). El detalle de relevamiento muestra un badge verde "Sincronizado con GESTIONAR" cuando esta en `True`, y un badge gris "Pendiente sincronizacion" en el bloque del primer seguimiento mientras siga en `False`.
+Tanto `Relevamiento` como `PrimerSeguimiento` exponen el booleano `sincronizado_gestionar` (default `False`). El detalle muestra un badge verde "Sincronizado con GESTIONAR" cuando esta en `True`, y un badge gris "Pendiente sincronizacion" mientras siga en `False`. Se marca `True` por dos vias:
+
+1. **POST saliente confirmado:** tanto `AsyncSendRelevamientoToGestionar` como `AsyncSendPrimerSeguimientoToGestionar` marcan `sincronizado_gestionar=True` solo cuando GESTIONAR responde `2xx` **y devuelve filas** (`Rows`). AppSheet responde `200` aun cuando rechaza el alta (p. ej. el `Id_Relevamiento` no existe en GESTIONAR o falta una columna requerida), pero en ese caso devuelve `Rows` vacio: ahi NO se marca sincronizado y se deja un `logger.warning` con el cuerpo para diagnostico. Esto evita el falso "exito" del log cuando la fila no se registro realmente.
+2. **PATCH entrante:** cada `PATCH` exitoso desde GESTIONAR tambien lo marca en `True` via `update()` (sin disparar signals), y trae los bloques completos.
 
 ## Referente en el PATCH del primer seguimiento
 
@@ -62,7 +65,7 @@ Si no viene `documento` ni `sisoc_id`, cae al patron previo de busqueda por nomb
 
 - No mas de un relevamiento con estado `Pendiente` o `Visita pendiente` por comedor.
 - No mas de un `PrimerSeguimiento` para el mismo `Relevamiento`, reforzado por `OneToOneField`.
-- El modal exige territorial para crear relevamiento inicial o primer seguimiento.
+- El alta exige territorial cuando se crea un relevamiento (inicial o ancla de un primer seguimiento sin relevamiento previo). El primer seguimiento sobre un relevamiento existente NO pide territorial: lo hereda del relevamiento.
 - `Segundo seguimiento` queda rechazado hasta implementar la fase 2.
 - Los choices no confirmados se guardan como `CharField`; las escalas usan validadores 1..4 o 1..11.
 - Las firmas recibidas desde GESTIONAR se guardan como URL/string, no como `FileField`.
@@ -71,7 +74,7 @@ Si no viene `documento` ni `sisoc_id`, cae al patron previo de busqueda por nomb
 
 - ValidationError por relevamiento activo duplicado: revisar estados pendientes del comedor.
 - ValidationError por primer seguimiento duplicado: revisar si el ancla ya tiene `primer_seguimiento`.
-- Si se creo ancla local y aparece un alta de relevamiento inicial en GESTIONAR, revisar que el signal respete `_skip_gestionar_sync`.
+- El primer seguimiento "llega" a GESTIONAR con `2xx` pero no aparece la fila: revisar el `logger.warning` de `Rows` vacio. Causa tipica: el `Id_Relevamiento` apunta a un relevamiento que GESTIONAR no tiene. Desde 2026-06-04 el ancla creada para un primer seguimiento sin relevamiento previo SI se sincroniza (ya no usa `_skip_gestionar_sync`); si igual no enlaza, validar con el dueno de la app AppSheet que la tabla `Seguimientos1erVisita` no exija columnas adicionales.
 - Fallas HTTP a GESTIONAR: revisar `GESTIONAR_API_KEY`, `GESTIONAR_API_CREAR_RELEVAMIENTO`, `GESTIONAR_API_BORRAR_RELEVAMIENTO`, `GESTIONAR_API_CREAR_PRIMER_SEGUIMIENTO` y `GESTIONAR_API_BORRAR_PRIMER_SEGUIMIENTO`.
 
 ## Tests

--- a/docs/registro/cambios/2026-06-04-primer-seguimiento-ajustes-produccion.md
+++ b/docs/registro/cambios/2026-06-04-primer-seguimiento-ajustes-produccion.md
@@ -1,0 +1,148 @@
+# 2026-06-04 - Ajustes de produccion del primer seguimiento
+
+## Resumen
+Tres correcciones reportadas al probar primer seguimiento en produccion:
+
+1. El detalle del primer seguimiento quedaba en "Pendiente sincronizacion" aunque
+   el POST a GESTIONAR habia sido exitoso (logueaba "...sincronizado con GESTIONAR
+   con exito").
+2. El listado de relevamientos mostraba "Sin asignar" como fallback de la fecha,
+   leyendose como si el relevamiento no estuviera asignado.
+3. El boton `Agregar` vivia en el cuerpo de la card; se pidio moverlo al header
+   (alineado con "Relevamientos") y sumar un boton `Agregar` por cada relevamiento
+   para crear un seguimiento sobre ese relevamiento puntual.
+
+## Cambios realizados
+
+### 1. Estado de sincronizacion del primer seguimiento
+- `relevamientos/tasks.py` (`AsyncSendPrimerSeguimientoToGestionar.run`): tras un
+  POST `2xx`, ademas de guardar `gestionar_id` (si viene en la respuesta) se marca
+  `sincronizado_gestionar=True`. El registro ya esta del lado de GESTIONAR, asi que
+  el badge deja de figurar "Pendiente" sin esperar al `PATCH` de vuelta (que igual
+  lo mantiene en `True`). `Relevamiento` conserva su comportamiento (solo lo marca
+  el `PATCH` entrante).
+- `relevamientos/templates/primer_seguimiento_detail.html` y
+  `relevamientos/templates/relevamiento_detail.html`: se ajusto el `title` del badge
+  ("se sincronizo con GESTIONAR" / "Todavia no se sincronizo con GESTIONAR") para no
+  afirmar "datos recibidos".
+
+### 2. Texto "Sin asignar" en el listado
+- `relevamientos/templates/relevamiento_list.html`: el fallback de la fecha
+  (`default_if_none`) pasa de `"Sin asignar"` a `"Sin fecha"`, tanto para el
+  relevamiento como para el seguimiento.
+
+### 3. Ubicacion de los botones `Agregar`
+- `relevamientos/templates/relevamiento_list.html`:
+  - El boton `Agregar` (abre `#modalRelevamientoNuevo`) se movio al header de la
+    card, alineado con el titulo "Relevamientos".
+  - Cada relevamiento (no los seguimientos) que aun no tiene primer seguimiento
+    muestra un boton `Agregar` que abre `#modalSeguimientoNuevo` con
+    `data-relevamiento-id`.
+  - Nuevo modal `#modalSeguimientoNuevo` (tipo primer/segundo seguimiento -segundo
+    deshabilitado, fase 2- + territorial) que postea a `relevamiento_create_edit_ajax`
+    con un hidden `relevamiento_id`. El select de territorial reutiliza el cache JS
+    (`id` con substring `update_territorial_select`).
+  - JS que setea el hidden `relevamiento_id` al abrir el modal (`show.bs.modal`).
+- `relevamientos/views/web_views.py` (`RelevamientoListView`): cada item padre
+  expone `has_seguimiento` para decidir si mostrar el boton por fila.
+- `relevamientos/primer_seguimiento_service.py` (`create_asignado`): nuevo parametro
+  opcional `relevamiento_id`. Si viene, se ancla a ese relevamiento del comedor
+  (`get_object_or_404` scopeado al comedor); si no, se mantiene la resolucion previa
+  del ancla activa. El mensaje de duplicado pasa a "...para este relevamiento.".
+- `comedores/views/relevamientos.py` (`_handle_create_primer_seguimiento`): reenvia
+  `relevamiento_id` desde el POST al servicio.
+
+## Tests
+- `tests/test_primer_seguimiento_relevamientos.py`: el envio saliente marca
+  `sincronizado_gestionar` (con y sin `gestionar_id` en la respuesta); alta con
+  `relevamiento_id` explicito; rechazo si el `relevamiento_id` es de otro comedor.
+- `tests/test_relevamientos_web_views_unit.py`: los items del listado incluyen
+  `has_seguimiento`.
+- `comedores/tests.py`: el endpoint reenvia `relevamiento_id` al servicio.
+
+## Comportamiento observable
+- Detalle del primer seguimiento: badge verde "Sincronizado con GESTIONAR" apenas el
+  envio saliente responde OK.
+- Listado: la fecha ausente se muestra como "Sin fecha".
+- Listado: `Agregar` general en el header; `Agregar` por relevamiento sin seguimiento
+  para crear el primer seguimiento de ese relevamiento puntual.
+
+## Segunda ronda (mismo dia): por que no llegaba a GESTIONAR + territorial + badge relevamiento
+
+### Diagnostico "no llega a GESTIONAR"
+Causa raiz: cuando se crea un primer seguimiento **sin relevamiento inicial**, el
+servicio creaba un ancla `Relevamiento` con `_skip_gestionar_sync=True`, asi que ese
+relevamiento **nunca se enviaba a GESTIONAR**. El seguimiento se POSTeaba a la tabla
+`Seguimientos1erVisita` con `Id_Relevamiento` apuntando a un relevamiento inexistente
+en GESTIONAR -> AppSheet responde `200` pero **no registra la fila** (devuelve `Rows`
+vacio). El codigo logueaba "sincronizado con exito" ante cualquier `2xx`, enmascarando
+el rechazo; el `gestionar_id` vacio ("Sin asignar") es justamente la senal.
+
+### Cambios
+- `relevamientos/tasks.py`: `AsyncSendPrimerSeguimientoToGestionar` y
+  `AsyncSendRelevamientoToGestionar` ahora marcan `sincronizado_gestionar=True` **solo si
+  GESTIONAR devuelve `Rows`**. Si responde `2xx` sin filas, `logger.warning` con el cuerpo
+  y NO se marca (estado honesto). Esto revierte la marca incondicional en `2xx` de la
+  primera ronda para el seguimiento.
+- `AsyncSendRelevamientoToGestionar` ahora **marca el badge del relevamiento** en el POST
+  saliente confirmado (pedido explicito: aplicar el cambio de badge tambien a relevamiento).
+- `relevamientos/primer_seguimiento_service.py`:
+  - El ancla creada para un primer seguimiento sin relevamiento previo **ya NO usa
+    `_skip_gestionar_sync`**: se crea como relevamiento asignado (`Visita pendiente`, con el
+    territorial del formulario) y se sincroniza a GESTIONAR, para que el seguimiento pueda
+    enlazar por `Id_Relevamiento`.
+  - **Territorial:** sin relevamiento previo, el territorial del formulario se aplica al
+    ancla y al seguimiento; con relevamiento existente (o `relevamiento_id` puntual), el
+    `tecnico` se **hereda** de `relevamiento.territorial_uid`.
+- `comedores/views/relevamientos.py`: el dispatch del endpoint AJAX reconoce el alta por
+  `tipo_relevamiento` (ademas de `territorial`), porque el modal por-fila ya no manda
+  territorial.
+- `relevamientos/templates/relevamiento_list.html`: el modal `#modalSeguimientoNuevo` ya
+  no pide territorial (lo hereda); ayuda actualizada.
+- `relevamientos/templates/relevamiento_detail.html`: tooltip del badge del relevamiento.
+
+### Decision a confirmar
+El ancla de un primer seguimiento sin relevamiento inicial ahora **crea un relevamiento en
+GESTIONAR** (revierte la decision previa de `_skip_gestionar_sync`). Es necesario para que
+el seguimiento enlace (un `Seguimientos1erVisita` referencia un `RelevamientoComedores`).
+Si se prefiere no crear ese relevamiento en GESTIONAR, hay que rediseniar el contrato con
+el dueno de la app AppSheet.
+
+### Tests
+- `tests/test_relevamientos_tasks_unit.py`: el sync de relevamiento marca/omite el badge
+  segun haya `Rows`.
+- `tests/test_primer_seguimiento_relevamientos.py`: herencia de territorial (ancla nueva vs
+  relevamiento existente vs `relevamiento_id`), ancla nueva sincroniza a GESTIONAR, y el
+  seguimiento NO se marca sincronizado si GESTIONAR no devuelve filas.
+
+## Tercera ronda: causa raiz REAL verificada contra la API de AppSheet (2026-06-04)
+
+Se probo la API real (`.../tables/Seguimientos1erVisita/Action`, app `7ca73a85-...`) con
+consultas `Find` (read-only) y un `Add`/`Delete` de diagnostico (creado y borrado, tabla
+queda en 0). Hallazgos:
+
+- La tabla `Seguimientos1erVisita` estaba **vacia (0 filas)**: ningun primer seguimiento
+  llego nunca, pese a los logs "con exito". La de relevamientos (`RelevamientoComedores`)
+  tiene 5171 filas → los relevamientos SI sincronizan.
+- **Causa raiz:** el alta mandaba `ID_Seguimiento1` (nuestro PK), que es la **CLAVE
+  autogenerada** de la tabla. AppSheet rechaza en silencio el `Add` que la incluye
+  (responde `200` con cuerpo vacio, no crea fila). Verificado:
+  - `{"Id_Relevamiento":"8584"}` -> 200 y crea la fila; GESTIONAR genera `ID_Seguimiento1`
+    (ej. "a7341aaa") y deriva `tecnico`/`ESTADO` del relevamiento.
+  - `{"ID_Seguimiento1":"...","Id_Relevamiento":"8584","Id_SISOC":"..."}` -> 200 con cuerpo
+    vacio (rechazado).
+- La **clave de la tabla es compuesta** (`ID_Seguimiento1` + `Id_Relevamiento`): el `Delete`
+  con solo `ID_Seguimiento1` da `400 "Row key field 'Id_Relevamiento' value is missing"`.
+- La tabla **no tiene** columna `Id_SISOC` (se ignoraba).
+
+### Fixes
+- `build_primer_seguimiento_payload`: el `Add` manda **solo** `{"Id_Relevamiento": "<id>"}`.
+- `AsyncSendPrimerSeguimientoToGestionar.run`: persiste el `ID_Seguimiento1` que devuelve
+  GESTIONAR en `gestionar_id` (ya lo hacia) y marca sincronizado al confirmar `Rows`.
+- `AsyncRemovePrimerSeguimientoToGestionar`: el `Delete` manda la clave compuesta
+  (`ID_Seguimiento1` + `Id_Relevamiento`); recibe `relevamiento_id` (lo pasa la signal
+  `remove_primer_seguimiento_to_gestionar`).
+- `PrimerSeguimientoService.create_asignado`: cuando crea un ancla nueva, envia el
+  relevamiento a GESTIONAR de forma **sincronica y ordenada** (relevamiento antes que
+  seguimiento) para que el `Id_Relevamiento` ya exista al dar de alta el seguimiento (el
+  ancla se crea con `_skip_gestionar_sync=True` y el envio lo hace el service en orden).

--- a/relevamientos/primer_seguimiento_service.py
+++ b/relevamientos/primer_seguimiento_service.py
@@ -12,7 +12,9 @@ from relevamientos.models import PrimerSeguimiento, Relevamiento
 from relevamientos.service import _parse_territorial_payload
 from relevamientos.tasks import (
     AsyncSendPrimerSeguimientoToGestionar,
+    AsyncSendRelevamientoToGestionar,
     build_primer_seguimiento_payload,
+    build_relevamiento_payload,
 )
 
 logger = logging.getLogger("django")
@@ -36,36 +38,86 @@ class PrimerSeguimientoService:
         )
 
     @classmethod
-    def _crear_ancla_local(cls, comedor):
-        relevamiento = Relevamiento(comedor=comedor, estado="Pendiente")
+    def _crear_ancla(cls, comedor, territorial_uid, territorial_nombre):
+        """Crea el relevamiento ancla cuando no hay relevamiento inicial.
+
+        Lleva el territorial elegido en el formulario, como un relevamiento
+        asignado normal (estado ``Visita pendiente``). Se crea con
+        ``_skip_gestionar_sync=True`` para que NO lo envie el signal: el envio a
+        GESTIONAR lo hace ``create_asignado`` de forma sincronica y ORDENADA
+        (relevamiento antes que seguimiento), porque el alta del seguimiento
+        referencia este relevamiento por ``Id_Relevamiento`` y GESTIONAR lo
+        necesita ya presente (incluso deriva el tecnico del relevamiento).
+        """
+        relevamiento = Relevamiento(
+            comedor=comedor,
+            estado="Visita pendiente",
+            territorial_uid=territorial_uid,
+            territorial_nombre=territorial_nombre,
+        )
         relevamiento._skip_gestionar_sync = True  # pylint: disable=protected-access
         relevamiento.save()
         return relevamiento
 
     @classmethod
-    def resolve_or_create_relevamiento_ancla(cls, comedor):
-        return cls._get_relevamiento_activo(comedor) or cls._crear_ancla_local(comedor)
+    def _resolver_relevamiento_y_tecnico(
+        cls, comedor, relevamiento_id, raw_territorial_data
+    ):
+        """Resuelve el relevamiento ancla y el tecnico del seguimiento.
 
-    @classmethod
-    def create_asignado(cls, comedor_id, raw_territorial_data):
-        territorial_uid, _territorial_nombre = _parse_territorial_payload(
+        - ``relevamiento_id`` informado (alta desde la fila de un relevamiento) o
+          ancla activa ya existente: el territorial se HEREDA del relevamiento.
+        - sin relevamiento previo: el territorial del formulario se aplica al
+          nuevo ancla y al seguimiento.
+
+        Devuelve ``(relevamiento, tecnico_uid, ancla_nueva)``. ``ancla_nueva`` es
+        ``True`` solo cuando se creo un relevamiento ancla nuevo (hay que enviarlo
+        a GESTIONAR antes que el seguimiento).
+        """
+        if relevamiento_id:
+            relevamiento = get_object_or_404(
+                Relevamiento, id=relevamiento_id, comedor=comedor
+            )
+            return relevamiento, relevamiento.territorial_uid, False
+
+        existente = cls._get_relevamiento_activo(comedor)
+        if existente is not None:
+            return existente, existente.territorial_uid, False
+
+        territorial_uid, territorial_nombre = _parse_territorial_payload(
             raw_territorial_data
         )
+        relevamiento = cls._crear_ancla(comedor, territorial_uid, territorial_nombre)
+        return relevamiento, territorial_uid, True
+
+    @classmethod
+    def create_asignado(cls, comedor_id, raw_territorial_data, relevamiento_id=None):
         comedor = get_object_or_404(Comedor, id=comedor_id)
 
         with transaction.atomic():
-            relevamiento = cls.resolve_or_create_relevamiento_ancla(comedor)
+            relevamiento, tecnico, ancla_nueva = cls._resolver_relevamiento_y_tecnico(
+                comedor, relevamiento_id, raw_territorial_data
+            )
             if PrimerSeguimiento.objects.filter(id_relevamiento=relevamiento).exists():
                 raise ValidationError(
-                    "Ya existe un primer seguimiento para el relevamiento activo."
+                    "Ya existe un primer seguimiento para este relevamiento."
                 )
 
             seguimiento = PrimerSeguimiento.objects.create(
                 id_relevamiento=relevamiento,
-                tecnico=territorial_uid,
+                tecnico=tecnico,
                 estado=PrimerSeguimiento.ESTADO_ASIGNADO,
             )
 
-        payload = build_primer_seguimiento_payload(seguimiento)
-        AsyncSendPrimerSeguimientoToGestionar(seguimiento.id, payload).start()
+        # Si se creo un ancla nueva, primero aseguramos que el relevamiento exista
+        # en GESTIONAR (envio sincronico), porque el alta del seguimiento lo
+        # referencia. Recien despues enviamos el seguimiento.
+        if ancla_nueva:
+            AsyncSendRelevamientoToGestionar(
+                relevamiento.id, build_relevamiento_payload(relevamiento)
+            ).run()
+
+        AsyncSendPrimerSeguimientoToGestionar(
+            seguimiento.id, build_primer_seguimiento_payload(seguimiento)
+        ).start()
         return seguimiento

--- a/relevamientos/signals.py
+++ b/relevamientos/signals.py
@@ -45,4 +45,6 @@ def remove_relevamiento_to_gestionar(sender, instance, **kwargs):
 def remove_primer_seguimiento_to_gestionar(sender, instance, **kwargs):
     if not instance.gestionar_id:
         return
-    AsyncRemovePrimerSeguimientoToGestionar(instance.id, instance.gestionar_id).start()
+    AsyncRemovePrimerSeguimientoToGestionar(
+        instance.id, instance.gestionar_id, instance.id_relevamiento_id
+    ).start()

--- a/relevamientos/tasks.py
+++ b/relevamientos/tasks.py
@@ -63,14 +63,18 @@ def build_relevamiento_payload(relevamiento):
 
 
 def build_primer_seguimiento_payload(seguimiento):
+    # IMPORTANTE: el alta SOLO debe mandar Id_Relevamiento. En la tabla AppSheet
+    # `Seguimientos1erVisita`, `ID_Seguimiento1` es la CLAVE autogenerada: si el
+    # payload la incluye, AppSheet rechaza el alta en silencio (responde 200 con
+    # cuerpo vacio y no crea la fila). GESTIONAR genera el `ID_Seguimiento1` y lo
+    # devuelve en la respuesta; SISOC lo persiste en `gestionar_id`. `Id_SISOC` no
+    # es columna de esa tabla. Verificado contra la API real el 2026-06-04.
     return {
         "Action": "Add",
         "Properties": {"Locale": "es-ES"},
         "Rows": [
             {
-                "ID_Seguimiento1": f"{seguimiento.id}",
                 "Id_Relevamiento": f"{seguimiento.id_relevamiento_id}",
-                "Id_SISOC": f"{seguimiento.id}",
             }
         ],
     }
@@ -119,16 +123,27 @@ class AsyncSendRelevamientoToGestionar(threading.Thread):
                 timeout=TIMEOUT,
             )
             response.raise_for_status()
-            response_data = response.json()
-            logger.info(
-                f"RELEVAMIENTO {self.relevamiento_id} sincronizado con GESTIONAR con exito"
-            )
-            gestionar_pdf = response_data["Rows"][0].get("docPDF", "")
-            if gestionar_pdf:
-                # El .update() en el queryset es para evitar que salten las signals
-                Relevamiento.objects.filter(pk=self.relevamiento_id).update(
-                    docPDF=gestionar_pdf
+            response_data = response.json() if response.content else {}
+            rows = response_data.get("Rows") or []
+            if not rows:
+                logger.warning(
+                    "RELEVAMIENTO %s: GESTIONAR respondio 2xx pero no devolvio filas; "
+                    "la alta podria no haberse registrado. Respuesta: %s",
+                    self.relevamiento_id,
+                    response_data,
                 )
+                return
+            # GESTIONAR confirmo la fila: marcamos sincronizado (mas el docPDF si
+            # lo devolvio). El .update() en el queryset evita disparar signals.
+            campos_sync = {"sincronizado_gestionar": True}
+            gestionar_pdf = rows[0].get("docPDF", "")
+            if gestionar_pdf:
+                campos_sync["docPDF"] = gestionar_pdf
+            Relevamiento.objects.filter(pk=self.relevamiento_id).update(**campos_sync)
+            logger.info(
+                "RELEVAMIENTO %s sincronizado con GESTIONAR con exito",
+                self.relevamiento_id,
+            )
 
         except Exception:
             logger.exception(
@@ -240,14 +255,30 @@ class AsyncSendPrimerSeguimientoToGestionar(threading.Thread):
             )
             response.raise_for_status()
             response_data = response.json() if response.content else {}
-            gestionar_id = ""
             rows = response_data.get("Rows") or []
-            if rows:
-                gestionar_id = (rows[0].get("ID_Seguimiento1") or "").strip()
-            if gestionar_id:
-                PrimerSeguimiento.objects.filter(pk=self.seguimiento_id).update(
-                    gestionar_id=gestionar_id
+            if not rows:
+                # AppSheet responde 200 aunque rechace el alta (p. ej. el
+                # Id_Relevamiento apunta a un relevamiento que GESTIONAR no tiene,
+                # o falta una columna requerida de la tabla): en esos casos no
+                # devuelve filas. No marcamos sincronizado para no mostrar un
+                # estado enganoso, y dejamos el cuerpo en el log para diagnostico.
+                logger.warning(
+                    "PRIMER SEGUIMIENTO %s: GESTIONAR respondio 2xx pero no devolvio "
+                    "filas; la alta podria no haberse registrado. Respuesta: %s",
+                    self.seguimiento_id,
+                    response_data,
                 )
+                return
+            # GESTIONAR confirmo la fila: marcamos sincronizado (mas el
+            # gestionar_id si lo devolvio). El PATCH entrante con los bloques
+            # completos lo mantiene en True.
+            gestionar_id = (rows[0].get("ID_Seguimiento1") or "").strip()
+            campos_sync = {"sincronizado_gestionar": True}
+            if gestionar_id:
+                campos_sync["gestionar_id"] = gestionar_id
+            PrimerSeguimiento.objects.filter(pk=self.seguimiento_id).update(
+                **campos_sync
+            )
             logger.info(
                 "PRIMER SEGUIMIENTO %s sincronizado con GESTIONAR con exito",
                 self.seguimiento_id,
@@ -264,10 +295,11 @@ class AsyncSendPrimerSeguimientoToGestionar(threading.Thread):
 class AsyncRemovePrimerSeguimientoToGestionar(threading.Thread):
     """Hilo para eliminar primer seguimiento de GESTIONAR asincronamente"""
 
-    def __init__(self, seguimiento_id, gestionar_id):
+    def __init__(self, seguimiento_id, gestionar_id, relevamiento_id=None):
         super().__init__()
         self.seguimiento_id = seguimiento_id
         self.gestionar_id = gestionar_id
+        self.relevamiento_id = relevamiento_id
 
     def start(self):  # type: ignore[override]
         if not _is_gestionar_integration_enabled():
@@ -292,10 +324,18 @@ class AsyncRemovePrimerSeguimientoToGestionar(threading.Thread):
         if not _is_gestionar_integration_enabled():
             return
         close_old_connections()
+        # La tabla `Seguimientos1erVisita` tiene CLAVE COMPUESTA
+        # (ID_Seguimiento1 + Id_Relevamiento): el Delete debe informar ambos o
+        # AppSheet responde 400 "Row key field 'Id_Relevamiento' value is missing".
         data = {
             "Action": "Delete",
             "Properties": {"Locale": "es-ES"},
-            "Rows": [{"ID_Seguimiento1": f"{self.gestionar_id}"}],
+            "Rows": [
+                {
+                    "ID_Seguimiento1": f"{self.gestionar_id}",
+                    "Id_Relevamiento": f"{self.relevamiento_id}",
+                }
+            ],
         }
         headers = {
             "applicationAccessKey": os.getenv("GESTIONAR_API_KEY"),

--- a/relevamientos/templates/primer_seguimiento_detail.html
+++ b/relevamientos/templates/primer_seguimiento_detail.html
@@ -15,10 +15,11 @@
     </span>
     <span class="ml-2 h5">{{ seguimiento.estado | default_if_none:"Sin información" }}</span>
     {% if seguimiento.sincronizado_gestionar %}
-        <span class="badge bg-success ml-2" title="Datos recibidos desde GESTIONAR">Sincronizado con GESTIONAR</span>
+        <span class="badge bg-success ml-2"
+              title="El primer seguimiento se sincronizó con GESTIONAR">Sincronizado con GESTIONAR</span>
     {% else %}
         <span class="badge bg-secondary ml-2"
-              title="Aún no se recibieron datos desde GESTIONAR">Pendiente sincronización</span>
+              title="Todavía no se sincronizó con GESTIONAR">Pendiente sincronización</span>
     {% endif %}
 {% endblock titulo-pagina %}
 {% block breadcrumb %}

--- a/relevamientos/templates/relevamiento_detail.html
+++ b/relevamientos/templates/relevamiento_detail.html
@@ -17,7 +17,8 @@
         {{ relevamiento.estado | default_if_none:"Sin información" }}
     </span>
     {% if relevamiento.sincronizado_gestionar %}
-        <span class="badge bg-success ml-2" title="Datos recibidos desde GESTIONAR">Sincronizado con GESTIONAR</span>
+        <span class="badge bg-success ml-2"
+              title="El relevamiento se sincronizó con GESTIONAR">Sincronizado con GESTIONAR</span>
     {% endif %}
 {% endblock %}
 
@@ -1394,10 +1395,11 @@
                 <div class="card-header d-flex align-items-center justify-content-between">
                     <h5 class="mb-0">Primer seguimiento</h5>
                     {% if seguimiento.sincronizado_gestionar %}
-                        <span class="badge bg-success" title="Datos recibidos desde GESTIONAR">Sincronizado con GESTIONAR</span>
+                        <span class="badge bg-success"
+                              title="El primer seguimiento se sincronizó con GESTIONAR">Sincronizado con GESTIONAR</span>
                     {% else %}
                         <span class="badge bg-secondary"
-                              title="Aún no se recibieron datos desde GESTIONAR">Pendiente sincronización</span>
+                              title="Todavía no se sincronizó con GESTIONAR">Pendiente sincronización</span>
                     {% endif %}
                 </div>
                 <div class="card-body d-flex align-items-center justify-content-between flex-wrap gap-2">

--- a/relevamientos/templates/relevamiento_list.html
+++ b/relevamientos/templates/relevamiento_list.html
@@ -24,9 +24,15 @@
             <div class="row">
                 <div class="col-12">
                     <div class="card card-informacion">
-                        <div class="card-header">
-                            <h3 class="card-title font-weight-bold mr-3 pt-1">Relevamientos</h3>
-                            <div class="card-tools">
+                        <div class="card-header d-flex align-items-center">
+                            <h3 class="card-title font-weight-bold mr-3 pt-1 mb-0">Relevamientos</h3>
+                            {% if perms.relevamientos.add_relevamiento %}
+                                <button type="button"
+                                        class="btn btn-primary btn-sm"
+                                        data-bs-toggle="modal"
+                                        data-bs-target="#modalRelevamientoNuevo">Agregar</button>
+                            {% endif %}
+                            <div class="card-tools ml-auto">
                                 <button type="button" class="btn btn-tool" data-card-widget="collapse">
                                     <i class="fas fa-minus"></i>
                                 </button>
@@ -34,78 +40,83 @@
                         </div>
                         <div class="card-body card-comments p-0 pb-1">
                             <div class="nav nav-pills row my-3">
-                                <div class="col-10">
+                                <div class="col-12">
                                     <div class="nav-item d-flex">
-                                        <div class="comment-text comment-text d-flex row w-100">
+                                        <div class="comment-text w-100">
                                             {% for item in relevamientos_items %}
-                                                <div class="col-3 d-flex">
-                                                    {% if item.is_child %}
-                                                        <div style="padding-left: 20px;">
-                                                            <span class="text-muted">└─</span>
-                                                            <a href="{% url 'primer_seguimiento_detalle' comedor.id item.parent_id %}">{{ item.id }} - {{ item.fecha|default_if_none:"Sin asignar" }}</a>
-                                                        </div>
-                                                    {% else %}
-                                                        <a href="{% url 'relevamiento_detalle' comedor.id item.id %}">{{ item.id }} - {{ item.fecha|default_if_none:"Sin asignar" }}</a>
-                                                    {% endif %}
-                                                </div>
-                                                <div class="col-3 d-flex">
-                                                    <p {% if item.estado == "Pendiente" %} style="color: yellow;" {% elif item.estado == "Visita pendiente" %} style="color: green;" {% else %} style="color: white;" {% endif %}>
-                                                        {{ item.estado|default:"Sin información" }}
-                                                    </p>
-                                                </div>
-                                                <div class="col-6 mb-2">
-                                                    {% if item.is_child %}
-                                                        <span class="badge bg-info">Primer seguimiento</span>
-                                                    {% else %}
-                                                        <div id="numero-if-display-{{ item.id }}"
-                                                             class="d-flex align-items-end gap-2">
-                                                            <div class="flex-grow-1 d-flex align-items-center gap-2">
-                                                                <span>Número de IF:</span>
-                                                                <span class="fw-semibold">{{ item.numero_if|default:"Sin número de IF" }}</span>
+                                                <div class="row align-items-center w-100 mx-0 mb-2">
+                                                    <div class="col-3 d-flex">
+                                                        {% if item.is_child %}
+                                                            <div style="padding-left: 20px;">
+                                                                <span class="text-muted">└─</span>
+                                                                <a href="{% url 'primer_seguimiento_detalle' comedor.id item.parent_id %}">{{ item.id }} - {{ item.fecha|default_if_none:"Sin fecha" }}</a>
+                                                            </div>
+                                                        {% else %}
+                                                            <a href="{% url 'relevamiento_detalle' comedor.id item.id %}">{{ item.id }} - {{ item.fecha|default_if_none:"Sin fecha" }}</a>
+                                                        {% endif %}
+                                                    </div>
+                                                    <div class="col-2 d-flex">
+                                                        <p {% if item.estado == "Pendiente" %} style="color: yellow;" {% elif item.estado == "Visita pendiente" %} style="color: green;" {% else %} style="color: white;" {% endif %}>
+                                                            {{ item.estado|default:"Sin información" }}
+                                                        </p>
+                                                    </div>
+                                                    <div class="col-5">
+                                                        {% if item.is_child %}
+                                                            <span class="badge bg-info">Primer seguimiento</span>
+                                                        {% else %}
+                                                            <div id="numero-if-display-{{ item.id }}"
+                                                                 class="d-flex align-items-end gap-2">
+                                                                <div class="flex-grow-1 d-flex align-items-center gap-2">
+                                                                    <span>Número de IF:</span>
+                                                                    <span class="fw-semibold">{{ item.numero_if|default:"Sin número de IF" }}</span>
+                                                                </div>
+                                                                {% if perms.relevamientos.change_relevamiento %}
+                                                                    <button type="button"
+                                                                            class="btn btn-sm btn-primary mb-0 py-1 px-2"
+                                                                            data-numero-if-edit="{{ item.id }}">
+                                                                        Actualizar IF
+                                                                    </button>
+                                                                {% endif %}
                                                             </div>
                                                             {% if perms.relevamientos.change_relevamiento %}
-                                                                <button type="button"
-                                                                        class="btn btn-sm btn-primary mb-0 py-1 px-2"
-                                                                        data-numero-if-edit="{{ item.id }}">
-                                                                    Actualizar IF
-                                                                </button>
+                                                                <form method="post"
+                                                                      id="numero-if-form-{{ item.id }}"
+                                                                      class="d-none align-items-end gap-2">
+                                                                    {% csrf_token %}
+                                                                    <input type="hidden" name="relevamiento_id" value="{{ item.id }}" />
+                                                                    <div class="flex-grow-1">
+                                                                        <label class="form-label mb-1">Número de IF</label>
+                                                                        <input type="text"
+                                                                               name="numero_if"
+                                                                               maxlength="255"
+                                                                               class="form-control form-control-sm"
+                                                                               value="{{ item.numero_if|default_if_none:'' }}" />
+                                                                    </div>
+                                                                    <button type="submit" class="btn btn-sm btn-primary mb-0">Guardar</button>
+                                                                    <button type="button"
+                                                                            class="btn btn-sm btn-secondary mb-0"
+                                                                            data-numero-if-cancel="{{ item.id }}">
+                                                                        Cancelar
+                                                                    </button>
+                                                                </form>
                                                             {% endif %}
-                                                        </div>
-                                                        {% if perms.relevamientos.change_relevamiento %}
-                                                            <form method="post"
-                                                                  id="numero-if-form-{{ item.id }}"
-                                                                  class="d-none align-items-end gap-2">
-                                                                {% csrf_token %}
-                                                                <input type="hidden" name="relevamiento_id" value="{{ item.id }}" />
-                                                                <div class="flex-grow-1">
-                                                                    <label class="form-label mb-1">Número de IF</label>
-                                                                    <input type="text"
-                                                                           name="numero_if"
-                                                                           maxlength="255"
-                                                                           class="form-control form-control-sm"
-                                                                           value="{{ item.numero_if|default_if_none:'' }}" />
-                                                                </div>
-                                                                <button type="submit" class="btn btn-sm btn-primary mb-0">Guardar</button>
-                                                                <button type="button"
-                                                                        class="btn btn-sm btn-secondary mb-0"
-                                                                        data-numero-if-cancel="{{ item.id }}">
-                                                                    Cancelar
-                                                                </button>
-                                                            </form>
                                                         {% endif %}
-                                                    {% endif %}
+                                                    </div>
+                                                    <div class="col-2 d-flex justify-content-end">
+                                                        {% if not item.is_child and not item.has_seguimiento and perms.relevamientos.add_relevamiento %}
+                                                            <button type="button"
+                                                                    class="btn btn-sm btn-primary mb-0 py-1 px-2"
+                                                                    data-bs-toggle="modal"
+                                                                    data-bs-target="#modalSeguimientoNuevo"
+                                                                    data-relevamiento-id="{{ item.id }}">
+                                                                Agregar
+                                                            </button>
+                                                        {% endif %}
+                                                    </div>
                                                 </div>
                                             {% endfor %}
                                         </div>
                                     </div>
-                                </div>
-                                <div class="col-2 d-flex justify-content-end align-items-start my-3">
-                                    {% if perms.relevamientos.add_relevamiento %}
-                                        <button type="button"
-                                                class="btn btn-primary btn-margin-right"
-                                                data-bs-toggle="modal"
-                                                data-bs-target="#modalRelevamientoNuevo">Agregar</button>
-                                    {% endif %}
                                 </div>
                             </div>
                         </div>
@@ -164,6 +175,48 @@
                 </div>
             </div>
         </div>
+        <div class="modal fade"
+             id="modalSeguimientoNuevo"
+             tabindex="-1"
+             aria-labelledby="modalSeguimientoNuevoLabel"
+             aria-hidden="true">
+            <div class="modal-dialog modal-dialog-centered">
+                <div class="modal-content">
+                    <form method="post"
+                          action="{% url 'relevamiento_create_edit_ajax' comedor.id %}">
+                        {% csrf_token %}
+                        <input type="hidden"
+                               name="relevamiento_id"
+                               id="seguimiento_relevamiento_id"
+                               value="" />
+                        <div class="modal-header">
+                            <h5 class="modal-title" id="modalSeguimientoNuevoLabel">Agregar seguimiento</h5>
+                            <button type="button"
+                                    class="btn-close"
+                                    data-bs-dismiss="modal"
+                                    aria-label="Cerrar"></button>
+                        </div>
+                        <div class="modal-body">
+                            <div class="mb-2">
+                                <label for="tipo_seguimiento_select" class="form-label">Tipo</label>
+                                <select id="tipo_seguimiento_select"
+                                        name="tipo_relevamiento"
+                                        class="form-select"
+                                        required>
+                                    <option value="primer_seguimiento" selected>Primer seguimiento</option>
+                                    <option value="segundo_seguimiento" disabled>Segundo seguimiento</option>
+                                </select>
+                            </div>
+                            <small class="text-muted">El seguimiento se agrega a este relevamiento y hereda su territorial asignado.</small>
+                        </div>
+                        <div class="modal-footer">
+                            <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Cancelar</button>
+                            <button type="submit" class="btn btn-primary">Crear seguimiento</button>
+                        </div>
+                    </form>
+                </div>
+            </div>
+        </div>
     {% endif %}
 {% endblock %}
 
@@ -171,6 +224,21 @@
     {% if perms.relevamientos.add_relevamiento %}
         <script nonce="{{ request.csp_nonce }}">const comedorId = "{{ comedor.id }}";</script>
         <script src="{% static 'custom/js/comedordetail_territorial_cache.js' %}"></script>
+        <script nonce="{{ request.csp_nonce }}">
+            document.addEventListener("DOMContentLoaded", function () {
+                var seguimientoModal = document.getElementById("modalSeguimientoNuevo");
+                if (seguimientoModal) {
+                    seguimientoModal.addEventListener("show.bs.modal", function (event) {
+                        var trigger = event.relatedTarget;
+                        var relevamientoId = trigger ? trigger.getAttribute("data-relevamiento-id") : "";
+                        var input = document.getElementById("seguimiento_relevamiento_id");
+                        if (input) {
+                            input.value = relevamientoId || "";
+                        }
+                    });
+                }
+            });
+        </script>
     {% endif %}
     {% if perms.relevamientos.change_relevamiento %}
         <script nonce="{{ request.csp_nonce }}">

--- a/relevamientos/views/web_views.py
+++ b/relevamientos/views/web_views.py
@@ -127,6 +127,7 @@ class RelevamientoListView(LoginRequiredMixin, ListView):
 
         items = []
         for rel in context["relevamientos"]:
+            seguimiento = _get_primer_seguimiento(rel)
             items.append(
                 {
                     "id": rel.id,
@@ -135,9 +136,9 @@ class RelevamientoListView(LoginRequiredMixin, ListView):
                     "numero_if": rel.numero_if,
                     "is_child": False,
                     "parent_id": None,
+                    "has_seguimiento": seguimiento is not None,
                 }
             )
-            seguimiento = _get_primer_seguimiento(rel)
             if seguimiento is not None:
                 items.append(
                     {

--- a/tests/test_primer_seguimiento_relevamientos.py
+++ b/tests/test_primer_seguimiento_relevamientos.py
@@ -7,6 +7,7 @@ from django.contrib.auth import get_user_model
 from django.contrib.auth.models import Permission
 from django.core.exceptions import ValidationError as DjangoValidationError
 from django.db import IntegrityError
+from django.http import Http404
 from django.urls import reverse
 
 from comedores.models import Comedor, Referente
@@ -83,7 +84,12 @@ def test_primer_seguimiento_bloquea_duplicado_por_ancla(comedor):
 
 def test_servicio_usa_ultimo_relevamiento_activo_no_finalizado(comedor, mocker):
     Relevamiento.objects.create(comedor=comedor, estado="En Proceso")
-    esperado = Relevamiento.objects.create(comedor=comedor, estado="Pendiente")
+    esperado = Relevamiento.objects.create(
+        comedor=comedor,
+        estado="Pendiente",
+        territorial_uid="uid-esperado",
+        territorial_nombre="Territorial Esperado",
+    )
     Relevamiento.objects.create(comedor=comedor, estado="Finalizado")
     send_task = mocker.patch(
         "relevamientos.primer_seguimiento_service.AsyncSendPrimerSeguimientoToGestionar"
@@ -96,15 +102,21 @@ def test_servicio_usa_ultimo_relevamiento_activo_no_finalizado(comedor, mocker):
 
     assert seguimiento.id_relevamiento_id == esperado.id
     assert seguimiento.estado == PrimerSeguimiento.ESTADO_ASIGNADO
-    assert seguimiento.tecnico == "uid-1"
+    # El relevamiento ya existia: el tecnico se HEREDA del relevamiento, no del
+    # territorial del formulario.
+    assert seguimiento.tecnico == "uid-esperado"
     assert Relevamiento.objects.filter(comedor=comedor).count() == 3
     send_task.assert_called_once()
     send_task.return_value.start.assert_called_once_with()
 
 
-def test_servicio_crea_ancla_local_sin_sync_inicial_si_no_existe(comedor, mocker):
-    initial_sync = mocker.patch(
-        "relevamientos.signals.AsyncSendRelevamientoToGestionar.start"
+def test_servicio_crea_ancla_con_territorial_y_sincroniza_a_gestionar(comedor, mocker):
+    # Sin relevamiento previo se crea un ancla que LLEVA el territorial del
+    # formulario (para el relevamiento y el seguimiento) y se envia a GESTIONAR
+    # de forma sincronica ANTES que el seguimiento (el seguimiento lo referencia
+    # por Id_Relevamiento, asi que GESTIONAR necesita conocerlo primero).
+    rel_send = mocker.patch(
+        "relevamientos.primer_seguimiento_service.AsyncSendRelevamientoToGestionar"
     )
     send_task = mocker.patch(
         "relevamientos.primer_seguimiento_service.AsyncSendPrimerSeguimientoToGestionar"
@@ -117,9 +129,54 @@ def test_servicio_crea_ancla_local_sin_sync_inicial_si_no_existe(comedor, mocker
 
     relevamiento = seguimiento.id_relevamiento
     assert relevamiento.comedor_id == comedor.id
-    assert relevamiento.territorial_uid is None
-    assert initial_sync.call_count == 0
-    assert send_task.called
+    assert relevamiento.territorial_uid == "uid-1"
+    assert relevamiento.territorial_nombre == "Territorial Norte"
+    assert relevamiento.estado == "Visita pendiente"
+    assert seguimiento.tecnico == "uid-1"
+    # El ancla se envia sincronicamente (run) y antes del seguimiento.
+    rel_send.assert_called_once()
+    rel_send.return_value.run.assert_called_once_with()
+    send_task.assert_called_once()
+    send_task.return_value.start.assert_called_once_with()
+
+
+def test_servicio_usa_relevamiento_id_explicito_y_hereda_territorial(comedor, mocker):
+    # Hay un relevamiento "mas activo" (Pendiente) que el servicio elegiria por
+    # defecto, pero al pasar relevamiento_id se ancla al relevamiento puntual y
+    # el tecnico se HEREDA de ese relevamiento (no del territorial del form).
+    Relevamiento.objects.create(comedor=comedor, estado="Pendiente")
+    objetivo = Relevamiento.objects.create(
+        comedor=comedor,
+        estado="En Proceso",
+        territorial_uid="uid-objetivo",
+        territorial_nombre="Territorial Objetivo",
+    )
+    send_task = mocker.patch(
+        "relevamientos.primer_seguimiento_service.AsyncSendPrimerSeguimientoToGestionar"
+    )
+
+    seguimiento = PrimerSeguimientoService.create_asignado(
+        comedor.id,
+        _territorial_payload(),
+        relevamiento_id=objetivo.id,
+    )
+
+    assert seguimiento.id_relevamiento_id == objetivo.id
+    assert seguimiento.tecnico == "uid-objetivo"
+    assert Relevamiento.objects.filter(comedor=comedor).count() == 2
+    send_task.assert_called_once()
+
+
+def test_servicio_relevamiento_id_de_otro_comedor_no_resuelve(comedor):
+    otro_comedor = Comedor.objects.create(nombre="Otro comedor")
+    ajeno = Relevamiento.objects.create(comedor=otro_comedor, estado="En Proceso")
+
+    with pytest.raises(Http404):
+        PrimerSeguimientoService.create_asignado(
+            comedor.id,
+            _territorial_payload(),
+            relevamiento_id=ajeno.id,
+        )
 
 
 def test_servicio_exige_territorial_valido(comedor):
@@ -153,13 +210,9 @@ def test_build_payload_primer_seguimiento(comedor):
 
     assert payload["Action"] == "Add"
     assert payload["Properties"] == {"Locale": "es-ES"}
-    assert payload["Rows"] == [
-        {
-            "ID_Seguimiento1": str(seguimiento.id),
-            "Id_Relevamiento": str(relevamiento.id),
-            "Id_SISOC": str(seguimiento.id),
-        }
-    ]
+    # Solo Id_Relevamiento: GESTIONAR genera ID_Seguimiento1 (mandar la clave
+    # autogenerada hace que AppSheet rechace el alta).
+    assert payload["Rows"] == [{"Id_Relevamiento": str(relevamiento.id)}]
 
 
 def test_async_send_guarda_gestionar_id_de_la_respuesta(comedor, mocker, settings):
@@ -183,6 +236,35 @@ def test_async_send_guarda_gestionar_id_de_la_respuesta(comedor, mocker, setting
 
     seguimiento.refresh_from_db()
     assert seguimiento.gestionar_id == "afbeaa6c"
+    assert seguimiento.sincronizado_gestionar is True
+
+
+def test_async_send_no_marca_sincronizado_si_gestionar_no_devuelve_filas(
+    comedor, mocker, settings
+):
+    settings.GESTIONAR_INTEGRATION_ENABLED = True
+    relevamiento = Relevamiento.objects.create(comedor=comedor, estado="En Proceso")
+    seguimiento = PrimerSeguimiento.objects.create(
+        id_relevamiento=relevamiento,
+        estado=PrimerSeguimiento.ESTADO_ASIGNADO,
+    )
+
+    response = mocker.Mock()
+    response.raise_for_status.return_value = None
+    response.content = b'{"Rows": []}'
+    response.json.return_value = {"Rows": []}
+    mocker.patch("relevamientos.tasks.requests.post", return_value=response)
+
+    AsyncSendPrimerSeguimientoToGestionar(
+        seguimiento.id,
+        build_primer_seguimiento_payload(seguimiento),
+    ).run()
+
+    seguimiento.refresh_from_db()
+    # AppSheet respondio 200 pero sin filas (alta rechazada / no registrada):
+    # NO se marca sincronizado para no mostrar un estado enganoso.
+    assert seguimiento.sincronizado_gestionar is False
+    assert seguimiento.gestionar_id is None
 
 
 def test_async_remove_usa_gestionar_id_y_omite_si_falta(comedor, mocker, settings):
@@ -196,15 +278,18 @@ def test_async_remove_usa_gestionar_id_y_omite_si_falta(comedor, mocker, setting
     post_mock = mocker.patch("relevamientos.tasks.requests.post")
 
     AsyncRemovePrimerSeguimientoToGestionar(
-        seguimiento.id, seguimiento.gestionar_id
+        seguimiento.id, seguimiento.gestionar_id, relevamiento.id
     ).run()
 
     body_enviado = post_mock.call_args.kwargs["json"]
     assert body_enviado["Action"] == "Delete"
-    assert body_enviado["Rows"] == [{"ID_Seguimiento1": "afbeaa6c"}]
+    # Clave compuesta: ID_Seguimiento1 + Id_Relevamiento.
+    assert body_enviado["Rows"] == [
+        {"ID_Seguimiento1": "afbeaa6c", "Id_Relevamiento": str(relevamiento.id)}
+    ]
 
     post_mock.reset_mock()
-    AsyncRemovePrimerSeguimientoToGestionar(seguimiento.id, "").start()
+    AsyncRemovePrimerSeguimientoToGestionar(seguimiento.id, "", relevamiento.id).start()
     post_mock.assert_not_called()
 
 

--- a/tests/test_relevamientos_tasks_unit.py
+++ b/tests/test_relevamientos_tasks_unit.py
@@ -1,5 +1,7 @@
 """Tests unitarios para relevamientos.tasks."""
 
+import pytest
+
 from relevamientos import tasks as module
 
 
@@ -58,3 +60,54 @@ def test_async_send_start_omits_when_integration_disabled(mocker, monkeypatch):
     assert result is None
     mock_submit.assert_not_called()
     mock_run.assert_not_called()
+
+
+@pytest.mark.django_db
+def test_async_send_relevamiento_marca_sincronizado_con_filas(mocker, settings):
+    from comedores.models import Comedor
+    from relevamientos.models import Relevamiento
+
+    comedor = Comedor.objects.create(nombre="Comedor Sync Relevamiento")
+    # Se crea con la integracion apagada (default en tests) para que el signal
+    # no dispare un POST real durante el alta.
+    relevamiento = Relevamiento.objects.create(comedor=comedor, estado="En Proceso")
+
+    settings.GESTIONAR_INTEGRATION_ENABLED = True
+    response = mocker.Mock()
+    response.raise_for_status.return_value = None
+    response.content = b'{"Rows": [{"docPDF": "https://gestionar.test/r.pdf"}]}'
+    response.json.return_value = {"Rows": [{"docPDF": "https://gestionar.test/r.pdf"}]}
+    mocker.patch("relevamientos.tasks.requests.post", return_value=response)
+
+    module.AsyncSendRelevamientoToGestionar(
+        relevamiento.id,
+        module.build_relevamiento_payload(relevamiento),
+    ).run()
+
+    relevamiento.refresh_from_db()
+    assert relevamiento.sincronizado_gestionar is True
+    assert relevamiento.docPDF == "https://gestionar.test/r.pdf"
+
+
+@pytest.mark.django_db
+def test_async_send_relevamiento_no_marca_sincronizado_sin_filas(mocker, settings):
+    from comedores.models import Comedor
+    from relevamientos.models import Relevamiento
+
+    comedor = Comedor.objects.create(nombre="Comedor Sync Relevamiento 2")
+    relevamiento = Relevamiento.objects.create(comedor=comedor, estado="En Proceso")
+
+    settings.GESTIONAR_INTEGRATION_ENABLED = True
+    response = mocker.Mock()
+    response.raise_for_status.return_value = None
+    response.content = b'{"Rows": []}'
+    response.json.return_value = {"Rows": []}
+    mocker.patch("relevamientos.tasks.requests.post", return_value=response)
+
+    module.AsyncSendRelevamientoToGestionar(
+        relevamiento.id,
+        module.build_relevamiento_payload(relevamiento),
+    ).run()
+
+    relevamiento.refresh_from_db()
+    assert relevamiento.sincronizado_gestionar is False

--- a/tests/test_relevamientos_web_views_unit.py
+++ b/tests/test_relevamientos_web_views_unit.py
@@ -208,6 +208,7 @@ def test_list_view_construye_items_solo_padre_sin_seguimiento(mocker):
             "numero_if": "IF-11",
             "is_child": False,
             "parent_id": None,
+            "has_seguimiento": False,
         }
     ]
 
@@ -236,6 +237,7 @@ def test_list_view_construye_items_padre_seguido_de_hijo(mocker):
     items = context["relevamientos_items"]
     assert len(items) == 2
     assert items[0]["id"] == 42 and items[0]["is_child"] is False
+    assert items[0]["has_seguimiento"] is True
     assert items[1]["id"] == 900
     assert items[1]["is_child"] is True
     assert items[1]["parent_id"] == 42


### PR DESCRIPTION
## Problema

En produccion, el **primer seguimiento nunca llegaba a GESTIONAR** a pesar de que el log decia `PRIMER SEGUIMIENTO N sincronizado con GESTIONAR con exito`. Ademas, en el listado de relevamientos: el boton de alta estaba mal ubicado, decia "Sin asignar" donde faltaba la fecha, y el badge de sincronizacion solo aplicaba al seguimiento.

## Causa raiz (verificada contra la API real de AppSheet)

Se probo la API real (`tables/Seguimientos1erVisita/Action`) con `Find` (read-only) y un `Add`/`Delete` de diagnostico (creado y borrado; la tabla quedo en 0):

- La tabla de seguimientos estaba **vacia (0 filas)** -> nunca llego nada. `RelevamientoComedores` tiene 5171 filas (los relevamientos si sincronizan; endpoint/apikey OK).
- El alta mandaba `ID_Seguimiento1` (nuestro PK), que es la **clave autogenerada** de la tabla. AppSheet **rechaza en silencio** el `Add` que la incluye (responde `200` con cuerpo vacio y no crea la fila). El `gestionar_id` vacio ("Sin asignar") era la senal.
  - `{"Id_Relevamiento":"<id>"}` -> 200 y crea la fila; GESTIONAR genera `ID_Seguimiento1` y deriva `tecnico`/`ESTADO` del relevamiento.
  - `{"ID_Seguimiento1":...,"Id_Relevamiento":...,"Id_SISOC":...}` -> 200 con cuerpo vacio (rechazado).
- La **clave de la tabla es compuesta** (`ID_Seguimiento1` + `Id_Relevamiento`): el `Delete` con solo `ID_Seguimiento1` daba `400 "Row key field 'Id_Relevamiento' value is missing"`.

## Cambios

### Sincronizacion con GESTIONAR
- `build_primer_seguimiento_payload`: el alta manda **solo** `Id_Relevamiento`. GESTIONAR genera el `ID_Seguimiento1` y SISOC lo persiste en `gestionar_id`.
- `AsyncSendRelevamientoToGestionar` y `AsyncSendPrimerSeguimientoToGestionar`: marcan `sincronizado_gestionar=True` **solo cuando GESTIONAR confirma filas**; si responde `200` sin filas, `logger.warning` con el cuerpo y no marca (estado honesto, evita el falso "exito").
- `AsyncRemovePrimerSeguimientoToGestionar`: la baja usa la **clave compuesta** y recibe `relevamiento_id` (lo pasa la signal `remove_primer_seguimiento_to_gestionar`).
- `PrimerSeguimientoService.create_asignado`: cuando se crea un seguimiento **sin relevamiento previo**, el ancla se envia a GESTIONAR de forma **sincronica y ordenada** (relevamiento antes que seguimiento), porque el alta del seguimiento referencia ese relevamiento y GESTIONAR deriva el tecnico de el.
- **Territorial:** el ancla nueva lleva el territorial del formulario (para relevamiento y seguimiento); sobre un relevamiento existente, el tecnico se **hereda** del relevamiento.

### UI del listado de relevamientos
- Boton **"Agregar" general movido al header** de la card, alineado con "Relevamientos".
- Boton **"Agregar" por cada relevamiento** para sumarle un primer seguimiento a ese relevamiento puntual (modal que hereda el territorial; el dispatch del AJAX reconoce el alta por `tipo_relevamiento`).
- Fallback de fecha **"Sin asignar" -> "Sin fecha"**.
- Badge **"Sincronizado con GESTIONAR" tambien para el relevamiento**; tooltips ajustados.

## Verificacion
- 82+ tests verdes en la imagen Docker (SQLite, con migraciones): `tests/test_primer_seguimiento_relevamientos.py`, `tests/test_relevamientos_tasks_unit.py`, `tests/test_relevamientos_web_views_unit.py`, `relevamientos/tests.py` (render de templates), `comedores/tests.py` (endpoint AJAX). `black --check`, `djlint --check` y `python manage.py check` OK.
- **El payload que genera el codigo es exactamente el que se verifico en vivo que crea la fila.** Como prod ya tiene bien configurado endpoint/apikey (los `200` lo confirman), deployando esto los seguimientos deberian aparecer en GESTIONAR.

## Notas para el reviewer
- Se **revierte la decision previa** de no enviar el ancla a GESTIONAR (`_skip_gestionar_sync`): un `Seguimientos1erVisita` referencia un `RelevamientoComedores`, asi que el relevamiento DEBE existir en GESTIONAR. El ancla se crea como relevamiento asignado (`Visita pendiente`).
- Doc actualizada: `docs/flujos/relevamiento_sync.md` y `docs/registro/cambios/2026-06-04-primer-seguimiento-ajustes-produccion.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
