### PR TITLE
fix(dispositivos): municipio dropdown filtrado por scope desde el inicio

### DIFF
--- a/core/views.py
+++ b/core/views.py
@@ -47,6 +47,7 @@ from core.services.favorite_filters import (
 )
 from organizaciones.models import Organizacion
 from historial.services.historial_service import HistorialService
+from users.territorial_scope import get_geography_scope_map
 
 logger = logging.getLogger(__name__)
 
@@ -63,22 +64,11 @@ CHANGELOG_HEADER_PATTERN = re.compile(
 @require_GET
 def load_municipios(request):
     """Carga municipios filtrados por provincia y por el scope territorial del usuario."""
-    from users.territorial_scope import is_territorial_user, get_effective_scopes
-
     provincia_id = request.GET.get("provincia_id")
     municipios = Municipio.objects.filter(provincia=provincia_id).order_by("nombre")
 
-    if is_territorial_user(request.user):
-        scope_map = {}
-        for scope in get_effective_scopes(request.user):
-            pid = scope.provincia_id
-            if pid in scope_map and scope_map[pid] is None:
-                continue
-            if scope.municipio_id is None:
-                scope_map[pid] = None
-            else:
-                scope_map.setdefault(pid, set()).add(scope.municipio_id)
-
+    scope_map = get_geography_scope_map(request.user)
+    if scope_map is not None:
         try:
             pid = int(provincia_id) if provincia_id else None
         except (ValueError, TypeError):

--- a/core/views.py
+++ b/core/views.py
@@ -62,9 +62,33 @@ CHANGELOG_HEADER_PATTERN = re.compile(
 @login_required
 @require_GET
 def load_municipios(request):
-    """Carga municipios filtrados por provincia."""
+    """Carga municipios filtrados por provincia y por el scope territorial del usuario."""
+    from users.territorial_scope import is_territorial_user, get_effective_scopes
+
     provincia_id = request.GET.get("provincia_id")
-    municipios = Municipio.objects.filter(provincia=provincia_id)
+    municipios = Municipio.objects.filter(provincia=provincia_id).order_by("nombre")
+
+    if is_territorial_user(request.user):
+        scope_map = {}
+        for scope in get_effective_scopes(request.user):
+            pid = scope.provincia_id
+            if pid in scope_map and scope_map[pid] is None:
+                continue
+            if scope.municipio_id is None:
+                scope_map[pid] = None
+            else:
+                scope_map.setdefault(pid, set()).add(scope.municipio_id)
+
+        try:
+            pid = int(provincia_id) if provincia_id else None
+        except (ValueError, TypeError):
+            pid = None
+
+        if pid not in scope_map:
+            municipios = Municipio.objects.none()
+        elif scope_map[pid] is not None:
+            municipios = municipios.filter(pk__in=scope_map[pid])
+
     return JsonResponse(list(municipios.values("id", "nombre")), safe=False)
 
 

--- a/dispositivos/services.py
+++ b/dispositivos/services.py
@@ -1,6 +1,10 @@
 from django.db.models import Q
 
-from users.territorial_scope import get_effective_scopes, get_geography_scope_map, is_territorial_user
+from users.territorial_scope import (
+    get_effective_scopes,
+    get_geography_scope_map,
+    is_territorial_user,
+)
 
 from .models import Dispositivo
 

--- a/dispositivos/services.py
+++ b/dispositivos/services.py
@@ -1,6 +1,6 @@
 from django.db.models import Q
 
-from users.territorial_scope import get_effective_scopes, is_territorial_user
+from users.territorial_scope import get_effective_scopes, get_geography_scope_map, is_territorial_user
 
 from .models import Dispositivo
 
@@ -46,26 +46,9 @@ def apply_dispositivos_scope(queryset, user):
 def get_dispositivos_geography_scope(user):
     """Mapa ``provincia_id -> set(municipio_id) | None`` para acotar el formulario.
 
-    Devuelve ``None`` si el usuario no tiene restricción territorial (sin usuario,
-    superusuario o usuario no provincial). Cuando el valor de una provincia es
-    ``None`` significa que se permite la provincia completa; un ``set`` limita a
-    esos municipios.
+    Devuelve ``None`` si el usuario no tiene restricción territorial.
     """
-    if not user or not getattr(user, "is_authenticated", False):
-        return None
-    if getattr(user, "is_superuser", False) or not is_territorial_user(user):
-        return None
-
-    restriccion = {}
-    for scope in get_effective_scopes(user):
-        provincia_id = scope.provincia_id
-        if provincia_id in restriccion and restriccion[provincia_id] is None:
-            continue
-        if scope.municipio_id is None:
-            restriccion[provincia_id] = None
-        else:
-            restriccion.setdefault(provincia_id, set()).add(scope.municipio_id)
-    return restriccion
+    return get_geography_scope_map(user)
 
 
 def save_dispositivo_from_form(form, *, instance=None):

--- a/tests/test_core_views_unit.py
+++ b/tests/test_core_views_unit.py
@@ -225,7 +225,9 @@ def test_load_municipios_no_territorial(mocker):
     mocker.patch("core.views.get_geography_scope_map", return_value=None)
     mocker.patch(
         "core.views.Municipio.objects.filter",
-        return_value=_MunicipioQS([{"id": 1, "nombre": "M1"}, {"id": 2, "nombre": "M2"}]),
+        return_value=_MunicipioQS(
+            [{"id": 1, "nombre": "M1"}, {"id": 2, "nombre": "M2"}]
+        ),
     )
 
     import json
@@ -242,7 +244,9 @@ def test_load_municipios_territorial_municipios_especificos(mocker):
     mocker.patch("core.views.get_geography_scope_map", return_value={2: {1}})
     mocker.patch(
         "core.views.Municipio.objects.filter",
-        return_value=_MunicipioQS([{"id": 1, "nombre": "M1"}, {"id": 2, "nombre": "M2"}]),
+        return_value=_MunicipioQS(
+            [{"id": 1, "nombre": "M1"}, {"id": 2, "nombre": "M2"}]
+        ),
     )
 
     import json
@@ -260,7 +264,9 @@ def test_load_municipios_territorial_provincia_completa(mocker):
     mocker.patch("core.views.get_geography_scope_map", return_value={2: None})
     mocker.patch(
         "core.views.Municipio.objects.filter",
-        return_value=_MunicipioQS([{"id": 1, "nombre": "M1"}, {"id": 2, "nombre": "M2"}]),
+        return_value=_MunicipioQS(
+            [{"id": 1, "nombre": "M1"}, {"id": 2, "nombre": "M2"}]
+        ),
     )
 
     import json

--- a/tests/test_core_views_unit.py
+++ b/tests/test_core_views_unit.py
@@ -198,37 +198,119 @@ def test_detalle_filtro_favorito_paths(mocker):
     assert module.detalle_filtro_favorito(req_bad_sec, 1).status_code == 400
 
 
-def test_load_localidad_y_load_municipios(mocker):
+class _MunicipioQS:
+    """Queryset double para tests de load_municipios."""
+
+    def __init__(self, items):
+        self._items = list(items)
+
+    def order_by(self, *_):
+        return self
+
+    def filter(self, **kw):
+        if "pk__in" in kw:
+            allowed = set(kw["pk__in"])
+            return _MunicipioQS([i for i in self._items if i["id"] in allowed])
+        return self
+
+    def values(self, *_):
+        return list(self._items)
+
+
+def test_load_municipios_no_territorial(mocker):
+    rf = RequestFactory()
+    req = rf.get("/core/municipios", {"provincia_id": "2"})
+    req.user = _auth_user()
+
+    mocker.patch("core.views.get_geography_scope_map", return_value=None)
+    mocker.patch(
+        "core.views.Municipio.objects.filter",
+        return_value=_MunicipioQS([{"id": 1, "nombre": "M1"}, {"id": 2, "nombre": "M2"}]),
+    )
+
+    import json
+
+    data = json.loads(module.load_municipios(req).content)
+    assert len(data) == 2
+
+
+def test_load_municipios_territorial_municipios_especificos(mocker):
+    rf = RequestFactory()
+    req = rf.get("/core/municipios", {"provincia_id": "2"})
+    req.user = _auth_user()
+
+    mocker.patch("core.views.get_geography_scope_map", return_value={2: {1}})
+    mocker.patch(
+        "core.views.Municipio.objects.filter",
+        return_value=_MunicipioQS([{"id": 1, "nombre": "M1"}, {"id": 2, "nombre": "M2"}]),
+    )
+
+    import json
+
+    data = json.loads(module.load_municipios(req).content)
+    assert len(data) == 1
+    assert data[0]["id"] == 1
+
+
+def test_load_municipios_territorial_provincia_completa(mocker):
+    rf = RequestFactory()
+    req = rf.get("/core/municipios", {"provincia_id": "2"})
+    req.user = _auth_user()
+
+    mocker.patch("core.views.get_geography_scope_map", return_value={2: None})
+    mocker.patch(
+        "core.views.Municipio.objects.filter",
+        return_value=_MunicipioQS([{"id": 1, "nombre": "M1"}, {"id": 2, "nombre": "M2"}]),
+    )
+
+    import json
+
+    data = json.loads(module.load_municipios(req).content)
+    assert len(data) == 2
+
+
+def test_load_municipios_territorial_provincia_fuera_scope(mocker):
+    rf = RequestFactory()
+    req = rf.get("/core/municipios", {"provincia_id": "5"})
+    req.user = _auth_user()
+
+    mocker.patch("core.views.get_geography_scope_map", return_value={2: {1}})
+    mocker.patch(
+        "core.views.Municipio.objects.filter",
+        return_value=_MunicipioQS([{"id": 3, "nombre": "M3"}]),
+    )
+    mocker.patch(
+        "core.views.Municipio.objects.none",
+        return_value=_MunicipioQS([]),
+    )
+
+    import json
+
+    data = json.loads(module.load_municipios(req).content)
+    assert data == []
+
+
+def test_load_localidad(mocker):
     rf = RequestFactory()
     user = _auth_user()
 
-    req_m = rf.get("/core/municipios", {"provincia_id": "2"})
-    req_m.user = user
-    mocker.patch(
-        "core.views.Municipio.objects.filter",
-        return_value=SimpleNamespace(
-            values=lambda *_a, **_k: [{"id": 1, "nombre": "M"}]
-        ),
-    )
-    assert module.load_municipios(req_m).status_code == 200
-
-    req_l_none = rf.get("/core/localidades")
-    req_l_none.user = user
+    req_none = rf.get("/core/localidades")
+    req_none.user = user
     mocker.patch(
         "core.views.Localidad.objects.none",
         return_value=SimpleNamespace(values=lambda *_a, **_k: []),
     )
-    assert module.load_localidad(req_l_none).status_code == 200
+    assert module.load_localidad(req_none).status_code == 200
 
-    req_l = rf.get("/core/localidades", {"municipio_id": "9"})
-    req_l.user = user
+    req = rf.get("/core/localidades", {"municipio_id": "9"})
+    req.user = user
     mocker.patch(
         "core.views.Localidad.objects.filter",
         return_value=SimpleNamespace(
             values=lambda *_a, **_k: [{"id": 1, "nombre": "L"}]
         ),
     )
-    assert module.load_localidad(req_l).status_code == 200
+    assert module.load_localidad(req).status_code == 200
 
 
 def test_load_organizaciones_paginado(mocker):

--- a/users/territorial_scope.py
+++ b/users/territorial_scope.py
@@ -102,6 +102,32 @@ def get_effective_scopes(user_or_profile) -> list[TerritorialScope]:
     return []
 
 
+def get_geography_scope_map(user) -> "dict[int, set[int] | None] | None":
+    """Mapa ``provincia_id -> set(municipio_id) | None`` para restricción territorial.
+
+    Devuelve ``None`` si el usuario no tiene restricción (superusuario o no-territorial).
+    Devuelve un dict (vacío o con entradas) para usuarios territoriales:
+    - valor ``None`` en una provincia → provincia completa accesible.
+    - ``set`` de ids → solo esos municipios.
+    - provincia ausente del dict → sin acceso.
+    """
+    if not user or not getattr(user, "is_authenticated", False):
+        return None
+    if getattr(user, "is_superuser", False) or not is_territorial_user(user):
+        return None
+
+    restriccion: dict = {}
+    for scope in get_effective_scopes(user):
+        pid = scope.provincia_id
+        if pid in restriccion and restriccion[pid] is None:
+            continue
+        if scope.municipio_id is None:
+            restriccion[pid] = None
+        else:
+            restriccion.setdefault(pid, set()).add(scope.municipio_id)
+    return restriccion
+
+
 def serialize_profile_scopes(profile: Profile | None) -> list[dict[str, int | None]]:
     return [scope.as_dict() for scope in get_effective_scopes(profile)]
 


### PR DESCRIPTION
## Problema

Al ingresar un nuevo Dispositivo, el desplegable `Municipio` mostraba todos los municipios de la provincia en lugar de solo los asociados al usuario. Solo después de enviar el formulario y recibir un error de validación, el dropdown se filtraba correctamente.

## Causa raíz

El endpoint AJAX `load_municipios` (`core/views.py:64`) devolvía todos los municipios de la provincia sin considerar el scope territorial del usuario. El formulario Django sí aplica el scope en `_configure_geography_fields`, pero ese filtro solo funciona con datos de formulario ya enviados (`self.data`). En la carga inicial (GET), el JS llama al AJAX y recibe el listado sin restricciones.

## Fix

Se aplica el mismo mapa de scope que usa `get_dispositivos_geography_scope` directamente en `load_municipios`:
- Usuario sin restricción territorial (superusuario, no-territorial): comportamiento sin cambios.
- Usuario territorial con provincia completa (`scope_map[pid] is None`): devuelve todos los municipios de esa provincia.
- Usuario territorial con municipios específicos: devuelve solo los municipios permitidos.
- Provincia fuera del scope del usuario: devuelve lista vacía.

Closes #1824

## Test plan

- [ ] Usuario con scope a municipio específico: al abrir el formulario de nuevo Dispositivo, el desplegable Municipio muestra solo los municipios permitidos desde el inicio.
- [ ] Usuario superusuario: el desplegable muestra todos los municipios de la provincia (sin cambio).
- [ ] Usuario con scope a provincia completa: el desplegable muestra todos los municipios de esa provincia.

🤖 Generated with [Claude Code](https://claude.com/claude-code)