### PR TITLE
feat(ticketera): PATCH usuarios + solicitar reset password

### DIFF
--- a/docs/plans/2026-06-08-ticketera-edit-usuarios-y-reset-password.md
+++ b/docs/plans/2026-06-08-ticketera-edit-usuarios-y-reset-password.md
@@ -1,0 +1,393 @@
+# Plan — Extender API Ticketera: editar usuarios + solicitar reset de contraseña
+
+**Fecha:** 2026-06-08
+**Estado:** Borrador para revisión humana. **No** implementar hasta OK.
+
+---
+
+## 1. Contexto y objetivo
+
+La integración server-to-server con la Ticketera ([ADR 2026-05-27](../registro/decisiones/2026-05-27-integracion-ticketera.md), [hardening 2026-05-28](../registro/cambios/2026-05-28-integracion-ticketera-hardening.md)) hoy expone tres endpoints: alta/reconciliación de usuarios, verificación de credenciales y cambio de la temporal por la definitiva. La Ticketera necesita además poder **(1) editar datos básicos del usuario** (email/nombre/apellido) que provisionó y **(2) iniciar el reset de contraseña** de usuarios suyos cuando el portador olvida la clave o pide regenerarla. Este plan diseña ambas extensiones manteniendo los contratos de los tres endpoints actuales y reutilizando los patrones existentes (HasAPIKey, rate limit, `audit_context`, `_is_ticketera_source`).
+
+---
+
+## 2. Decisiones pendientes (con recomendación marcada)
+
+> El humano revisa y confirma este bloque **antes** de pasar a código.
+
+### 2.1 Capacidad 1 — PATCH usuarios
+
+#### D1. Forma de la URL para PATCH
+
+- **A. `PATCH /api/ticketera/usuarios/<username>/` (recomendada)** — REST estándar, drf-spectacular documenta el path param explícito, deja `name="ticketera-usuarios-detail"`. El POST de alta sigue en `/usuarios/`.
+- B. `PATCH /api/ticketera/usuarios/` con `username` en body. Mantiene el shape del POST, pero "edit by body" es no idiomático en DRF/OpenAPI y arrastra branching innecesario sobre el mismo path.
+
+**Por qué A:** REST estándar y separación clara recurso/datos. Path param permite cobertura sencilla del 404 anti-enumeration. Costo: una nueva URL pero la app ya tiene tres → no se rompe el estilo `ticketera-*`.
+
+#### D2. 403 vs 404 cuando el usuario existe pero no es Ticketera
+
+> El brief decía "decisión ya tomada: 403". Evalúo el tradeoff igual.
+
+- **A. 403 `{ "error": "user_not_ticketera" }` (recomendada, respeta lo ya decidido).** Pros: la Ticketera distingue "no existe" de "no te pertenece" → soporte operativo más simple. Contras: permite enumeration de usernames SISOC al portador de la API Key.
+- B. 404 idéntico al "no existe". Anti-enumeration estricta. Contras: opaco para soporte; la Ticketera no sabe si bañaba en datos o si chocó con un username SISOC homónimo.
+
+**Por qué A:** el canal es S2S detrás de API Key (no público), el universo "enumerable" es muy chico y la Ticketera ya conoce sus altas. La operatividad pesa más que la pseudoanonimidad. Documentar en el ADR el tradeoff.
+
+#### D3. Campos editables
+
+- **email**: SÍ. Decisión clave: ¿unicidad? **Recomendado: NO** (mantener el comportamiento actual de SISOC, que permite emails repetidos en `auth_user`). Imponer unicidad solo en este canal abre divergencia: usuarios provisionados desde el backoffice podrían ya colisionar y el PATCH no podría reparar el suyo. Si la Ticketera lo necesita, pedir un campo aparte (`email_normalizado`) o tratar como issue separado.
+- **first_name, last_name**: SÍ.
+- **username**: NO. Cambiarlo rompe `authenticate()` (ModelBackend case-sensitive) y obliga a re-emitir credenciales. Si en el futuro hace falta, será una operación distinta (rename con migración explícita).
+- **password**: NO. Tiene su endpoint dedicado `/auth/cambiar-password/` (y el `/auth/solicitar-reset-password/` de la capacidad 2). Mezclar canales borra trazabilidad.
+- **is_active**: **NO en este MVP (recomendada).** Permitir bajar `is_active` desde la Ticketera obliga a decidir qué pasa con sesiones web, `must_change_password` y reactivaciones; introduce un canal de desactivación que hoy solo existe en el backoffice. Si la Ticketera lo pide, se evalúa por separado.
+- **source**: nunca editable desde la API.
+
+#### D4. Idempotencia del PATCH
+
+- **Recomendada:** aplicar solo los cambios reales (`update_fields` derivado de los campos que llegaron y que difieren del valor actual). Si nada cambia, `save()` no se invoca y auditlog no genera `LogEntry`. Respuesta `200 OK` con el snapshot del usuario.
+- Justificación: el patrón ya está implícito en `_existing_user_response` del POST (responder el snapshot existente sin tocar nada). Evita ruido en `auditlog`/`AuditEntryMeta`.
+
+#### D5. Lookup case-insensitive del path param
+
+- **Recomendada:** mismo criterio que el POST (`username__iexact`). El `<username>` del path se resuelve con `iexact` para no esquivar el 404 por mayúsculas/minúsculas; el username almacenado **no se normaliza** y la respuesta devuelve el username canónico de la fila.
+
+#### D6. ¿Aceptar PATCH vacío?
+
+- **Recomendada:** sí → `200 OK` con el snapshot actual (idempotente). Refleja el mismo principio que el alta idempotente.
+
+### 2.2 Capacidad 2 — Reset de contraseña
+
+#### D7. Diseño del reset (A vs B)
+
+- **A. La Ticketera dispara el reset y SISOC manda el mail con link a `password_reset_confirm` (recomendada para esta entrega).** Reusa `request_password_reset_for_email`/`request_password_reset_for_username` tal cual; cero superficie de cierre. El usuario completa el reset por web (UX coherente con el reset PWA/backoffice). Pros: mínima superficie nueva, sin manejo de tokens en la integración. Contras: la UX termina en SISOC; la Ticketera no puede ofrecer una pantalla nativa para fijar la nueva clave.
+- B. Endpoint devuelve `{uid, token}` + nuevo `POST /api/ticketera/auth/confirmar-reset-password/` que valida `(uid, token)` con `default_token_generator` y aplica vía `confirm_password_reset`. Pros: UX nativa Ticketera. Contras: doble endpoint, token con TTL Django (`PASSWORD_RESET_TIMEOUT`) en tránsito, mayor superficie para logs/leaks; obliga a definir si la Ticketera arma el mail o si SISOC los manda igual.
+
+**Por qué A:** alinea con el "principio de mínima superficie" del ADR, no agrega un canal de tokens fuera de SISOC y reusa el link que ya validamos en producción. Si más adelante la Ticketera necesita UX nativa de reset, se agrega B como follow-up (sigue siendo aditivo, no breaking). En la sección 3.2 documento ambas opciones para que el humano decida ya.
+
+#### D8. Identificación del usuario en el request
+
+- **Recomendada:** `username` o `email` (exclusivos) en el body, mismo patrón que `PasswordResetRequestSerializer` ([users/api_serializers.py:134-161](../../users/api_serializers.py)). Validación equivalente: exactamente uno de los dos.
+
+#### D9. Filtro por origen
+
+- **A. Solo usuarios con `_is_ticketera_source(profile.source)` (recomendada).** Coherente con el espíritu del canal: la Ticketera opera sobre sus propios usuarios; un reset cross-origen entre canales es sospechoso. El 200 genérico anti-enumeration cubre cualquier filtro silencioso.
+- B. Cualquier usuario activo. Más permisivo (la Ticketera podría disparar reset de usuarios SISOC), pero abre un canal lateral con API Key.
+
+**Por qué A:** la API Key es un perímetro fuerte, pero darle palanca para iniciar reset de usuarios de otros canales acopla sin necesidad. Operativamente la Ticketera solo conoce sus usuarios.
+
+#### D10. Anti-enumeration
+
+- **Recomendada:** `200 OK` SIEMPRE con `{"detail": "Si el usuario existe en el sistema, se registró la solicitud de reseteo."}` (texto idéntico al de la API web actual). No 401/404. Igual que [users/api_views.py:231-238](../../users/api_views.py).
+
+#### D11. Rate limit
+
+- **Recomendada:** scope `ticketera_solicitar_reset`, `limit=5`, `window_seconds=900`, identidad `f"{ip}:{username or email lowercased}"`. Mismo perfil que `password_reset_request` (5/15 min) — el reset es más sensible que `verificar` y debe ser más restrictivo. La identidad incluye IP por consistencia con el resto de la app; no se agrega contador por-IP separado por la misma razón documentada en el hardening 2026-05-28.
+
+#### D12. Auditoría del reset
+
+- **Recomendada:** emitir `LogEntry` explícito con `action=ACCESS` sobre el `User` (mismo recurso que `verificar`), con `changes={"password_reset_requested": [None, <isoformat>]}` y `audittrail_source="ticketera"`, dentro de `audit_context(source="ticketera", extra={"remote_source": ...})`. Hoy el flujo web solo loguea con `logger.info`; para este canal queremos rastro en auditlog ya que es server-to-server y no hay sesión que correlacionar.
+- Cuando no exista el usuario o el origen no sea Ticketera: **no se emite LogEntry** (no se confirma la existencia ni para el log).
+
+#### D13. Compatibilidad con `must_change_password`
+
+- En **Opción A** el ciclo termina en `confirm_password_reset` ([users/services_auth.py:119](../../users/services_auth.py)), que ya baja `must_change_password`, limpia `initial_password_expires_at`, `password_reset_requested_at` y `temporary_password_plaintext`. **Nada que tocar.**
+- En Opción B el endpoint `confirmar` reusa la misma función. **Nada que tocar.**
+
+---
+
+## 3. Diseño detallado
+
+### 3.1 Capacidad 1 — PATCH `/api/ticketera/usuarios/<username>/`
+
+#### Endpoint
+
+- Método: `PATCH`.
+- Path: `/api/ticketera/usuarios/<str:username>/` — `name="ticketera-usuarios-detail"`.
+- Auth: `HasAPIKey` (mismo perímetro que el POST).
+- Flag: `settings.TICKETERA_ENABLED` (503 si está off, vía `_ticketera_disabled_response`).
+- Mismo `tags=["Ticketera"]` en `@extend_schema`.
+
+#### Request body
+
+```json
+{
+  "email": "nuevo@ejemplo.gob.ar",
+  "first_name": "Juan Pablo",
+  "last_name": "Pérez",
+  "source": "ticketera-qa"
+}
+```
+
+- Todos los campos opcionales.
+- `source`: informativo (igual semántica que el POST: alimenta `extra.remote_source` para auditoría; **no** se persiste sobre `profile.source` en este endpoint).
+- Cualquier otro field se ignora (DRF default; no se valida exclusión estricta).
+
+#### Response shapes
+
+- **200** — snapshot canónico del usuario:
+  ```json
+  {"id": 17, "username": "juan.perez", "email": "...", "first_name": "...", "last_name": "..."}
+  ```
+- **400** — payload inválido (email malformado, tipos incorrectos) con la shape estándar de DRF (`{"email": ["Enter a valid email address."]}`).
+- **403** — `{"error": "user_not_ticketera", "message": "El usuario existe pero no fue provisionado por la Ticketera."}` (cuando el lookup `iexact` matchea pero `profile.source` no pasa `_is_ticketera_source`).
+- **404** — `{"error": "user_not_found", "message": "No existe un usuario con ese username."}`.
+- **503** — integración off (igual shape que los endpoints actuales).
+
+#### Serializer
+
+- Nuevo `TicketeraUsuarioPatchSerializer` en [ticketera/api_serializers.py](../../ticketera/api_serializers.py):
+  - `email = serializers.EmailField(max_length=254, required=False)`
+  - `first_name = serializers.CharField(max_length=150, allow_blank=True, required=False)`
+  - `last_name = serializers.CharField(max_length=150, allow_blank=True, required=False)`
+  - `source = serializers.CharField(max_length=50, required=False, default="ticketera")`
+  - Pylint disable abstract-method (mismo patrón que el resto del módulo).
+- **No** reusa `TicketeraUsuarioCreateSerializer` para no arrastrar `username/password` como required ni para acoplar dos contratos distintos.
+- Response serializer nuevo `TicketeraUsuarioDetailSerializer` (id, username, email, first_name, last_name) — los actuales devuelven solo `(id, username, email)` y queremos exponer nombres en la respuesta del PATCH para que la Ticketera confirme.
+
+#### Lógica de la view (prosa)
+
+`TicketeraUsuarioUpdateView(APIView)`:
+
+1. Si `not settings.TICKETERA_ENABLED` → 503.
+2. Validar serializer (raise_exception=True).
+3. Resolver `existing = User.objects.select_related("profile").filter(username__iexact=username_path).first()`.
+4. Si `existing is None` → 404.
+5. Si no `_is_ticketera_source(existing.profile.source or "")` → 403.
+6. Construir `update_fields` recorriendo los fields del serializer que llegaron y comparando contra el valor actual. Si no cambia ninguno → 200 con el snapshot.
+7. Dentro de `with audit_context(source="ticketera", extra={"remote_source": source}): with transaction.atomic():` aplicar `setattr` + `existing.save(update_fields=[...])`. **Solo** se persisten los fields que cambiaron.
+8. Responder 200 con `TicketeraUsuarioDetailSerializer(existing).data`.
+
+#### Auditoría
+
+- `auditlog` registra el `UPDATE` de `auth_user` automáticamente con el diff de los campos cambiados (los campos editables `email/first_name/last_name` **no** están en `excluded_fields` del Usuario — ver [audittrail/constants.py:108-112](../../audittrail/constants.py): solo `password` está excluido fijo y `last_login` opcional).
+- **No** se requiere `LogEntry` explícito (el diff lo captura `auditlog`).
+- `audit_context` inyecta `source="ticketera"` y `extra={"remote_source": source}` (siempre, aunque no haya cambios — pero no llegará a tocar nada si no hay diff).
+
+#### Rate limit
+
+- **No se aplica** rate limit a este endpoint en el MVP. Justificación: el riesgo es bajo (no toca credenciales ni revela info sensible), el canal está protegido por API Key y la Ticketera no tiene incentivo para spammear. Si aparece abuso, se agrega scope `ticketera_editar_usuario` con `(limit=20, window=300)` por `f"{ip}:{username}"`.
+
+#### Errores y códigos (resumen)
+
+| Status | Cuándo | Body |
+|---|---|---|
+| 200 | Edición aplicada o idempotente | snapshot del usuario |
+| 400 | Email malformado / payload inválido | shape DRF default |
+| 403 | Existe con origen no Ticketera | `{"error": "user_not_ticketera", "message": "..."}` |
+| 404 | No existe | `{"error": "user_not_found", "message": "..."}` |
+| 503 | `TICKETERA_ENABLED=False` | `{"error": "integration_disabled", "message": "..."}` |
+
+### 3.2 Capacidad 2 — POST `/api/ticketera/auth/solicitar-reset-password/`
+
+#### Endpoint
+
+- Método: `POST`.
+- Path: `/api/ticketera/auth/solicitar-reset-password/` — `name="ticketera-auth-solicitar-reset-password"`.
+- Auth: `HasAPIKey`. Flag `TICKETERA_ENABLED`.
+- `tags=["Ticketera"]`.
+
+#### Request body
+
+```json
+{
+  "username": "juan.perez",
+  "source": "ticketera"
+}
+```
+
+o
+
+```json
+{
+  "email": "juan.perez@ejemplo.gob.ar",
+  "source": "ticketera"
+}
+```
+
+Exactamente uno de `username` o `email` (excluyentes). `source` informativo.
+
+#### Response shapes
+
+- **200** SIEMPRE: `{"detail": "Si el usuario existe en el sistema, se registró la solicitud de reseteo."}` (string idéntico al de la API web).
+- **400** — solo cuando faltan ambos identificadores o llegan los dos (validación de serializer). Shape DRF default.
+- **429** — `{"error": "too_many_attempts", "message": "Demasiados intentos. Esperá unos minutos."}`.
+- **503** — integración off.
+
+> No se devuelve 401/404: anti-enumeration absoluta.
+
+#### Serializer
+
+- Nuevo `TicketeraSolicitarResetSerializer`:
+  - `username = serializers.CharField(max_length=150, required=False)`
+  - `email = serializers.EmailField(max_length=254, required=False)`
+  - `source = serializers.CharField(max_length=50, required=False, default="ticketera")`
+  - `validate()`: replicar el XOR de `PasswordResetRequestSerializer` ([users/api_serializers.py:147-161](../../users/api_serializers.py)) — si llegan ambos o ninguno, `ValidationError`.
+
+#### Lógica de la view (prosa) — Opción A (recomendada)
+
+`TicketeraSolicitarResetPasswordView(APIView)`:
+
+1. Si `not settings.TICKETERA_ENABLED` → 503.
+2. Validar serializer.
+3. Aplicar `hit_rate_limit(scope="ticketera_solicitar_reset", identity=f"{ip}:{username_or_email_lower}", limit=5, window_seconds=900)` → 429 si supera.
+4. Resolver `user`:
+   - Si vino `username`: `User.objects.filter(username__iexact=username, is_active=True).select_related("profile").first()`.
+   - Si vino `email`: `User.objects.filter(email__iexact=email, is_active=True).select_related("profile").order_by("id").first()` (criterio determinístico ante duplicados de email, que SISOC permite).
+5. Si `user` existe y `_is_ticketera_source(getattr(user.profile, "source", ""))`:
+   - Dentro de `audit_context(source="ticketera", extra={"remote_source": source})`:
+     - Llamar a `request_password_reset_for_email(email=user.email, request=request)` cuando el usuario tiene email; esto cubre el caso por email **y** el caso por username (en ese último, leemos el email del usuario resuelto). **No** se llama a `request_password_reset_for_username` (es un canal mobile distinto que solo setea `password_reset_requested_at` sin mandar mail).
+     - Si el usuario no tiene email registrado, no se manda nada (logger.warning) — la respuesta sigue siendo 200 anti-enumeration.
+     - Emitir `LogEntry.objects.log_create(user, action=ACCESS, changes={"password_reset_requested": [None, now.isoformat()]}, actor=user, additional_data={"audittrail_source": "ticketera", "audittrail_context": {"remote_source": source}})`.
+6. Responder 200 con el mensaje genérico (existe / no existe / origen no Ticketera son indistinguibles para el cliente).
+
+#### Lógica de la view (prosa) — Opción B (si el humano la elige en lugar de A)
+
+`TicketeraSolicitarResetPasswordView` (igual a 1-4 anteriores) pero devuelve `{ "uid": <urlsafe_base64>, "token": <token> }` cuando `user` cumple los filtros. Anti-enumeration: cuando el usuario no cumple, devolver un par `uid/token` falso desbalancearía la respuesta → preferible mantener 200 con `{"detail": "..."}` cuando no aplica (asimétrico observable). Esta asimetría es el costo de B y otra razón para preferir A.
+
+Si se elige B, agregar un segundo endpoint `POST /api/ticketera/auth/confirmar-reset-password/` con:
+- Body `{ "uid", "token", "new_password", "source" }`.
+- Validación de fortaleza con `password_validation.validate_password(new_password, user)`.
+- Reusar `confirm_password_reset(uid, token, new_password)` ([users/services_auth.py:119](../../users/services_auth.py)) — que ya limpia `must_change_password`, `initial_password_expires_at`, `password_reset_requested_at` y `temporary_password_plaintext`.
+- Tras el reset, `Token.objects.filter(user=user).delete()` (mismo patrón que [users/api_views.py:279](../../users/api_views.py)).
+- Rate limit propio scope `ticketera_confirmar_reset` (limit=10, window=900) por `ip` (no por uid, que es el secreto que estamos defendiendo).
+- Respuestas: 200 `{"changed": true}`; 400 `{"detail": "Token inválido o expirado."}`; 429; 503.
+
+> El plan **recomienda Opción A** y la implementa por defecto. Opción B queda diseñada acá pero **no se implementa** salvo decisión explícita del humano.
+
+#### Auditoría
+
+- Opción A: ver paso 5; un `LogEntry ACCESS` cuando se dispara el envío, con `audittrail_source="ticketera"`.
+- Opción B (si se elige): el `confirmar` invoca `set_password` + `save(update_fields=["password"])` que **no** genera diff (password excluido). Replicar el patrón de `cambiar-password` y emitir `LogEntry UPDATE` con `changes={"password": ["***", "***"]}`.
+
+#### Rate limit
+
+- Solicitar: `scope="ticketera_solicitar_reset"`, `limit=5`, `window_seconds=900`, identidad `f"{ip}:{identity_lower}"`.
+- Confirmar (solo B): `scope="ticketera_confirmar_reset"`, `limit=10`, `window_seconds=900`, identidad `ip`.
+
+#### Errores y códigos (resumen)
+
+| Status | Cuándo | Body |
+|---|---|---|
+| 200 | Siempre que el payload sea válido y no se supere RL | `{"detail": "..."}` |
+| 400 | Falta XOR (ambos o ninguno) | shape DRF |
+| 429 | Rate limit | `{"error": "too_many_attempts", ...}` |
+| 503 | Integración off | `{"error": "integration_disabled", ...}` |
+
+---
+
+## 4. Archivos a tocar
+
+> Lista exhaustiva. Cada item indica motivo. **Ningún cambio** rompe los tres endpoints actuales.
+
+- [ticketera/api_views.py](../../ticketera/api_views.py) — agrega `TicketeraUsuarioUpdateView` y `TicketeraSolicitarResetPasswordView` (y `TicketeraConfirmarResetPasswordView` si va Opción B). Reusa `_is_ticketera_source`, `_ticketera_disabled_response`, `AUDIT_SOURCE`.
+- [ticketera/api_serializers.py](../../ticketera/api_serializers.py) — agrega `TicketeraUsuarioPatchSerializer`, `TicketeraUsuarioDetailSerializer`, `TicketeraSolicitarResetSerializer` (y `TicketeraConfirmarResetSerializer` en Opción B). Mantener el `pylint: disable=abstract-method` del módulo.
+- [ticketera/api_urls.py](../../ticketera/api_urls.py) — agrega `path("usuarios/<str:username>/", TicketeraUsuarioUpdateView.as_view(), name="ticketera-usuarios-detail")` y `path("auth/solicitar-reset-password/", ...)`. (Opción B suma `auth/confirmar-reset-password/`).
+- [tests/test_ticketera.py](../../tests/test_ticketera.py) — agrega bloques PATCH y reset (ver sección 5).
+- [ticketera/tests.py](../../ticketera/tests.py) — agrega smoke tests del 503 con flag deshabilitado para los endpoints nuevos (mantener cobertura paritaria con los actuales).
+- [docs/registro/decisiones/2026-06-08-ticketera-edit-usuarios-y-reset-password.md](../registro/decisiones/2026-06-08-ticketera-edit-usuarios-y-reset-password.md) **nueva** — ADR con las decisiones de la sección 2.
+- [docs/registro/cambios/2026-06-08-ticketera-edit-usuarios-y-reset-password.md](../registro/cambios/2026-06-08-ticketera-edit-usuarios-y-reset-password.md) **nueva** — registro de cambio del PR.
+
+**No** se tocan:
+- `users/services_auth.py` (Opción A reusa sin modificar; Opción B también).
+- `users/models.py`, `users/migrations/` (no hay nuevos campos).
+- `core/api_auth.py`, `users/rate_limits.py`, `audittrail/context.py` (reusados sin modificar).
+- `config/settings.py` (`TICKETERA_ENABLED` ya existe).
+
+---
+
+## 5. Tests nuevos
+
+Todos en [tests/test_ticketera.py](../../tests/test_ticketera.py) salvo los smoke que van en [ticketera/tests.py](../../ticketera/tests.py).
+
+### PATCH `/usuarios/<username>/`
+
+1. `test_patch_usuario_actualiza_email_y_nombres_devuelve_200` — happy path; verifica que `auditlog` registró un UPDATE con `source=ticketera`.
+2. `test_patch_usuario_otro_origen_devuelve_403` — usuario con `source=sisoc` → 403 `user_not_ticketera`, sin modificar.
+3. `test_patch_usuario_inexistente_devuelve_404` — username que no existe → 404, sin LogEntry.
+4. `test_patch_usuario_acepta_variantes_de_capitalizacion` — `username__iexact` resuelve `Juan.Perez` cuando la fila es `juan.perez`.
+5. `test_patch_usuario_email_invalido_devuelve_400` — payload `{"email": "no-es"}` → 400 sin tocar la fila.
+6. `test_patch_usuario_idempotente_no_emite_logentry` — mandar los mismos valores actuales → 200 y `auditlog` no suma entradas.
+7. `test_patch_usuario_intento_username_o_password_ignorado` — `{"username": "otro", "password": "x"}` no cambia nada y responde 200 con el snapshot actual (DRF ignora fields no declarados).
+8. `test_patch_usuario_source_no_se_persiste_en_profile` — mandar `"source": "ticketera-qa"` no escribe en `profile.source` (solo a `extra.remote_source`).
+9. `test_patch_usuario_503_con_flag_deshabilitado` (smoke en `ticketera/tests.py`).
+10. `test_patch_usuario_sin_api_key_rechaza` — parametrizar con el resto.
+
+### POST `/auth/solicitar-reset-password/`
+
+11. `test_solicitar_reset_con_username_existente_ticketera_devuelve_200_y_envia_mail` — verifica que `send_password_reset_link` fue invocado (mock); LogEntry ACCESS con `source=ticketera`.
+12. `test_solicitar_reset_con_email_existente_ticketera_devuelve_200_y_envia_mail` — idem por email.
+13. `test_solicitar_reset_usuario_inexistente_devuelve_200_sin_enviar_mail` — anti-enumeration; mock de send no se llama; sin LogEntry.
+14. `test_solicitar_reset_usuario_de_otro_origen_devuelve_200_sin_enviar_mail` — `source=sisoc`; anti-enumeration; mock de send no se llama; sin LogEntry.
+15. `test_solicitar_reset_usuario_inactivo_devuelve_200_sin_enviar_mail` — `is_active=False`; mock de send no se llama.
+16. `test_solicitar_reset_payload_invalido_devuelve_400` — ni username ni email → 400; ambos → 400.
+17. `test_solicitar_reset_supera_rate_limit_devuelve_429_en_el_intento_6` — 5 ok, el 6° bloqueado (limit=5, window=900).
+18. `test_solicitar_reset_503_con_flag_deshabilitado` (smoke en `ticketera/tests.py`).
+19. `test_solicitar_reset_sin_api_key_rechaza` — parametrizar con el resto.
+
+> Si se elige Opción B, sumar:
+> 20. `test_confirmar_reset_token_valido_aplica_y_baja_must_change_password`.
+> 21. `test_confirmar_reset_token_invalido_devuelve_400`.
+> 22. `test_confirmar_reset_password_debil_devuelve_400`.
+> 23. `test_confirmar_reset_supera_rate_limit_429`.
+> 24. `test_confirmar_reset_503_con_flag_deshabilitado`.
+
+### Cómo correr los tests
+
+`docker run --rm` con la imagen `*-django` ya construida y `USE_SQLITE_FOR_TESTS=1`, igual que el hardening 2026-05-28 (ver sección Validación de [ese cambio](../registro/cambios/2026-05-28-integracion-ticketera-hardening.md)). El Python local sigue con el `ImportError` documentado en la memoria de validación. Limitar a `pytest tests/test_ticketera.py ticketera/tests.py` para mantener tiempo bajo. **No** se requiere migración.
+
+---
+
+## 6. Documentación a actualizar
+
+- **Nueva ADR**: [docs/registro/decisiones/2026-06-08-ticketera-edit-usuarios-y-reset-password.md](../registro/decisiones/2026-06-08-ticketera-edit-usuarios-y-reset-password.md). Contiene:
+  - Decisiones de sección 2 con su justificación final.
+  - Contratos de los dos endpoints (mismo estilo que el ADR 2026-05-27).
+  - Tradeoff Opción A vs B documentado, con la decisión final.
+- **Nuevo registro de cambio**: [docs/registro/cambios/2026-06-08-ticketera-edit-usuarios-y-reset-password.md](../registro/cambios/2026-06-08-ticketera-edit-usuarios-y-reset-password.md). Lista archivos tocados, decisiones, impacto y validación corrida.
+- Apéndice corto en [docs/registro/decisiones/2026-05-27-integracion-ticketera.md](../registro/decisiones/2026-05-27-integracion-ticketera.md) → sección "Extensiones (2026-06-08)" con un link al nuevo ADR (para que el ADR base siga siendo el índice).
+
+---
+
+## 7. Riesgos y mitigaciones
+
+1. **Mail no llega o llega tarde** — el envío de SISOC es síncrono (`send_mail`, `fail_silently=False`). Si el SMTP está caído, el endpoint responde 200 igual (anti-enumeration), pero el mail falla. Mitigación: el `except Exception` que ya tiene `request_password_reset_for_email` loguea con `logger.exception`; pedir a Infra que vigile el log; documentar que **no** hay retry automático y que la Ticketera puede reintentar (cubre el caso vía rate limit).
+2. **Token de password reset Django expirado mientras el mail no llega** — `PASSWORD_RESET_TIMEOUT` controla la TTL. Verificar el valor configurado en `config/settings.py` antes del merge (si está en default 3 días, alcanza; si está reducido, ajustar). Mitigación: documentar en el ADR el valor efectivo.
+3. **PATCH idempotente que se transforma en update sin cambios** — si la lógica no compara `getattr` actual vs nuevo, podríamos disparar `save()` y generar `LogEntry` UPDATE espurio en cada PATCH. Mitigación: comparar campo a campo antes de poblar `update_fields`; test 6 cubre la regresión.
+4. **403 vs 404 trade-off en PATCH** — la Ticketera con su API Key puede enumerar usernames SISOC (4xx distinto entre "no existe" y "no Ticketera"). Mitigación: documentar en el ADR; rotar la API Key si hay sospecha de leak; si el equipo de seguridad pide cerrar el canal, switch a 404 unificado es trivial (un branch).
+5. **Email duplicado en SISOC** — un reset por email matchea N usuarios; hoy `request_password_reset_for_email` itera todos y envía a cada uno. Si el universo es chico (gobiernos provinciales), es ruidoso pero seguro. Mitigación: documentar el comportamiento; si en el futuro hace falta, restringir a `order_by("id").first()` solo dentro del canal Ticketera.
+6. **Filtración del `source` informativo en logs** — el body del PATCH/solicitar acepta cualquier string en `source`. El `audit_context` lo guarda en `extra`. Mitigación: validar `max_length=50` (ya está en los serializers actuales), evitar loggear el cuerpo crudo.
+7. **Rate limit insuficiente en `/solicitar-reset/`** — 5/15 min puede ser laxo si la Ticketera fanea solicitudes desde una sola IP. Mitigación: monitorear; el `f"{ip}:{identity}"` previene rotación de identidades desde la misma IP.
+
+---
+
+## 8. Checklist de verificación previa al merge
+
+- [ ] Decisiones de sección 2 confirmadas por el humano (D1-D13).
+- [ ] PR apunta a `development` (`--base development`).
+- [ ] Los tres endpoints actuales pasan sin cambios (regresión: `tests/test_ticketera.py` original y `ticketera/tests.py` original).
+- [ ] Tests nuevos (sección 5) pasan en Docker con `USE_SQLITE_FOR_TESTS=1`.
+- [ ] `drf-spectacular` schema check sin warnings (`@extend_schema` cubre todos los responses).
+- [ ] `black --check ticketera/`.
+- [ ] `pylint` sobre `ticketera/api_views.py`, `ticketera/api_serializers.py`, `ticketera/api_urls.py` (Docker, mismo workaround del hardening).
+- [ ] ADR nueva y registro de cambio escritos antes del último commit.
+- [ ] El ADR 2026-05-27 referencia el nuevo bloque "Extensiones (2026-06-08)".
+- [ ] `makemigrations --check --dry-run` corre limpio (no hay nuevas migraciones esperadas).
+- [ ] El changelog automático ([scripts/ci/pr_doc_automation.py](../../scripts/ci/pr_doc_automation.py)) tomó el cambio en el PR doc.
+- [ ] Verificación manual con `curl`/Postman documentada en el PR description: PATCH happy path + 200 anti-enumeration del solicitar-reset.
+
+---
+
+## Apéndice — Referencias rápidas
+
+- `_is_ticketera_source`: [ticketera/api_views.py:42](../../ticketera/api_views.py).
+- `_ticketera_disabled_response`: [ticketera/api_views.py:52](../../ticketera/api_views.py).
+- `audit_context`: [audittrail/context.py:42](../../audittrail/context.py).
+- `hit_rate_limit`: [users/rate_limits.py:4](../../users/rate_limits.py).
+- `HasAPIKey`: [core/api_auth.py:3](../../core/api_auth.py).
+- `request_password_reset_for_email`: [users/services_auth.py:73](../../users/services_auth.py).
+- `confirm_password_reset`: [users/services_auth.py:119](../../users/services_auth.py).
+- `PasswordResetRequestViewSet` (referencia de patrón): [users/api_views.py:199](../../users/api_views.py).
+- `PasswordResetRequestSerializer` (XOR username/email): [users/api_serializers.py:134](../../users/api_serializers.py).
+- Campos excluidos del diff de Usuario en auditlog: [audittrail/constants.py:107-112](../../audittrail/constants.py) (`password` fijo, `last_login` opcional). `email`, `first_name`, `last_name` **no** excluidos.
+- `Profile.source`: [users/models.py:122](../../users/models.py).
+- Tests existentes a respetar: [tests/test_ticketera.py](../../tests/test_ticketera.py), [ticketera/tests.py](../../ticketera/tests.py).

