### PR TITLE
Fix 1867

### DIFF
--- a/VAT/templates/vat/catalogo/planversioncurricular_list.html
+++ b/VAT/templates/vat/catalogo/planversioncurricular_list.html
@@ -8,98 +8,98 @@
     <link rel="stylesheet" href="{% static 'custom/css/vat_design.css' %}" />
 
     <div class="vat-ui">
-    {% url 'vat_planversioncurricular_list' as reset_url %}
-    {% include 'components/search_bar.html' with titulo="Buscar Plan de Estudio" placeholder="Buscar por sector, título o modalidad" help_text="Buscar por sector, título o modalidad" reset_url=reset_url add_url='vat_planversioncurricular_create' add_text='Agregar' query=request.GET.busqueda %}
+        {% url 'vat_planversioncurricular_list' as reset_url %}
+        {% include 'components/search_bar.html' with titulo="Buscar Plan de Estudio" placeholder="Buscar por sector, título o modalidad" help_text="Buscar por sector, título o modalidad" reset_url=reset_url add_url='vat_planversioncurricular_create' add_text='Agregar' query=request.GET.busqueda %}
 
-    <div class="row mt-5 max-width-100">
-        <div class="col-12">
-            <div class="card">
-                <div class="card-body">
-                    <div class="table-responsive-lg">
-                        <table class="table table-bordered table-striped projects">
-                            <thead>
-                                <tr>
-                                    <th>Sector</th>
-                                    <th>Subsector</th>
-                                    <th class="sortable" data-column="titulo">
-                                        Nombre
-                                        <i class="fas fa-sort sort-icon"></i>
-                                    </th>
-                                    <th>Modalidad</th>
-                                    <th>Horas</th>
-                                    <th>Estado</th>
-                                    <th class="notexport">Acciones</th>
-                                </tr>
-                            </thead>
-                            <tbody>
-                                {% for plan in planes %}
+        <div class="row mt-5 max-width-100">
+            <div class="col-12">
+                <div class="card">
+                    <div class="card-body">
+                        <div class="table-responsive-lg">
+                            <table class="table table-bordered table-striped projects">
+                                <thead>
                                     <tr>
-                                        <td>{{ plan.sector.nombre }}</td>
-                                        <td>{{ plan.subsector.nombre|default:"—" }}</td>
-                                        <td data-titulo="{{ plan.nombre }}">
-                                            <a href="{% url 'vat_planversioncurricular_detail' plan.id %}"
-                                               class="link-handler"
-                                               title="Ver detalles">{{ plan.nombre }}</a>
-                                        </td>
-                                        <td>{{ plan.modalidad_cursada.nombre }}</td>
-                                        <td>{{ plan.horas_reloj|default:"—" }}</td>
-                                        <td>
-                                            {% if plan.activo %}
-                                                <span class="badge-validacion validado">
-                                                    <i class="fas fa-check-circle"></i> Activo
-                                                </span>
-                                            {% else %}
-                                                <span class="badge-validacion no-validado">
-                                                    <i class="fas fa-times-circle"></i> Inactivo
-                                                </span>
-                                            {% endif %}
-                                        </td>
-                                        <td>
-                                            <div class="action-buttons" role="group">
+                                        <th>Sector</th>
+                                        <th>Subsector</th>
+                                        <th class="sortable" data-column="titulo">
+                                            Nombre
+                                            <i class="fas fa-sort sort-icon"></i>
+                                        </th>
+                                        <th>Modalidad</th>
+                                        <th>Horas</th>
+                                        <th>Estado</th>
+                                        <th class="notexport">Acciones</th>
+                                    </tr>
+                                </thead>
+                                <tbody>
+                                    {% for plan in planes %}
+                                        <tr>
+                                            <td>{{ plan.sector.nombre }}</td>
+                                            <td>{{ plan.subsector.nombre|default:"—" }}</td>
+                                            <td data-titulo="{{ plan.nombre }}">
                                                 <a href="{% url 'vat_planversioncurricular_detail' plan.id %}"
-                                                   class="btn btn-primary link-handler"
-                                                   title="Ver detalle">
-                                                    <i class="fas fa-eye"></i>
-                                                    Ver
-                                                </a>
-                                                {% if perms.VAT.change_planversioncurricular %}
-                                                    <a href="{% url 'vat_planversioncurricular_update' plan.id %}"
-                                                       class="btn btn-editar link-handler"
-                                                       title="Editar plan">
-                                                        <i class="fas fa-edit"></i>
-                                                        Editar
-                                                    </a>
+                                                   class="link-handler"
+                                                   title="Ver detalles">{{ plan.nombre }}</a>
+                                            </td>
+                                            <td>{{ plan.modalidad_cursada.nombre }}</td>
+                                            <td>{{ plan.horas_reloj|default:"—" }}</td>
+                                            <td>
+                                                {% if plan.activo %}
+                                                    <span class="badge-validacion validado">
+                                                        <i class="fas fa-check-circle"></i> Activo
+                                                    </span>
+                                                {% else %}
+                                                    <span class="badge-validacion no-validado">
+                                                        <i class="fas fa-times-circle"></i> Inactivo
+                                                    </span>
                                                 {% endif %}
-                                                {% if perms.VAT.delete_planversioncurricular %}
-                                                    <a href="{% url 'vat_planversioncurricular_delete' plan.id %}"
-                                                       class="btn btn-eliminar link-handler"
-                                                       title="Eliminar plan">
-                                                        <i class="fas fa-trash-alt"></i>
-                                                        Eliminar
+                                            </td>
+                                            <td>
+                                                <div class="action-buttons" role="group">
+                                                    <a href="{% url 'vat_planversioncurricular_detail' plan.id %}"
+                                                       class="btn btn-primary link-handler"
+                                                       title="Ver detalle">
+                                                        <i class="fas fa-eye"></i>
+                                                        Ver
                                                     </a>
-                                                {% endif %}
-                                            </div>
-                                        </td>
-                                    </tr>
-                                {% empty %}
-                                    <tr>
-                                        <td colspan="8">
-                                            <div class="no-comedores-message">
-                                                <h3>No se encontraron planes de estudio</h3>
-                                                <p>No hay planes registrados.</p>
-                                            </div>
-                                        </td>
-                                    </tr>
-                                {% endfor %}
-                            </tbody>
-                        </table>
+                                                    {% if perms.VAT.change_planversioncurricular %}
+                                                        <a href="{% url 'vat_planversioncurricular_update' plan.id %}"
+                                                           class="btn btn-editar link-handler"
+                                                           title="Editar plan">
+                                                            <i class="fas fa-edit"></i>
+                                                            Editar
+                                                        </a>
+                                                    {% endif %}
+                                                    {% if perms.VAT.delete_planversioncurricular %}
+                                                        <a href="{% url 'vat_planversioncurricular_delete' plan.id %}"
+                                                           class="btn btn-eliminar link-handler"
+                                                           title="Eliminar plan">
+                                                            <i class="fas fa-trash-alt"></i>
+                                                            Eliminar
+                                                        </a>
+                                                    {% endif %}
+                                                </div>
+                                            </td>
+                                        </tr>
+                                    {% empty %}
+                                        <tr>
+                                            <td colspan="8">
+                                                <div class="no-comedores-message">
+                                                    <h3>No se encontraron planes de estudio</h3>
+                                                    <p>No hay planes registrados.</p>
+                                                </div>
+                                            </td>
+                                        </tr>
+                                    {% endfor %}
+                                </tbody>
+                            </table>
+                        </div>
                     </div>
                 </div>
             </div>
         </div>
-    </div>
 
-    {% include 'components/pagination.html' with is_paginated=is_paginated page_obj=page_obj prev_text='Volver' next_text='Continuar' %}
+        {% include 'components/pagination.html' with is_paginated=is_paginated page_obj=page_obj prev_text='Volver' next_text='Continuar' %}
     </div>
 
 {% endblock %}

--- a/VAT/templates/vat/centros/centro_detail.html
+++ b/VAT/templates/vat/centros/centro_detail.html
@@ -1370,389 +1370,389 @@
     </style>
 
     <div class="sisoc-centro-page">
-    {% with primary_contacto=contactos.0 %}
-        <div class="ci-hero d-print-none">
-            <div class="sisoc-title-row">
-                <div class="sisoc-title-block">
-                    <h1>{{ centro.nombre }}</h1>
+        {% with primary_contacto=contactos.0 %}
+            <div class="ci-hero d-print-none">
+                <div class="sisoc-title-row">
+                    <div class="sisoc-title-block">
+                        <h1>{{ centro.nombre }}</h1>
+                    </div>
+                    <div class="sisoc-title-meta">
+                        <span class="sisoc-cue-text">CUE {{ centro.codigo|default:"-" }}</span>
+                        {% if centro.activo %}
+                            <span class="sisoc-status-pill">Activo</span>
+                        {% else %}
+                            <span class="sisoc-status-pill is-inactive">Inactivo</span>
+                        {% endif %}
+                    </div>
                 </div>
-                <div class="sisoc-title-meta">
-                    <span class="sisoc-cue-text">CUE {{ centro.codigo|default:"-" }}</span>
-                    {% if centro.activo %}
-                        <span class="sisoc-status-pill">Activo</span>
-                    {% else %}
-                        <span class="sisoc-status-pill is-inactive">Inactivo</span>
-                    {% endif %}
-                </div>
-            </div>
 
-            <div class="sisoc-info-shell">
-                <div class="sisoc-side-tabs sisoc-side-tabs--left"
-                     role="tablist"
-                     aria-label="Secciones visitadas">
-                    <button type="button"
-                            class="sisoc-side-tab is-active"
-                            data-sisoc-tab-target="general"
-                            aria-selected="true">
-                        <span>Información general</span>
-                    </button>
-                    <button type="button"
-                            class="sisoc-side-tab"
-                            data-sisoc-tab-target="ubicaciones"
-                            aria-selected="false"
-                            hidden>
-                        <span>Ubicaciones adicionales</span>
-                    </button>
-                    <button type="button"
-                            class="sisoc-side-tab"
-                            data-sisoc-tab-target="contactos"
-                            aria-selected="false"
-                            hidden>
-                        <span>Contactos adicionales</span>
-                    </button>
-                </div>
-                <div class="sisoc-info-content">
-                    <section class="sisoc-info-panel is-active" data-sisoc-panel="general">
-                        <div class="sisoc-panel-section">
-                            <div class="sisoc-general-layout">
-                                <div class="sisoc-general-main">
-                                    <div class="sisoc-section-header">
-                                        <h2>Información general sobre el establecimiento</h2>
-                                    </div>
-                                    <hr class="sisoc-section-divider" />
-                                    <div class="sisoc-general-grid">
-                                    <div class="sisoc-data-item">
-                                        <p class="sisoc-data-label">CUE</p>
-                                        <p class="sisoc-data-value">#{{ centro.codigo|default:"-" }}</p>
-                                    </div>
-                                    <div class="sisoc-data-item">
-                                        <p class="sisoc-data-label">Sector de gestión</p>
-                                        <p class="sisoc-data-value">{{ centro.tipo_gestion|default:"-" }}</p>
-                                    </div>
-                                    <div class="sisoc-data-item">
-                                        <p class="sisoc-data-label">Domicilio</p>
-                                        <p class="sisoc-data-value">
-                                            {% if centro.calle %}
-                                                {{ centro.calle }}
-                                                {% if centro.numero %}{{ centro.numero }}{% endif %}
-                                            {% else %}
-                                                {{ centro.domicilio_actividad|default:"-" }}
-                                            {% endif %}
-                                        </p>
-                                    </div>
-                                    <div class="sisoc-data-item">
-                                        <p class="sisoc-data-label">Teléfono</p>
-                                        <p class="sisoc-data-value">{{ centro.telefono|default:"-" }}</p>
-                                    </div>
-                                    <div class="sisoc-data-item">
-                                        <p class="sisoc-data-label">Celular</p>
-                                        <p class="sisoc-data-value">{{ centro.celular|default:"-" }}</p>
-                                    </div>
-                                    <div class="sisoc-data-item">
-                                        <p class="sisoc-data-label">Correo electrónico</p>
-                                        <p class="sisoc-data-value">
-                                            {% if centro.correo %}
-                                                <a href="mailto:{{ centro.correo }}">{{ centro.correo }}</a>
-                                            {% else %}
-                                                -
-                                            {% endif %}
-                                        </p>
-                                    </div>
-                                </div>
-                                </div>
-                                <div class="sisoc-map-preview">
-                                    {% if centro.calle and centro.localidad and centro.provincia %}
-                                        <iframe title="Mapa del centro"
-                                                frameborder="0"
-                                                style="border:0"
-                                                loading="lazy"
-                                                referrerpolicy="no-referrer-when-downgrade"
-                                                src="https://maps.google.com/maps?hl=es&amp;q={{ centro.calle|urlencode }}{% if centro.numero %}+{{ centro.numero|urlencode }}{% endif %},+{{ centro.localidad.nombre|urlencode }},+{{ centro.provincia.nombre|urlencode }},+Argentina+({{ centro.nombre|urlencode }})&amp;t=&amp;z=16&amp;ie=UTF8&amp;iwloc=B&amp;output=embed"
-                                                allowfullscreen>
-                                        </iframe>
-                                    {% else %}
-                                        <div class="sisoc-map-placeholder">
-                                            <i class="fas fa-map-marker-alt"></i>
-                                            <span>Sin datos suficientes para mostrar el mapa</span>
+                <div class="sisoc-info-shell">
+                    <div class="sisoc-side-tabs sisoc-side-tabs--left"
+                         role="tablist"
+                         aria-label="Secciones visitadas">
+                        <button type="button"
+                                class="sisoc-side-tab is-active"
+                                data-sisoc-tab-target="general"
+                                aria-selected="true">
+                            <span>Información general</span>
+                        </button>
+                        <button type="button"
+                                class="sisoc-side-tab"
+                                data-sisoc-tab-target="ubicaciones"
+                                aria-selected="false"
+                                hidden>
+                            <span>Ubicaciones adicionales</span>
+                        </button>
+                        <button type="button"
+                                class="sisoc-side-tab"
+                                data-sisoc-tab-target="contactos"
+                                aria-selected="false"
+                                hidden>
+                            <span>Contactos adicionales</span>
+                        </button>
+                    </div>
+                    <div class="sisoc-info-content">
+                        <section class="sisoc-info-panel is-active" data-sisoc-panel="general">
+                            <div class="sisoc-panel-section">
+                                <div class="sisoc-general-layout">
+                                    <div class="sisoc-general-main">
+                                        <div class="sisoc-section-header">
+                                            <h2>Información general sobre el establecimiento</h2>
                                         </div>
