### PR TITLE
feat(relevamientos): badges Completado/Sincronizado en detalle y listado

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 
 - [relevamientos] Depuración de imports duplicados y sin uso en relevamientos/views/web_views.py para limpiar el job pylint de CI. (PR #1856)
 - [sin-area] feat(relevamientos): badges Completo/Sincronizado y mejoras UX en seguimiento. (PR #1861)
+- [sin-area] feat(relevamientos): badges Completado/Sincronizado en detalle y listado. (PR #1864)
 <!-- AUTO-GENERATED RELEASE END: 2026-06-10 -->
 
 <!-- AUTO-GENERATED RELEASE START: 2026-06-03 -->

--- a/docs/contexto/features/pr-1864-feat-relevamientos-badges-completado-sincronizado-en-detalle-y-listado.md
+++ b/docs/contexto/features/pr-1864-feat-relevamientos-badges-completado-sincronizado-en-detalle-y-listado.md
@@ -1,0 +1,48 @@
+# Contexto de feature PR #1864 - feat(relevamientos): badges Completado/Sincronizado en detalle y listado
+
+## Resumen
+
+- PR: https://github.com/dsocial118/SISOC/pull/1864
+- Base: `main`
+- Rama origen: `claude/awesome-taussig-ede43a`
+- Autor: `juanikitro`
+
+## Contexto funcional
+
+- No informado explícitamente; inferir desde el título del PR y el diff.
+
+## Arquitectura tocada
+
+- Hay cambios en vistas web y puede existir impacto en permisos o renderizado.
+- Se modifican templates, con posible impacto visual o de composición UI.
+
+## Decisiones y supuestos detectados
+
+- Tipo de cambio declarado: No informado
+- Área principal declarada: No informada
+- Impacto usuario declarado: No informado
+- Riesgos / rollback: No informado
+
+## Design system y UI
+
+- El PR toca piezas de UI y conviene revisar consistencia visual con el patrón existente.
+- Archivos visuales relevantes: relevamientos/templates/primer_seguimiento_detail.html, relevamientos/templates/relevamiento_detail.html, relevamientos/templates/relevamiento_list.html
+
+## Memoria operativa para agentes
+
+- Empezar por `docs/registro/prs/PR-1864.md` para contexto resumido del PR.
+- Revisar primero estos archivos del diff:
+- `relevamientos/templates/primer_seguimiento_detail.html`
+- `relevamientos/templates/relevamiento_detail.html`
+- `relevamientos/templates/relevamiento_list.html`
+- `relevamientos/views/web_views.py`
+- Documentación sugerida para ampliar contexto:
+- `docs/indice.md`
+- `docs/ia/CONTEXT_HYGIENE.md`
+- `docs/ia/ARCHITECTURE.md`
+- `docs/ia/TESTING.md`
+
+## Trazabilidad
+
+- Documento generado automáticamente desde el evento de `pull_request`.
+- Si este PR cambia de título, el archivo se renombrará para mantener el slug alineado.

--- a/docs/registro/prs/PR-1864.md
+++ b/docs/registro/prs/PR-1864.md
@@ -1,0 +1,49 @@
+# PR #1864 - feat(relevamientos): badges Completado/Sincronizado en detalle y listado
+
+## Metadata
+
+- PR: https://github.com/dsocial118/SISOC/pull/1864
+- Base: `main`
+- Rama origen: `claude/awesome-taussig-ede43a`
+- Autor: `juanikitro`
+- Última actualización: `2026-06-05T13:52:41Z`
+
+## Resumen operativo
+
+- Tipo de cambio: No informado
+- Área principal: No informada
+- Contexto funcional: No informado explícitamente; revisar título, diff y documentación relacionada.
+- Resumen para changelog: No informado
+- Impacto usuario: No informado
+
+## Áreas afectadas
+
+- `relevamientos`
+
+## Archivos relevantes del diff
+
+- `relevamientos/templates/primer_seguimiento_detail.html`
+- `relevamientos/templates/relevamiento_detail.html`
+- `relevamientos/templates/relevamiento_list.html`
+- `relevamientos/views/web_views.py`
+
+## Validación declarada
+
+- Pruebas automáticas: No informado en el PR.
+- Pruebas manuales: No informado en el PR.
+
+## Riesgos y rollback
+
+- No informado explícitamente en el PR.
+
+## Documentación sugerida para lectura
+
+- `docs/indice.md`
+- `docs/ia/CONTEXT_HYGIENE.md`
+- `docs/ia/ARCHITECTURE.md`
+- `docs/ia/TESTING.md`
+
+## Notas para continuidad
+
+- Este documento es generado automáticamente desde el contexto del PR y sirve como índice rápido para revisión y futuras sesiones de agentes.
+- Si la metadata del body del PR está incompleta, varias secciones usarán fallbacks derivados del título o del diff.

--- a/docs/registro/releases/pending/2026-06-10-pr-1864.md
+++ b/docs/registro/releases/pending/2026-06-10-pr-1864.md
@@ -1,0 +1,19 @@
+---
+pr: 1864
+release_date: 2026-06-10
+category: Actualizaciones
+area: sin-area
+title: feat(relevamientos): badges Completado/Sincronizado en detalle y listado
+summary: feat(relevamientos): badges Completado/Sincronizado en detalle y listado
+impact: No informado
+source_url: https://github.com/dsocial118/SISOC/pull/1864
+---
+# Release note preliminar PR #1864
+
+- Fecha objetivo de release: 2026-06-10
+- Categoría: Actualizaciones
+- Área: sin-area
+- Título del PR: feat(relevamientos): badges Completado/Sincronizado en detalle y listado
+- Resumen: feat(relevamientos): badges Completado/Sincronizado en detalle y listado
+- Impacto usuario: No informado
+- Fuente: https://github.com/dsocial118/SISOC/pull/1864

--- a/relevamientos/templates/primer_seguimiento_detail.html
+++ b/relevamientos/templates/primer_seguimiento_detail.html
@@ -13,7 +13,11 @@
     <span class="ml-2 h5">|
         {{ seguimiento.fecha_hora | default_if_none:"Sin información" }} |
     </span>
-    <span class="ml-2 h5">{{ seguimiento.estado | default_if_none:"Sin información" }}</span>
+    {% if seguimiento.estado == "Completo" %}
+        <span class="badge bg-success ml-2">Completado</span>
+    {% else %}
+        <span class="badge bg-secondary ml-2">No completado</span>
+    {% endif %}
     {% if seguimiento.sincronizado_gestionar %}
         <span class="badge bg-success ml-2"
               title="El primer seguimiento se sincronizó con GESTIONAR">Sincronizado con GESTIONAR</span>

--- a/relevamientos/templates/relevamiento_detail.html
+++ b/relevamientos/templates/relevamiento_detail.html
@@ -1394,13 +1394,20 @@
             <div class="card mt-4">
                 <div class="card-header d-flex align-items-center justify-content-between">
                     <h5 class="mb-0">Primer seguimiento</h5>
-                    {% if seguimiento.sincronizado_gestionar %}
-                        <span class="badge bg-success"
-                              title="El primer seguimiento se sincronizó con GESTIONAR">Sincronizado con GESTIONAR</span>
-                    {% else %}
-                        <span class="badge bg-secondary"
-                              title="Todavía no se sincronizó con GESTIONAR">Pendiente sincronización</span>
-                    {% endif %}
+                    <div class="d-flex gap-2">
+                        {% if seguimiento.estado == "Completo" %}
+                            <span class="badge bg-success">Completado</span>
+                        {% else %}
+                            <span class="badge bg-secondary">No completado</span>
+                        {% endif %}
+                        {% if seguimiento.sincronizado_gestionar %}
+                            <span class="badge bg-success"
+                                  title="El primer seguimiento se sincronizó con GESTIONAR">Sincronizado con GESTIONAR</span>
+                        {% else %}
+                            <span class="badge bg-secondary"
+                                  title="Todavía no se sincronizó con GESTIONAR">Pendiente sincronización</span>
+                        {% endif %}
+                    </div>
                 </div>
                 <div class="card-body d-flex align-items-center justify-content-between flex-wrap gap-2">
                     <span class="text-muted">Ver el detalle completo del primer seguimiento cargado para este relevamiento.</span>

--- a/relevamientos/templates/relevamiento_list.html
+++ b/relevamientos/templates/relevamiento_list.html
@@ -62,44 +62,63 @@
                                                     </div>
                                                     <div class="col-5">
                                                         {% if item.is_child %}
-                                                            <span class="badge bg-info">Primer seguimiento</span>
-                                                        {% else %}
-                                                            <div id="numero-if-display-{{ item.id }}"
-                                                                 class="d-flex align-items-end gap-2">
-                                                                <div class="flex-grow-1 d-flex align-items-center gap-2">
-                                                                    <span>Número de IF:</span>
-                                                                    <span class="fw-semibold">{{ item.numero_if|default:"Sin número de IF" }}</span>
-                                                                </div>
-                                                                {% if perms.relevamientos.change_relevamiento %}
-                                                                    <button type="button"
-                                                                            class="btn btn-sm btn-primary mb-0 py-1 px-2"
-                                                                            data-numero-if-edit="{{ item.id }}">
-                                                                        Actualizar IF
-                                                                    </button>
+                                                            <div class="d-flex flex-wrap gap-1">
+                                                                <span class="badge bg-info">Primer seguimiento</span>
+                                                                {% if item.sincronizado_gestionar %}
+                                                                    <span class="badge bg-success">Sincronizado</span>
+                                                                {% else %}
+                                                                    <span class="badge bg-secondary">No sincronizado</span>
+                                                                {% endif %}
+                                                                {% if item.estado == "Completo" %}
+                                                                    <span class="badge bg-success">Completado</span>
+                                                                {% else %}
+                                                                    <span class="badge bg-secondary">No completado</span>
                                                                 {% endif %}
                                                             </div>
-                                                            {% if perms.relevamientos.change_relevamiento %}
-                                                                <form method="post"
-                                                                      id="numero-if-form-{{ item.id }}"
-                                                                      class="d-none align-items-end gap-2">
-                                                                    {% csrf_token %}
-                                                                    <input type="hidden" name="relevamiento_id" value="{{ item.id }}" />
-                                                                    <div class="flex-grow-1">
-                                                                        <label class="form-label mb-1">Número de IF</label>
-                                                                        <input type="text"
-                                                                               name="numero_if"
-                                                                               maxlength="255"
-                                                                               class="form-control form-control-sm"
-                                                                               value="{{ item.numero_if|default_if_none:'' }}" />
+                                                        {% else %}
+                                                            <div class="d-flex flex-column gap-1">
+                                                                {% if item.sincronizado_gestionar %}
+                                                                    <span class="badge bg-success align-self-start">Sincronizado</span>
+                                                                {% else %}
+                                                                    <span class="badge bg-secondary align-self-start">No sincronizado</span>
+                                                                {% endif %}
+                                                                <div id="numero-if-display-{{ item.id }}"
+                                                                     class="d-flex align-items-end gap-2">
+                                                                    <div class="flex-grow-1 d-flex align-items-center gap-2">
+                                                                        <span>Número de IF:</span>
+                                                                        <span class="fw-semibold">{{ item.numero_if|default:"Sin número de IF" }}</span>
                                                                     </div>
-                                                                    <button type="submit" class="btn btn-sm btn-primary mb-0">Guardar</button>
-                                                                    <button type="button"
-                                                                            class="btn btn-sm btn-secondary mb-0"
-                                                                            data-numero-if-cancel="{{ item.id }}">
-                                                                        Cancelar
-                                                                    </button>
-                                                                </form>
-                                                            {% endif %}
+                                                                    {% if perms.relevamientos.change_relevamiento %}
+                                                                        <button type="button"
+                                                                                class="btn btn-sm btn-primary mb-0 py-1 px-2"
+                                                                                data-numero-if-edit="{{ item.id }}">
+                                                                            Actualizar IF
+                                                                        </button>
+                                                                    {% endif %}
+                                                                </div>
+                                                                {% if perms.relevamientos.change_relevamiento %}
+                                                                    <form method="post"
+                                                                          id="numero-if-form-{{ item.id }}"
+                                                                          class="d-none align-items-end gap-2">
+                                                                        {% csrf_token %}
+                                                                        <input type="hidden" name="relevamiento_id" value="{{ item.id }}" />
+                                                                        <div class="flex-grow-1">
+                                                                            <label class="form-label mb-1">Número de IF</label>
+                                                                            <input type="text"
+                                                                                   name="numero_if"
+                                                                                   maxlength="255"
+                                                                                   class="form-control form-control-sm"
+                                                                                   value="{{ item.numero_if|default_if_none:'' }}" />
+                                                                        </div>
+                                                                        <button type="submit" class="btn btn-sm btn-primary mb-0">Guardar</button>
+                                                                        <button type="button"
+                                                                                class="btn btn-sm btn-secondary mb-0"
+                                                                                data-numero-if-cancel="{{ item.id }}">
+                                                                            Cancelar
+                                                                        </button>
+                                                                    </form>
+                                                                {% endif %}
+                                                            </div>
                                                         {% endif %}
                                                     </div>
                                                     <div class="col-2 d-flex justify-content-end">

--- a/relevamientos/views/web_views.py
+++ b/relevamientos/views/web_views.py
@@ -119,6 +119,7 @@ class RelevamientoListView(LoginRequiredMixin, ListView):
                     "is_child": False,
                     "parent_id": None,
                     "has_seguimiento": seguimiento is not None,
+                    "sincronizado_gestionar": rel.sincronizado_gestionar,
                 }
             )
             if seguimiento is not None:
@@ -130,6 +131,7 @@ class RelevamientoListView(LoginRequiredMixin, ListView):
                         "numero_if": None,
                         "is_child": True,
                         "parent_id": rel.id,
+                        "sincronizado_gestionar": seguimiento.sincronizado_gestionar,
                     }
                 )
         context["relevamientos_items"] = items


