### PR TITLE
fix(celiaquia): subsanación muestra el motivo elegido en vez del genérico

### DIFF
--- a/celiaquia/models.py
+++ b/celiaquia/models.py
@@ -365,6 +365,37 @@ class ExpedienteCiudadano(SoftDeleteModelMixin, models.Model):
             ],
         )
 
+    SUBSANACION_TIPO_LABELS = {
+        "RENAPER": "RENAPER",
+        "DOCUMENTACION": "Documentación",
+        "DATOS_PERSONALES": "Datos personales",
+        "OTROS": "Otros",
+    }
+
+    @property
+    def subsanacion_tipo_display(self):
+        """Etiqueta legible del tipo de subsanación elegido al solicitarla.
+
+        Devuelve cadena vacía cuando el legajo no tiene tipo registrado
+        (subsanaciones antiguas o creadas por flujos que no lo guardan).
+        """
+        if not self.subsanacion_tipo:
+            return ""
+        return self.SUBSANACION_TIPO_LABELS.get(
+            self.subsanacion_tipo, self.subsanacion_tipo
+        )
+
+    @property
+    def subsanacion_respuesta_label(self):
+        """Rótulo de la respuesta de la provincia, reflejando el motivo original.
+
+        Sin tipo registrado cae al texto genérico, sin el viejo sufijo "Renaper".
+        """
+        tipo = self.subsanacion_tipo_display
+        if tipo:
+            return f"Respuesta a subsanación ({tipo})"
+        return "Respuesta a subsanación"
+
     def tiene_documento(self, tipo_documento_nombre):
         """Verifica si tiene un documento específico."""
         return self.documentos.filter(

--- a/celiaquia/templates/celiaquia/expediente_detail.html
+++ b/celiaquia/templates/celiaquia/expediente_detail.html
@@ -628,7 +628,7 @@
                                                     <!-- Archivo subsanación Renaper -->
                                                     {% if leg.subsanacion_renaper_comentario or leg.subsanacion_renaper_archivo %}
                                                         <div class="mt-3 p-2 rounded" style="background:rgba(255,193,7,.1);">
-                                                            <div class="small muted mb-1">Respuesta subsanación Renaper</div>
+                                                            <div class="small muted mb-1">{{ leg.subsanacion_respuesta_label }}</div>
                                                             {% if leg.subsanacion_renaper_comentario %}
                                                                 <div class="small mb-2">
                                                                     <strong>Comentario:</strong> {{ leg.subsanacion_renaper_comentario }}
@@ -655,11 +655,17 @@
                                                     {% elif leg.estado_validacion_renaper == 3 %}
                                                         <div class="mt-3 p-2 rounded" style="background:rgba(255,193,7,.1);">
                                                             <div class="small muted mb-1">
-                                                                {% if leg.subsanacion_tipo == "RENAPER" %}Subsanación RENAPER solicitada
-                                                                {% elif leg.subsanacion_tipo == "DOCUMENTACION" %}Subsanación por documentación solicitada
-                                                                {% elif leg.subsanacion_tipo == "DATOS_PERSONALES" %}Subsanación por datos personales solicitada
-                                                                {% elif leg.subsanacion_tipo == "OTROS" %}Subsanación por otros motivos solicitada
-                                                                {% else %}Subsanación solicitada{% endif %}
+                                                                {% if leg.subsanacion_tipo == "RENAPER" %}
+                                                                    Subsanación RENAPER solicitada
+                                                                {% elif leg.subsanacion_tipo == "DOCUMENTACION" %}
+                                                                    Subsanación por documentación solicitada
+                                                                {% elif leg.subsanacion_tipo == "DATOS_PERSONALES" %}
+                                                                    Subsanación por datos personales solicitada
+                                                                {% elif leg.subsanacion_tipo == "OTROS" %}
+                                                                    Subsanación por otros motivos solicitada
+                                                                {% else %}
+                                                                    Subsanación solicitada
+                                                                {% endif %}
                                                             </div>
                                                             <div class="small text-warning mb-2">Pendiente de respuesta</div>
                                                             {% if is_prov and leg.revision_tecnico != 'SUBSANADO' %}
@@ -830,7 +836,7 @@
                                     <!-- Archivo subsanación Renaper -->
                                     {% if leg.subsanacion_renaper_comentario or leg.subsanacion_renaper_archivo %}
                                         <div class="mt-3 p-2 rounded" style="background:rgba(255,193,7,.1);">
-                                            <div class="small muted mb-1">Respuesta subsanación Renaper</div>
+                                            <div class="small muted mb-1">{{ leg.subsanacion_respuesta_label }}</div>
                                             {% if leg.subsanacion_renaper_comentario %}
                                                 <div class="small mb-2">
                                                     <strong>Comentario:</strong> {{ leg.subsanacion_renaper_comentario }}
@@ -857,11 +863,17 @@
                                     {% elif leg.estado_validacion_renaper == 3 %}
                                         <div class="mt-3 p-2 rounded" style="background:rgba(255,193,7,.1);">
                                             <div class="small muted mb-1">
-                                                {% if leg.subsanacion_tipo == "RENAPER" %}Subsanación RENAPER solicitada
-                                                {% elif leg.subsanacion_tipo == "DOCUMENTACION" %}Subsanación por documentación solicitada
-                                                {% elif leg.subsanacion_tipo == "DATOS_PERSONALES" %}Subsanación por datos personales solicitada
-                                                {% elif leg.subsanacion_tipo == "OTROS" %}Subsanación por otros motivos solicitada
-                                                {% else %}Subsanación solicitada{% endif %}
+                                                {% if leg.subsanacion_tipo == "RENAPER" %}
+                                                    Subsanación RENAPER solicitada
+                                                {% elif leg.subsanacion_tipo == "DOCUMENTACION" %}
+                                                    Subsanación por documentación solicitada
+                                                {% elif leg.subsanacion_tipo == "DATOS_PERSONALES" %}
+                                                    Subsanación por datos personales solicitada
+                                                {% elif leg.subsanacion_tipo == "OTROS" %}
+                                                    Subsanación por otros motivos solicitada
+                                                {% else %}
+                                                    Subsanación solicitada
+                                                {% endif %}
                                             </div>
                                             <div class="small text-warning mb-2">Pendiente de respuesta</div>
                                             {% if is_prov and leg.revision_tecnico != 'SUBSANADO' %}

--- a/celiaquia/tests/test_expediente_detail.py
+++ b/celiaquia/tests/test_expediente_detail.py
@@ -449,3 +449,121 @@ def test_expediente_detail_expone_motivo_rechazo_para_tecnico(client):
     assert "Falta certificado" in row_html
     assert "Motivo del Rechazo" in response.content.decode()
     assert "Falta certificado" in response.content.decode()
+
+
+def test_subsanacion_tipo_display_devuelve_etiqueta_legible():
+    """La property traduce el código de tipo a un texto legible."""
+    assert (
+        ExpedienteCiudadano(subsanacion_tipo="DOCUMENTACION").subsanacion_tipo_display
+        == "Documentación"
+    )
+    assert (
+        ExpedienteCiudadano(
+            subsanacion_tipo="DATOS_PERSONALES"
+        ).subsanacion_tipo_display
+        == "Datos personales"
+    )
+    assert (
+        ExpedienteCiudadano(subsanacion_tipo="RENAPER").subsanacion_tipo_display
+        == "RENAPER"
+    )
+    # Sin tipo registrado (subsanaciones antiguas) no rompe y cae a vacío.
+    assert ExpedienteCiudadano().subsanacion_tipo_display == ""
+
+
+def test_subsanacion_respuesta_label_refleja_el_tipo():
+    """El rótulo de la respuesta lleva el motivo y no el viejo sufijo 'Renaper'."""
+    assert (
+        ExpedienteCiudadano(
+            subsanacion_tipo="DATOS_PERSONALES"
+        ).subsanacion_respuesta_label
+        == "Respuesta a subsanación (Datos personales)"
+    )
+    # Sin tipo: genérico, nunca "Renaper".
+    assert (
+        ExpedienteCiudadano().subsanacion_respuesta_label == "Respuesta a subsanación"
+    )
+
+
+@pytest.mark.django_db
+def test_expediente_detail_muestra_motivo_subsanacion_solicitada(client):
+    """El estado de la subsanación refleja el tipo elegido, no el genérico."""
+    user = User.objects.create_user(username="prov_sub_tipo", password="pass")
+    permission = Permission.objects.get(
+        content_type__app_label="celiaquia",
+        codename="view_expediente",
+    )
+    user.user_permissions.add(permission)
+
+    estado_expediente = EstadoExpediente.objects.create(nombre="EN_ESPERA_SUB_TIPO")
+    estado_legajo = EstadoLegajo.objects.create(nombre="PENDIENTE_SUBSANACION_TIPO")
+    expediente = Expediente.objects.create(
+        usuario_provincia=user,
+        estado=estado_expediente,
+    )
+    ciudadano = Ciudadano.objects.create(
+        apellido="Lopez",
+        nombre="Sofia",
+        fecha_nacimiento=date(2000, 3, 3),
+        documento=34555666,
+    )
+    ExpedienteCiudadano.objects.create(
+        expediente=expediente,
+        ciudadano=ciudadano,
+        estado=estado_legajo,
+        revision_tecnico=RevisionTecnico.SUBSANAR,
+        estado_validacion_renaper=3,
+        subsanacion_tipo="DOCUMENTACION",
+        subsanacion_motivo="Falta el certificado médico",
+    )
+
+    client.force_login(user)
+    response = client.get(reverse("expediente_detail", args=[expediente.pk]))
+
+    assert response.status_code == 200
+    content = response.content.decode()
+    assert "Subsanación por documentación solicitada" in content
+    # No debe quedar el texto genérico cuando hay un tipo seleccionado.
+    assert "Subsanación solicitada" not in content
+
+
+@pytest.mark.django_db
+def test_expediente_detail_respuesta_subsanacion_refleja_tipo(client):
+    """La respuesta a la subsanación conserva el motivo y no se rotula 'Renaper'."""
+    user = User.objects.create_user(username="prov_resp_tipo", password="pass")
+    permission = Permission.objects.get(
+        content_type__app_label="celiaquia",
+        codename="view_expediente",
+    )
+    user.user_permissions.add(permission)
+
+    estado_expediente = EstadoExpediente.objects.create(nombre="EN_ESPERA_RESP_TIPO")
+    estado_legajo = EstadoLegajo.objects.create(nombre="PENDIENTE_SUBSANACION_RESP")
+    expediente = Expediente.objects.create(
+        usuario_provincia=user,
+        estado=estado_expediente,
+    )
+    ciudadano = Ciudadano.objects.create(
+        apellido="Diaz",
+        nombre="Marta",
+        fecha_nacimiento=date(1999, 9, 9),
+        documento=35666777,
+    )
+    ExpedienteCiudadano.objects.create(
+        expediente=expediente,
+        ciudadano=ciudadano,
+        estado=estado_legajo,
+        revision_tecnico=RevisionTecnico.SUBSANAR,
+        estado_validacion_renaper=3,
+        subsanacion_tipo="DATOS_PERSONALES",
+        subsanacion_motivo="Corregir fecha de nacimiento",
+        subsanacion_renaper_comentario="Se adjunta partida corregida",
+    )
+
+    client.force_login(user)
+    response = client.get(reverse("expediente_detail", args=[expediente.pk]))
+
+    assert response.status_code == 200
+    content = response.content.decode()
+    assert "Respuesta a subsanación (Datos personales)" in content
+    assert "Respuesta subsanación Renaper" not in content

--- a/celiaquia/views/respuesta_subsanacion_renaper.py
+++ b/celiaquia/views/respuesta_subsanacion_renaper.py
@@ -92,7 +92,7 @@ class RespuestaSubsanacionRenaperView(View):
             return JsonResponse(
                 {
                     "success": True,
-                    "message": "Respuesta a subsanación Renaper enviada correctamente",
+                    "message": "Respuesta a subsanación enviada correctamente",
                 }
             )
 

--- a/celiaquia/views/validacion_renaper.py
+++ b/celiaquia/views/validacion_renaper.py
@@ -421,11 +421,15 @@ class ValidacionRenaperView(View):
             comentario = request.POST.get("comentario")
             if validacion_estado == "3" and comentario:
                 legajo.subsanacion_motivo = comentario
+                # Subsanación originada en la validación RENAPER: registrar el tipo
+                # para que el detalle muestre el motivo y no el texto genérico.
+                legajo.subsanacion_tipo = "RENAPER"
                 legajo.revision_tecnico = "SUBSANAR"
                 legajo.save(
                     update_fields=[
                         "estado_validacion_renaper",
                         "subsanacion_motivo",
+                        "subsanacion_tipo",
                         "revision_tecnico",
                         "modificado_en",
                     ]

--- a/docs/registro/cambios/2026-06-09-celiaquia-subsanacion-motivo.md
+++ b/docs/registro/cambios/2026-06-09-celiaquia-subsanacion-motivo.md
@@ -1,0 +1,54 @@
+# 2026-06-09 - Celiaquía: subsanación muestra el motivo elegido
+
+## Qué cambió
+
+- Al solicitar una subsanación desde el modal `Subsanar`, ahora se envía el `tipo_subsanacion`
+  elegido (RENAPER / Documentación / Datos personales / Otros). Antes el JS armaba el `FormData`
+  sólo con `accion` y `motivo`, descartando el tipo, por lo que `subsanacion_tipo` quedaba en
+  `None` y el detalle siempre mostraba el texto genérico "Subsanación solicitada".
+- El detalle del expediente ahora rotula la respuesta de la provincia según el motivo original
+  ("Respuesta a subsanación (Documentación)" …) en lugar del fijo "Respuesta subsanación Renaper".
+- El toast de éxito al responder una subsanación ya no dice "Renaper".
+- La subsanación originada en la validación RENAPER (`ValidacionRenaperView`) ahora registra
+  `subsanacion_tipo="RENAPER"`, para que ese flujo también muestre el motivo y no el genérico.
+
+## Decisión clave
+
+- La causa raíz del estado genérico era el frontend (no se enviaba `tipo_subsanacion`), no el
+  backend: `RevisarLegajoView` ya leía y persistía el tipo. El fix es mínimo en JS.
+- Para el rótulo de la respuesta se agregaron dos properties (sin migración: sólo lógica de
+  presentación): `subsanacion_tipo_display` (traduce el código a etiqueta legible) y
+  `subsanacion_respuesta_label` (arma el rótulo completo). El template usa esta última como un
+  único `{{ ... }}`, evitando un condicional inline en el HTML. Legajos sin tipo (subsanaciones
+  antiguas o creadas por flujos que no lo registran) caen a "Respuesta a subsanación" sin romper.
+- No se endureció la validación server-side del tipo para preservar compatibilidad hacia atrás
+  (el `<select>` ya es `required` en el cliente y hay un guard adicional en el JS).
+
+## Archivos tocados
+
+- `static/custom/js/expediente_detail.js`
+- `celiaquia/models.py`
+- `celiaquia/templates/celiaquia/expediente_detail.html`
+- `celiaquia/views/respuesta_subsanacion_renaper.py`
+- `celiaquia/views/validacion_renaper.py`
+- `tests/test_celiaquia_expediente_view_helpers_unit.py`
+- `tests/test_validacion_renaper_view_unit.py`
+- `celiaquia/tests/test_expediente_detail.py`
+
+## Validación
+
+- `pytest` (SQLite, contenedor one-off) de los tests afectados y el barrido de celiaquía: 158 passed.
+- `black --check` limpio sobre los archivos Python tocados.
+- `python manage.py makemigrations celiaquia --check --dry-run`: "No changes detected" (las properties no generan migración).
+- `pylint --rcfile=.pylintrc`: los archivos tocados no agregan mensajes nuevos (los de `validacion_renaper.py` son preexistentes, en funciones no modificadas).
+- `node --check static/custom/js/expediente_detail.js`: OK.
+- `djlint --reformat` sobre el template: además de mi cambio, normalizó a multilínea los dos bloques
+  `{% if leg.subsanacion_tipo ... %}` de "subsanación solicitada" que ya estaban inline (drift
+  preexistente del archivo). Tras el reformateo, los tests siguen pasando.
+
+## Cómo probar manualmente
+
+1. Como técnico/coordinador, evaluar un legajo y elegir Subsanar con tipo "Documentación" y un motivo.
+2. En el detalle, el estado debe decir "Subsanación por documentación solicitada" (no el genérico).
+3. Como provincia, responder la subsanación: el bloque de respuesta debe rotularse
+   "Respuesta a subsanación (Documentación)" y el toast no debe mencionar "Renaper".

--- a/static/custom/js/expediente_detail.js
+++ b/static/custom/js/expediente_detail.js
@@ -495,6 +495,8 @@ document.addEventListener('DOMContentLoaded', () => {
       modalSubsanar.querySelector('#subsanar-legajo-id').value = legajoId;
       const ta = modalSubsanar.querySelector('#subsanar-motivo');
       if (ta) ta.value = '';
+      const tipoSel = modalSubsanar.querySelector('#subsanar-tipo');
+      if (tipoSel) tipoSel.value = '';
     });
 
     const formSubsanar = document.getElementById('form-subsanar');
@@ -503,11 +505,16 @@ document.addEventListener('DOMContentLoaded', () => {
 
       const legajoId = modalSubsanar.querySelector('#subsanar-legajo-id').value;
       const motivo = (modalSubsanar.querySelector('#subsanar-motivo').value || '').trim();
+      const tipoSubsanacion = (modalSubsanar.querySelector('#subsanar-tipo')?.value || '').trim();
       const btn = document.getElementById('btn-confirm-subsanar');
       const original = btn.innerHTML;
 
       if (!legajoId) {
         showAlert('danger', 'No se pudo identificar el legajo.');
+        return;
+      }
+      if (!tipoSubsanacion) {
+        showAlert('warning', 'Seleccioná el tipo de subsanación.');
         return;
       }
       if (!motivo) {
@@ -529,6 +536,7 @@ document.addEventListener('DOMContentLoaded', () => {
         // Enviar exactamente lo que espera RevisarLegajoView
         const fd = new FormData();
         fd.append('accion', 'SUBSANAR');
+        fd.append('tipo_subsanacion', tipoSubsanacion);
         fd.append('motivo', motivo);
 
         const resp = await fetch(url, {

--- a/tests/test_celiaquia_expediente_view_helpers_unit.py
+++ b/tests/test_celiaquia_expediente_view_helpers_unit.py
@@ -493,7 +493,11 @@ def test_subir_cruce_excel_and_revisar_legajo_branches(mocker):
 
     req_subs = SimpleNamespace(
         user=_user_stub(user_id=1, tec=True),
-        POST={"accion": "SUBSANAR", "motivo": "faltan docs"},
+        POST={
+            "accion": "SUBSANAR",
+            "motivo": "faltan docs",
+            "tipo_subsanacion": "DOCUMENTACION",
+        },
     )
     resp_sub = revisar.post(req_subs, pk=1, legajo_id=3)
     assert resp_sub.status_code == 400
@@ -517,6 +521,9 @@ def test_subir_cruce_excel_and_revisar_legajo_branches(mocker):
     resp_subsanado = revisar.post(req_subs, pk=1, legajo_id=3)
     assert resp_subsanado.status_code == 200
     assert leg.estado_validacion_renaper == 3
+    # El tipo y el motivo elegidos deben persistir en el legajo.
+    assert leg.subsanacion_tipo == "DOCUMENTACION"
+    assert leg.subsanacion_motivo == "faltan docs"
 
 
 def test_expediente_import_view_success_and_errors(mocker):

--- a/tests/test_validacion_renaper_view_unit.py
+++ b/tests/test_validacion_renaper_view_unit.py
@@ -143,6 +143,8 @@ def test_guardar_validacion_estado_paths(mocker):
     assert json.loads(subsanar.content)["success"] is True
     assert legajo.revision_tecnico == "SUBSANAR"
     assert "subsanacion_motivo" in legajo.saved_fields
+    assert legajo.subsanacion_tipo == "RENAPER"
+    assert "subsanacion_tipo" in legajo.saved_fields
 
     mocker.patch(
         "celiaquia.views.validacion_renaper.get_object_or_404",


### PR DESCRIPTION
# Información de la Tarea

### **Resumen de la Solución:**
- Al solicitar una subsanación, el sistema mostraba siempre **"Subsanación solicitada"** sin reflejar el motivo elegido (Renaper / Documentación / Datos personales / Otros).
- Al cargar la respuesta, se rotulaba **"Respuesta Subsanación Renaper"** aunque el motivo original fuese distinto.
- Este PR muestra el motivo específico tanto en el estado de la subsanación como en su respuesta.

### **Información Adicional:**
- Causa raíz: el `<select name="tipo_subsanacion">` del modal *Subsanar* existía en el HTML, pero el JS armaba el `FormData` a mano sólo con `accion` y `motivo`, **descartando el tipo**. El backend (`RevisarLegajoView`) ya leía y persistía el tipo correctamente; el bug era 100% del frontend.
- El rótulo "Respuesta Subsanación Renaper" estaba **hardcodeado** en el template y en el toast del backend.
- También se completó el flujo de Validación RENAPER (`ValidacionRenaperView`), que marcaba SUBSANAR sin setear `subsanacion_tipo`, cayendo también en el genérico.

# Descripción de los Cambios

### **Cambios:**
- **JS** (`static/custom/js/expediente_detail.js`): envía `tipo_subsanacion`, resetea el select al abrir el modal, guard si falta el tipo.
- **Modelo** (`celiaquia/models.py`): properties `subsanacion_tipo_display` y `subsanacion_respuesta_label` para encapsular el rótulo y mantener el template DRY. **Sin migración** (sólo lógica de presentación).
- **Template** (`celiaquia/templates/celiaquia/expediente_detail.html`): la etiqueta de respuesta usa la property (`{{ leg.subsanacion_respuesta_label }}`) en lugar del texto hardcodeado "Renaper". El reformateo de djlint normalizó además dos bloques `{% if leg.subsanacion_tipo … %}` preexistentes que estaban inline (drift previo del archivo).
- **Backend Validación RENAPER** (`celiaquia/views/validacion_renaper.py`): al pasar un legajo a SUBSANAR desde el modal de validación, ahora registra `subsanacion_tipo="RENAPER"`.
- **Backend Respuesta** (`celiaquia/views/respuesta_subsanacion_renaper.py`): toast genérico, sin "Renaper".
- Documentación: `docs/registro/cambios/2026-06-09-celiaquia-subsanacion-motivo.md`.

# Cómo Testear los Cambios

### **Pruebas Automáticas:**
- Property + persistencia + render end-to-end: `pytest celiaquia/tests/test_expediente_detail.py tests/test_celiaquia_expediente_view_helpers_unit.py tests/test_validacion_renaper_view_unit.py` → 58 passed.
- Barrido del módulo: `pytest celiaquia/tests/ tests/test_celiaquia_expediente_view_helpers_unit.py tests/test_validacion_renaper_view_unit.py tests/test_comentarios_service_unit.py` → 158 passed, 0 regresiones.
- `black --check`, `node --check static/custom/js/expediente_detail.js`, `makemigrations celiaquia --check --dry-run` ("No changes detected").

### **Pruebas Manuales:**
1. Como `TecnicoCeliaquia`, en un legajo PENDIENTE → botón **Subsanar** → elegir tipo "Documentación" + motivo → confirmar.
2. En el detalle del legajo, el bloque amarillo debe decir **"Subsanación por documentación solicitada"** (probar también RENAPER, Datos personales, Otros).
3. Como `ProvinciaCeliaquia`, en el mismo legajo → **Responder** → completar comentario y archivo → enviar.
4. El bloque de respuesta debe decir **"Respuesta a subsanación (Documentación)"** y el toast no debe mencionar "Renaper".
5. Caso RENAPER: como técnico → **Validar Renaper** → Subsanar con comentario → el detalle muestra **"Subsanación RENAPER solicitada"**.
6. Edge case: abrir el modal Subsanar sin elegir tipo y confirmar → el frontend bloquea con "Seleccioná el tipo de subsanación".

# Metadata para documentación automática

- Contexto funcional: Celiaquía – revisión técnica de legajos y respuesta de provincia.
- Tipo de cambio: fix (visualización del motivo de subsanación) + mejora menor (registro del tipo en el flujo RENAPER).
- Área principal: celiaquia.
- Resumen para changelog: la subsanación muestra el motivo elegido (Renaper / Documentación / Datos personales / Otros) en el estado y en la respuesta, en lugar del texto genérico "Subsanación solicitada" / "Respuesta Subsanación Renaper".
- Impacto usuario: técnicos y provincias identifican de inmediato la causa de la observación; deja de confundirse con un caso RENAPER cuando no lo es.
- Riesgos / rollback: bajo. Sin migración. Legajos antiguos sin `subsanacion_tipo` registrado caen al texto genérico, sin romper. Rollback = revertir el commit.

# Capturas de Pantalla
N/A — el cambio es de copy/UX visible siguiendo el guion de pruebas manuales arriba.