+                                        <hr class="sisoc-section-divider" />
+                                        <div class="sisoc-general-grid">
+                                            <div class="sisoc-data-item">
+                                                <p class="sisoc-data-label">CUE</p>
+                                                <p class="sisoc-data-value">#{{ centro.codigo|default:"-" }}</p>
+                                            </div>
+                                            <div class="sisoc-data-item">
+                                                <p class="sisoc-data-label">Sector de gestión</p>
+                                                <p class="sisoc-data-value">{{ centro.tipo_gestion|default:"-" }}</p>
+                                            </div>
+                                            <div class="sisoc-data-item">
+                                                <p class="sisoc-data-label">Domicilio</p>
+                                                <p class="sisoc-data-value">
+                                                    {% if centro.calle %}
+                                                        {{ centro.calle }}
+                                                        {% if centro.numero %}{{ centro.numero }}{% endif %}
+                                                    {% else %}
+                                                        {{ centro.domicilio_actividad|default:"-" }}
+                                                    {% endif %}
+                                                </p>
+                                            </div>
+                                            <div class="sisoc-data-item">
+                                                <p class="sisoc-data-label">Teléfono</p>
+                                                <p class="sisoc-data-value">{{ centro.telefono|default:"-" }}</p>
+                                            </div>
+                                            <div class="sisoc-data-item">
+                                                <p class="sisoc-data-label">Celular</p>
+                                                <p class="sisoc-data-value">{{ centro.celular|default:"-" }}</p>
+                                            </div>
+                                            <div class="sisoc-data-item">
+                                                <p class="sisoc-data-label">Correo electrónico</p>
+                                                <p class="sisoc-data-value">
+                                                    {% if centro.correo %}
+                                                        <a href="mailto:{{ centro.correo }}">{{ centro.correo }}</a>
+                                                    {% else %}
+                                                        -
+                                                    {% endif %}
+                                                </p>
+                                            </div>
+                                        </div>
+                                    </div>
+                                    <div class="sisoc-map-preview">
+                                        {% if centro.calle and centro.localidad and centro.provincia %}
+                                            <iframe title="Mapa del centro"
+                                                    frameborder="0"
+                                                    style="border:0"
+                                                    loading="lazy"
+                                                    referrerpolicy="no-referrer-when-downgrade"
+                                                    src="https://maps.google.com/maps?hl=es&amp;q={{ centro.calle|urlencode }}{% if centro.numero %}+{{ centro.numero|urlencode }}{% endif %},+{{ centro.localidad.nombre|urlencode }},+{{ centro.provincia.nombre|urlencode }},+Argentina+({{ centro.nombre|urlencode }})&amp;t=&amp;z=16&amp;ie=UTF8&amp;iwloc=B&amp;output=embed"
+                                                    allowfullscreen>
+                                            </iframe>
+                                        {% else %}
+                                            <div class="sisoc-map-placeholder">
+                                                <i class="fas fa-map-marker-alt"></i>
+                                                <span>Sin datos suficientes para mostrar el mapa</span>
+                                            </div>
+                                        {% endif %}
+                                    </div>
+                                </div>
+                                <hr class="sisoc-section-divider" />
+                                <div class="sisoc-section-header">
+                                    <h2>Referente del centro</h2>
+                                </div>
+                                <ul class="sisoc-referente-list">
+                                    <li class="sisoc-referente-item">
+                                        <span class="sisoc-referente-icon"><i class="fas fa-signature"></i></span>
+                                        <div class="sisoc-referente-copy">
+                                            <span>Nombre y apellido</span>
+                                            <strong>
+                                                {% if centro.nombre_referente or centro.apellido_referente %}
+                                                    {{ centro.nombre_referente }} {{ centro.apellido_referente }}
+                                                {% elif primary_contacto and primary_contacto.nombre_contacto %}
+                                                    {{ primary_contacto.nombre_contacto }}
+                                                {% else %}
+                                                    -
+                                                {% endif %}
+                                            </strong>
+                                        </div>
+                                    </li>
+                                    <li class="sisoc-referente-item">
+                                        <span class="sisoc-referente-icon"><i class="fas fa-phone"></i></span>
+                                        <div class="sisoc-referente-copy">
+                                            <span>Teléfono</span>
+                                            <strong>
+                                                {% if centro.telefono_referente %}
+                                                    {{ centro.telefono_referente }}
+                                                {% elif primary_contacto and primary_contacto.telefono_contacto %}
+                                                    {{ primary_contacto.telefono_contacto }}
+                                                {% else %}
+                                                    -
+                                                {% endif %}
+                                            </strong>
+                                        </div>
+                                    </li>
+                                    <li class="sisoc-referente-item">
+                                        <span class="sisoc-referente-icon"><i class="fas fa-user-check"></i></span>
+                                        <div class="sisoc-referente-copy">
+                                            <span>Usuario del sistema</span>
+                                            <div>
+                                                {% for referente_usuario in referentes_centro %}
+                                                    {% if not forloop.first %}<span class="d-none">,</span>{% endif %}
+                                                    {{ referente_usuario.get_full_name|default:referente_usuario.username }}
+                                                    {% if not forloop.last %},{% endif %}
+                                                {% empty %}
+                                                    -
+                                                {% endfor %}
+                                            </div>
+                                        </div>
+                                    </li>
+                                    <li class="sisoc-referente-item">
+                                        <span class="sisoc-referente-icon"><i class="fas fa-id-card"></i></span>
+                                        <div class="sisoc-referente-copy">
+                                            <span>DNI</span>
+                                            <strong>
+                                                {% if primary_contacto and primary_contacto.documento %}
+                                                    {{ primary_contacto.documento }}
+                                                {% else %}
+                                                    -
+                                                {% endif %}
+                                            </strong>
+                                        </div>
+                                    </li>
+                                    <li class="sisoc-referente-item">
+                                        <span class="sisoc-referente-icon"><i class="fas fa-envelope"></i></span>
+                                        <div class="sisoc-referente-copy">
+                                            <span>Correo electrónico</span>
+                                            <strong>
+                                                {% if centro.correo_referente %}
+                                                    {{ centro.correo_referente }}
+                                                {% elif primary_contacto and primary_contacto.email_contacto %}
+                                                    {{ primary_contacto.email_contacto }}
+                                                {% else %}
+                                                    -
+                                                {% endif %}
+                                            </strong>
+                                        </div>
+                                    </li>
+                                </ul>
+                            </div>
+
+                        </section>
+
+                        <section class="sisoc-info-panel" data-sisoc-panel="ubicaciones">
+                            <div class="sisoc-panel-section">
+                                <div class="sisoc-section-header">
+                                    <h2>Ubicaciones adicionales</h2>
+                                    {% if can_edit_centro and perms.VAT.add_institucionubicacion %}
+                                        <button type="button"
+                                                class="sisoc-btn sisoc-btn--add"
+                                                data-bs-toggle="modal"
+                                                data-bs-target="#modalUbicacion">
+                                            <i class="fas fa-plus"></i>
+                                            <span>Agregar sede</span>
+                                        </button>
                                     {% endif %}
                                 </div>
-                            </div>
-                            <hr class="sisoc-section-divider" />
-                            <div class="sisoc-section-header">
-                                <h2>Referente del centro</h2>
-                            </div>
-                            <ul class="sisoc-referente-list">
-                                <li class="sisoc-referente-item">
-                                    <span class="sisoc-referente-icon"><i class="fas fa-signature"></i></span>
-                                    <div class="sisoc-referente-copy">
-                                        <span>Nombre y apellido</span>
-                                        <strong>
-                                            {% if centro.nombre_referente or centro.apellido_referente %}
-                                                {{ centro.nombre_referente }} {{ centro.apellido_referente }}
-                                            {% elif primary_contacto and primary_contacto.nombre_contacto %}
-                                                {{ primary_contacto.nombre_contacto }}
-                                            {% else %}
-                                                -
-                                            {% endif %}
-                                        </strong>
-                                    </div>
-                                </li>
-                                <li class="sisoc-referente-item">
-                                    <span class="sisoc-referente-icon"><i class="fas fa-phone"></i></span>
-                                    <div class="sisoc-referente-copy">
-                                        <span>Teléfono</span>
-                                        <strong>
-                                            {% if centro.telefono_referente %}
-                                                {{ centro.telefono_referente }}
-                                            {% elif primary_contacto and primary_contacto.telefono_contacto %}
-                                                {{ primary_contacto.telefono_contacto }}
-                                            {% else %}
-                                                -
-                                            {% endif %}
-                                        </strong>
-                                    </div>
-                                </li>
-                                <li class="sisoc-referente-item">
-                                    <span class="sisoc-referente-icon"><i class="fas fa-user-check"></i></span>
-                                    <div class="sisoc-referente-copy">
-                                        <span>Usuario del sistema</span>
-                                        <div>
-                                            {% for referente_usuario in referentes_centro %}
-                                                {% if not forloop.first %}<span class="d-none">,</span>{% endif %}
-                                                {{ referente_usuario.get_full_name|default:referente_usuario.username }}
-                                                {% if not forloop.last %},{% endif %}
-                                            {% empty %}
-                                                -
-                                            {% endfor %}
+                                <hr class="sisoc-section-divider" />
+                                {% if ubicaciones %}
+                                    <div class="sisoc-table-shell">
+                                        <div class="sisoc-table-wrap">
+                                            <table class="sisoc-table">
+                                                <thead>
+                                                    <tr>
+                                                        <th>Nombre</th>
+                                                        <th>Característica</th>
+                                                        <th>Localidad</th>
+                                                        <th>Domicilio</th>
+                                                        <th>Acciones</th>
+                                                    </tr>
+                                                </thead>
+                                                <tbody>
+                                                    {% for u in ubicaciones %}
+                                                        <tr>
+                                                            <td>{{ u.nombre_ubicacion|default:u.get_rol_ubicacion_display }}</td>
+                                                            <td>{{ u.get_rol_ubicacion_display }}</td>
+                                                            <td>{{ u.localidad|default:"-" }}</td>
+                                                            <td>{{ u.domicilio|default:"-" }}</td>
+                                                            <td>
+                                                                <div class="sisoc-table-actions">
+                                                                    {% if can_edit_centro and perms.VAT.change_institucionubicacion %}
+                                                                        <button type="button"
+                                                                                class="sisoc-btn sisoc-btn--edit"
+                                                                                onclick="editUbicacion({{ u.id }})">
+                                                                            <i class="fas fa-pen"></i>
+                                                                            <span>Editar</span>
+                                                                        </button>
+                                                                    {% endif %}
+                                                                    {% if can_edit_centro and perms.VAT.delete_institucionubicacion %}
+                                                                        <button type="button"
+                                                                                class="sisoc-btn sisoc-btn--delete"
+                                                                                onclick="deleteUbicacion({{ u.id }})">
+                                                                            <i class="fas fa-trash"></i>
+                                                                            <span>Borrar</span>
+                                                                        </button>
+                                                                    {% endif %}
+                                                                </div>
+                                                            </td>
+                                                        </tr>
+                                                    {% endfor %}
+                                                </tbody>
+                                            </table>
                                         </div>
                                     </div>