--- a/docs/registro/cambios/2026-06-08-ticketera-edit-usuarios-y-reset-password.md
+++ b/docs/registro/cambios/2026-06-08-ticketera-edit-usuarios-y-reset-password.md
@@ -1,0 +1,95 @@
+# 2026-06-08 - Ticketera: edición de usuarios y solicitud de reset de contraseña
+
+## Contexto
+
+Extensión aditiva de la API server-to-server con la Ticketera
+([ticketera/api_views.py](../../../ticketera/api_views.py)). Se agregan dos
+endpoints sin tocar los tres existentes:
+
+- `PATCH /api/ticketera/usuarios/<username>/` — edita `email`, `first_name`,
+  `last_name` de un usuario provisionado por la Ticketera.
+- `POST /api/ticketera/auth/solicitar-reset-password/` — inicia el reset de
+  contraseña; SISOC envía el mail con link a `password_reset_confirm`.
+
+Arquitectura, decisiones y contratos:
+[docs/registro/decisiones/2026-06-08-ticketera-edit-usuarios-y-reset-password.md](../decisiones/2026-06-08-ticketera-edit-usuarios-y-reset-password.md).
+Plan original (con tradeoffs): [docs/plans/2026-06-08-ticketera-edit-usuarios-y-reset-password.md](../../plans/2026-06-08-ticketera-edit-usuarios-y-reset-password.md).
+
+## Cambios aplicados
+
+- **PATCH `/usuarios/<username>/` (`TicketeraUsuarioUpdateView`).**
+  - Solo edita si `_is_ticketera_source(profile.source)` ([ticketera/api_views.py:42](../../../ticketera/api_views.py)); responde `403 user_not_ticketera` en caso contrario, `404 user_not_found` si no existe.
+  - Lookup case-insensitive (`username__iexact`); el username almacenado no
+    se normaliza.
+  - Idempotente: solo persiste los fields que cambian (`update_fields=[...]`);
+    PATCH con body vacío o con valores iguales a los actuales responde `200`
+    sin tocar nada y sin generar `LogEntry`.
+  - Auditoría delegada a `auditlog` sobre `auth_user` (diff automático de
+    los tres campos editables; `password` y `last_login` son los únicos
+    excluidos del modelo Usuario).
+  - Sin rate limit en el MVP.
+- **POST `/auth/solicitar-reset-password/` (`TicketeraSolicitarResetPasswordView`).**
+  - XOR `username`/`email` (mismo patrón que `PasswordResetRequestSerializer`).
+  - Filtro de origen: procesa el reset solo si el usuario activo tiene
+    `_is_ticketera_source(profile.source)`. Anti-enumeration: respuesta
+    `200` con detalle genérico siempre (existe, no existe, otro origen,
+    inactivo, sin email).
+  - Dispara `users.services_auth.request_password_reset_for_email` ([users/services_auth.py:73](../../../users/services_auth.py)) — el cierre del ciclo lo
+    hace `confirm_password_reset` cuando el portador entra al link.
+  - Rate limit `scope="ticketera_solicitar_reset"`, `limit=5`,
+    `window_seconds=900`, identidad `f"{ip}:{identity_lower}"`.
+  - Emite `LogEntry.ACCESS` explícito sobre el `User` con
+    `changes={"password_reset_requested": [None, <isoformat>]}` y
+    `audittrail_source="ticketera"`.
+- **Serializers nuevos** ([ticketera/api_serializers.py](../../../ticketera/api_serializers.py)):
+  `TicketeraUsuarioPatchSerializer`, `TicketeraUsuarioDetailSerializer`,
+  `TicketeraSolicitarResetSerializer`, `TicketeraSolicitarResetResponseSerializer`.
+- **URLs** ([ticketera/api_urls.py](../../../ticketera/api_urls.py)): suman los
+  paths nuevos con names `ticketera-usuarios-detail` y
+  `ticketera-auth-solicitar-reset-password`.
+
+## Decisiones
+
+Resumidas — ver el ADR para justificación completa.
+
+- **PATCH editable solo a `email`/`first_name`/`last_name`.** `username` y
+  `password` quedan fuera (rompen `authenticate()` o tienen canal propio);
+  `is_active` y `source` quedan fuera del MVP.
+- **`403` (no `404`) cuando el usuario existe con otro origen.** Mantiene
+  utilidad operativa frente al riesgo bajo de enumeración detrás de API Key.
+- **Email sin validación de unicidad.** Coherente con `auth_user` actual; no
+  se introduce divergencia entre canales.
+- **Reset = Opción A (link a `password_reset_confirm`).** Mínima superficie y
+  reusa el flujo web. La Opción B (uid+token + endpoint de confirmar) queda
+  diseñada en el plan como aditivo futuro si la Ticketera necesita UX nativa.
+- **Anti-enumeration en el reset.** 200 genérico siempre.
+
+## Impacto esperado
+
+- Contratos de los tres endpoints actuales sin cambios (200/201/400/401/409/429
+  conservan su shape).
+- Sin migraciones nuevas, sin cambios en settings.
+- La Ticketera puede:
+  - corregir email/nombre/apellido de los usuarios que provisionó;
+  - disparar el reset de contraseña por mail cuando el portador olvida la
+    clave o pide regenerarla.
+
+## Validación
+
+- `pytest tests/test_ticketera.py ticketera/tests.py` en Docker con
+  `USE_SQLITE_FOR_TESTS=1` (el Python local sigue con el `ImportError` de
+  `punycode` documentado en validaciones previas).
+- `black --check ticketera/` sobre los tres archivos del módulo.
+- `makemigrations --check --dry-run` — sin nuevas migraciones.
+
+## Riesgos y rollback
+
+- **SMTP caído:** el envío es síncrono (`send_mail(fail_silently=False)`);
+  el endpoint responde 200 (anti-enumeration) pero el mail falla. Mitigación:
+  `request_password_reset_for_email` ya loguea la excepción con
+  `logger.exception`; la Ticketera puede reintentar dentro del rate limit.
+- **`PASSWORD_RESET_TIMEOUT`:** verificar el valor efectivo en `config/settings.py`
+  antes del rollout (default Django: 3 días).
+- **Rollback:** revertir el commit del PR. Los cambios están acotados a los
+  tres archivos de `ticketera/`, dos archivos nuevos en `docs/registro/` y
+  el apéndice del ADR base.

