### PR TITLE
fix(ci): sanea tests, black y pylint para el predeploy #1872

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -240,17 +240,15 @@ jobs:
               run: |
                   python - <<'PY'
                   import json
-                  import multiprocessing
                   import os
                   import subprocess
 
                   templates = json.loads(
                       os.environ.get("TEMPLATE_FILES_JSON") or "[]"
                   )
-                  workers = max(1, multiprocessing.cpu_count())
-                  print("Running djlint on", len(templates), "template file(s) with", workers, "worker(s)")
+                  print("Running djlint on", len(templates), "template file(s)")
                   subprocess.run(
-                      ["djlint", *templates, "--check", "--configuration=.djlintrc", f"--workers={workers}"],
+                      ["djlint", *templates, "--check", "--configuration=.djlintrc"],
                       check=True,
                   )
                   PY

--- a/VAT/tests.py
+++ b/VAT/tests.py
@@ -1488,7 +1488,7 @@ def test_plan_version_curricular_form_inet_provincia_restringe_campos_estrategic
 @pytest.mark.django_db
 @override_settings(ROOT_URLCONF="config.urls")
 def test_inet_provincia_no_puede_modificar_campos_bloqueados_en_centro_update(
-    client, vat_geo_data
+    client, vat_geo_data, vat_referente_user
 ):
     provincia, municipio, localidad = vat_geo_data
     call_command("create_groups", verbosity=0)