-                                </li>
-                                <li class="sisoc-referente-item">
-                                    <span class="sisoc-referente-icon"><i class="fas fa-id-card"></i></span>
-                                    <div class="sisoc-referente-copy">
-                                        <span>DNI</span>
-                                        <strong>
-                                            {% if primary_contacto and primary_contacto.documento %}
-                                                {{ primary_contacto.documento }}
-                                            {% else %}
-                                                -
-                                            {% endif %}
-                                        </strong>
+                                    <div class="sisoc-table-footer">
+                                        <span>Mostrando 1-{{ ubicaciones|length }} de {{ ubicaciones|length }}</span>
+                                        <div class="sisoc-pager" aria-hidden="true">
+                                            <button type="button">&lt;</button>
+                                            <span>1 de 1</span>
+                                            <button type="button">&gt;</button>
+                                        </div>
                                     </div>
-                                </li>
-                                <li class="sisoc-referente-item">
-                                    <span class="sisoc-referente-icon"><i class="fas fa-envelope"></i></span>
-                                    <div class="sisoc-referente-copy">
-                                        <span>Correo electrónico</span>
-                                        <strong>
-                                            {% if centro.correo_referente %}
-                                                {{ centro.correo_referente }}
-                                            {% elif primary_contacto and primary_contacto.email_contacto %}
-                                                {{ primary_contacto.email_contacto }}
-                                            {% else %}
-                                                -
-                                            {% endif %}
-                                        </strong>
-                                    </div>
-                                </li>
-                            </ul>
-                        </div>
-
-                    </section>
-
-                    <section class="sisoc-info-panel" data-sisoc-panel="ubicaciones">
-                        <div class="sisoc-panel-section">
-                            <div class="sisoc-section-header">
-                                <h2>Ubicaciones adicionales</h2>
-                                {% if can_edit_centro and perms.VAT.add_institucionubicacion %}
-                                    <button type="button"
-                                            class="sisoc-btn sisoc-btn--add"
-                                            data-bs-toggle="modal"
-                                            data-bs-target="#modalUbicacion">
-                                        <i class="fas fa-plus"></i>
-                                        <span>Agregar sede</span>
-                                    </button>
+                                {% else %}
+                                    <div class="sisoc-empty-state">No hay ubicaciones registradas para este centro.</div>
                                 {% endif %}
                             </div>
-                            <hr class="sisoc-section-divider" />
-                            {% if ubicaciones %}
-                                <div class="sisoc-table-shell">
-                                    <div class="sisoc-table-wrap">
-                                        <table class="sisoc-table">
-                                            <thead>
-                                                <tr>
-                                                    <th>Nombre</th>
-                                                    <th>Característica</th>
-                                                    <th>Localidad</th>
-                                                    <th>Domicilio</th>
-                                                    <th>Acciones</th>
-                                                </tr>
-                                            </thead>
-                                            <tbody>
-                                                {% for u in ubicaciones %}
-                                                    <tr>
-                                                        <td>{{ u.nombre_ubicacion|default:u.get_rol_ubicacion_display }}</td>
-                                                        <td>{{ u.get_rol_ubicacion_display }}</td>
-                                                        <td>{{ u.localidad|default:"-" }}</td>
-                                                        <td>{{ u.domicilio|default:"-" }}</td>
-                                                        <td>
-                                                            <div class="sisoc-table-actions">
-                                                                {% if can_edit_centro and perms.VAT.change_institucionubicacion %}
-                                                                    <button type="button"
-                                                                            class="sisoc-btn sisoc-btn--edit"
-                                                                            onclick="editUbicacion({{ u.id }})">
-                                                                        <i class="fas fa-pen"></i>
-                                                                        <span>Editar</span>
-                                                                    </button>
-                                                                {% endif %}
-                                                                {% if can_edit_centro and perms.VAT.delete_institucionubicacion %}
-                                                                    <button type="button"
-                                                                            class="sisoc-btn sisoc-btn--delete"
-                                                                            onclick="deleteUbicacion({{ u.id }})">
-                                                                        <i class="fas fa-trash"></i>
-                                                                        <span>Borrar</span>
-                                                                    </button>
-                                                                {% endif %}
-                                                            </div>
-                                                        </td>
-                                                    </tr>
-                                                {% endfor %}
-                                            </tbody>
-                                        </table>
-                                    </div>
-                                </div>
-                                <div class="sisoc-table-footer">
-                                    <span>Mostrando 1-{{ ubicaciones|length }} de {{ ubicaciones|length }}</span>
-                                    <div class="sisoc-pager" aria-hidden="true">
-                                        <button type="button">&lt;</button>
-                                        <span>1 de 1</span>
-                                        <button type="button">&gt;</button>
-                                    </div>
-                                </div>
-                            {% else %}
-                                <div class="sisoc-empty-state">No hay ubicaciones registradas para este centro.</div>
-                            {% endif %}
-                        </div>
-                    </section>
+                        </section>
 
-                    <section class="sisoc-info-panel" data-sisoc-panel="contactos">
-                        <div class="sisoc-panel-section">
-                            <div class="sisoc-section-header">
-                                <h2>Contactos adicionales</h2>
-                                {% if can_edit_centro and perms.VAT.add_institucioncontacto %}
-                                    <button type="button"
-                                            class="sisoc-btn sisoc-btn--add"
-                                            data-bs-toggle="modal"
-                                            data-bs-target="#modalContacto">
-                                        <i class="fas fa-plus"></i>
-                                        <span>Agregar contacto</span>
-                                    </button>
+                        <section class="sisoc-info-panel" data-sisoc-panel="contactos">
+                            <div class="sisoc-panel-section">
+                                <div class="sisoc-section-header">
+                                    <h2>Contactos adicionales</h2>
+                                    {% if can_edit_centro and perms.VAT.add_institucioncontacto %}
+                                        <button type="button"
+                                                class="sisoc-btn sisoc-btn--add"
+                                                data-bs-toggle="modal"
+                                                data-bs-target="#modalContacto">
+                                            <i class="fas fa-plus"></i>
+                                            <span>Agregar contacto</span>
+                                        </button>
+                                    {% endif %}
+                                </div>
+                                <hr class="sisoc-section-divider" />
+                                {% if contactos %}
+                                    <div class="sisoc-table-shell">
+                                        <div class="sisoc-table-wrap">
+                                            <table class="sisoc-table">
+                                                <thead>
+                                                    <tr>
+                                                        <th>Nombre y apellido</th>
+                                                        <th>Documento</th>
+                                                        <th>Rol</th>
+                                                        <th>Principal</th>
+                                                        <th>Teléfono</th>
+                                                        <th>Acciones</th>
+                                                    </tr>
+                                                </thead>
+                                                <tbody>
+                                                    {% for c in contactos %}
+                                                        <tr>
+                                                            <td>{{ c.nombre_contacto|default:"-" }}</td>
+                                                            <td>{{ c.documento|default:"-" }}</td>
+                                                            <td>{{ c.rol_area|default:"-" }}</td>
+                                                            <td>
+                                                                {% if c.es_principal %}
+                                                                    Sí
+                                                                {% else %}
+                                                                    No
+                                                                {% endif %}
+                                                            </td>
+                                                            <td>{{ c.telefono_contacto|default:"-" }}</td>
+                                                            <td>
+                                                                <div class="sisoc-table-actions">
+                                                                    {% if can_edit_centro and perms.VAT.change_institucioncontacto %}
+                                                                        <button type="button"
+                                                                                class="sisoc-btn sisoc-btn--edit"
+                                                                                onclick="editContacto({{ c.id }})">
+                                                                            <i class="fas fa-pen"></i>
+                                                                            <span>Editar</span>
+                                                                        </button>
+                                                                    {% endif %}
+                                                                    {% if can_edit_centro and perms.VAT.delete_institucioncontacto %}
+                                                                        <button type="button"
+                                                                                class="sisoc-btn sisoc-btn--delete"
+                                                                                onclick="deleteContacto({{ c.id }})">
+                                                                            <i class="fas fa-trash"></i>
+                                                                            <span>Borrar</span>
+                                                                        </button>
+                                                                    {% endif %}
+                                                                </div>
+                                                            </td>
+                                                        </tr>
+                                                    {% endfor %}
+                                                </tbody>
+                                            </table>
+                                        </div>
+                                    </div>
+                                {% else %}
+                                    <div class="sisoc-empty-state">No hay contactos adicionales cargados.</div>
                                 {% endif %}
                             </div>
-                            <hr class="sisoc-section-divider" />
-                            {% if contactos %}
-                                <div class="sisoc-table-shell">
-                                    <div class="sisoc-table-wrap">
-                                        <table class="sisoc-table">
-                                            <thead>
-                                                <tr>
-                                                    <th>Nombre y apellido</th>
-                                                    <th>Documento</th>
-                                                    <th>Rol</th>
-                                                    <th>Principal</th>
-                                                    <th>Teléfono</th>
-                                                    <th>Acciones</th>
-                                                </tr>
-                                            </thead>
-                                            <tbody>
-                                                {% for c in contactos %}
-                                                    <tr>
-                                                        <td>{{ c.nombre_contacto|default:"-" }}</td>
-                                                        <td>{{ c.documento|default:"-" }}</td>
-                                                        <td>{{ c.rol_area|default:"-" }}</td>
-                                                        <td>
-                                                            {% if c.es_principal %}
-                                                                Sí
-                                                            {% else %}
-                                                                No
-                                                            {% endif %}
-                                                        </td>
-                                                        <td>{{ c.telefono_contacto|default:"-" }}</td>
-                                                        <td>
-                                                            <div class="sisoc-table-actions">
-                                                                {% if can_edit_centro and perms.VAT.change_institucioncontacto %}
-                                                                    <button type="button"
-                                                                            class="sisoc-btn sisoc-btn--edit"
-                                                                            onclick="editContacto({{ c.id }})">
-                                                                        <i class="fas fa-pen"></i>
-                                                                        <span>Editar</span>
-                                                                    </button>
-                                                                {% endif %}
-                                                                {% if can_edit_centro and perms.VAT.delete_institucioncontacto %}
-                                                                    <button type="button"
-                                                                            class="sisoc-btn sisoc-btn--delete"
-                                                                            onclick="deleteContacto({{ c.id }})">
-                                                                        <i class="fas fa-trash"></i>
-                                                                        <span>Borrar</span>
-                                                                    </button>
-                                                                {% endif %}
-                                                            </div>
-                                                        </td>
-                                                    </tr>
-                                                {% endfor %}
-                                            </tbody>
-                                        </table>
-                                    </div>
-                                </div>
-                            {% else %}
-                                <div class="sisoc-empty-state">No hay contactos adicionales cargados.</div>
-                            {% endif %}
-                        </div>
-                    </section>
+                        </section>
+                    </div>
+
+                    <div class="sisoc-side-tabs sisoc-side-tabs--right"
+                         role="tablist"
+                         aria-label="Secciones pendientes">
+                        <button type="button"
+                                class="sisoc-side-tab"
+                                data-sisoc-tab-target="general"
+                                aria-selected="false"
+                                hidden>
+                            <span>Información general</span>
+                        </button>
+                        <button type="button"
+                                class="sisoc-side-tab"
+                                data-sisoc-tab-target="ubicaciones"
+                                aria-selected="false">
+                            <span>Ubicaciones adicionales</span>
+                        </button>
+                        <button type="button"
+                                class="sisoc-side-tab"
+                                data-sisoc-tab-target="contactos"
+                                aria-selected="false">
+                            <span>Contactos adicionales</span>
+                        </button>
+                    </div>
                 </div>
+            </div>
+        {% endwith %}
 