--- a/docs/registro/decisiones/2026-05-27-integracion-ticketera.md
+++ b/docs/registro/decisiones/2026-05-27-integracion-ticketera.md
@@ -307,3 +307,19 @@ Cuatro correcciones sobre los endpoints **sin cambiar los contratos existentes**
   nuevo endpoint (happy path/ciclo, `401`/`400`/`429`, auditoría, `503` por flag).
 - `docs/registro/cambios/2026-05-28-integracion-ticketera-cambiar-password.md`.
 - Reutiliza sin modificar: `users.services_auth.change_password_for_authenticated_user`.
+
+---
+
+## Extensiones (2026-06-08)
+
+Extensiones aditivas al canal Ticketera. **Los contratos de los tres endpoints
+originales no cambian.** Detalle completo en
+[docs/registro/decisiones/2026-06-08-ticketera-edit-usuarios-y-reset-password.md](2026-06-08-ticketera-edit-usuarios-y-reset-password.md).
+
+- `PATCH /api/ticketera/usuarios/<username>/` — edita `email`, `first_name`,
+  `last_name` solo si `_is_ticketera_source(profile.source)` (403 en otro
+  caso, 404 si no existe). Idempotente.
+- `POST /api/ticketera/auth/solicitar-reset-password/` — dispara
+  `request_password_reset_for_email` con anti-enumeration (200 siempre) y
+  rate limit `ticketera_solicitar_reset` (5/15 min). Reusa el flujo web de
+  reset (link a `password_reset_confirm`).

