### PR TITLE
docs(postman): completar endpoints GESTIONAR en colección External APIs

### DIFF
--- a/postman/External APIs.postman_collection.json
+++ b/postman/External APIs.postman_collection.json
@@ -84,6 +84,41 @@
           "response": []
         },
         {
+          "name": "Borrar Comedor",
+          "request": {
+            "method": "POST",
+            "header": [
+              {
+                "key": "applicationAccessKey",
+                "value": "{{gestionarApiKey}}",
+                "type": "text"
+              },
+              {
+                "key": "Content-Type",
+                "value": "application/json",
+                "type": "text"
+              }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n    \"Action\": \"Delete\",\n    \"Properties\": {\n        \"Locale\": \"es-ES\"\n    },\n    \"Rows\": [\n        {\n            \"ComedorID\": \"10\"\n        }\n    ]\n}",
+              "options": {
+                "raw": {
+                  "language": "json"
+                }
+              }
+            },
+            "url": {
+              "raw": "{{gestionarBorrarComedorAction}}",
+              "host": [
+                "{{gestionarBorrarComedorAction}}"
+              ]
+            },
+            "description": "Baja de Comedor en GESTIONAR. Disparado por `AsyncRemoveComedorToGestionar` (`comedores/tasks.py`) en el signal `pre_delete` del modelo Comedor. El `ComedorID` se envía como string. Endpoint configurado en `GESTIONAR_API_BORRAR_COMEDOR`."
+          },
+          "response": []
+        },
+        {
           "name": "Obtener territoriales",
           "request": {
             "method": "POST",
@@ -122,6 +157,76 @@
                 "Action"
               ]
             }
+          },
+          "response": []
+        },
+        {
+          "name": "Crear Referente",
+          "request": {
+            "method": "POST",
+            "header": [
+              {
+                "key": "applicationAccessKey",
+                "value": "{{gestionarApiKey}}",
+                "type": "text"
+              },
+              {
+                "key": "Content-Type",
+                "value": "application/json",
+                "type": "text"
+              }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n    \"Action\": \"Add\",\n    \"Properties\": {\n        \"Locale\": \"es-ES\"\n    },\n    \"Rows\": [\n        {\n            \"documento\": \"12345678\",\n            \"nombre\": \"Juan\",\n            \"apellido\": \"Pérez\",\n            \"mail\": \"juan@example.com\",\n            \"celular\": \"1123456789\"\n        }\n    ]\n}",
+              "options": {
+                "raw": {
+                  "language": "json"
+                }
+              }
+            },
+            "url": {
+              "raw": "{{gestionarReferenteAction}}",
+              "host": [
+                "{{gestionarReferenteAction}}"
+              ]
+            },
+            "description": "Alta de Referente en GESTIONAR. Disparado por `AsyncSendReferenteToGestionar` (`comedores/tasks.py`) en el signal `post_save` del modelo Referente. Solo se envía si `documento` no está vacío. Endpoint configurado en `GESTIONAR_API_CREAR_REFERENTE`."
+          },
+          "response": []
+        },
+        {
+          "name": "Crear Observación",
+          "request": {
+            "method": "POST",
+            "header": [
+              {
+                "key": "applicationAccessKey",
+                "value": "{{gestionarApiKey}}",
+                "type": "text"
+              },
+              {
+                "key": "Content-Type",
+                "value": "application/json",
+                "type": "text"
+              }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n    \"Action\": \"Add\",\n    \"Properties\": {\n        \"Locale\": \"es-ES\"\n    },\n    \"Rows\": [\n        {\n            \"Comedor_Id\": 10,\n            \"OBSERVACION\": \"Texto de la observación\",\n            \"Adjunto\": \"\",\n            \"Usr\": \"\",\n            \"FechaHora\": \"04/06/2026 10:00\"\n        }\n    ]\n}",
+              "options": {
+                "raw": {
+                  "language": "json"
+                }
+              }
+            },
+            "url": {
+              "raw": "{{gestionarObservacionAction}}",
+              "host": [
+                "{{gestionarObservacionAction}}"
+              ]
+            },
+            "description": "Alta de Observación en GESTIONAR. Disparado por `AsyncSendObservacionToGestionar` (`comedores/tasks.py`) en el signal `post_save` del modelo Observacion. `FechaHora` se formatea como DD/MM/YYYY HH:MM. Endpoint configurado en `GESTIONAR_API_CREAR_OBSERVACION`."
           },
           "response": []
         },


### PR DESCRIPTION
## Summary

- Agrega **Borrar Comedor**, **Crear Referente** y **Crear Observación** a la carpeta `Gestionar` de `postman/External APIs.postman_collection.json`
- La carpeta queda con cobertura completa de las 11 llamadas que SISOC hace contra la integración AppSheet de GESTIONAR

## Detalle de requests nuevos

| Request | Env var Django | Variable Postman |
|---|---|---|
| Borrar Comedor | `GESTIONAR_API_BORRAR_COMEDOR` | `{{gestionarBorrarComedorAction}}` |
| Crear Referente | `GESTIONAR_API_CREAR_REFERENTE` | `{{gestionarReferenteAction}}` |
| Crear Observación | `GESTIONAR_API_CREAR_OBSERVACION` | `{{gestionarObservacionAction}}` |

## Para el reviewer

- Agregar las 3 variables nuevas al environment de Postman apuntando a las URLs reales de AppSheet (equivalentes a las de producción en `.env.prod`)
- Sin cambios de código Python, sin migraciones, sin impacto en producción

🤖 Generated with [Claude Code](https://claude.com/claude-code)