-                <div class="sisoc-side-tabs sisoc-side-tabs--right"
-                     role="tablist"
-                     aria-label="Secciones pendientes">
-                    <button type="button"
-                            class="sisoc-side-tab"
-                            data-sisoc-tab-target="general"
-                            aria-selected="false"
-                            hidden>
-                        <span>Información general</span>
-                    </button>
-                    <button type="button"
-                            class="sisoc-side-tab"
-                            data-sisoc-tab-target="ubicaciones"
-                            aria-selected="false">
-                        <span>Ubicaciones adicionales</span>
-                    </button>
-                    <button type="button"
-                            class="sisoc-side-tab"
-                            data-sisoc-tab-target="contactos"
-                            aria-selected="false">
-                        <span>Contactos adicionales</span>
-                    </button>
+        <div class="sisoc-cursos-pane"
+             id="cursos"
+             data-cursos-panel-url="{{ cursos_panel_url }}">
+            <div id="centroCursosPanelContainer" data-panel-loaded="0">
+                <div class="sisoc-section-card">
+                    <div class="sisoc-empty-state">
+                        <div class="spinner-border spinner-border-sm text-light mb-3"
+                             role="status"
+                             aria-hidden="true"></div>
+                        <p class="mb-0">Cargando oferta educativa y comisiones...</p>
+                    </div>
                 </div>
             </div>
         </div>
-    {% endwith %}
-
-    <div class="sisoc-cursos-pane"
-         id="cursos"
-         data-cursos-panel-url="{{ cursos_panel_url }}">
-        <div id="centroCursosPanelContainer" data-panel-loaded="0">
-            <div class="sisoc-section-card">
-                <div class="sisoc-empty-state">
-                    <div class="spinner-border spinner-border-sm text-light mb-3"
-                         role="status"
-                         aria-hidden="true"></div>
-                    <p class="mb-0">Cargando oferta educativa y comisiones...</p>
-                </div>
-            </div>
-        </div>
-    </div>
     </div>
 
     {% if can_edit_centro %}

--- a/VAT/templates/vat/centros/partials/centro_cursos_panel.html
+++ b/VAT/templates/vat/centros/partials/centro_cursos_panel.html
@@ -121,7 +121,9 @@
                 </div>
                 <div class="sisoc-table-footer">
                     <span id="cursosFilterSummary">Mostrando 1-{{ cursos|length }} de {{ cursos|length }}</span>
-                    <div id="cursosPagination" class="sisoc-page-buttons" aria-label="Paginación de cursos"></div>
+                    <div id="cursosPagination"
+                         class="sisoc-page-buttons"
+                         aria-label="Paginación de cursos"></div>
                 </div>
             {% else %}
                 <div class="sisoc-empty-state">Sin cursos registrados para este centro.</div>

--- a/VAT/templates/vat/comision_curso_wizard/step1_info.html
+++ b/VAT/templates/vat/comision_curso_wizard/step1_info.html
@@ -74,13 +74,17 @@
                         <label class="sisoc-wizard-check-text"
                                for="{{ form.acepta_lista_espera.id_for_label }}">Acepta lista de espera</label>
                     </div>
-                    {% if form.acepta_lista_espera.errors %}<div class="text-danger">{{ form.acepta_lista_espera.errors.0 }}</div>{% endif %}
+                    {% if form.acepta_lista_espera.errors %}
+                        <div class="text-danger">{{ form.acepta_lista_espera.errors.0 }}</div>
+                    {% endif %}
                 </div>
                 <div class="sisoc-wizard-field"
                      id="wizard-cupo-espera-wrapper"
                      {% if not form.acepta_lista_espera.value %}hidden{% endif %}>
                     <label class="sisoc-wizard-label"
-                           for="{{ form.cupo_lista_espera.id_for_label }}">Cantidad que acepta la lista de espera</label>
+                           for="{{ form.cupo_lista_espera.id_for_label }}">
+                        Cantidad que acepta la lista de espera
+                    </label>
                     {{ form.cupo_lista_espera }}
                     {% if form.cupo_lista_espera.errors %}<div class="text-danger">{{ form.cupo_lista_espera.errors.0 }}</div>{% endif %}
                 </div>

--- a/VAT/templates/vat/institucion/contacto_form.html
+++ b/VAT/templates/vat/institucion/contacto_form.html
@@ -18,7 +18,11 @@
         </a>
         <div class="vp-hero">
             <h1>
-                {% if form.instance.id %}Editar Contacto{% else %}Nuevo Contacto{% endif %}
+                {% if form.instance.id %}
+                    Editar Contacto
+                {% else %}
+                    Nuevo Contacto
+                {% endif %}
             </h1>
         </div>
 

--- a/VAT/templates/vat/institucion/contacto_list.html
+++ b/VAT/templates/vat/institucion/contacto_list.html
@@ -8,88 +8,88 @@
     <link rel="stylesheet" href="{% static 'custom/css/vat_design.css' %}" />
 
     <div class="vat-ui">
-    {% url 'vat_institucion_contacto_list' as reset_url %}
-    {% include 'components/search_bar.html' with titulo="Buscar Contacto" placeholder="Buscar por centro, tipo o valor" help_text="Buscar por centro, tipo o valor" reset_url=reset_url add_url='vat_institucion_contacto_create' add_text='Agregar' query=request.GET.busqueda %}
+        {% url 'vat_institucion_contacto_list' as reset_url %}
+        {% include 'components/search_bar.html' with titulo="Buscar Contacto" placeholder="Buscar por centro, tipo o valor" help_text="Buscar por centro, tipo o valor" reset_url=reset_url add_url='vat_institucion_contacto_create' add_text='Agregar' query=request.GET.busqueda %}
 
-    <div class="row mt-5 max-width-100">
-        <div class="col-12">
-            <div class="card">
-                <div class="card-body">
-                    <div class="table-responsive-lg">
-                        <table class="table table-bordered table-striped projects">
-                            <thead>
-                                <tr>
-                                    <th class="sortable" data-column="centro">
-                                        Centro
-                                        <i class="fas fa-sort sort-icon"></i>
-                                    </th>
-                                    <th>Tipo</th>
-                                    <th>Valor</th>
-                                    <th>Principal</th>
-                                    <th class="notexport">Acciones</th>
-                                </tr>
-                            </thead>
-                            <tbody>
-                                {% for contacto in contactos %}
+        <div class="row mt-5 max-width-100">
+            <div class="col-12">
+                <div class="card">
+                    <div class="card-body">
+                        <div class="table-responsive-lg">
+                            <table class="table table-bordered table-striped projects">
+                                <thead>
                                     <tr>
-                                        <td data-centro="{{ contacto.centro.nombre }}">{{ contacto.centro.nombre }}</td>
-                                        <td>{{ contacto.get_tipo_display }}</td>
-                                        <td>{{ contacto.valor }}</td>
-                                        <td>
-                                            {% if contacto.es_principal %}
-                                                <span class="badge-validacion validado">
-                                                    <i class="fas fa-check-circle"></i> Sí
-                                                </span>
-                                            {% else %}
-                                                <span class="badge-validacion pendiente">No</span>
-                                            {% endif %}
-                                        </td>
-                                        <td>
-                                            <div class="action-buttons" role="group">
-                                                <a href="{% url 'vat_institucion_contacto_detail' contacto.id %}"
-                                                   class="btn btn-primary link-handler"
-                                                   title="Ver detalle">
-                                                    <i class="fas fa-eye"></i>
-                                                    Ver
-                                                </a>
-                                                {% if perms.VAT.change_institucioncontacto %}
-                                                    <a href="{% url 'vat_institucion_contacto_update' contacto.id %}"
-                                                       class="btn btn-editar link-handler"
-                                                       title="Editar contacto">
-                                                        <i class="fas fa-edit"></i>
-                                                        Editar
-                                                    </a>
-                                                {% endif %}
-                                                {% if perms.VAT.delete_institucioncontacto %}
-                                                    <a href="{% url 'vat_institucion_contacto_delete' contacto.id %}"
-                                                       class="btn btn-eliminar link-handler"
-                                                       title="Eliminar contacto">
-                                                        <i class="fas fa-trash-alt"></i>
-                                                        Eliminar
-                                                    </a>
-                                                {% endif %}
-                                            </div>
-                                        </td>
+                                        <th class="sortable" data-column="centro">
+                                            Centro
+                                            <i class="fas fa-sort sort-icon"></i>
+                                        </th>
+                                        <th>Tipo</th>
+                                        <th>Valor</th>
+                                        <th>Principal</th>
+                                        <th class="notexport">Acciones</th>
                                     </tr>
-                                {% empty %}
-                                    <tr>
-                                        <td colspan="5">
-                                            <div class="no-comedores-message">
-                                                <h3>No se encontraron contactos</h3>
-                                                <p>No hay contactos registrados.</p>
-                                            </div>
-                                        </td>
-                                    </tr>
-                                {% endfor %}
-                            </tbody>
-                        </table>
+                                </thead>
+                                <tbody>
+                                    {% for contacto in contactos %}
+                                        <tr>
+                                            <td data-centro="{{ contacto.centro.nombre }}">{{ contacto.centro.nombre }}</td>
+                                            <td>{{ contacto.get_tipo_display }}</td>
+                                            <td>{{ contacto.valor }}</td>
+                                            <td>
+                                                {% if contacto.es_principal %}
+                                                    <span class="badge-validacion validado">
+                                                        <i class="fas fa-check-circle"></i> Sí
+                                                    </span>
+                                                {% else %}
+                                                    <span class="badge-validacion pendiente">No</span>
+                                                {% endif %}
+                                            </td>
+                                            <td>
+                                                <div class="action-buttons" role="group">
+                                                    <a href="{% url 'vat_institucion_contacto_detail' contacto.id %}"
+                                                       class="btn btn-primary link-handler"
+                                                       title="Ver detalle">
+                                                        <i class="fas fa-eye"></i>
+                                                        Ver
+                                                    </a>
+                                                    {% if perms.VAT.change_institucioncontacto %}
+                                                        <a href="{% url 'vat_institucion_contacto_update' contacto.id %}"
+                                                           class="btn btn-editar link-handler"
+                                                           title="Editar contacto">
+                                                            <i class="fas fa-edit"></i>
+                                                            Editar
+                                                        </a>
+                                                    {% endif %}
+                                                    {% if perms.VAT.delete_institucioncontacto %}
+                                                        <a href="{% url 'vat_institucion_contacto_delete' contacto.id %}"
+                                                           class="btn btn-eliminar link-handler"
+                                                           title="Eliminar contacto">
+                                                            <i class="fas fa-trash-alt"></i>
+                                                            Eliminar
+                                                        </a>
+                                                    {% endif %}
+                                                </div>
+                                            </td>
+                                        </tr>
+                                    {% empty %}
+                                        <tr>
+                                            <td colspan="5">
+                                                <div class="no-comedores-message">
+                                                    <h3>No se encontraron contactos</h3>
+                                                    <p>No hay contactos registrados.</p>
+                                                </div>
+                                            </td>
+                                        </tr>
+                                    {% endfor %}
+                                </tbody>
+                            </table>
+                        </div>
                     </div>
                 </div>
             </div>
         </div>
-    </div>
 
-    {% include 'components/pagination.html' with is_paginated=is_paginated page_obj=page_obj prev_text='Volver' next_text='Continuar' %}
+        {% include 'components/pagination.html' with is_paginated=is_paginated page_obj=page_obj prev_text='Volver' next_text='Continuar' %}
     </div>
 
 {% endblock %}

--- a/VAT/templates/vat/institucion/identificador_form.html
+++ b/VAT/templates/vat/institucion/identificador_form.html
@@ -13,12 +13,17 @@
 {% block content %}
     <link rel="stylesheet" href="{% static 'custom/css/vat_design.css' %}" />
     <div class="vat-ui container-fluid py-4">
-        <a href="{% url 'vat_institucion_identificador_list' %}" class="vat-back">
+        <a href="{% url 'vat_institucion_identificador_list' %}"
+           class="vat-back">
             <i class="bi bi-arrow-left"></i> Volver
         </a>
         <div class="vp-hero">
             <h1>
-                {% if form.instance.id %}Editar Identificador{% else %}Nuevo Identificador{% endif %}
+                {% if form.instance.id %}
+                    Editar Identificador
+                {% else %}
+                    Nuevo Identificador
+                {% endif %}
             </h1>
         </div>
 

--- a/VAT/templates/vat/institucion/identificador_list.html
+++ b/VAT/templates/vat/institucion/identificador_list.html
@@ -8,92 +8,92 @@
     <link rel="stylesheet" href="{% static 'custom/css/vat_design.css' %}" />
 
     <div class="vat-ui">
