### PR TITLE
feat(relevamientos): badges Completo/Sincronizado y mejoras UX en seguimiento

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 ## Actualizaciones
 
 - [relevamientos] Depuración de imports duplicados y sin uso en relevamientos/views/web_views.py para limpiar el job pylint de CI. (PR #1856)
+- [sin-area] feat(relevamientos): badges Completo/Sincronizado y mejoras UX en seguimiento. (PR #1861)
 <!-- AUTO-GENERATED RELEASE END: 2026-06-10 -->
 
 <!-- AUTO-GENERATED RELEASE START: 2026-06-03 -->

--- a/docs/contexto/features/pr-1861-feat-relevamientos-badges-completo-sincronizado-y-mejoras-ux-en-seguimiento.md
+++ b/docs/contexto/features/pr-1861-feat-relevamientos-badges-completo-sincronizado-y-mejoras-ux-en-seguimiento.md
@@ -1,0 +1,45 @@
+# Contexto de feature PR #1861 - feat(relevamientos): badges Completo/Sincronizado y mejoras UX en seguimiento
+
+## Resumen
+
+- PR: https://github.com/dsocial118/SISOC/pull/1861
+- Base: `main`
+- Rama origen: `claude/flamboyant-lamport-ede6e7`
+- Autor: `juanikitro`
+
+## Contexto funcional
+
+- No informado explícitamente; inferir desde el título del PR y el diff.
+
+## Arquitectura tocada
+
+- Se modifican templates, con posible impacto visual o de composición UI.
+
+## Decisiones y supuestos detectados
+
+- Tipo de cambio declarado: No informado
+- Área principal declarada: No informada
+- Impacto usuario declarado: No informado
+- Riesgos / rollback: No informado
+
+## Design system y UI
+
+- El PR toca piezas de UI y conviene revisar consistencia visual con el patrón existente.
+- Archivos visuales relevantes: relevamientos/templates/primer_seguimiento_detail.html, relevamientos/templates/relevamiento_detail.html
+
+## Memoria operativa para agentes
+
+- Empezar por `docs/registro/prs/PR-1861.md` para contexto resumido del PR.
+- Revisar primero estos archivos del diff:
+- `relevamientos/templates/primer_seguimiento_detail.html`
+- `relevamientos/templates/relevamiento_detail.html`
+- Documentación sugerida para ampliar contexto:
+- `docs/indice.md`
+- `docs/ia/CONTEXT_HYGIENE.md`
+- `docs/ia/ARCHITECTURE.md`
+- `docs/ia/TESTING.md`
+
+## Trazabilidad
+
+- Documento generado automáticamente desde el evento de `pull_request`.
+- Si este PR cambia de título, el archivo se renombrará para mantener el slug alineado.

--- a/docs/registro/prs/PR-1861.md
+++ b/docs/registro/prs/PR-1861.md
@@ -1,0 +1,47 @@
+# PR #1861 - feat(relevamientos): badges Completo/Sincronizado y mejoras UX en seguimiento
+
+## Metadata
+
+- PR: https://github.com/dsocial118/SISOC/pull/1861
+- Base: `main`
+- Rama origen: `claude/flamboyant-lamport-ede6e7`
+- Autor: `juanikitro`
+- Última actualización: `2026-06-04T19:48:54Z`
+
+## Resumen operativo
+
+- Tipo de cambio: No informado
+- Área principal: No informada
+- Contexto funcional: No informado explícitamente; revisar título, diff y documentación relacionada.
+- Resumen para changelog: No informado
+- Impacto usuario: No informado
+
+## Áreas afectadas
+
+- `relevamientos`
+
+## Archivos relevantes del diff
+
+- `relevamientos/templates/primer_seguimiento_detail.html`
+- `relevamientos/templates/relevamiento_detail.html`
+
+## Validación declarada
+
+- Pruebas automáticas: No informado en el PR.
+- Pruebas manuales: No informado en el PR.
+
+## Riesgos y rollback
+
+- No informado explícitamente en el PR.
+
+## Documentación sugerida para lectura
+
+- `docs/indice.md`
+- `docs/ia/CONTEXT_HYGIENE.md`
+- `docs/ia/ARCHITECTURE.md`
+- `docs/ia/TESTING.md`
+
+## Notas para continuidad
+
+- Este documento es generado automáticamente desde el contexto del PR y sirve como índice rápido para revisión y futuras sesiones de agentes.
+- Si la metadata del body del PR está incompleta, varias secciones usarán fallbacks derivados del título o del diff.

--- a/docs/registro/releases/pending/2026-06-10-pr-1861.md
+++ b/docs/registro/releases/pending/2026-06-10-pr-1861.md
@@ -1,0 +1,19 @@
+---
+pr: 1861
+release_date: 2026-06-10
+category: Actualizaciones
+area: sin-area
+title: feat(relevamientos): badges Completo/Sincronizado y mejoras UX en seguimiento
+summary: feat(relevamientos): badges Completo/Sincronizado y mejoras UX en seguimiento
+impact: No informado
+source_url: https://github.com/dsocial118/SISOC/pull/1861
+---
+# Release note preliminar PR #1861
+
+- Fecha objetivo de release: 2026-06-10
+- Categoría: Actualizaciones
+- Área: sin-area
+- Título del PR: feat(relevamientos): badges Completo/Sincronizado y mejoras UX en seguimiento
+- Resumen: feat(relevamientos): badges Completo/Sincronizado y mejoras UX en seguimiento
+- Impacto usuario: No informado
+- Fuente: https://github.com/dsocial118/SISOC/pull/1861

--- a/relevamientos/templates/primer_seguimiento_detail.html
+++ b/relevamientos/templates/primer_seguimiento_detail.html
@@ -18,8 +18,12 @@
         <span class="badge bg-success ml-2"
               title="El primer seguimiento se sincronizó con GESTIONAR">Sincronizado con GESTIONAR</span>
     {% else %}
-        <span class="badge bg-secondary ml-2"
-              title="Todavía no se sincronizó con GESTIONAR">Pendiente sincronización</span>
+        <span class="badge bg-danger ml-2" title="Todavía no se sincronizó con GESTIONAR">No sincronizado con GESTIONAR</span>
+    {% endif %}
+    {% if seguimiento.estado == "Completo" %}
+        <span class="badge bg-success ml-2">Completo</span>
+    {% else %}
+        <span class="badge bg-danger ml-2">No completo</span>
     {% endif %}
 {% endblock titulo-pagina %}
 {% block breadcrumb %}
@@ -49,7 +53,7 @@
         <div class="card-header">
             <h3 class="card-title font-weight-bold mr-3 pt-1">Resumen</h3>
         </div>
-        <div class="card-body card-comments p-0 pb-1">
+        <div class="card-body card-comments pt-0 pb-1">
             <div class="nav nav-pills row my-3">
                 <div class="nav-item col-md-3 col-sm-6 d-flex">
                     <div class="comment-text d-flex flex-column text-sm">
@@ -84,7 +88,7 @@
                 <div class="card-header">
                     <h3 class="card-title font-weight-bold mr-3 pt-1">{{ bloque.label }}</h3>
                 </div>
-                <div class="card-body card-comments p-0 pb-1">
+                <div class="card-body card-comments pt-0 pb-1">
                     <div class="nav nav-pills row my-3">
                         {% for campo in bloque.campos %}
                             <div class="nav-item col-md-4 col-sm-6 d-flex mb-2">

--- a/relevamientos/templates/relevamiento_detail.html
+++ b/relevamientos/templates/relevamiento_detail.html
@@ -62,6 +62,12 @@
                    target="_blank"
                    class="btn btn-secondary mr-1 d-none d-sm-inline">Imprimir</a>
             {% endif %}
+            {% with ps=relevamiento.primer_seguimiento %}
+                {% if ps %}
+                    <a href="#section-primer-seguimiento"
+                       class="btn btn-info mr-1 d-none d-sm-inline">Ver primer seguimiento</a>
+                {% endif %}
+            {% endwith %}
             {% if perms.auditlog.view_logentry %}
                 <a href="{% url 'audittrail:log_instance' 'relevamientos' 'relevamiento' relevamiento.pk %}"
                    class="btn btn-outline-light mr-1">Historial</a>
@@ -1391,16 +1397,21 @@
     </div>
     {% with seguimiento=relevamiento.primer_seguimiento %}
         {% if seguimiento %}
-            <div class="card mt-4">
+            <div class="card mt-4" id="section-primer-seguimiento">
                 <div class="card-header d-flex align-items-center justify-content-between">
                     <h5 class="mb-0">Primer seguimiento</h5>
-                    {% if seguimiento.sincronizado_gestionar %}
-                        <span class="badge bg-success"
-                              title="El primer seguimiento se sincronizó con GESTIONAR">Sincronizado con GESTIONAR</span>
-                    {% else %}
-                        <span class="badge bg-secondary"
-                              title="Todavía no se sincronizó con GESTIONAR">Pendiente sincronización</span>
-                    {% endif %}
+                    <div class="d-flex gap-2">
+                        {% if seguimiento.sincronizado_gestionar %}
+                            <span class="badge bg-success" title="El primer seguimiento se sincronizó con GESTIONAR">Sincronizado con GESTIONAR</span>
+                        {% else %}
+                            <span class="badge bg-danger" title="Todavía no se sincronizó con GESTIONAR">No sincronizado con GESTIONAR</span>
+                        {% endif %}
+                        {% if seguimiento.estado == "Completo" %}
+                            <span class="badge bg-success">Completo</span>
+                        {% else %}
+                            <span class="badge bg-danger">No completo</span>
+                        {% endif %}
+                    </div>
                 </div>
                 <div class="card-body d-flex align-items-center justify-content-between flex-wrap gap-2">
                     <span class="text-muted">Ver el detalle completo del primer seguimiento cargado para este relevamiento.</span>


### PR DESCRIPTION
## Summary

- **Margen izquierdo en primer-seguimiento-detail**: las cards usaban `p-0` en el card-body, dejando el contenido pegado al borde izquierdo. Cambiado a `pt-0` para respetar el padding horizontal por defecto de Bootstrap y alinear con el header de cada card.
- **Badge "No sincronizado con GESTIONAR"**: el badge gris de "Pendiente sincronización" reemplazado por un badge rojo "No sincronizado con GESTIONAR" en `primer_seguimiento_detail.html` y en la card de primer seguimiento dentro de `relevamiento_detail.html`.
- **Badge "Completo" / "No completo"**: nuevo badge (verde/rojo) basado en `seguimiento.estado == "Completo"`, visible en ambas vistas.
- **Botón "Ver primer seguimiento"**: aparece junto al botón "Imprimir" en el detalle de relevamiento, solo cuando existe un primer seguimiento vinculado; actúa como ancla hacia la card al pie de la misma página.

## Test plan

- [ ] Abrir detalle de primer seguimiento con `sincronizado_gestionar=False`: verificar badge rojo "No sincronizado con GESTIONAR" + badge rojo "No completo"
- [ ] Abrir detalle de primer seguimiento con `sincronizado_gestionar=True` y `estado="Completo"`: verificar ambos badges verdes
- [ ] Verificar que los labels de campos en las cards (ID SISOC, etc.) estén alineados con el título del header
- [ ] Abrir detalle de relevamiento con primer seguimiento asociado: verificar que aparece el botón "Ver primer seguimiento" junto a "Imprimir" y que hace scroll al pie
- [ ] Abrir detalle de relevamiento sin primer seguimiento: verificar que NO aparece el botón

🤖 Generated with [Claude Code](https://claude.com/claude-code)