@@ -1501,7 +1501,7 @@ def test_inet_provincia_no_puede_modificar_campos_bloqueados_en_centro_update(
     _assign_user_profile_provincia(user, provincia, es_usuario_provincial=True)
 
     centro = _create_vat_centro(
-        codigo="INET-LOCK-001",
+        codigo="500144901",
         provincia=provincia,
         municipio=municipio,
         localidad=localidad,
@@ -1532,6 +1532,7 @@ def test_inet_provincia_no_puede_modificar_campos_bloqueados_en_centro_update(
             "celular": "221-2222222",
             "correo": "inet-lock@vat.test",
             "sitio_web": "https://inet-lock.test",
+            "referente": str(vat_referente_user.pk),
             "referentes": [],
             "revisores": [],
             "tipo_gestion": "Privada",
@@ -1755,7 +1756,7 @@ def test_inet_provincia_no_puede_modificar_campos_bloqueados_en_comision_update(
         plan_curricular=plan,
         programa=programa,
         nombre_local="Oferta Comision B",
-        ciclo_lectivo=2026,
+        ciclo_lectivo=2027,
         estado="publicada",
     )
 

--- a/VAT/urls.py
+++ b/VAT/urls.py
@@ -1,3 +1,4 @@
+# pylint: disable=too-many-lines
 from django.urls import path
 from core.decorators import permissions_any_required
 

--- a/celiaquia/models.py
+++ b/celiaquia/models.py
@@ -1,3 +1,4 @@
+# pylint: disable=too-many-lines
 from django.contrib.auth import get_user_model
 from django.core.exceptions import ObjectDoesNotExist
 from django.db import models

--- a/centrodefamilia/admin.py
+++ b/centrodefamilia/admin.py
@@ -69,7 +69,14 @@ class ResponsableAdmin(admin.ModelAdmin):
 
 @admin.register(Beneficiario)
 class BeneficiarioAdmin(admin.ModelAdmin):
-    list_display = ("apellido", "nombre", "dni", "cuil", "genero", "maximo_nivel_educativo")
+    list_display = (
+        "apellido",
+        "nombre",
+        "dni",
+        "cuil",
+        "genero",
+        "maximo_nivel_educativo",
+    )
     list_filter = ("genero", "maximo_nivel_educativo", "estado_academico")
     search_fields = ("apellido", "nombre", "dni", "cuil")
     raw_id_fields = ("responsable", "creado_por")
@@ -87,15 +94,35 @@ class AccesoCDFAdmin(admin.ModelAdmin):
 
 @admin.register(CabalArchivo)
 class CabalArchivoAdmin(admin.ModelAdmin):
-    list_display = ("nombre_original", "usuario", "fecha_subida", "total_filas", "total_validas", "total_invalidas")
+    list_display = (
+        "nombre_original",
+        "usuario",
+        "fecha_subida",
+        "total_filas",
+        "total_validas",
+        "total_invalidas",
+    )
     search_fields = ("nombre_original",)
     raw_id_fields = ("usuario",)
-    readonly_fields = ("fecha_subida", "total_filas", "total_validas", "total_invalidas")
+    readonly_fields = (
+        "fecha_subida",
+        "total_filas",
+        "total_validas",
+        "total_invalidas",
+    )
 
 
 @admin.register(InformeCabalRegistro)
 class InformeCabalRegistroAdmin(admin.ModelAdmin):
-    list_display = ("archivo", "centro", "nro_comercio", "razon_social", "importe", "fecha_trx", "no_coincidente")
+    list_display = (
+        "archivo",
+        "centro",
+        "nro_comercio",
+        "razon_social",
+        "importe",
+        "fecha_trx",
+        "no_coincidente",
+    )
     list_filter = ("no_coincidente",)
     search_fields = ("nro_comercio", "razon_social", "nro_tarjeta")
     raw_id_fields = ("archivo", "centro")

--- a/ciudadanos/admin.py
+++ b/ciudadanos/admin.py
@@ -76,15 +76,41 @@ class InteraccionAdmin(admin.ModelAdmin):
 
 @admin.register(CiudadanosImportJob)
 class CiudadanosImportJobAdmin(admin.ModelAdmin):
-    list_display = ("id", "requested_by", "original_filename", "status", "total_rows", "processed_rows", "requested_at")
+    list_display = (
+        "id",
+        "requested_by",
+        "original_filename",
+        "status",
+        "total_rows",
+        "processed_rows",
+        "requested_at",
+    )
     list_filter = ("status",)
     search_fields = ("original_filename", "requested_by__username")
     readonly_fields = (
-        "requested_by", "original_filename", "archivo", "status",
-        "total_rows", "processed_rows", "created_rows", "existing_rows", "failed_rows",
-        "pending_rows", "next_row_index", "last_successful_row", "last_successful_documento",
-        "last_attempted_row", "last_attempted_documento", "last_error_message", "last_error_type",
-        "last_error_at", "resume_count", "requested_at", "started_at", "finished_at", "last_activity_at",
+        "requested_by",
+        "original_filename",
+        "archivo",
+        "status",
+        "total_rows",
+        "processed_rows",
+        "created_rows",
+        "existing_rows",
+        "failed_rows",
+        "pending_rows",
+        "next_row_index",
+        "last_successful_row",
+        "last_successful_documento",
+        "last_attempted_row",
+        "last_attempted_documento",
+        "last_error_message",
+        "last_error_type",
+        "last_error_at",
+        "resume_count",
+        "requested_at",
+        "started_at",
+        "finished_at",
+        "last_activity_at",
     )
 
     def has_add_permission(self, request):
@@ -101,8 +127,19 @@ class CiudadanosImportJobRowAdmin(admin.ModelAdmin):
     search_fields = ("documento_raw", "dni", "cuil")
     raw_id_fields = ("job", "ciudadano")
     readonly_fields = (
-        "job", "fila", "documento_raw", "dni", "cuil", "sexo", "sexos_intentados",
-        "status", "ciudadano", "mensaje", "error_type", "attempts", "processed_at",
+        "job",
+        "fila",
+        "documento_raw",
+        "dni",
+        "cuil",
+        "sexo",
+        "sexos_intentados",
+        "status",
+        "ciudadano",
+        "mensaje",
+        "error_type",
+        "attempts",
+        "processed_at",
     )
 
     def has_add_permission(self, request):

--- a/comedores/admin.py
+++ b/comedores/admin.py
@@ -53,7 +53,13 @@ admin.site.register(ImagenComedor)
 
 @admin.register(ComedorDatosConvenioPnud)
 class ComedorDatosConvenioPnudAdmin(admin.ModelAdmin):
-    list_display = ("comedor", "nro_convenio", "monto_total_conveniado", "personas_conveniadas", "actualizado_en")
+    list_display = (
+        "comedor",
+        "nro_convenio",
+        "monto_total_conveniado",
+        "personas_conveniadas",
+        "actualizado_en",
+    )
     search_fields = ("comedor__nombre", "nro_convenio")
     raw_id_fields = ("comedor",)
     readonly_fields = ("actualizado_en",)
@@ -63,14 +69,25 @@ class ComedorDatosConvenioPnudAdmin(admin.ModelAdmin):
 class ColaboradorEspacioAdmin(admin.ModelAdmin):
     list_display = ("ciudadano", "comedor", "genero", "fecha_alta", "fecha_baja")
     list_filter = ("genero",)
-    search_fields = ("ciudadano__apellido", "ciudadano__nombre", "ciudadano__documento", "comedor__nombre")
+    search_fields = (
+        "ciudadano__apellido",
+        "ciudadano__nombre",
+        "ciudadano__documento",
+        "comedor__nombre",
+    )
     raw_id_fields = ("comedor", "ciudadano", "creado_por", "modificado_por")
     readonly_fields = ("fecha_creado", "fecha_modificado")
 
 
 @admin.register(CapacitacionComedorCertificado)
 class CapacitacionComedorCertificadoAdmin(admin.ModelAdmin):
-    list_display = ("comedor", "capacitacion", "estado", "fecha_presentacion", "fecha_revision")
+    list_display = (
+        "comedor",
+        "capacitacion",
+        "estado",
+        "fecha_presentacion",
+        "fecha_revision",
+    )
     list_filter = ("estado", "capacitacion")
     search_fields = ("comedor__nombre",)
     raw_id_fields = ("comedor", "presentado_por", "revisado_por")

--- a/comedores/templates/comedor/actividades_pnud_form.html
+++ b/comedores/templates/comedor/actividades_pnud_form.html
@@ -79,7 +79,7 @@
             </div>
         </div>
     </div>
-    <script>
+    <script nonce="{{ request.csp_nonce }}">
         (function () {
             const modeInput = document.getElementById('{{ form.categoria_modo.id_for_label }}');
             const buttons = document.querySelectorAll('[data-categoria-mode-button]');

--- a/config/settings_preview.py
+++ b/config/settings_preview.py
@@ -1,6 +1,6 @@
 from pathlib import Path
 
-from config.settings import *  # noqa: F401,F403
+from config.settings import *  # noqa: F401,F403  # pylint: disable=wildcard-import,unused-wildcard-import
 
 BASE_DIR = Path(__file__).resolve().parent.parent
 ROOT_URLCONF = "config.urls_preview"

--- a/core/admin.py
+++ b/core/admin.py
@@ -36,7 +36,14 @@ class NacionalidadAdmin(admin.ModelAdmin):
 
 @admin.register(MontoPrestacionPrograma)
 class MontoPrestacionProgramaAdmin(admin.ModelAdmin):
-    list_display = ("programa", "desayuno_valor", "almuerzo_valor", "merienda_valor", "cena_valor", "fecha_creacion")
+    list_display = (
+        "programa",
+        "desayuno_valor",
+        "almuerzo_valor",
+        "merienda_valor",
+        "cena_valor",
+        "fecha_creacion",
+    )
     list_filter = ("programa",)
     raw_id_fields = ("usuario_creador",)
     readonly_fields = ("fecha_creacion", "fecha_modificacion")

--- a/docs/registro/cambios/2026-06-10-saneamiento-ci-predeploy-1872.md
+++ b/docs/registro/cambios/2026-06-10-saneamiento-ci-predeploy-1872.md
@@ -26,6 +26,9 @@
 ### Seguridad (CSP)
 - `comedores/templates/comedor/actividades_pnud_form.html`: el `<script>` inline ahora incluye `nonce="{{ request.csp_nonce }}"` (lo exige `test_all_inline_script_tags_have_nonce`).
 
+### CI (djlint)
+- `.github/workflows/lint.yml`: se quita el flag `--workers` del job `djlint` (djlint 1.34.2 no lo soporta → `No such option '--workers'`, exit 2 → el job falla en cualquier PR con templates cambiados). Reaplica el fix `78ee17512` que un merge volvió a pisar. El template editado pasa `djlint --check` sin drift.
+
 ## Validación local (Docker, SQLite, igual que CI)
 - `pytest -n auto`: 2797 passed, 8 skipped, 0 failed.
 - `black --check`: sin drift en los archivos tocados.

--- a/docs/registro/cambios/2026-06-10-saneamiento-ci-predeploy-1872.md
+++ b/docs/registro/cambios/2026-06-10-saneamiento-ci-predeploy-1872.md
@@ -1,0 +1,33 @@
+# 2026-06-10 - Saneamiento de CI para el predeploy (PR #1872)
+
+## Resumen
+- El PR de predeploy `development -> main` (#1872) tenía en rojo los jobs `pytest`, `black` y `pylint`.
+- Este cambio sanea esos fallos en `development` sin tocar la lógica de negocio: arregla tests desactualizados, formatea con black y limpia mensajes de pylint.
+- El job `autofix` no podía auto-corregir el formato porque `development` está protegido y rechaza el push del bot; por eso el formateo se aplica manualmente acá.
+
+## Cambios realizados
+
+### Tests (13 fallos heredados)
+- `tests/test_pwa_actividades_api.py`: el endpoint de actividades sólo aplica a comedores PNUD (`_get_pnud_scoped_comedor_or_404` devuelve 404 si no lo es). El fixture `comedor` ahora crea un `Programas` con nombre "PNUD" para que las pruebas lleguen a la vista.
+- `tests/test_pwa_actividades_models.py`: el assert del seed esperaba `Cultura / Taller de pintura`; se alinea con el catálogo real sembrado por la migración `0017` (`Culturales y/o artísticas / Taller de pintura/dibujo`).
+- `tests/test_nomina_views_unit.py`: `NominaDetailView` ahora calcula `is_pnud_comedor(admision.comedor)` y pasa `nomina_tab` a `get_nomina_detail`. El test mockea `is_pnud_comedor` y actualiza la aserción de la llamada.
+- `tests/test_relevamientos_web_views_unit.py`: el listado agrega `sincronizado_gestionar` a cada item; se agrega el atributo a los stubs y a las aserciones.
+- `VAT/tests.py`:
+  - `..._centro_update`: se usa un CUE válido de 9 dígitos (el campo `codigo` queda bloqueado/re-inyectado para INET_PROVINCIA y el form exige 9 numéricos) y se envía un referente válido (el form ahora exige al menos uno).
+  - `..._comision_update`: la oferta "tampered" usa `ciclo_lectivo=2027` para no chocar con el `unique(centro, plan_curricular, ciclo_lectivo)` de `OfertaInstitucional`.
+
+### Formato (black)
+- `centrodefamilia/admin.py`, `ciudadanos/admin.py`, `comedores/admin.py`, `core/admin.py`, `users/admin.py`: reformateo automático (sólo formato, sin cambios de lógica).
+
+### Lint (pylint)
+- `VAT/urls.py` y `celiaquia/models.py`: `# pylint: disable=too-many-lines` (convención ya usada en el repo).
+- `config/settings_preview.py`: `# pylint: disable=wildcard-import,unused-wildcard-import` en el `from config.settings import *` (patrón estándar de settings override).
+
+### Seguridad (CSP)
+- `comedores/templates/comedor/actividades_pnud_form.html`: el `<script>` inline ahora incluye `nonce="{{ request.csp_nonce }}"` (lo exige `test_all_inline_script_tags_have_nonce`).
+
+## Validación local (Docker, SQLite, igual que CI)
+- `pytest -n auto`: 2797 passed, 8 skipped, 0 failed.
+- `black --check`: sin drift en los archivos tocados.
+- `pylint **/*.py --rcfile=.pylintrc`: 10.00/10, exit 0.
+- `djlint --check` del template editado: sin cambios.

--- a/tests/test_nomina_views_unit.py
+++ b/tests/test_nomina_views_unit.py
@@ -61,6 +61,7 @@ def test_nomina_detail_context_data(mocker):
         "comedores.views.nomina._get_admision_del_comedor_or_404",
         return_value=SimpleNamespace(pk=77, comedor="comedor"),
     )
+    mocker.patch("comedores.views.nomina.is_pnud_comedor", return_value=False)
 
     view = module.NominaDetailView()
     view.kwargs = {"pk": 9, "admision_pk": 77}
@@ -73,7 +74,9 @@ def test_nomina_detail_context_data(mocker):
     assert ctx["cantidad_nomina"] == 6
     assert ctx["menores"] == 5
     assert ctx["dni_query"] == "1234"
-    get_nomina_detail_mock.assert_called_once_with(77, 2, dni_query="1234")
+    get_nomina_detail_mock.assert_called_once_with(
+        77, 2, dni_query="1234", nomina_tab="todas"
+    )
 
 
 def test_prepare_renaper_initial_data_uses_data_and_datos_api(mocker):

--- a/tests/test_pwa_actividades_api.py
+++ b/tests/test_pwa_actividades_api.py
@@ -6,7 +6,7 @@ from rest_framework.test import APIClient
 
 from admisiones.models.admisiones import Admision
 from ciudadanos.models import Ciudadano
-from comedores.models import Comedor, Nomina
+from comedores.models import Comedor, Nomina, Programas
 from core.models import Dia, Provincia, Sexo
 from pwa.models import (
     ActividadEspacioPWA,
@@ -20,7 +20,10 @@ from users.models import AccesoComedorPWA
 @pytest.fixture
 def comedor(db):
     provincia = Provincia.objects.create(nombre="Buenos Aires")
-    return Comedor.objects.create(nombre="Comedor Actividades API", provincia=provincia)
+    programa = Programas.objects.create(nombre="PNUD")
+    return Comedor.objects.create(
+        nombre="Comedor Actividades API", provincia=provincia, programa=programa
+    )
 
 
 @pytest.fixture

--- a/tests/test_pwa_actividades_models.py
+++ b/tests/test_pwa_actividades_models.py
@@ -30,8 +30,8 @@ def admision(comedor):
 @pytest.mark.django_db
 def test_catalogo_actividades_seed_inicial_existe():
     assert CatalogoActividadPWA.objects.filter(
-        categoria="Cultura",
-        actividad="Taller de pintura",
+        categoria="Culturales y/o artísticas",
+        actividad="Taller de pintura/dibujo",
         activo=True,
     ).exists()
 

--- a/tests/test_relevamientos_web_views_unit.py
+++ b/tests/test_relevamientos_web_views_unit.py
@@ -160,13 +160,20 @@ def test_list_view_get_context_data_agrega_comedor(mocker):
 
 
 def _make_relevamiento_stub(
-    rel_id, *, fecha="2026-01-01", estado="Pendiente", numero_if=None, seguimiento=None
+    rel_id,
+    *,
+    fecha="2026-01-01",
+    estado="Pendiente",
+    numero_if=None,
+    seguimiento=None,
+    sincronizado_gestionar=False,
 ):
     rel = SimpleNamespace(
         id=rel_id,
         fecha_visita=fecha,
         estado=estado,
         numero_if=numero_if,
+        sincronizado_gestionar=sincronizado_gestionar,
     )
     if seguimiento is None:
         from relevamientos.models import PrimerSeguimiento
@@ -209,6 +216,7 @@ def test_list_view_construye_items_solo_padre_sin_seguimiento(mocker):
             "is_child": False,
             "parent_id": None,
             "has_seguimiento": False,
+            "sincronizado_gestionar": False,
         }
     ]
 
@@ -217,7 +225,9 @@ def test_list_view_construye_items_padre_seguido_de_hijo(mocker):
     view = RelevamientoListView()
     view.kwargs = {"comedor_pk": 5}
     rel = _make_relevamiento_stub(42, numero_if="IF-42")
-    seguimiento = SimpleNamespace(id=900, fecha_hora="2026-02-02", estado="Asignado")
+    seguimiento = SimpleNamespace(
+        id=900, fecha_hora="2026-02-02", estado="Asignado", sincronizado_gestionar=True
+    )
     mocker.patch(
         "django.views.generic.list.MultipleObjectMixin.get_context_data",
         return_value={"relevamientos": [rel]},
@@ -244,6 +254,8 @@ def test_list_view_construye_items_padre_seguido_de_hijo(mocker):
     assert items[1]["fecha"] == "2026-02-02"
     assert items[1]["estado"] == "Asignado"
     assert items[1]["numero_if"] is None
+    assert items[0]["sincronizado_gestionar"] is False
+    assert items[1]["sincronizado_gestionar"] is True
 
 
 def test_get_primer_seguimiento_helper_devuelve_none_si_no_existe():

--- a/users/admin.py
+++ b/users/admin.py
@@ -5,7 +5,12 @@ from users.models import Profile
 
 @admin.register(Profile)
 class ProfileAdmin(admin.ModelAdmin):
-    list_display = ("user", "source", "must_change_password", "initial_password_expires_at")
+    list_display = (
+        "user",
+        "source",
+        "must_change_password",
+        "initial_password_expires_at",
+    )
     list_filter = ("must_change_password", "source")
     search_fields = ("user__username", "user__email")
     raw_id_fields = ("user",)


### PR DESCRIPTION
# Información de la Tarea
Sanea los jobs en rojo del PR de predeploy #1872 (`development` → `main`). Como `development` está protegida, los arreglos van en este PR aparte.

### **Resumen de la Solución:**
- Deja en verde `pytest`, `black` y `pylint` en `development` arreglando 13 tests heredados rotos y limpiando formato/lint. **Sin cambios de lógica de negocio.**

### **Información Adicional:**
- El job `autofix` no puede auto-formatear sobre `development`: la rama está protegida y rechaza el push del bot (`GH013 ... push declined`). Por eso el formateo se aplica manualmente acá.

# Descripción de los Cambios

### **Cambios:**
- **Tests (13 fallos heredados):**
  - `tests/test_pwa_actividades_api.py`: el endpoint de actividades sólo aplica a comedores PNUD (`_get_pnud_scoped_comedor_or_404` → 404 si no lo es). El fixture `comedor` ahora crea un `Programas` "PNUD".
  - `tests/test_pwa_actividades_models.py`: assert del seed alineado al catálogo real sembrado por la migración `0017` (`Culturales y/o artísticas / Taller de pintura/dibujo`).
  - `tests/test_nomina_views_unit.py`: `NominaDetailView` calcula `is_pnud_comedor` y pasa `nomina_tab` a `get_nomina_detail`; el test lo mockea y ajusta la aserción.
  - `tests/test_relevamientos_web_views_unit.py`: el listado agrega `sincronizado_gestionar` a cada item; se actualizan stubs y aserciones.
  - `VAT/tests.py`: centro_update usa CUE de 9 dígitos + referente requerido; comision_update usa `ciclo_lectivo=2027` en la oferta "tampered" para no chocar con `unique(centro, plan_curricular, ciclo_lectivo)`.
  - `comedores/templates/comedor/actividades_pnud_form.html`: `<script>` inline con `nonce` (CSP).
- **black:** reformateo de `centrodefamilia/ciudadanos/comedores/core/users` `admin.py` (sólo formato).
- **pylint:** `# pylint: disable=too-many-lines` en `VAT/urls.py` y `celiaquia/models.py`; `disable=wildcard-import,unused-wildcard-import` en `config/settings_preview.py`.

# Cómo Testear los Cambios

### **Pruebas Automáticas:**
- `pytest -n auto` (Docker/SQLite, igual que el job de CI): **2797 passed, 8 skipped, 0 failed** (antes: 13 failed).
- `pylint **/*.py --rcfile=.pylintrc`: **10.00/10**, exit 0.
- `black --check`: sin drift en los archivos tocados. `djlint --check` del template editado: sin cambios.

### **Prubeas Manuales:**
- No aplica (saneamiento de tests/formato/lint; sin cambios de comportamiento).

# Metadata para documentación automática

- Contexto funcional: Saneamiento de CI para habilitar el predeploy a producción.
- Tipo de cambio: fix (tests + tooling), sin lógica de negocio.
- Área principal: CI / tests (PWA, VAT, nómina, relevamientos).
- Resumen para changelog: Se sanearon los jobs de CI (pytest, black, pylint) bloqueantes del predeploy #1872.
- Impacto usuario: Ninguno.
- Riesgos / rollback: Bajo. Rollback = revertir el merge; sólo toca tests, formato, comentarios de lint y un nonce en un template.

# Relación con #1872
Al mergear este PR a `development`, re-disparar los checks de #1872 (`development` → `main`) para que queden en verde.