-    {% url 'vat_institucion_identificador_list' as reset_url %}
-    {% include 'components/search_bar.html' with titulo="Buscar Identificador" placeholder="Buscar por centro, tipo o valor" help_text="Buscar por centro, tipo o valor" reset_url=reset_url add_url='vat_institucion_identificador_create' add_text='Agregar' query=request.GET.busqueda %}
+        {% url 'vat_institucion_identificador_list' as reset_url %}
+        {% include 'components/search_bar.html' with titulo="Buscar Identificador" placeholder="Buscar por centro, tipo o valor" help_text="Buscar por centro, tipo o valor" reset_url=reset_url add_url='vat_institucion_identificador_create' add_text='Agregar' query=request.GET.busqueda %}
 
-    <div class="row mt-5 max-width-100">
-        <div class="col-12">
-            <div class="card">
-                <div class="card-body">
-                    <div class="table-responsive-lg">
-                        <table class="table table-bordered table-striped projects">
-                            <thead>
-                                <tr>
-                                    <th class="sortable" data-column="centro">
-                                        Centro
-                                        <i class="fas fa-sort sort-icon"></i>
-                                    </th>
-                                    <th>Tipo</th>
-                                    <th>Valor</th>
-                                    <th>Rol</th>
-                                    <th>Actual</th>
-                                    <th class="notexport">Acciones</th>
-                                </tr>
-                            </thead>
-                            <tbody>
-                                {% for identificador in identificadores %}
+        <div class="row mt-5 max-width-100">
+            <div class="col-12">
+                <div class="card">
+                    <div class="card-body">
+                        <div class="table-responsive-lg">
+                            <table class="table table-bordered table-striped projects">
+                                <thead>
                                     <tr>
-                                        <td data-centro="{{ identificador.centro.nombre }}">{{ identificador.centro.nombre }}</td>
-                                        <td>{{ identificador.get_tipo_identificador_display }}</td>
-                                        <td>{{ identificador.valor_identificador }}</td>
-                                        <td>{{ identificador.get_rol_institucional_display|default:"—" }}</td>
-                                        <td>
-                                            {% if identificador.es_actual %}
-                                                <span class="badge-validacion validado">
-                                                    <i class="fas fa-check-circle"></i> Sí
-                                                </span>
-                                            {% else %}
-                                                <span class="badge-validacion no-validado">
-                                                    <i class="fas fa-times-circle"></i> No
-                                                </span>
-                                            {% endif %}
-                                        </td>
-                                        <td>
-                                            <div class="action-buttons" role="group">
-                                                <a href="{% url 'vat_institucion_identificador_detail' identificador.id %}"
-                                                   class="btn btn-primary link-handler"
-                                                   title="Ver detalle">
-                                                    <i class="fas fa-eye"></i>
-                                                    Ver
-                                                </a>
-                                                {% if perms.VAT.change_institucionidentificadorhist %}
-                                                    <a href="{% url 'vat_institucion_identificador_update' identificador.id %}"
-                                                       class="btn btn-editar link-handler"
-                                                       title="Editar identificador">
-                                                        <i class="fas fa-edit"></i>
-                                                        Editar
-                                                    </a>
-                                                {% endif %}
-                                                {% if perms.VAT.delete_institucionidentificadorhist %}
-                                                    <a href="{% url 'vat_institucion_identificador_delete' identificador.id %}"
-                                                       class="btn btn-eliminar link-handler"
-                                                       title="Eliminar identificador">
-                                                        <i class="fas fa-trash-alt"></i>
-                                                        Eliminar
-                                                    </a>
-                                                {% endif %}
-                                            </div>
-                                        </td>
+                                        <th class="sortable" data-column="centro">
+                                            Centro
+                                            <i class="fas fa-sort sort-icon"></i>
+                                        </th>
+                                        <th>Tipo</th>
+                                        <th>Valor</th>
+                                        <th>Rol</th>
+                                        <th>Actual</th>
+                                        <th class="notexport">Acciones</th>
                                     </tr>
-                                {% empty %}
-                                    <tr>
-                                        <td colspan="6">
-                                            <div class="no-comedores-message">
-                                                <h3>No se encontraron identificadores</h3>
-                                                <p>No hay identificadores registrados.</p>
-                                            </div>
-                                        </td>
-                                    </tr>
-                                {% endfor %}
-                            </tbody>
-                        </table>
+                                </thead>
+                                <tbody>
+                                    {% for identificador in identificadores %}
+                                        <tr>
+                                            <td data-centro="{{ identificador.centro.nombre }}">{{ identificador.centro.nombre }}</td>
+                                            <td>{{ identificador.get_tipo_identificador_display }}</td>
+                                            <td>{{ identificador.valor_identificador }}</td>
+                                            <td>{{ identificador.get_rol_institucional_display|default:"—" }}</td>
+                                            <td>
+                                                {% if identificador.es_actual %}
+                                                    <span class="badge-validacion validado">
+                                                        <i class="fas fa-check-circle"></i> Sí
+                                                    </span>
+                                                {% else %}
+                                                    <span class="badge-validacion no-validado">
+                                                        <i class="fas fa-times-circle"></i> No
+                                                    </span>
+                                                {% endif %}
+                                            </td>
+                                            <td>
+                                                <div class="action-buttons" role="group">
+                                                    <a href="{% url 'vat_institucion_identificador_detail' identificador.id %}"
+                                                       class="btn btn-primary link-handler"
+                                                       title="Ver detalle">
+                                                        <i class="fas fa-eye"></i>
+                                                        Ver
+                                                    </a>
+                                                    {% if perms.VAT.change_institucionidentificadorhist %}
+                                                        <a href="{% url 'vat_institucion_identificador_update' identificador.id %}"
+                                                           class="btn btn-editar link-handler"
+                                                           title="Editar identificador">
+                                                            <i class="fas fa-edit"></i>
+                                                            Editar
+                                                        </a>
+                                                    {% endif %}
+                                                    {% if perms.VAT.delete_institucionidentificadorhist %}
+                                                        <a href="{% url 'vat_institucion_identificador_delete' identificador.id %}"
+                                                           class="btn btn-eliminar link-handler"
+                                                           title="Eliminar identificador">
+                                                            <i class="fas fa-trash-alt"></i>
+                                                            Eliminar
+                                                        </a>
+                                                    {% endif %}
+                                                </div>
+                                            </td>
+                                        </tr>
+                                    {% empty %}
+                                        <tr>
+                                            <td colspan="6">
+                                                <div class="no-comedores-message">
+                                                    <h3>No se encontraron identificadores</h3>
+                                                    <p>No hay identificadores registrados.</p>
+                                                </div>
+                                            </td>
+                                        </tr>
+                                    {% endfor %}
+                                </tbody>
+                            </table>
+                        </div>
                     </div>
                 </div>
             </div>
         </div>
-    </div>
 
-    {% include 'components/pagination.html' with is_paginated=is_paginated page_obj=page_obj prev_text='Volver' next_text='Continuar' %}
+        {% include 'components/pagination.html' with is_paginated=is_paginated page_obj=page_obj prev_text='Volver' next_text='Continuar' %}
     </div>
 
 {% endblock %}

--- a/VAT/templates/vat/institucion/ubicacion_form.html
+++ b/VAT/templates/vat/institucion/ubicacion_form.html
@@ -17,7 +17,11 @@
            class="vat-back"><i class="bi bi-arrow-left"></i> Volver</a>
         <div class="vp-hero">
             <h1>
-                {% if form.instance.id %}Editar Ubicación{% else %}Nueva Ubicación{% endif %}
+                {% if form.instance.id %}
+                    Editar Ubicación
+                {% else %}
+                    Nueva Ubicación
+                {% endif %}
             </h1>
         </div>
 

--- a/VAT/templates/vat/institucion/ubicacion_list.html
+++ b/VAT/templates/vat/institucion/ubicacion_list.html
@@ -8,90 +8,90 @@
     <link rel="stylesheet" href="{% static 'custom/css/vat_design.css' %}" />
 
     <div class="vat-ui">
-    {% url 'vat_institucion_ubicacion_list' as reset_url %}
-    {% include 'components/search_bar.html' with titulo="Buscar Ubicación" placeholder="Buscar por centro, localidad o domicilio" help_text="Buscar por centro, localidad o domicilio" reset_url=reset_url add_url='vat_institucion_ubicacion_create' add_text='Agregar' query=request.GET.busqueda %}
+        {% url 'vat_institucion_ubicacion_list' as reset_url %}
+        {% include 'components/search_bar.html' with titulo="Buscar Ubicación" placeholder="Buscar por centro, localidad o domicilio" help_text="Buscar por centro, localidad o domicilio" reset_url=reset_url add_url='vat_institucion_ubicacion_create' add_text='Agregar' query=request.GET.busqueda %}
 
-    <div class="row mt-5 max-width-100">
-        <div class="col-12">
-            <div class="card">
-                <div class="card-body">
-                    <div class="table-responsive-lg">
-                        <table class="table table-bordered table-striped projects">
-                            <thead>
-                                <tr>
-                                    <th class="sortable" data-column="centro">
-                                        Centro
-                                        <i class="fas fa-sort sort-icon"></i>
-                                    </th>
-                                    <th>Localidad</th>
-                                    <th>Rol</th>
-                                    <th>Domicilio</th>
-                                    <th>Principal</th>
-                                    <th class="notexport">Acciones</th>
-                                </tr>
-                            </thead>
-                            <tbody>
-                                {% for ubicacion in ubicaciones %}
+        <div class="row mt-5 max-width-100">
+            <div class="col-12">
+                <div class="card">
+                    <div class="card-body">
+                        <div class="table-responsive-lg">
+                            <table class="table table-bordered table-striped projects">
+                                <thead>
                                     <tr>
-                                        <td data-centro="{{ ubicacion.centro.nombre }}">{{ ubicacion.centro.nombre }}</td>
-                                        <td>{{ ubicacion.localidad }}</td>
-                                        <td>{{ ubicacion.get_rol_ubicacion_display }}</td>
-                                        <td>{{ ubicacion.domicilio|default:"—"|truncatechars:40 }}</td>
-                                        <td>
-                                            {% if ubicacion.es_principal %}
-                                                <span class="badge-validacion validado">
-                                                    <i class="fas fa-check-circle"></i> Sí
-                                                </span>
-                                            {% else %}
-                                                <span class="badge-validacion pendiente">No</span>
-                                            {% endif %}
-                                        </td>
-                                        <td>
-                                            <div class="action-buttons" role="group">
-                                                <a href="{% url 'vat_institucion_ubicacion_detail' ubicacion.id %}"
-                                                   class="btn btn-primary link-handler"
-                                                   title="Ver detalle">
-                                                    <i class="fas fa-eye"></i>
-                                                    Ver
-                                                </a>
-                                                {% if perms.VAT.change_institucionubicacion %}
-                                                    <a href="{% url 'vat_institucion_ubicacion_update' ubicacion.id %}"
-                                                       class="btn btn-editar link-handler"
-                                                       title="Editar ubicación">
-                                                        <i class="fas fa-edit"></i>
-                                                        Editar
-                                                    </a>
-                                                {% endif %}
-                                                {% if perms.VAT.delete_institucionubicacion %}
-                                                    <a href="{% url 'vat_institucion_ubicacion_delete' ubicacion.id %}"
-                                                       class="btn btn-eliminar link-handler"
-                                                       title="Eliminar ubicación">
-                                                        <i class="fas fa-trash-alt"></i>
-                                                        Eliminar
-                                                    </a>
-                                                {% endif %}
-                                            </div>
-                                        </td>
+                                        <th class="sortable" data-column="centro">
+                                            Centro
+                                            <i class="fas fa-sort sort-icon"></i>
+                                        </th>
+                                        <th>Localidad</th>
+                                        <th>Rol</th>
+                                        <th>Domicilio</th>
+                                        <th>Principal</th>
+                                        <th class="notexport">Acciones</th>
                                     </tr>
