### PR TITLE
fix(users): merge migrations para destrabar arranque de Django

### DIFF
--- a/users/migrations/0035_merge_actividades_pnud_rendicion_final.py
+++ b/users/migrations/0035_merge_actividades_pnud_rendicion_final.py
@@ -1,0 +1,11 @@
+from django.db import migrations
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ("users", "0033_bootstrap_actividades_pnud_groups"),
+        ("users", "0034_bootstrap_rendicion_final_permission"),
+    ]
+
+    operations = []


### PR DESCRIPTION
# Información de la Tarea

### **Resumen de la Solución:**
- Crear migración de merge en `users` para unir los dos leaf nodes que impedían que el contenedor Django arrancara (`migrate auth` fallaba con *multiple leaf nodes in the migration graph*).

### **Información Adicional:**
- En `development` quedaron dos leafs colgando de `0032_merge_cdf_referente_profile_source`:
  - `0033_bootstrap_actividades_pnud_groups`
  - `0034_bootstrap_rendicion_final_permission` (depende de `0033_bootstrap_rendicion_mensual_permission`)
- El merge `0035_merge_actividades_pnud_rendicion_final` no agrega operaciones; solo unifica el grafo, igual que el merge previo `0032`.

# Descripción de los Cambios

### **Cambios:**
- `users/migrations/0035_merge_actividades_pnud_rendicion_final.py`: nuevo nodo de merge con `operations = []` que depende de los dos leafs.

# Cómo Testear los Cambios

### **Pruebas Automáticas:**
- `python manage.py makemigrations --check` no reporta cambios nuevos.

### **Prubeas Manuales:**
- Levantar Docker (`docker compose up django`) y verificar que `migrate auth` ya no aborta con `CommandError: Conflicting migrations detected`.
- `python manage.py showmigrations users` muestra `0035_merge_actividades_pnud_rendicion_final` aplicado tras `0033/0034`.

# Metadata para documentación automática

- Contexto funcional: Infraestructura / arranque de Django
- Tipo de cambio: fix
- Área principal: users (migraciones)
- Resumen para changelog: Se resuelve conflicto de leaf nodes en las migraciones de `users` que bloqueaba el arranque del contenedor.
- Impacto usuario: Ninguno funcional; restablece el deploy/arranque local.
- Riesgos / rollback: Bajo. Migración vacía de merge; rollback = `migrate users 0034` (o el leaf previo correspondiente) y borrar el archivo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)