### PR DESCRIPTION
## Summary

- **primer_seguimiento_detail**: reemplaza el texto plano del estado por badge `Completado` (verde) / `No completado` (gris). Resuelve que al recibir PATCH de GESTIONAR con `estado = \"Completo\"` no aparecía ningún badge visible.
- **relevamiento_detail**: agrega badge `Completado` / `No completado` en el card del primer seguimiento, junto al badge de sincronización existente.
- **web_views.py** (`RelevamientoListView`): expone el campo `sincronizado_gestionar` en el dict de items para relevamientos y primer_seguimientos (faltaba, por eso el template no podía usarlo).
- **relevamiento_list**: en el listado de relevamientos de un comedor:
  - Items hijo (primer seguimiento): badges `Primer seguimiento` + `Sincronizado`/`No sincronizado` + `Completado`/`No completado`
  - Items padre (relevamiento): badge `Sincronizado`/`No sincronizado`

## Test plan

- [ ] Abrir `/comedores/<id>/relevamiento/listar` → verificar badges Sincronizado/No sincronizado en relevamientos y en primer seguimientos
- [ ] En listado, verificar badge Completado/No completado en primer seguimientos
- [ ] Mandar PATCH a `/api/primer-seguimiento/` con `estado: "Completo"` → en el detalle del primer seguimiento debe aparecer badge verde **Completado**
- [ ] Abrir detalle de un relevamiento con primer seguimiento → verificar badge Completado/No completado en el card del primer seguimiento

🤖 Generated with [Claude Code](https://claude.com/claude-code)