-                                {% empty %}
-                                    <tr>
-                                        <td colspan="6">
-                                            <div class="no-comedores-message">
-                                                <h3>No se encontraron ubicaciones</h3>
-                                                <p>No hay ubicaciones registradas.</p>
-                                            </div>
-                                        </td>
-                                    </tr>
-                                {% endfor %}
-                            </tbody>
-                        </table>
+                                </thead>
+                                <tbody>
+                                    {% for ubicacion in ubicaciones %}
+                                        <tr>
+                                            <td data-centro="{{ ubicacion.centro.nombre }}">{{ ubicacion.centro.nombre }}</td>
+                                            <td>{{ ubicacion.localidad }}</td>
+                                            <td>{{ ubicacion.get_rol_ubicacion_display }}</td>
+                                            <td>{{ ubicacion.domicilio|default:"—"|truncatechars:40 }}</td>
+                                            <td>
+                                                {% if ubicacion.es_principal %}
+                                                    <span class="badge-validacion validado">
+                                                        <i class="fas fa-check-circle"></i> Sí
+                                                    </span>
+                                                {% else %}
+                                                    <span class="badge-validacion pendiente">No</span>
+                                                {% endif %}
+                                            </td>
+                                            <td>
+                                                <div class="action-buttons" role="group">
+                                                    <a href="{% url 'vat_institucion_ubicacion_detail' ubicacion.id %}"
+                                                       class="btn btn-primary link-handler"
+                                                       title="Ver detalle">
+                                                        <i class="fas fa-eye"></i>
+                                                        Ver
+                                                    </a>
+                                                    {% if perms.VAT.change_institucionubicacion %}
+                                                        <a href="{% url 'vat_institucion_ubicacion_update' ubicacion.id %}"
+                                                           class="btn btn-editar link-handler"
+                                                           title="Editar ubicación">
+                                                            <i class="fas fa-edit"></i>
+                                                            Editar
+                                                        </a>
+                                                    {% endif %}
+                                                    {% if perms.VAT.delete_institucionubicacion %}
+                                                        <a href="{% url 'vat_institucion_ubicacion_delete' ubicacion.id %}"
+                                                           class="btn btn-eliminar link-handler"
+                                                           title="Eliminar ubicación">
+                                                            <i class="fas fa-trash-alt"></i>
+                                                            Eliminar
+                                                        </a>
+                                                    {% endif %}
+                                                </div>
+                                            </td>
+                                        </tr>
+                                    {% empty %}
+                                        <tr>
+                                            <td colspan="6">
+                                                <div class="no-comedores-message">
+                                                    <h3>No se encontraron ubicaciones</h3>
+                                                    <p>No hay ubicaciones registradas.</p>
+                                                </div>
+                                            </td>
+                                        </tr>
+                                    {% endfor %}
+                                </tbody>
+                            </table>
+                        </div>
                     </div>
                 </div>
             </div>
         </div>
-    </div>
 
-    {% include 'components/pagination.html' with is_paginated=is_paginated page_obj=page_obj prev_text='Volver' next_text='Continuar' %}
+        {% include 'components/pagination.html' with is_paginated=is_paginated page_obj=page_obj prev_text='Volver' next_text='Continuar' %}
     </div>
 
 {% endblock %}

--- a/VAT/templates/vat/oferta_institucional/asistencia_sesion.html
+++ b/VAT/templates/vat/oferta_institucional/asistencia_sesion.html
@@ -429,13 +429,17 @@
                                     <th>Nombre</th>
                                     <th class="asis-col-check">
                                         <label class="asis-mark asis-mark-all">
-                                            <input type="checkbox" class="asis-check asis-check--present" id="asisMarcarPresentes" />
+                                            <input type="checkbox"
+                                                   class="asis-check asis-check--present"
+                                                   id="asisMarcarPresentes" />
                                             Marcar todos
                                         </label>
                                     </th>
                                     <th class="asis-col-check">
                                         <label class="asis-mark asis-mark-all">
-                                            <input type="checkbox" class="asis-check asis-check--absent" id="asisMarcarAusentes" />
+                                            <input type="checkbox"
+                                                   class="asis-check asis-check--absent"
+                                                   id="asisMarcarAusentes" />
                                             Marcar todos
                                         </label>
                                     </th>
@@ -447,7 +451,9 @@
                                         <td>{{ fila.inscripcion.ciudadano.apellido|default:"—" }}</td>
                                         <td>{{ fila.inscripcion.ciudadano.nombre|default:"—" }}</td>
                                         <td>
-                                            <input type="hidden" name="obs_{{ fila.inscripcion.pk }}" value="{{ fila.observaciones|default:'' }}" />
+                                            <input type="hidden"
+                                                   name="obs_{{ fila.inscripcion.pk }}"
+                                                   value="{{ fila.observaciones|default:'' }}" />
                                             <label class="asis-mark">
                                                 <input type="radio"
                                                        class="asis-check asis-check--present asis-present"
@@ -473,9 +479,7 @@
                         </table>
                     </div>
                     <div class="asis-foot">
-                        <span id="asisConteo">
-                            Mostrando {{ filas|length|yesno:"1,0" }}-{{ filas|length }} de {{ filas|length }}
-                        </span>
+                        <span id="asisConteo">Mostrando {{ filas|length|yesno:"1,0" }}-{{ filas|length }} de {{ filas|length }}</span>
                         <div class="asis-pager">
                             <button type="button"
                                     class="asis-pager-prev"

--- a/VAT/templates/vat/oferta_institucional/comision_detail.html
+++ b/VAT/templates/vat/oferta_institucional/comision_detail.html
@@ -1048,39 +1048,31 @@
             </div>
         </div>
 
-        <div class="sisoc-tabs-rail" role="tablist" aria-label="Secciones de la comisión">
+        <div class="sisoc-tabs-rail"
+             role="tablist"
+             aria-label="Secciones de la comisión">
             <button type="button"
                     class="sisoc-tab-chip is-active"
                     data-sisoc-tab-target="general"
-                    aria-selected="true">
-                Información
-            </button>
+                    aria-selected="true">Información</button>
             <button type="button"
                     class="sisoc-tab-chip"
                     data-sisoc-tab-target="inscriptos"
-                    aria-selected="false">
-                Inscriptos
-            </button>
+                    aria-selected="false">Inscriptos</button>
             {% if comision.acepta_lista_espera or lista_espera %}
                 <button type="button"
                         class="sisoc-tab-chip"
                         data-sisoc-tab-target="espera"
-                        aria-selected="false">
-                    Lista de espera
-                </button>
+                        aria-selected="false">Lista de espera</button>
             {% endif %}
             <button type="button"
                     class="sisoc-tab-chip"
                     data-sisoc-tab-target="sesiones"
-                    aria-selected="false">
-                Clases
-            </button>
+                    aria-selected="false">Clases</button>
             <button type="button"
                     class="sisoc-tab-chip"
                     data-sisoc-tab-target="horarios"
-                    aria-selected="false">
-                Horarios
-            </button>
+                    aria-selected="false">Horarios</button>
         </div>
 
         <div class="sisoc-metric-grid" id="sisocMetricGridGlobal">
@@ -1255,8 +1247,7 @@
                                 </a>
                             {% endif %}
                             {% if export_inscriptos_url %}
-                                <a href="{{ export_inscriptos_url }}"
-                                   class="sisoc-btn sisoc-btn--ghost">
+                                <a href="{{ export_inscriptos_url }}" class="sisoc-btn sisoc-btn--ghost">
                                     <i class="bi bi-file-earmark-excel"></i><span>Descargar inscriptos</span>
                                 </a>
                             {% endif %}
@@ -1271,9 +1262,7 @@
                                         <th>Email</th>
                                         <th>Teléfono</th>
                                         <th>Asistencia</th>
-                                        {% if puede_cambiar_inscripcion or puede_eliminar_inscripcion %}
-                                            <th class="ci-tbl-col-actions">&nbsp;</th>
-                                        {% endif %}
+                                        {% if puede_cambiar_inscripcion or puede_eliminar_inscripcion %}<th class="ci-tbl-col-actions">&nbsp;</th>{% endif %}
                                     </tr>
                                 </thead>
                                 <tbody id="inscriptosTablaBody">
@@ -1374,9 +1363,7 @@
                                             <th>Documento</th>
                                             <th>Fecha</th>
                                             <th>Estado</th>
-                                            {% if puede_cambiar_inscripcion %}
-                                                <th class="ci-tbl-col-actions">Acciones</th>
-                                            {% endif %}
+                                            {% if puede_cambiar_inscripcion %}<th class="ci-tbl-col-actions">Acciones</th>{% endif %}
                                         </tr>
                                     </thead>
                                     <tbody id="esperaTablaBody">
@@ -1388,7 +1375,9 @@
                                                 <td>{{ insc.ciudadano.nombre|default:"—" }}</td>
                                                 <td>{{ insc.ciudadano.documento|default:"—" }}</td>
                                                 <td>{{ insc.fecha_inscripcion|date:"d/m/Y" }}</td>
-                                                <td><span class="ci-pill ci-pill-yellow">{{ insc.get_estado_display }}</span></td>
+                                                <td>
+                                                    <span class="ci-pill ci-pill-yellow">{{ insc.get_estado_display }}</span>
+                                                </td>
                                                 {% if puede_cambiar_inscripcion %}
                                                     <td>
                                                         <div class="ci-tbl-actions">
@@ -1487,9 +1476,7 @@
                                         <th>Estado</th>
                                         <th>Presentes</th>
                                         <th>Ausentes</th>
-                                        {% if puede_gestionar_asistencia %}
-                                            <th class="ci-tbl-col-actions">Acciones</th>
-                                        {% endif %}
+                                        {% if puede_gestionar_asistencia %}<th class="ci-tbl-col-actions">Acciones</th>{% endif %}
                                     </tr>
                                 </thead>
                                 <tbody id="sesionesTablaBody">
@@ -1509,8 +1496,20 @@
                                                     <span class="ci-pill ci-pill-gray"><i class="bi bi-circle me-1"></i>Pendiente</span>
                                                 {% endif %}
                                             </td>
-                                            <td>{% if sesion.estado == 'realizada' %}{{ sesion.presentes }}{% else %}—{% endif %}</td>
-                                            <td>{% if sesion.estado == 'realizada' %}{{ sesion.ausentes }}{% else %}—{% endif %}</td>
+                                            <td>
+                                                {% if sesion.estado == 'realizada' %}
+                                                    {{ sesion.presentes }}
+                                                {% else %}
+                                                    —
+                                                {% endif %}
+                                            </td>
+                                            <td>
+                                                {% if sesion.estado == 'realizada' %}
+                                                    {{ sesion.ausentes }}
+                                                {% else %}
+                                                    —
+                                                {% endif %}
+                                            </td>
                                             {% if puede_gestionar_asistencia %}
                                                 <td>
                                                     <div class="ci-tbl-actions">
@@ -1605,7 +1604,11 @@
                                             <td>{{ horario.aula_espacio|default:"—" }}</td>
                                             <td>
                                                 <span class="ci-pill {% if horario.vigente %}ci-pill-green{% else %}ci-pill-gray{% endif %}">
-                                                    {% if horario.vigente %}Vigente{% else %}Inactivo{% endif %}
+                                                    {% if horario.vigente %}
+                                                        Vigente
+                                                    {% else %}
+                                                        Inactivo
+                                                    {% endif %}
                                                 </span>
                                             </td>
                                             {% if puede_editar_comision_horario or puede_eliminar_comision_horario %}

--- a/VAT/templates/vat/oferta_institucional/comision_form.html
+++ b/VAT/templates/vat/oferta_institucional/comision_form.html
@@ -140,7 +140,8 @@
                     </div>
                     <div class="ci-form">
                         {% if inet_provincia_restricted_fields and form.instance.id %}
-                            <div class="alert alert-warning d-flex align-items-start gap-2" role="alert">
+                            <div class="alert alert-warning d-flex align-items-start gap-2"
+                                 role="alert">
                                 <i class="bi bi-shield-lock mt-1"></i>
                                 <div>
                                     <strong>Edición parcial por perfil INET_PROVINCIA.</strong>

--- a/VAT/templates/vat/oferta_institucional/oferta_form.html
+++ b/VAT/templates/vat/oferta_institucional/oferta_form.html
@@ -42,7 +42,8 @@
                         <form method="post" novalidate>
                             {% csrf_token %}
                             {% if inet_provincia_restricted_fields and form.instance.id %}
-                                <div class="alert alert-warning d-flex align-items-start gap-2" role="alert">
+                                <div class="alert alert-warning d-flex align-items-start gap-2"
+                                     role="alert">
                                     <i class="bi bi-shield-lock mt-1"></i>
                                     <div>
                                         <strong>Edición parcial por perfil INET_PROVINCIA.</strong>

--- a/VAT/templates/vat/reportes/inscripciones_asistencia.html
+++ b/VAT/templates/vat/reportes/inscripciones_asistencia.html
@@ -442,7 +442,8 @@
                             <span class="rep-field__label">Nivel</span>
                             <select id="id_nivel" name="nivel">
                                 {% for value, label in nivel_choices %}
-                                    <option value="{{ value }}" {% if value == filtros.nivel %}selected{% endif %}>{{ label }}</option>
+                                    <option value="{{ value }}"
+                                            {% if value == filtros.nivel %}selected{% endif %}>{{ label }}</option>
                                 {% endfor %}
                             </select>
                         </label>
