### PR TITLE
fix(comunicados): agregar servicio Docker mailing_worker

### DIFF
--- a/docker-compose.produccion.yml
+++ b/docker-compose.produccion.yml
@@ -26,3 +26,17 @@ services:
       - .:/sisoc/
     user: "${RUN_UID:-0}:${RUN_GID:-0}"
     restart: unless-stopped
+
+  mailing_worker:
+    build:
+      context: .
+      dockerfile: ./docker/django/Dockerfile
+    env_file:
+      - .env
+    environment:
+      TZ: America/Argentina/Buenos_Aires
+      DJANGO_SERVICE_ROLE: mailing_worker
+    volumes:
+      - .:/sisoc/
+    user: "${RUN_UID:-0}:${RUN_GID:-0}"
+    restart: unless-stopped

--- a/docker/django/entrypoint.py
+++ b/docker/django/entrypoint.py
@@ -15,6 +15,7 @@ DEPLOY_GUNICORN_ENVIRONMENTS = {"qa", "homologacion", "prd"}
 SERVICE_ROLE_WEB = "web"
 SERVICE_ROLE_BULK_CREDENTIALS_WORKER = "bulk_credentials_worker"
 SERVICE_ROLE_CIUDADANOS_IMPORT_WORKER = "ciudadanos_import_worker"
+SERVICE_ROLE_MAILING_WORKER = "mailing_worker"
 
 
 def run_command(cmd, *, stage, **kwargs):
@@ -192,6 +193,15 @@ def run_ciudadanos_import_worker():
     )
 
 
+def run_mailing_worker():
+    """Inicia el worker dedicado de mailing masivo."""
+    logger.info("[worker] Iniciando worker de mailing masivo...")
+    run_command(
+        ["python", "manage.py", "process_mailing_jobs"],
+        stage="mailing_worker",
+    )
+
+
 def main():
     wait_for_mysql()
     service_role = os.getenv("DJANGO_SERVICE_ROLE", SERVICE_ROLE_WEB).strip().lower()
@@ -200,6 +210,9 @@ def main():
         return
     if service_role == SERVICE_ROLE_CIUDADANOS_IMPORT_WORKER:
         run_ciudadanos_import_worker()
+        return
+    if service_role == SERVICE_ROLE_MAILING_WORKER:
+        run_mailing_worker()
         return
     run_django_commands()
 


### PR DESCRIPTION
## Problema

El PR #1888 (`feature/mailing-masivo`) agregó el management command `process_mailing_jobs` pero no registró el servicio correspondiente en la infraestructura Docker de producción. Al subir un Excel de mailing, el job se crea en estado PENDING con todos los contadores en 0 (`total_rows`, `processed_rows`, `enviadas`, `rechazadas`) porque `total_rows` se setea **dentro del worker al procesar el job**, no al momento del upload.

## Cambios

- `docker/django/entrypoint.py`: nueva constante `SERVICE_ROLE_MAILING_WORKER`, función `run_mailing_worker()` y branch en `main()` para activarlo vía `DJANGO_SERVICE_ROLE=mailing_worker`.
- `docker-compose.produccion.yml`: nuevo servicio `mailing_worker` con el mismo patrón que `bulk_credentials_worker` y `ciudadanos_import_worker`.

## Cómo probar

Después de mergear y levantar en producción:

```bash
docker compose -f docker-compose.produccion.yml up -d mailing_worker
```

Subir un Excel de mailing → el job debe pasar a PROCESSING y mostrar `total_rows > 0`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)