--- a/docs/registro/decisiones/2026-06-08-ticketera-edit-usuarios-y-reset-password.md
+++ b/docs/registro/decisiones/2026-06-08-ticketera-edit-usuarios-y-reset-password.md
@@ -1,0 +1,206 @@
+# Decisión: Ticketera — edición de usuarios y solicitud de reset de contraseña
+
+**Fecha:** 2026-06-08
+**Extiende:** [2026-05-27 - Integración SISOC ↔ Ticketera](2026-05-27-integracion-ticketera.md) y el [hardening del 2026-05-28](../cambios/2026-05-28-integracion-ticketera-hardening.md).
+
+---
+
+## Contexto
+
+La integración server-to-server con la Ticketera ya cuenta con tres endpoints:
+alta/reconciliación de usuarios, verificación de credenciales y cambio de la
+temporal por la definitiva. Faltan dos operaciones para cerrar el ciclo de
+gestión de cuentas que la Ticketera necesita:
+
+1. **Editar datos básicos** de un usuario provisionado (email/nombre/apellido),
+   por ejemplo cuando el portador corrige su mail o nombre desde el perfil de
+   la Ticketera.
+2. **Iniciar un reset de contraseña** cuando el portador olvida la clave o pide
+   regenerarla, sin atravesar el cambio de la temporal.
+
+Ambas operaciones deben respetar los principios del ADR base: API Key,
+HTTP 503 controlado por `TICKETERA_ENABLED`, `audit_context(source="ticketera")`,
+rate limit con `users.rate_limits.hit_rate_limit`, y no romper los contratos
+existentes de los tres endpoints actuales.
+
+---
+
+## Decisión
+
+Agregar dos endpoints REST nuevos bajo `/api/ticketera/`, protegidos por
+`core.api_auth.HasAPIKey` y gated por `settings.TICKETERA_ENABLED`:
+
+| Método | Ruta | Función |
+|---|---|---|
+| PATCH | `/usuarios/<username>/` | Edita parcialmente `email`/`first_name`/`last_name` del usuario. |
+| POST  | `/auth/solicitar-reset-password/` | Dispara el envío del mail de reset (link a `password_reset_confirm`). |
+
+Plan completo (con tradeoffs y decisiones individuales): [docs/plans/2026-06-08-ticketera-edit-usuarios-y-reset-password.md](../../plans/2026-06-08-ticketera-edit-usuarios-y-reset-password.md).
+
+### Patrones reutilizados
+
+- **Permiso:** `HasAPIKey` (canal S2S detrás de API Key, sin Token DRF).
+- **Filtro de origen:** `_is_ticketera_source(profile.source)` ([ticketera/api_views.py:42](../../../ticketera/api_views.py)) — alcanza `"ticketera"` y sus variantes por entorno (`"ticketera-qa"`, etc.).
+- **Auditoría:** `audit_context(source="ticketera", extra={"remote_source": <source>})`.
+- **Rate limit:** `hit_rate_limit` con `identity=f"{ip}:{identidad}"`, mismo patrón que `verificar`/`cambiar-password` y que `PasswordResetRequestViewSet`.
+- **Reset por mail:** se reusa `users.services_auth.request_password_reset_for_email` ([users/services_auth.py:73](../../../users/services_auth.py)) sin modificarlo. El cierre del ciclo (validar token + setear nueva clave + limpiar `must_change_password`) lo hace `confirm_password_reset` ([users/services_auth.py:119](../../../users/services_auth.py)) cuando el portador entra al link del mail.
+
+### Sin cambios de modelo
+
+Ninguna migración requerida.
+
+---
+
+## Decisiones explícitas
+
+### Capacidad 1 — PATCH `/usuarios/<username>/`
+
+- **URL con `<username>` como path param.** Es REST estándar, deja un name
+  `ticketera-usuarios-detail` y queda mejor documentado por drf-spectacular que
+  un PATCH "edit by body" sobre `/usuarios/`. El POST original mantiene el path
+  `/usuarios/`.
+- **Campos editables:** `email`, `first_name`, `last_name`. No editables por
+  este canal:
+  - `username` rompe `authenticate()` (ModelBackend case-sensitive) y obliga a
+    re-emitir credenciales — fuera de alcance.
+  - `password` tiene su propio endpoint `/auth/cambiar-password/` y el reset
+    via mail (`/auth/solicitar-reset-password/`); mezclar canales borra
+    trazabilidad.
+  - `is_active` queda fuera del MVP: introducir desactivación implica decidir
+    el flujo de reactivación y la interacción con sesiones web. Se evalúa por
+    separado si la Ticketera lo pide.
+  - `source` no es editable; se acepta en el body como hint informativo y se
+    propaga a `extra.remote_source` para auditoría.
+- **Email sin validación de unicidad.** SISOC no impone unicidad de email en
+  `auth_user`; sumarla solo en este canal abre divergencia (usuarios SISOC
+  existentes podrían ya colisionar y el PATCH no podría reparar el suyo). Si
+  la Ticketera necesita unicidad, se discute como cambio aparte.
+- **Lookup case-insensitive con `username__iexact`,** mismo criterio que el
+  alta. El username almacenado **no** se normaliza.
+- **Idempotencia:** solo se persisten los fields que cambian
+  (`update_fields=[...]`). Si nada cambia (incluyendo PATCH con body vacío) se
+  devuelve `200` con el snapshot actual sin llamar a `save()` y sin generar
+  `LogEntry`.
+- **403 vs 404 cuando el usuario existe con otro origen:** se mantiene `403
+  user_not_ticketera`. El tradeoff (la Ticketera puede enumerar usernames
+  SISOC) es chico frente al beneficio operativo (soporte diferencia "no
+  existe" de "no te pertenece"). El canal es S2S detrás de API Key, el
+  universo enumerable es acotado y la Ticketera ya conoce sus altas. Si
+  seguridad pide cerrar el canal, switch a 404 unificado es un branch.
+- **Auditoría:** `auditlog` registra el `UPDATE` de `auth_user` con su diff
+  automático (los tres campos editables **no** están en `excluded_fields` de
+  Usuario — ver [audittrail/constants.py:107-112](../../../audittrail/constants.py): solo `password` y `last_login` están excluidos). No se emite
+  `LogEntry` explícito.
+- **Sin rate limit en el MVP.** Endpoint baja superficie de riesgo (no toca
+  credenciales). Si aparece abuso, agregar `scope="ticketera_editar_usuario"`
+  por `f"{ip}:{username}"`.
+
+### Capacidad 2 — POST `/auth/solicitar-reset-password/`
+
+- **Opción A elegida:** el endpoint dispara `request_password_reset_for_email`;
+  el mail contiene el link a `password_reset_confirm` y el portador completa la
+  nueva clave en SISOC. Pros: mínima superficie nueva, sin tokens fuera de
+  SISOC, reusa flujo ya validado. Contras: la UX de cierre vive en SISOC. Si
+  la Ticketera necesita UX nativa, se evalúa una Opción B aditiva
+  (`uid+token` + `/auth/confirmar-reset-password/`) en otra entrega.
+- **Identificación:** `username` o `email`, excluyentes (XOR validado en el
+  serializer, mismo patrón que `PasswordResetRequestSerializer`
+  ([users/api_serializers.py:134-161](../../../users/api_serializers.py))).
+- **Filtro por origen:** solo se procesa el reset si
+  `_is_ticketera_source(profile.source)`. La Ticketera no debería operar
+  resets sobre usuarios SISOC. La respuesta 200 anti-enumeration cubre el
+  filtro silenciosamente.
+- **Anti-enumeration absoluta:** respuesta `200` siempre (existe, no existe,
+  origen distinto, inactivo, sin email). Mismo texto que la API web actual:
+  `"Si el usuario existe en el sistema, se registró la solicitud de reseteo."`
+- **Rate limit:** `scope="ticketera_solicitar_reset"`, `limit=5`,
+  `window_seconds=900`, identidad `f"{ip}:{username_or_email_lower}"`. Misma
+  configuración que el `PasswordResetRequestViewSet` web — el reset es más
+  sensible que `verificar`. No se agrega contador por-IP separado (mismo
+  motivo documentado en el [hardening 2026-05-28](../cambios/2026-05-28-integracion-ticketera-hardening.md): tráfico legítimo viene de una IP/proxy
+  compartido en nombre de muchos usuarios).
+- **Auditoría:** cuando el reset se dispara, se emite un `LogEntry.ACCESS`
+  explícito sobre el `User` con `changes={"password_reset_requested": [None,
+  <isoformat>]}` y `audittrail_source="ticketera"`. El cierre del reset
+  (`confirm_password_reset`) seguirá su flujo web (no toca este canal).
+
+### Compatibilidad
+
+- Ningún cambio rompe los tres endpoints actuales (sus shapes `200`/`201`/
+  `400`/`401`/`409`/`429` se conservan).
+- Sin migraciones nuevas.
+- Sin cambios en `users.services_auth` ni en modelos.
+
+---
+
+## Contratos
+
+### PATCH `/api/ticketera/usuarios/<username>/`
+
+Request (todos los campos opcionales):
+
+```json
+{
+  "email": "nuevo@ejemplo.gob.ar",
+  "first_name": "Juan Pablo",
+  "last_name": "Pérez",
+  "source": "ticketera-qa"
+}
+```
+
+Respuestas:
+
+- `200 OK` — edición aplicada o idempotente (snapshot):
+  ```json
+  {"id": 17, "username": "juan.perez", "email": "...", "first_name": "...", "last_name": "..."}
+  ```
+- `400 Bad Request` — payload inválido (shape DRF; por ejemplo `{"email": ["Enter a valid email address."]}`).
+- `403 Forbidden` — `{"error": "user_not_ticketera", "message": "..."}` cuando el username existe con otro origen.
+- `404 Not Found` — `{"error": "user_not_found", "message": "..."}` cuando no existe.
+- `503 Service Unavailable` — flag deshabilitado.
+
+### POST `/api/ticketera/auth/solicitar-reset-password/`
+
+Request (XOR `username` / `email`):
+
+```json
+{ "username": "juan.perez", "source": "ticketera" }
+```
+
+o
+
+```json
+{ "email": "juan.perez@ejemplo.gob.ar", "source": "ticketera" }
+```
+
+Respuestas:
+
+- `200 OK` — siempre que el payload sea válido y no se supere RL:
+  `{"detail": "Si el usuario existe en el sistema, se registró la solicitud de reseteo."}`
+- `400 Bad Request` — faltan los dos identificadores o llegan los dos
+  (shape DRF).
+- `429 Too Many Requests` — `{"error": "too_many_attempts", "message": "..."}`.
+- `503 Service Unavailable` — flag deshabilitado.
+
+---
+
+## Archivos tocados
+
+- [ticketera/api_serializers.py](../../../ticketera/api_serializers.py) —
+  `TicketeraUsuarioPatchSerializer`, `TicketeraUsuarioDetailSerializer`,
+  `TicketeraSolicitarResetSerializer`, `TicketeraSolicitarResetResponseSerializer`.
+- [ticketera/api_views.py](../../../ticketera/api_views.py) —
+  `TicketeraUsuarioUpdateView`, `TicketeraSolicitarResetPasswordView`,
+  helper `_user_detail_payload`. Reusa `_is_ticketera_source`,
+  `_ticketera_disabled_response`, `AUDIT_SOURCE`.
+- [ticketera/api_urls.py](../../../ticketera/api_urls.py) — rutas
+  `usuarios/<str:username>/` y `auth/solicitar-reset-password/`.
+- [tests/test_ticketera.py](../../../tests/test_ticketera.py) — happy paths,
+  403/404, idempotencia, capitalización, anti-enumeration, rate limit,
+  auditoría.
+- [ticketera/tests.py](../../../ticketera/tests.py) — smoke 503 con flag
+  deshabilitado para los dos endpoints nuevos.
+- [docs/registro/cambios/2026-06-08-ticketera-edit-usuarios-y-reset-password.md](../cambios/2026-06-08-ticketera-edit-usuarios-y-reset-password.md) — registro de cambio del PR.
+- [docs/registro/decisiones/2026-05-27-integracion-ticketera.md](2026-05-27-integracion-ticketera.md) — apéndice "Extensiones (2026-06-08)".
+
+No se tocan: `users/services_auth.py`, `users/models.py`, migraciones, settings.

--- a/tests/test_ticketera.py
+++ b/tests/test_ticketera.py
@@ -22,7 +22,12 @@ from audittrail.models import AuditEntryMeta
 USUARIOS_URL = "/api/ticketera/usuarios/"
 VERIFICAR_URL = "/api/ticketera/auth/verificar/"
 CAMBIAR_PASSWORD_URL = "/api/ticketera/auth/cambiar-password/"
+SOLICITAR_RESET_URL = "/api/ticketera/auth/solicitar-reset-password/"
 AUDIT_SOURCE = "ticketera"
+
+
+def _usuario_url(username):
+    return f"{USUARIOS_URL}{username}/"
 
 
 @pytest.fixture(autouse=True)
@@ -496,7 +501,10 @@ def test_cambiar_password_registra_auditoria_con_source_ticketera(api_client):
 
 
 @pytest.mark.django_db
-@pytest.mark.parametrize("url", [USUARIOS_URL, VERIFICAR_URL, CAMBIAR_PASSWORD_URL])
+@pytest.mark.parametrize(
+    "url",
+    [USUARIOS_URL, VERIFICAR_URL, CAMBIAR_PASSWORD_URL, SOLICITAR_RESET_URL],
+)
 def test_sin_api_key_rechaza(url):
     client = APIClient()  # sin header Authorization: Api-Key
 
@@ -508,6 +516,20 @@ def test_sin_api_key_rechaza(url):
 
     # HasAPIKey deniega; con los autenticadores DRF por defecto (Token/Session)
     # el status real esperado es 401, pero aceptamos 403 por robustez.
+    assert response.status_code in (
+        status.HTTP_401_UNAUTHORIZED,
+        status.HTTP_403_FORBIDDEN,
+    )
+
+
+@pytest.mark.django_db
+def test_patch_usuario_sin_api_key_rechaza():
+    client = APIClient()
+    response = client.patch(
+        _usuario_url("alguno"),
+        {"email": "x@ejemplo.gob.ar"},
+        format="json",
+    )
     assert response.status_code in (
         status.HTTP_401_UNAUTHORIZED,
         status.HTTP_403_FORBIDDEN,
@@ -573,3 +595,352 @@ def test_verificar_valido_registra_acceso(api_client):
         meta.extra.get("custom_signal_context") or {}
     ).get("remote_source")
     assert remote_source == "ticketera"
+
+
+# --------------------------------------------------------------------------- #
+# PATCH /usuarios/<username>/
+# --------------------------------------------------------------------------- #
+
+
+@pytest.mark.django_db
+def test_patch_usuario_actualiza_email_y_nombres_devuelve_200(api_client):
+    user = _crear_usuario(username="edita.me", source="ticketera")
+    updates_antes = (
+        LogEntry.objects.get_for_object(user)
+        .filter(action=LogEntry.Action.UPDATE)
+        .count()
+    )
+
+    response = api_client.patch(
+        _usuario_url("edita.me"),
+        {
+            "email": "nuevo@ejemplo.gob.ar",
+            "first_name": "Editado",
+            "last_name": "Nuevo",
+        },
+        format="json",
+    )
+
+    assert response.status_code == status.HTTP_200_OK
+    assert response.data == {
+        "id": user.id,
+        "username": "edita.me",
+        "email": "nuevo@ejemplo.gob.ar",
+        "first_name": "Editado",
+        "last_name": "Nuevo",
+    }
+
+    user.refresh_from_db()
+    assert user.email == "nuevo@ejemplo.gob.ar"
+    assert user.first_name == "Editado"
+    assert user.last_name == "Nuevo"
+
+    updates = LogEntry.objects.get_for_object(user).filter(
+        action=LogEntry.Action.UPDATE
+    )
+    assert updates.count() == updates_antes + 1
+    entry = updates.latest("id")
+    assert entry.audittrail_meta.source == AUDIT_SOURCE
+
+
+@pytest.mark.django_db
+def test_patch_usuario_otro_origen_devuelve_403_sin_cambios(api_client):
+    user = _crear_usuario(username="ajeno", source="sisoc")
+
+    response = api_client.patch(
+        _usuario_url("ajeno"),
+        {"email": "intento@ejemplo.gob.ar"},
+        format="json",
+    )
+
+    assert response.status_code == status.HTTP_403_FORBIDDEN
+    assert response.data["error"] == "user_not_ticketera"
+    user.refresh_from_db()
+    assert user.email == "ajeno@example.com"
+
+
+@pytest.mark.django_db
+def test_patch_usuario_inexistente_devuelve_404(api_client):
+    response = api_client.patch(
+        _usuario_url("no.existo"),
+        {"email": "x@ejemplo.gob.ar"},
+        format="json",
+    )
+
+    assert response.status_code == status.HTTP_404_NOT_FOUND
+    assert response.data["error"] == "user_not_found"
+
+
+@pytest.mark.django_db
+def test_patch_usuario_acepta_variantes_de_capitalizacion(api_client):
+    user = _crear_usuario(username="caps.user", source="ticketera-qa")
+
+    response = api_client.patch(
+        _usuario_url("Caps.User"),
+        {"first_name": "Capi"},
+        format="json",
+    )
+
+    assert response.status_code == status.HTTP_200_OK
+    assert response.data["username"] == "caps.user"  # snapshot canónico
+    user.refresh_from_db()
+    assert user.first_name == "Capi"
+
+
+@pytest.mark.django_db
+def test_patch_usuario_email_invalido_devuelve_400_sin_cambios(api_client):
+    user = _crear_usuario(username="mail.malo", source="ticketera")
+    email_antes = user.email
+
+    response = api_client.patch(
+        _usuario_url("mail.malo"),
+        {"email": "no-es-un-email"},
+        format="json",
+    )
+
+    assert response.status_code == status.HTTP_400_BAD_REQUEST
+    assert "email" in response.data
+    user.refresh_from_db()
+    assert user.email == email_antes
+
+
+@pytest.mark.django_db
+def test_patch_usuario_idempotente_no_emite_logentry(api_client):
+    user = _crear_usuario(username="idem.user", source="ticketera")
+    user.first_name = "Juan"
+    user.last_name = "Pérez"
+    user.save(update_fields=["first_name", "last_name"])
+
+    updates_antes = (
+        LogEntry.objects.get_for_object(user)
+        .filter(action=LogEntry.Action.UPDATE)
+        .count()
+    )
+
+    response = api_client.patch(
+        _usuario_url("idem.user"),
+        {
+            "email": user.email,
+            "first_name": "Juan",
+            "last_name": "Pérez",
+        },
+        format="json",
+    )
+
+    assert response.status_code == status.HTTP_200_OK
+    assert (
+        LogEntry.objects.get_for_object(user)
+        .filter(action=LogEntry.Action.UPDATE)
+        .count()
+        == updates_antes
+    )
+
+
+@pytest.mark.django_db
+def test_patch_usuario_ignora_username_y_password_no_declarados(api_client):
+    user = _crear_usuario(
+        username="solo.editables",
+        source="ticketera",
+        password="OrigSegura123!",
+    )
+
+    response = api_client.patch(
+        _usuario_url("solo.editables"),
+        {
+            "username": "otro.username",
+            "password": "NuevaPass123!",
+            "is_active": False,
+        },
+        format="json",
+    )
+
+    assert response.status_code == status.HTTP_200_OK
+    user.refresh_from_db()
+    assert user.username == "solo.editables"
+    assert user.is_active is True
+    assert user.check_password("OrigSegura123!") is True
+
+
+@pytest.mark.django_db
+def test_patch_usuario_source_no_se_persiste_en_profile(api_client):
+    user = _crear_usuario(username="con.source", source="ticketera-qa")
+
+    response = api_client.patch(
+        _usuario_url("con.source"),
+        {"first_name": "Juan", "source": "ticketera-staging"},
+        format="json",
+    )
+
+    assert response.status_code == status.HTTP_200_OK
+    user.refresh_from_db()
+    # El source del Profile es invariante para este endpoint.
+    assert user.profile.source == "ticketera-qa"
+
+
+@pytest.mark.django_db
+def test_patch_usuario_payload_vacio_devuelve_200_con_snapshot(api_client):
+    user = _crear_usuario(username="vacio.body", source="ticketera")
+
+    response = api_client.patch(
+        _usuario_url("vacio.body"),
+        {},
+        format="json",
+    )
+
+    assert response.status_code == status.HTTP_200_OK
+    assert response.data["id"] == user.id
+    assert response.data["username"] == "vacio.body"
+
+
+# --------------------------------------------------------------------------- #
+# POST /auth/solicitar-reset-password/
+# --------------------------------------------------------------------------- #
+
+
+def _patch_send_reset(monkeypatch):
+    """Reemplaza send_password_reset_link por un mock para no tocar SMTP."""
+    calls = []
+
+    def _fake_send(*, user, reset_link):
+        calls.append({"user_id": user.id, "reset_link": reset_link})
+
+    monkeypatch.setattr("users.services_auth.send_password_reset_link", _fake_send)
+    return calls
+
+
+@pytest.mark.django_db
+def test_solicitar_reset_con_username_envia_mail_y_registra_audit(
+    api_client, monkeypatch
+):
+    user = _crear_usuario(username="reset.user", source="ticketera")
+    calls = _patch_send_reset(monkeypatch)
+    accesos_antes = (
+        LogEntry.objects.get_for_object(user)
+        .filter(action=LogEntry.Action.ACCESS)
+        .count()
+    )
+
+    response = api_client.post(
+        SOLICITAR_RESET_URL,
+        {"username": "reset.user"},
+        format="json",
+    )
+
+    assert response.status_code == status.HTTP_200_OK
+    assert response.data["detail"].startswith("Si el usuario existe")
+    assert len(calls) == 1
+    assert calls[0]["user_id"] == user.id
+
+    accesos = LogEntry.objects.get_for_object(user).filter(
+        action=LogEntry.Action.ACCESS
+    )
+    assert accesos.count() == accesos_antes + 1
+    entry = accesos.latest("id")
+    meta = entry.audittrail_meta
+    assert meta.source == AUDIT_SOURCE
+    remote_source = (meta.extra.get("context") or {}).get("remote_source") or (
+        meta.extra.get("custom_signal_context") or {}
+    ).get("remote_source")
+    assert remote_source == "ticketera"
+
+
+@pytest.mark.django_db
+def test_solicitar_reset_con_email_envia_mail(api_client, monkeypatch):
+    user = _crear_usuario(username="reset.email", source="ticketera")
+    calls = _patch_send_reset(monkeypatch)
+
+    response = api_client.post(
+        SOLICITAR_RESET_URL,
+        {"email": user.email},
+        format="json",
+    )
+
+    assert response.status_code == status.HTTP_200_OK
+    assert len(calls) == 1
+    assert calls[0]["user_id"] == user.id
+
+
+@pytest.mark.django_db
+def test_solicitar_reset_usuario_inexistente_no_envia_mail(api_client, monkeypatch):
+    calls = _patch_send_reset(monkeypatch)
+
+    response = api_client.post(
+        SOLICITAR_RESET_URL,
+        {"username": "no.existe"},
+        format="json",
+    )
+
+    assert response.status_code == status.HTTP_200_OK
+    assert calls == []
+
+
+@pytest.mark.django_db
+def test_solicitar_reset_otro_origen_no_envia_mail(api_client, monkeypatch):
+    _crear_usuario(username="ajeno.reset", source="sisoc")
+    calls = _patch_send_reset(monkeypatch)
+
+    response = api_client.post(
+        SOLICITAR_RESET_URL,
+        {"username": "ajeno.reset"},
+        format="json",
+    )
+
+    assert response.status_code == status.HTTP_200_OK
+    assert calls == []
+
+
+@pytest.mark.django_db
+def test_solicitar_reset_usuario_inactivo_no_envia_mail(api_client, monkeypatch):
+    _crear_usuario(username="inactivo.reset", source="ticketera", is_active=False)
+    calls = _patch_send_reset(monkeypatch)
+
+    response = api_client.post(
+        SOLICITAR_RESET_URL,
+        {"username": "inactivo.reset"},
+        format="json",
+    )
+
+    assert response.status_code == status.HTTP_200_OK
+    assert calls == []
+
+
+@pytest.mark.django_db
+@pytest.mark.parametrize(
+    "payload",
+    [
+        pytest.param({}, id="ambos-faltantes"),
+        pytest.param(
+            {"username": "x", "email": "x@ejemplo.gob.ar"}, id="ambos-presentes"
+        ),
+    ],
+)
+def test_solicitar_reset_payload_invalido_devuelve_400(api_client, payload):
+    response = api_client.post(SOLICITAR_RESET_URL, payload, format="json")
+    assert response.status_code == status.HTTP_400_BAD_REQUEST
+
+
+@pytest.mark.django_db
+def test_solicitar_reset_supera_rate_limit_devuelve_429_en_el_intento_6(
+    api_client, monkeypatch
+):
+    _crear_usuario(username="brute.reset", source="ticketera")
+    _patch_send_reset(monkeypatch)
+
+    # Límite: 5 intentos por ip:identidad (window 900s). Los primeros 5 pasan;
+    # el 6° queda bloqueado.
+    for _ in range(5):
+        previo = api_client.post(
+            SOLICITAR_RESET_URL,
+            {"username": "brute.reset"},
+            format="json",
+        )
+        assert previo.status_code == status.HTTP_200_OK
+
+    bloqueado = api_client.post(
+        SOLICITAR_RESET_URL,
+        {"username": "brute.reset"},
+        format="json",
+    )
+
+    assert bloqueado.status_code == status.HTTP_429_TOO_MANY_REQUESTS
+    assert bloqueado.data["error"] == "too_many_attempts"

--- a/ticketera/api_serializers.py
+++ b/ticketera/api_serializers.py
@@ -36,12 +36,71 @@ class TicketeraAuthCambiarPasswordSerializer(serializers.Serializer):
     source = serializers.CharField(max_length=50, required=False, default="ticketera")
 
 
+class TicketeraUsuarioPatchSerializer(serializers.Serializer):
+    """Payload para editar datos básicos de un usuario provisionado por la Ticketera.
+
+    Todos los campos son opcionales. Los campos no incluidos en la lista
+    (username, password, is_active, source) no son editables por este canal;
+    `source` se acepta solo como hint informativo para auditoría.
+    """
+
+    email = serializers.EmailField(max_length=254, required=False)
+    first_name = serializers.CharField(max_length=150, allow_blank=True, required=False)
+    last_name = serializers.CharField(max_length=150, allow_blank=True, required=False)
+    source = serializers.CharField(max_length=50, required=False, default="ticketera")
+
+
+class TicketeraSolicitarResetSerializer(serializers.Serializer):
+    """Payload para iniciar el reset de contraseña desde la Ticketera.
+
+    Mismo XOR que `users.api_serializers.PasswordResetRequestSerializer`: se
+    espera exactamente uno de ``username`` o ``email``.
+    """
+
+    username = serializers.CharField(max_length=150, required=False)
+    email = serializers.EmailField(max_length=254, required=False)
+    source = serializers.CharField(max_length=50, required=False, default="ticketera")
+
+    def validate(self, attrs):
+        email = (attrs.get("email") or "").strip()
+        username = (attrs.get("username") or "").strip()
+
+        if bool(email) == bool(username):
+            raise serializers.ValidationError(
+                {"detail": ("Debe enviar email o username para solicitar el reseteo.")}
+            )
+
+        if username:
+            attrs["username"] = username
+            attrs.pop("email", None)
+        else:
+            attrs["email"] = email
+            attrs.pop("username", None)
+        return attrs
+
+
 class TicketeraUsuarioResponseSerializer(serializers.Serializer):
     """Datos del usuario devueltos al crear o reconciliar (201/200)."""
 
     id = serializers.IntegerField()
     username = serializers.CharField()
     email = serializers.EmailField()
+
+
+class TicketeraUsuarioDetailSerializer(serializers.Serializer):
+    """Snapshot completo devuelto por el PATCH de usuario (200)."""
+
+    id = serializers.IntegerField()
+    username = serializers.CharField()
+    email = serializers.EmailField()
+    first_name = serializers.CharField(allow_blank=True)
+    last_name = serializers.CharField(allow_blank=True)
+
+
+class TicketeraSolicitarResetResponseSerializer(serializers.Serializer):
+    """Respuesta genérica del solicitar-reset (200 anti-enumeration)."""
+
+    detail = serializers.CharField()
 
 
 class TicketeraAuthVerificarUserSerializer(serializers.Serializer):

--- a/ticketera/api_urls.py
+++ b/ticketera/api_urls.py
@@ -5,7 +5,9 @@ from django.urls import path
 from ticketera.api_views import (
     TicketeraAuthCambiarPasswordView,
     TicketeraAuthVerificarView,
+    TicketeraSolicitarResetPasswordView,
     TicketeraUsuarioCreateView,
+    TicketeraUsuarioUpdateView,
 )
 
 
@@ -16,6 +18,11 @@ urlpatterns = [
         name="ticketera-usuarios",
     ),
     path(
+        "usuarios/<str:username>/",
+        TicketeraUsuarioUpdateView.as_view(),
+        name="ticketera-usuarios-detail",
+    ),
+    path(
         "auth/verificar/",
         TicketeraAuthVerificarView.as_view(),
         name="ticketera-auth-verificar",
@@ -24,5 +31,10 @@ urlpatterns = [
         "auth/cambiar-password/",
         TicketeraAuthCambiarPasswordView.as_view(),
         name="ticketera-auth-cambiar-password",
+    ),
+    path(
+        "auth/solicitar-reset-password/",
+        TicketeraSolicitarResetPasswordView.as_view(),
+        name="ticketera-auth-solicitar-reset-password",
     ),
 ]

--- a/ticketera/api_views.py
+++ b/ticketera/api_views.py
@@ -28,12 +28,19 @@ from ticketera.api_serializers import (
     TicketeraAuthVerificarResponseSerializer,
     TicketeraAuthVerificarSerializer,
     TicketeraErrorSerializer,
+    TicketeraSolicitarResetResponseSerializer,
+    TicketeraSolicitarResetSerializer,
     TicketeraUsuarioCreateSerializer,
+    TicketeraUsuarioDetailSerializer,
+    TicketeraUsuarioPatchSerializer,
     TicketeraUsuarioResponseSerializer,
 )
 from users.models import Profile
 from users.rate_limits import hit_rate_limit
-from users.services_auth import change_password_for_authenticated_user
+from users.services_auth import (
+    change_password_for_authenticated_user,
+    request_password_reset_for_email,
+)
 
 
 AUDIT_SOURCE = "ticketera"
@@ -437,5 +444,238 @@ class TicketeraAuthCambiarPasswordView(APIView):
 
         return Response(
             {"changed": True, "must_change_password": False},
+            status=status.HTTP_200_OK,
+        )
+
+
+def _user_detail_payload(user):
+    """Snapshot canónico devuelto por el PATCH (200) y reutilizable en idempotencia."""
+    return {
+        "id": user.id,
+        "username": user.username,
+        "email": user.email,
+        "first_name": user.first_name,
+        "last_name": user.last_name,
+    }
+
+
+@extend_schema(tags=["Ticketera"])
+class TicketeraUsuarioUpdateView(APIView):
+    """Edita datos básicos de un usuario provisionado por la Ticketera.
+
+    Solo modifica usuarios cuyo ``profile.source`` pasa
+    :func:`_is_ticketera_source` (origen Ticketera o sus variantes por entorno).
+    Campos editables: ``email``, ``first_name``, ``last_name``. ``username`` y
+    ``password`` no son editables por este canal (este último tiene su propio
+    endpoint); ``is_active`` y ``source`` quedan fuera del MVP.
+    """
+
+    permission_classes = [HasAPIKey]
+
+    @extend_schema(
+        summary="Edición parcial de un usuario provisionado por la Ticketera",
+        request=TicketeraUsuarioPatchSerializer,
+        responses={
+            200: OpenApiResponse(
+                response=TicketeraUsuarioDetailSerializer,
+                description=(
+                    "Edición aplicada o idempotente: snapshot canónico del usuario."
+                ),
+            ),
+            400: OpenApiResponse(
+                response=TicketeraErrorSerializer,
+                description="Payload inválido (por ejemplo, email malformado).",
+            ),
+            403: OpenApiResponse(
+                response=TicketeraErrorSerializer,
+                description="El usuario existe pero no fue provisionado por la Ticketera.",
+            ),
+            404: OpenApiResponse(
+                response=TicketeraErrorSerializer,
+                description="No existe un usuario con ese username.",
+            ),
+            503: OpenApiResponse(
+                response=TicketeraErrorSerializer,
+                description="Integración deshabilitada por configuración.",
+            ),
+        },
+    )
+    def patch(self, request, username):
+        if not settings.TICKETERA_ENABLED:
+            return _ticketera_disabled_response()
+
+        serializer = TicketeraUsuarioPatchSerializer(data=request.data)
+        serializer.is_valid(raise_exception=True)
+        data = serializer.validated_data
+
+        # Lookup case-insensitive: mismo criterio que el alta para que la
+        # capitalización no esquive ni el 404 ni el 403.
+        existing = (
+            User.objects.select_related("profile")
+            .filter(username__iexact=username)
+            .first()
+        )
+        if existing is None:
+            return Response(
+                {
+                    "error": "user_not_found",
+                    "message": "No existe un usuario con ese username.",
+                },
+                status=status.HTTP_404_NOT_FOUND,
+            )
+
+        existing_source = getattr(getattr(existing, "profile", None), "source", "")
+        if not _is_ticketera_source(existing_source):
+            return Response(
+                {
+                    "error": "user_not_ticketera",
+                    "message": (
+                        "El usuario existe pero no fue provisionado por la Ticketera."
+                    ),
+                },
+                status=status.HTTP_403_FORBIDDEN,
+            )
+
+        source = data.get("source", "ticketera")
+
+        # Solo persistimos los fields que cambian. Si nada cambia, no llamamos a
+        # save() y auditlog no genera LogEntry espurio.
+        editable_fields = ("email", "first_name", "last_name")
+        update_fields = []
+        for field in editable_fields:
+            if field not in data:
+                continue
+            new_value = data[field]
+            if getattr(existing, field) != new_value:
+                setattr(existing, field, new_value)
+                update_fields.append(field)
+
+        if update_fields:
+            with audit_context(
+                source=AUDIT_SOURCE,
+                extra={"remote_source": source},
+            ):
+                with transaction.atomic():
+                    existing.save(update_fields=update_fields)
+
+        return Response(_user_detail_payload(existing), status=status.HTTP_200_OK)
+
+
+@extend_schema(tags=["Ticketera"])
+class TicketeraSolicitarResetPasswordView(APIView):
+    """Dispara el envío del mail de reset de contraseña para un usuario Ticketera.
+
+    Reutiliza el flujo web de SISOC: el mail incluye el link a
+    ``password_reset_confirm`` que cierra el ciclo (vía
+    :func:`users.services_auth.confirm_password_reset`). La Ticketera solo
+    inicia el reset; el portador completa la nueva clave en SISOC.
+
+    Anti-enumeration: la respuesta es siempre ``200`` con un detalle genérico,
+    sin distinguir si el usuario existe, está inactivo o tiene otro origen.
+    """
+
+    permission_classes = [HasAPIKey]
+
+    @extend_schema(
+        summary="Inicia el reset de contraseña por cuenta de la Ticketera",
+        request=TicketeraSolicitarResetSerializer,
+        responses={
+            200: OpenApiResponse(
+                response=TicketeraSolicitarResetResponseSerializer,
+                description=(
+                    "Solicitud registrada (la respuesta es la misma exista o no "
+                    "el usuario, para evitar enumeración)."
+                ),
+            ),
+            400: OpenApiResponse(
+                description=(
+                    "Payload inválido: faltan ambos identificadores o llegan los dos."
+                ),
+            ),
+            429: OpenApiResponse(
+                response=TicketeraErrorSerializer,
+                description="Demasiados intentos (rate limit).",
+            ),
+            503: OpenApiResponse(
+                response=TicketeraErrorSerializer,
+                description="Integración deshabilitada por configuración.",
+            ),
+        },
+    )
+    def post(self, request):
+        if not settings.TICKETERA_ENABLED:
+            return _ticketera_disabled_response()
+
+        serializer = TicketeraSolicitarResetSerializer(data=request.data)
+        serializer.is_valid(raise_exception=True)
+        data = serializer.validated_data
+
+        username = data.get("username", "")
+        email = data.get("email", "")
+        source = data.get("source", "ticketera")
+
+        identity_value = (username or email or "").lower()
+        ip = request.META.get("REMOTE_ADDR", "anon")
+        if hit_rate_limit(
+            scope="ticketera_solicitar_reset",
+            identity=f"{ip}:{identity_value}",
+            limit=5,
+            window_seconds=900,
+        ):
+            return Response(
+                {
+                    "error": "too_many_attempts",
+                    "message": "Demasiados intentos. Esperá unos minutos.",
+                },
+                status=status.HTTP_429_TOO_MANY_REQUESTS,
+            )
+
+        if username:
+            user = (
+                User.objects.select_related("profile")
+                .filter(username__iexact=username, is_active=True)
+                .first()
+            )
+        else:
+            user = (
+                User.objects.select_related("profile")
+                .filter(email__iexact=email, is_active=True)
+                .order_by("id")
+                .first()
+            )
+
+        if user is not None and _is_ticketera_source(
+            getattr(getattr(user, "profile", None), "source", "")
+        ):
+            with audit_context(
+                source=AUDIT_SOURCE,
+                extra={"remote_source": source},
+            ):
+                if user.email:
+                    request_password_reset_for_email(email=user.email, request=request)
+                requested_at = timezone.now()
+                LogEntry.objects.log_create(
+                    user,
+                    action=LogEntry.Action.ACCESS,
+                    changes={
+                        "password_reset_requested": [
+                            None,
+                            requested_at.isoformat(),
+                        ]
+                    },
+                    actor=user,
+                    additional_data={
+                        "audittrail_source": AUDIT_SOURCE,
+                        "audittrail_context": {"remote_source": source},
+                    },
+                )
+
+        return Response(
+            {
+                "detail": (
+                    "Si el usuario existe en el sistema, se registró la solicitud "
+                    "de reseteo."
+                )
+            },
             status=status.HTTP_200_OK,
         )

--- a/ticketera/tests.py
+++ b/ticketera/tests.py
@@ -115,6 +115,37 @@ def test_cambiar_password_responde_503_con_flag_deshabilitado(api_client):
 
 @pytest.mark.smoke
 @pytest.mark.django_db
+@override_settings(TICKETERA_ENABLED=False)
+def test_patch_usuarios_responde_503_con_flag_deshabilitado(api_client):
+    response = api_client.patch(
+        reverse(
+            "ticketera-usuarios-detail",
+            kwargs={"username": "juan.perez"},
+        ),
+        {"email": "x@ejemplo.gob.ar"},
+        format="json",
+    )
+
+    assert response.status_code == status.HTTP_503_SERVICE_UNAVAILABLE
+    assert response.json()["error"] == "integration_disabled"
+
+
+@pytest.mark.smoke
+@pytest.mark.django_db
+@override_settings(TICKETERA_ENABLED=False)
+def test_solicitar_reset_responde_503_con_flag_deshabilitado(api_client):
+    response = api_client.post(
+        reverse("ticketera-auth-solicitar-reset-password"),
+        {"username": "juan.perez"},
+        format="json",
+    )
+
+    assert response.status_code == status.HTTP_503_SERVICE_UNAVAILABLE
+    assert response.json()["error"] == "integration_disabled"
+
+
+@pytest.mark.smoke
+@pytest.mark.django_db
 @override_settings(TICKETERA_ENABLED=True)
 def test_usuarios_opera_con_flag_habilitado(api_client):
     response = api_client.post(


### PR DESCRIPTION
## Summary

- Agrega `PATCH /api/ticketera/usuarios/<username>/` para editar `email`, `first_name`, `last_name` de usuarios provisionados por la Ticketera (filtro `_is_ticketera_source`; 403/404; idempotente).
- Agrega `POST /api/ticketera/auth/solicitar-reset-password/` que dispara `request_password_reset_for_email` con anti-enumeration y rate limit propio (5/15 min).
- Los tres endpoints existentes (`POST /usuarios/`, `/auth/verificar/`, `/auth/cambiar-password/`) mantienen sus contratos sin cambios. **Sin migraciones.**

## Decisiones tomadas (resumen — ADR completo en `docs/registro/decisiones/2026-06-08-…`)

- **PATCH editable solo a `email`/`first_name`/`last_name`.** `username`/`password` quedan fuera (rompen `authenticate()` o tienen canal propio); `is_active` y `source` fuera del MVP.
- **403 user_not_ticketera vs 404 user_not_found** — se elige 403 para otros orígenes; el tradeoff de enumeración es chico detrás de la API Key.
- **Email sin validación de unicidad** — coherente con `auth_user` actual.
- **Reset = Opción A (link a `password_reset_confirm`)** — mínima superficie. Opción B (uid+token) queda diseñada en el plan como aditivo futuro.
- **Anti-enumeration absoluta en el reset** — 200 genérico siempre.

Plan original con tradeoffs: `docs/plans/2026-06-08-ticketera-edit-usuarios-y-reset-password.md`.

## Test plan

- [x] `pytest tests/test_ticketera.py ticketera/tests.py` — **55 passed** en docker con `USE_SQLITE_FOR_TESTS=1`.
- [x] `black --check` sobre los tres archivos del módulo y los tests.
- [x] `python manage.py check` — sin issues.
- [ ] Verificación manual del PATCH (happy path + 403 + 404) con `curl`/Postman contra ambiente local.
- [ ] Verificación manual del solicitar-reset (200 anti-enumeration con usuario inexistente; mail entregado a usuario Ticketera).
- [ ] Confirmar valor efectivo de `PASSWORD_RESET_TIMEOUT` en `config/settings.py` antes del rollout.

🤖 Generated with [Claude Code](https://claude.com/claude-code)