@@ -451,19 +452,26 @@
                             <span class="rep-field__label">Agrupar por</span>
                             <select id="id_group_by" name="group_by">
                                 {% for value, label in group_by_choices %}
-                                    <option value="{{ value }}" {% if value == filtros.group_by %}selected{% endif %}>{{ label }}</option>
+                                    <option value="{{ value }}"
+                                            {% if value == filtros.group_by %}selected{% endif %}>{{ label }}</option>
                                 {% endfor %}
                             </select>
                         </label>
 
                         <label class="rep-field" for="id_fecha_desde">
                             <span class="rep-field__label">Fecha desde</span>
-                            <input id="id_fecha_desde" type="date" name="fecha_desde" value="{{ filtros.fecha_desde }}" />
+                            <input id="id_fecha_desde"
+                                   type="date"
+                                   name="fecha_desde"
+                                   value="{{ filtros.fecha_desde }}" />
                         </label>
 
                         <label class="rep-field" for="id_fecha_hasta">
                             <span class="rep-field__label">Fecha hasta</span>
-                            <input id="id_fecha_hasta" type="date" name="fecha_hasta" value="{{ filtros.fecha_hasta }}" />
+                            <input id="id_fecha_hasta"
+                                   type="date"
+                                   name="fecha_hasta"
+                                   value="{{ filtros.fecha_hasta }}" />
                         </label>
 
                         <label class="rep-field" for="id_provincia_id">
@@ -471,7 +479,10 @@
                             <select id="id_provincia_id" name="provincia_id">
                                 <option value="">Todas</option>
                                 {% for prov in provincias %}
-                                    <option value="{{ prov.provincia_id }}" {% if filtros.provincia_id == prov.provincia_id|stringformat:"s" %}selected{% endif %}>{{ prov.provincia__nombre }}</option>
+                                    <option value="{{ prov.provincia_id }}"
+                                            {% if filtros.provincia_id == prov.provincia_id|stringformat:"s" %}selected{% endif %}>
+                                        {{ prov.provincia__nombre }}
+                                    </option>
                                 {% endfor %}
                             </select>
                         </label>
@@ -482,7 +493,9 @@
                                 <option value="">Todos</option>
                                 {% for municipio in municipios %}
                                     <option value="{{ municipio.municipio_id }}"
-                                            {% if filtros.municipio_id == municipio.municipio_id|stringformat:"s" %}selected{% endif %}>{{ municipio.municipio__nombre }}</option>
+                                            {% if filtros.municipio_id == municipio.municipio_id|stringformat:"s" %}selected{% endif %}>
+                                        {{ municipio.municipio__nombre }}
+                                    </option>
                                 {% endfor %}
                             </select>
                         </label>
@@ -492,7 +505,10 @@
                             <select id="id_centro_id" name="centro_id">
                                 <option value="">Todos</option>
                                 {% for centro in centros %}
-                                    <option value="{{ centro.id }}" {% if filtros.centro_id == centro.id|stringformat:"s" %}selected{% endif %}>{{ centro.nombre }}</option>
+                                    <option value="{{ centro.id }}"
+                                            {% if filtros.centro_id == centro.id|stringformat:"s" %}selected{% endif %}>
+                                        {{ centro.nombre }}
+                                    </option>
                                 {% endfor %}
                             </select>
                         </label>
@@ -503,7 +519,9 @@
                                 <option value="">Todas</option>
                                 {% for comision in comisiones %}
                                     <option value="{{ comision.comision_id_ref }}"
-                                            {% if filtros.comision_id == comision.comision_id_ref|stringformat:"s" %}selected{% endif %}>{{ comision.comision_codigo_ref }} - {{ comision.centro_nombre_ref }}</option>
+                                            {% if filtros.comision_id == comision.comision_id_ref|stringformat:"s" %}selected{% endif %}>
+                                        {{ comision.comision_codigo_ref }} - {{ comision.centro_nombre_ref }}
+                                    </option>
                                 {% endfor %}
                             </select>
                         </label>
@@ -514,7 +532,9 @@
                                 <option value="">Todos</option>
                                 {% for curso in cursos %}
                                     <option value="{{ curso.unidad_formativa_id }}"
-                                            {% if filtros.curso_id == curso.unidad_formativa_id|stringformat:"s" %}selected{% endif %}>{{ curso.unidad_formativa_nombre }}</option>
+                                            {% if filtros.curso_id == curso.unidad_formativa_id|stringformat:"s" %}selected{% endif %}>
+                                        {{ curso.unidad_formativa_nombre }}
+                                    </option>
                                 {% endfor %}
                             </select>
                         </label>
@@ -525,7 +545,9 @@
                                 <option value="">Todos</option>
                                 {% for programa in programas %}
                                     <option value="{{ programa.programa_id_ref }}"
-                                            {% if filtros.programa_id == programa.programa_id_ref|stringformat:"s" %}selected{% endif %}>{{ programa.programa_nombre_ref }}</option>
+                                            {% if filtros.programa_id == programa.programa_id_ref|stringformat:"s" %}selected{% endif %}>
+                                        {{ programa.programa_nombre_ref }}
+                                    </option>
                                 {% endfor %}
                             </select>
                         </label>
@@ -536,7 +558,9 @@
                                 <option value="">Todos</option>
                                 {% for titulo in titulos %}
                                     <option value="{{ titulo.titulo_id_ref }}"
-                                            {% if filtros.titulo_id == titulo.titulo_id_ref|stringformat:"s" %}selected{% endif %}>{{ titulo.titulo_nombre_ref }}</option>
+                                            {% if filtros.titulo_id == titulo.titulo_id_ref|stringformat:"s" %}selected{% endif %}>
+                                        {{ titulo.titulo_nombre_ref }}
+                                    </option>
                                 {% endfor %}
                             </select>
                         </label>
@@ -547,7 +571,9 @@
                                 <option value="">Todas</option>
                                 {% for modalidad in modalidades %}
                                     <option value="{{ modalidad.modalidad_id_ref }}"
-                                            {% if filtros.modalidad_id == modalidad.modalidad_id_ref|stringformat:"s" %}selected{% endif %}>{{ modalidad.modalidad_nombre_ref }}</option>
+                                            {% if filtros.modalidad_id == modalidad.modalidad_id_ref|stringformat:"s" %}selected{% endif %}>
+                                        {{ modalidad.modalidad_nombre_ref }}
+                                    </option>
                                 {% endfor %}
                             </select>
                         </label>
@@ -557,7 +583,8 @@
                             <select id="id_estado" name="estado">
                                 <option value="">Todos</option>
                                 {% for value, label in estado_choices %}
-                                    <option value="{{ value }}" {% if filtros.estado == value %}selected{% endif %}>{{ label }}</option>
+                                    <option value="{{ value }}"
+                                            {% if filtros.estado == value %}selected{% endif %}>{{ label }}</option>
                                 {% endfor %}
                             </select>
                         </label>
@@ -566,7 +593,10 @@
                             <span class="rep-field__label">Usa voucher</span>
                             <select id="id_usa_voucher" name="usa_voucher">
                                 {% for value, label in usa_voucher_choices %}
-                                    <option value="{{ value }}" {% if filtros.usa_voucher == value %}selected{% endif %}>{{ label }}</option>
+                                    <option value="{{ value }}"
+                                            {% if filtros.usa_voucher == value %}selected{% endif %}>
+                                        {{ label }}
+                                    </option>
                                 {% endfor %}
                             </select>
                         </label>
@@ -576,7 +606,10 @@
                             <select id="id_estado_curso" name="estado_curso">
                                 <option value="">Todos</option>
                                 {% for value, label in curso_estado_choices %}
-                                    <option value="{{ value }}" {% if filtros.estado_curso == value %}selected{% endif %}>{{ label }}</option>
+                                    <option value="{{ value }}"
+                                            {% if filtros.estado_curso == value %}selected{% endif %}>
+                                        {{ label }}
+                                    </option>
                                 {% endfor %}
                             </select>
                         </label>
@@ -586,7 +619,10 @@
                             <select id="id_estado_comision" name="estado_comision">
                                 <option value="">Todos</option>
                                 {% for value, label in comision_estado_choices %}
-                                    <option value="{{ value }}" {% if filtros.estado_comision == value %}selected{% endif %}>{{ label }}</option>
+                                    <option value="{{ value }}"
+                                            {% if filtros.estado_comision == value %}selected{% endif %}>
+                                        {{ label }}
+                                    </option>
                                 {% endfor %}
                             </select>
                         </label>
@@ -596,7 +632,8 @@
                         <button type="submit" class="rep-btn rep-btn--primary">
                             <i class="bi bi-search"></i>Aplicar filtros
                         </button>
-                        <a href="{% url 'vat_reporte_inscripciones_asistencias' %}" class="rep-btn rep-btn--ghost">
+                        <a href="{% url 'vat_reporte_inscripciones_asistencias' %}"
+                           class="rep-btn rep-btn--ghost">
                             <i class="bi bi-arrow-clockwise"></i>Limpiar
                         </a>
                         <a href="?{% if querystring %}{{ querystring }}&{% endif %}export=csv"
@@ -744,12 +781,18 @@
         <div class="rep-card">
             <div class="rep-card-head">
                 <i class="bi bi-bar-chart"></i>
-                <span>Resumen por {% for value, label in group_by_choices %}{% if value == group_by %}{{ label|lower }}{% endif %}{% endfor %}</span>
+                <span>Resumen por
+                    {% for value, label in group_by_choices %}
+                        {% if value == group_by %}{{ label|lower }}{% endif %}
+                    {% endfor %}
+                </span>
             </div>
             <div class="rep-tbl-toolbar">
                 <label class="rep-field" for="reporteQuickSearch">
                     <span class="rep-field__label">Buscar en esta página</span>
-                    <input type="search" id="reporteQuickSearch" placeholder="Filtrar filas visibles" />
+                    <input type="search"
+                           id="reporteQuickSearch"
+                           placeholder="Filtrar filas visibles" />
                 </label>
                 <span id="reporteQuickCounter" class="rep-tbl-counter"></span>
             </div>
@@ -757,7 +800,11 @@
                 <table class="rep-tbl" id="reporteResumenTabla">
                     <thead>
                         <tr>
-                            <th>{% for value, label in group_by_choices %}{% if value == group_by %}{{ label }}{% endif %}{% endfor %}</th>
+                            <th>
+                                {% for value, label in group_by_choices %}
+                                    {% if value == group_by %}{{ label }}{% endif %}
+                                {% endfor %}
+                            </th>
                             <th>Inscriptos</th>
                             <th>Preinscriptos</th>
                             <th>En espera</th>
@@ -866,7 +913,9 @@
                             <tr class="rep-detalle-row">
                                 <td>{{ item.ciudadano__documento|default:"—" }}</td>
                                 <td>{{ item.ciudadano__apellido|default:"" }}, {{ item.ciudadano__nombre|default:"" }}</td>
-                                <td><span class="rep-pill">{{ item.estado }}</span></td>
+                                <td>
+                                    <span class="rep-pill">{{ item.estado }}</span>
+                                </td>
                                 <td>{{ item.centro_nombre_ref }}</td>
                                 <td>{{ item.comision_codigo_ref }}</td>
                                 <td>{{ item.unidad_formativa_nombre }}</td>
@@ -885,11 +934,19 @@
                     Mostrando {{ detalle_rows|length|yesno:"1,0" }}-{{ detalle_rows|length }} de {{ detalle_rows|length }}
                 </span>
                 <div class="rep-pager">
-                    <button type="button" class="rep-pager-prev" id="repDetallePrev" aria-label="Página anterior" disabled>
+                    <button type="button"
+                            class="rep-pager-prev"
+                            id="repDetallePrev"
+                            aria-label="Página anterior"
+                            disabled>
                         <i class="bi bi-chevron-left"></i>
                     </button>
                     <span class="rep-pager-label" id="repDetallePager">1 de 1</span>
-                    <button type="button" class="rep-pager-next" id="repDetalleNext" aria-label="Página siguiente" disabled>
+                    <button type="button"
+                            class="rep-pager-next"
+                            id="repDetalleNext"
+                            aria-label="Página siguiente"
+                            disabled>
                         <i class="bi bi-chevron-right"></i>
                     </button>
                 </div>

--- a/celiaquia/templates/celiaquia/reporter_provincias.html
+++ b/celiaquia/templates/celiaquia/reporter_provincias.html
@@ -56,9 +56,7 @@
                     </p>
                 {% else %}
                     <strong class="reporter-focus__title">Sin datos para el corte actual</strong>
-                    <p class="reporter-focus__body">
-                        Ajusta los filtros para reconstruir la foto operativa del reporte.
-                    </p>
+                    <p class="reporter-focus__body">Ajusta los filtros para reconstruir la foto operativa del reporte.</p>
                 {% endif %}
             </aside>
         </section>
@@ -177,11 +175,13 @@
                 </div>
 
                 <div class="reporter-filter-actions">
-                    <button type="submit" class="btn btn-success reporter-btn reporter-btn--primary">
+                    <button type="submit"
+                            class="btn btn-success reporter-btn reporter-btn--primary">
                         <i class="fa fa-search"></i>
                         Aplicar lectura
                     </button>
-                    <a href="{% url 'reporter_provincias' %}" class="btn btn-outline-light reporter-btn reporter-btn--ghost">
+                    <a href="{% url 'reporter_provincias' %}"
+                       class="btn btn-outline-light reporter-btn reporter-btn--ghost">
                         <i class="fa fa-redo"></i>
                         Reiniciar
                     </a>
@@ -211,7 +211,8 @@
                 {% if tendencia_mensual %}
                     <div class="trend-chart" aria-label="Tendencia mensual del reporter">
                         {% for item in tendencia_mensual %}
-                            <div class="trend-chart__item" title="{{ item.label }}: {{ item.count }} casos">
+                            <div class="trend-chart__item"
+                                 title="{{ item.label }}: {{ item.count }} casos">
                                 <div class="trend-chart__bar-shell">
                                     <div class="trend-chart__bar" style="--size: {{ item.size }};">
                                         <span class="trend-chart__value">{{ item.count }}</span>
@@ -358,7 +359,8 @@
                     </p>
                 </div>
                 <div class="reporter-table__tools">
-                    <label class="reporter-field reporter-field--compact" for="reporterQuickSearch">
+                    <label class="reporter-field reporter-field--compact"
+                           for="reporterQuickSearch">
                         <span class="reporter-field__label">Buscar en esta página</span>
                         <input type="search"
                                id="reporterQuickSearch"
@@ -388,7 +390,8 @@
                         {% for caso in ultimos_casos %}
                             <tr data-reporter-row>
                                 <td>
-                                    <a class="reporter-table__link" href="{% url 'expediente_detail' caso.expediente.id %}">{{ caso.ciudadano.documento }}</a>
+                                    <a class="reporter-table__link"
+                                       href="{% url 'expediente_detail' caso.expediente.id %}">{{ caso.ciudadano.documento }}</a>
                                 </td>
                                 <td>{{ caso.ciudadano.nombre }} {{ caso.ciudadano.apellido }}</td>
                                 <td>{{ caso.expediente.numero_expediente|default:"-" }}</td>

--- a/comedores/templates/comedor/comedor_detail.html
+++ b/comedores/templates/comedor/comedor_detail.html
@@ -44,6 +44,16 @@
                             <i class="bi bi-trash me-1"></i>Eliminar
                         </a>
                     </li>
+                        <li>
+                            <a class="dropdown-item" href="{% url 'dupla_asignar' pk=comedor.id %}">
+                                <i class="bi bi-person-workspace me-1"></i>
+                                    {% if comedor.estado == "Sin Ingreso" %}
+                                        Asignar Equipo T&eacute;cnico
+                                    {% else %}
+                                        Modificar Equipo T&eacute;cnico
+                                    {% endif %}
+                            </a>
+                        </li>
                     {% if comedor.estado != "Sin Ingreso" %}
                         <li>
                             <button class="dropdown-item text-start"
@@ -52,11 +62,6 @@
                                     data-bs-target="#modalAdmision">
                                 <i class="bi bi-box-arrow-in-up-right me-1"></i>Comenzar Admisión
                             </button>
-                        </li>
-                        <li>
-                            <a class="dropdown-item" href="{% url 'dupla_asignar' pk=comedor.id %}">
-                                <i class="bi bi-person-workspace me-1"></i>Modificar Equipo Técnico
-                            </a>
                         </li>
                     {% endif %}
                 </ul>
@@ -1167,14 +1172,6 @@
 </strong>
 </p>
 <div class="mt-3 d-flex flex-column flex-sm-row justify-content-center gap-2">
-    <a href="{% url 'dupla_asignar' pk=comedor.id %}"
-       class="btn btn-primary px-2 py-1 fs-7 w-100 w-sm-auto">
-        {% if comedor.estado == "Sin Ingreso" %}
-            Asignar Equipo T&eacute;cnico
-        {% else %}
-            Modificar Equipo T&eacute;cnico
-        {% endif %}
-    </a>
     {% if display_admision %}
         <a href="{% url 'admision_detalle' comedor.id display_admision.id %}"
            class="btn btn-primary px-2 py-1 fs-7 w-100 w-sm-auto">Ver detalles</a>

--- a/comedores/templates/comedor/comedor_detail.html
+++ b/comedores/templates/comedor/comedor_detail.html
@@ -44,16 +44,16 @@
                             <i class="bi bi-trash me-1"></i>Eliminar
                         </a>
                     </li>
-                        <li>
-                            <a class="dropdown-item" href="{% url 'dupla_asignar' pk=comedor.id %}">
-                                <i class="bi bi-person-workspace me-1"></i>
-                                    {% if comedor.estado == "Sin Ingreso" %}
-                                        Asignar Equipo T&eacute;cnico
-                                    {% else %}
-                                        Modificar Equipo T&eacute;cnico
-                                    {% endif %}
-                            </a>
-                        </li>
+                    <li>
+                        <a class="dropdown-item" href="{% url 'dupla_asignar' pk=comedor.id %}">
+                            <i class="bi bi-person-workspace me-1"></i>
+                            {% if comedor.estado == "Sin Ingreso" %}
+                                Asignar Equipo T&eacute;cnico
+                            {% else %}
+                                Modificar Equipo T&eacute;cnico
+                            {% endif %}
+                        </a>
+                    </li>
                     {% if comedor.estado != "Sin Ingreso" %}
                         <li>
                             <button class="dropdown-item text-start"

--- a/comedores/templates/comedor/comedor_detail.html
+++ b/comedores/templates/comedor/comedor_detail.html
@@ -44,16 +44,18 @@
                             <i class="bi bi-trash me-1"></i>Eliminar
                         </a>
                     </li>
-                    <li>
-                        <a class="dropdown-item" href="{% url 'dupla_asignar' pk=comedor.id %}">
-                            <i class="bi bi-person-workspace me-1"></i>
-                            {% if comedor.estado == "Sin Ingreso" %}
-                                Asignar Equipo T&eacute;cnico
-                            {% else %}
-                                Modificar Equipo T&eacute;cnico
-                            {% endif %}
-                        </a>
-                    </li>
+                    {% if perms.duplas.change_dupla %}
+                        <li>
+                            <a class="dropdown-item" href="{% url 'dupla_asignar' pk=comedor.id %}">
+                                <i class="bi bi-person-workspace me-1"></i>
+                                {% if comedor.estado == "Sin Ingreso" %}
+                                    Asignar Equipo T&eacute;cnico
+                                {% else %}
+                                    Modificar Equipo T&eacute;cnico
+                                {% endif %}
+                            </a>
+                        </li>
+                    {% endif %}
                     {% if comedor.estado != "Sin Ingreso" %}
                         <li>
                             <button class="dropdown-item text-start"

--- a/static/custom/js/comedordetail_territorial_cache.js
+++ b/static/custom/js/comedordetail_territorial_cache.js
@@ -615,16 +615,18 @@
             background: transparent;
             text-align: left;
             font-size: 0.875rem;
+            color: #212529;
         }
 
         .territorial-suggestion-item:hover,
         .territorial-suggestion-item:focus {
             background: #f8f9fa;
+            color: #212529;
             outline: none;
         }
 
         .territorial-suggestion-stale {
-            color: black;
+            color: #856404;
         }
 
         .territorial-suggestion-empty {

--- a/static/custom/js/comedordetail_territorial_cache.js
+++ b/static/custom/js/comedordetail_territorial_cache.js
@@ -624,7 +624,7 @@
         }
 
         .territorial-suggestion-stale {
-            color: #856404;
+            color: black;
         }
 
         .territorial-suggestion-empty {


### PR DESCRIPTION
# Información de la Tarea
- https://github.com/dsocial118/SISOC/issues/1867 (HOTFIX — equipo técnico en Acciones para todos los comedores)
- https://github.com/dsocial118/SISOC/issues/1896 (FIX — color del autocomplete de territorial)

### Resumen de la Solución
- Reorganiza el menú de Acciones del legajo del comedor para que la asignación / modificación del equipo técnico esté disponible para **todos** los comedores, sin depender del programa, y queda envuelto en `{% if perms.duplas.change_dupla %}` para mantener la misma lógica de permisos que ya operaba a nivel ruta.
- Elimina el botón duplicado de "Asignar/Modificar Equipo Técnico" del contenedor "Detalles de Admisión".
- Corrige el contraste del autocomplete de territorial en el modal de alta de relevamiento: las sugerencias declaran ahora `color: #212529` explícito para no heredar blanco desde contenedores oscuros del padre (causa raíz del reporte "se ve en blanco"). El marcador `.territorial-suggestion-stale` queda en `#856404` (matchea `.status-warning`).
- Aplica reformateo djlint repo-wide sobre templates VAT/celiaquia tocados recientemente.

# Descripción de los Cambios

### Cambios funcionales
- `comedores/templates/comedor/comedor_detail.html`
  - Nueva entrada en el dropdown "Acciones": label `Asignar Equipo Técnico` cuando `comedor.estado == "Sin Ingreso"`, `Modificar Equipo Técnico` en cualquier otro estado.
  - Gateada con `{% if perms.duplas.change_dupla %}`.
  - Se elimina la entrada duplicada que vivía dentro de `{% if comedor.estado != "Sin Ingreso" %}` y la del contenedor "Detalles de Admisión".
- `static/custom/js/comedordetail_territorial_cache.js`
  - `.territorial-suggestion-item, .territorial-suggestion-empty` y su `:hover/:focus` declaran `color: #212529`.
  - `.territorial-suggestion-stale` vuelve a `#856404` para preservar la marca visual de datos desactualizados.

### Cambios de formato (sin impacto funcional)
- Reindentado djlint sobre 16 templates VAT/celiaquia/oferta institucional. No hay cambios de lógica ni de marcado semántico en esos archivos.

# Cómo Testear los Cambios

### Pruebas Automáticas
- Tests existentes de `relevamientos/tests.py` (autocomplete de territorial) deben seguir verdes.
- Suite habitual de comedores (`pytest comedores/`).

### Pruebas Manuales
1. Loguear con un usuario CON permiso `duplas.change_dupla`:
   - Abrir un comedor con `estado="Sin Ingreso"` → desplegable Acciones muestra "Asignar Equipo Técnico" (no muestra "Comenzar Admisión").
   - Abrir un comedor con cualquier otro estado → desplegable Acciones muestra "Modificar Equipo Técnico" + "Comenzar Admisión".
   - Click en el item → redirige a `dupla_asignar` y permite asignar normalmente.
2. Loguear con un usuario SIN permiso `duplas.change_dupla`:
   - Abrir cualquier comedor → la entrada de equipo técnico no aparece en Acciones (antes aparecía y devolvía 403).
3. Verificar que el contenedor "Detalles de Admisión" ya no muestra el botón duplicado de equipo técnico (solo queda "Ver detalles" cuando hay `display_admision`).
4. En "Relevamientos" del comedor → modal "Nuevo relevamiento" → tipear apellido de territorial: las sugerencias se ven con texto oscuro (#212529), las desactualizadas con color de warning (#856404).

# Metadata para documentación automática

- Contexto funcional: Comedores / Relevamientos — asignación de equipo técnico y autocomplete de territorial.
- Tipo de cambio: fix
- Área principal: comedores
- Resumen para changelog: La asignación de equipo técnico vuelve a estar disponible para comedores de todos los programas (no solo PAC) y se mueve al menú de Acciones del legajo. Se corrige el contraste del autocomplete de territorial en el modal de alta de relevamiento.
- Impacto usuario: Los referentes de comedores PNUD y todos los demás programas recuperan la acción de asignar/modificar equipo técnico desde el legajo. El autocomplete del modal de alta de relevamiento muestra correctamente los nombres.
- Riesgos / rollback: Bajo. Revert puntual de los dos archivos funcionales (`comedores/templates/comedor/comedor_detail.html` y `static/custom/js/comedordetail_territorial_cache.js`) restituye el comportamiento previo. El reformateo djlint sobre VAT/celiaquia es cosmético.

# Capturas de Pantalla
- Pendientes del autor.