### PR TITLE
fix(comedores): alinear monto_prestacion_mensual mobile con la web

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+<!-- AUTO-GENERATED RELEASE START: 2026-06-24 -->
+# Versión SISOC 24.06.2026
+
+## Actualizaciones
+
+- [sin-area] fix(comedores): alinear monto_prestacion_mensual mobile con la web. (PR #1925)
+<!-- AUTO-GENERATED RELEASE END: 2026-06-24 -->
+
 <!-- AUTO-GENERATED RELEASE START: 2026-06-10 -->
 # Versión SISOC 10.06.2026
 

--- a/comedores/api_serializers.py
+++ b/comedores/api_serializers.py
@@ -1064,9 +1064,11 @@ class ComedorDetailSerializer(serializers.ModelSerializer):
 
     @staticmethod
     def _get_datos_convenio_alimentar(obj):
-        presupuestos = ComedorService.get_presupuestos(obj.id)
-        prestaciones_mensuales = presupuestos[0]
-        monto_prestacion_mensual = presupuestos[5]
+        # Misma fuente que el detalle web: prestaciones aprobadas del
+        # InformeTecnico finalizado de la admisión vigente (no el relevamiento).
+        resumen = ComedorService.get_prestaciones_aprobadas_resumen(obj.id)
+        prestaciones_mensuales = resumen["prestaciones_mensuales"]
+        monto_prestacion_mensual = resumen["monto_prestacion_mensual"]
         return {
             "tipo": "alimentar_comunidad",
             "vigencia_convenio_meses": 6,

--- a/comedores/services/comedor_service/impl.py
+++ b/comedores/services/comedor_service/impl.py
@@ -51,7 +51,7 @@ from comedores.utils import (
 )
 from centrodefamilia.services.consulta_renaper import consultar_datos_renaper
 from core.models import Provincia, Municipio, Localidad, Nacionalidad
-from admisiones.models.admisiones import Admision
+from admisiones.models.admisiones import Admision, InformeTecnico
 from rendicioncuentasmensual.models import RendicionCuentaMensual
 from intervenciones.models.intervenciones import Intervencion
 from expedientespagos.models import ExpedientePago
@@ -963,6 +963,49 @@ class ComedorService:
             "desayuno", 0
         ) + prestaciones_por_tipo.get("merienda", 0)
         return total_almuerzo_cena * 763 + total_desayuno_merienda * 383
+
+    @staticmethod
+    def get_prestaciones_aprobadas_resumen(comedor_id):
+        """Resumen de prestaciones/monto mensual basado en las prestaciones
+        aprobadas del InformeTecnico finalizado de la admision vigente del
+        comedor. Es la misma fuente que muestra el detalle web (acordeon
+        Prestaciones), por lo que web y mobile quedan alineados.
+
+        Devuelve None en ambos campos si no hay admision/informe tecnico
+        finalizado (la web muestra "-" en ese caso).
+        """
+        admisiones_qs = Admision.objects.filter(comedor_id=comedor_id).order_by("-id")
+        admision = admisiones_qs.filter(activa=True).first() or admisiones_qs.first()
+        if not admision:
+            return {
+                "prestaciones_mensuales": None,
+                "monto_prestacion_mensual": None,
+            }
+
+        informe_tecnico = (
+            InformeTecnico.objects.filter(
+                admision=admision, estado_formulario="finalizado"
+            )
+            .order_by("-id")
+            .first()
+        )
+        prestaciones_por_tipo = ComedorService.get_prestaciones_aprobadas_por_tipo(
+            informe_tecnico
+        )
+        if prestaciones_por_tipo is None:
+            return {
+                "prestaciones_mensuales": None,
+                "monto_prestacion_mensual": None,
+            }
+
+        return {
+            "prestaciones_mensuales": sum(prestaciones_por_tipo.values()),
+            "monto_prestacion_mensual": (
+                ComedorService.calcular_monto_prestacion_mensual_por_aprobadas(
+                    prestaciones_por_tipo
+                )
+            ),
+        }
 
     @staticmethod
     def get_nomina_detail(

--- a/docs/contexto/features/pr-1925-fix-comedores-alinear-monto-prestacion-mensual-mobile-con-la-web.md
+++ b/docs/contexto/features/pr-1925-fix-comedores-alinear-monto-prestacion-mensual-mobile-con-la-web.md
@@ -1,0 +1,46 @@
+# Contexto de feature PR #1925 - fix(comedores): alinear monto_prestacion_mensual mobile con la web
+
+## Resumen
+
+- PR: https://github.com/dsocial118/SISOC/pull/1925
+- Base: `main`
+- Rama origen: `claude/fix-monto-prestacion-mobile-aprobadas`
+- Autor: `juanikitro`
+
+## Contexto funcional
+
+- No informado explícitamente; inferir desde el título del PR y el diff.
+
+## Arquitectura tocada
+
+- El PR toca lógica en `services/`, por lo que impacta reglas de negocio u orquestación.
+- Hay cambios en capa API/DRF y conviene revisar contratos de request/response.
+
+## Decisiones y supuestos detectados
+
+- Tipo de cambio declarado: No informado
+- Área principal declarada: No informada
+- Impacto usuario declarado: No informado
+- Riesgos / rollback: No informado
+
+## Design system y UI
+
+- Sin cambios visibles de UI o design system detectados en el diff.
+
+## Memoria operativa para agentes
+
+- Empezar por `docs/registro/prs/PR-1925.md` para contexto resumido del PR.
+- Revisar primero estos archivos del diff:
+- `comedores/api_serializers.py`
+- `comedores/services/comedor_service/impl.py`
+- `tests/test_comedor_service_renaper_helpers_unit.py`
+- Documentación sugerida para ampliar contexto:
+- `docs/indice.md`
+- `docs/ia/CONTEXT_HYGIENE.md`
+- `docs/ia/ARCHITECTURE.md`
+- `docs/ia/TESTING.md`
+
+## Trazabilidad
+
+- Documento generado automáticamente desde el evento de `pull_request`.
+- Si este PR cambia de título, el archivo se renombrará para mantener el slug alineado.

--- a/docs/registro/prs/PR-1925.md
+++ b/docs/registro/prs/PR-1925.md
@@ -1,0 +1,49 @@
+# PR #1925 - fix(comedores): alinear monto_prestacion_mensual mobile con la web
+
+## Metadata
+
+- PR: https://github.com/dsocial118/SISOC/pull/1925
+- Base: `main`
+- Rama origen: `claude/fix-monto-prestacion-mobile-aprobadas`
+- Autor: `juanikitro`
+- Última actualización: `2026-06-18T13:38:03Z`
+
+## Resumen operativo
+
+- Tipo de cambio: No informado
+- Área principal: No informada
+- Contexto funcional: No informado explícitamente; revisar título, diff y documentación relacionada.
+- Resumen para changelog: No informado
+- Impacto usuario: No informado
+
+## Áreas afectadas
+
+- `comedores`
+- `tests`
+
+## Archivos relevantes del diff
+
+- `comedores/api_serializers.py`
+- `comedores/services/comedor_service/impl.py`
+- `tests/test_comedor_service_renaper_helpers_unit.py`
+
+## Validación declarada
+
+- Pruebas automáticas: No informado en el PR.
+- Pruebas manuales: No informado en el PR.
+
+## Riesgos y rollback
+
+- No informado explícitamente en el PR.
+
+## Documentación sugerida para lectura
+
+- `docs/indice.md`
+- `docs/ia/CONTEXT_HYGIENE.md`
+- `docs/ia/ARCHITECTURE.md`
+- `docs/ia/TESTING.md`
+
+## Notas para continuidad
+
+- Este documento es generado automáticamente desde el contexto del PR y sirve como índice rápido para revisión y futuras sesiones de agentes.
+- Si la metadata del body del PR está incompleta, varias secciones usarán fallbacks derivados del título o del diff.

--- a/docs/registro/releases/pending/2026-06-24-pr-1925.md
+++ b/docs/registro/releases/pending/2026-06-24-pr-1925.md
@@ -1,0 +1,19 @@
+---
+pr: 1925
+release_date: 2026-06-24
+category: Actualizaciones
+area: sin-area
+title: fix(comedores): alinear monto_prestacion_mensual mobile con la web
+summary: fix(comedores): alinear monto_prestacion_mensual mobile con la web
+impact: No informado
+source_url: https://github.com/dsocial118/SISOC/pull/1925
+---
+# Release note preliminar PR #1925
+
+- Fecha objetivo de release: 2026-06-24
+- Categoría: Actualizaciones
+- Área: sin-area
+- Título del PR: fix(comedores): alinear monto_prestacion_mensual mobile con la web
+- Resumen: fix(comedores): alinear monto_prestacion_mensual mobile con la web
+- Impacto usuario: No informado
+- Fuente: https://github.com/dsocial118/SISOC/pull/1925

--- a/tests/test_comedor_service_renaper_helpers_unit.py
+++ b/tests/test_comedor_service_renaper_helpers_unit.py
@@ -664,6 +664,67 @@ def test_relevamiento_resumen_presupuestos_and_aprobadas(mocker):
     )
 
 
+class _FakeQS:
+    """Queryset minimo encadenable para mockear .filter().order_by().first()."""
+
+    def __init__(self, result):
+        self._result = result
+
+    def filter(self, **_kwargs):
+        return self
+
+    def order_by(self, *_args, **_kwargs):
+        return self
+
+    def first(self):
+        return self._result
+
+
+def test_get_prestaciones_aprobadas_resumen_usa_aprobadas(mocker):
+    from comedores.services.comedor_service import impl as impl_module
+
+    admision = SimpleNamespace(id=7, activa=True)
+    informe = SimpleNamespace(
+        aprobadas_desayuno_lunes="2",
+        aprobadas_almuerzo_martes=3,
+        aprobadas_merienda_lunes=1,
+        aprobadas_cena_lunes=4,
+    )
+    mocker.patch.object(
+        impl_module.Admision,
+        "objects",
+        SimpleNamespace(filter=lambda **k: _FakeQS(admision)),
+    )
+    mocker.patch.object(
+        impl_module.InformeTecnico,
+        "objects",
+        SimpleNamespace(filter=lambda **k: _FakeQS(informe)),
+    )
+
+    resumen = impl_module.ComedorService.get_prestaciones_aprobadas_resumen(123)
+
+    # Mismo origen y formula que el detalle web (acordeon Prestaciones).
+    assert resumen["prestaciones_mensuales"] == 2 + 3 + 1 + 4
+    assert resumen["monto_prestacion_mensual"] == (3 + 4) * 763 + (2 + 1) * 383
+
+
+def test_get_prestaciones_aprobadas_resumen_sin_admision(mocker):
+    from comedores.services.comedor_service import impl as impl_module
+
+    mocker.patch.object(
+        impl_module.Admision,
+        "objects",
+        SimpleNamespace(filter=lambda **k: _FakeQS(None)),
+    )
+
+    resumen = impl_module.ComedorService.get_prestaciones_aprobadas_resumen(123)
+
+    assert resumen == {
+        "prestaciones_mensuales": None,
+        "monto_prestacion_mensual": None,
+    }
+
+
 def test_handle_legacy_relevamiento_post_branches(mocker):
     view = comedor_views_module.ComedorDetailView()
     view.object = SimpleNamespace(pk=22)


### PR DESCRIPTION
## Problema

La PWA mobile consume `GET /comedores/{id}/` y lee `datos_convenio_mobile`. Para comedores `tipo == 'alimentar_comunidad'`, el campo **`monto_prestacion_mensual`** (y `prestaciones_mensuales`) traía un valor distinto al que muestra la web en el detalle del comedor ("Monto prestacion mensual" / "Prestaciones mensuales").

## Causa raíz

Distinta **fuente de datos** (misma fórmula 763/383):

| | Web (detalle) | Mobile (antes) |
|---|---|---|
| Origen | InformeTecnico **finalizado** de la admisión vigente | Último **relevamiento** |
| Campos | `aprobadas_{tipo}_{dia}` | `{dia}_{tipo}_actual` |

- `comedores/api_serializers.py` → `_get_datos_convenio_alimentar` usaba `ComedorService.get_presupuestos()` (relevamiento, prestaciones *actuales*).
- La web (`comedores/views/comedor.py`) usa las prestaciones *aprobadas* del informe técnico vía `get_prestaciones_aprobadas_por_tipo` + `calcular_monto_prestacion_mensual_por_aprobadas`.

Resultado: divergían cuando aprobadas ≠ actuales, y la mobile devolvía `0` cuando no había relevamiento con prestaciones.

## Cambio

- Nuevo `ComedorService.get_prestaciones_aprobadas_resumen(comedor_id)`: resuelve la admisión vigente (activa, o la última) y su InformeTecnico finalizado, y devuelve `prestaciones_mensuales` + `monto_prestacion_mensual` con **la misma fuente y fórmula que el detalle web**.
- El serializer mobile consume ese resumen → web y mobile comparten una sola fuente.
- Si no hay informe técnico finalizado, devuelve `None` en ambos campos (la web muestra `-`), en lugar del `0` engañoso anterior.

## Tests

- `test_get_prestaciones_aprobadas_resumen_usa_aprobadas`
- `test_get_prestaciones_aprobadas_resumen_sin_admision`

(El pytest local no corre por un mismatch de Django en el entorno; la lógica de cálculo se verificó de forma aislada y los archivos compilan. CI corre sobre SQLite.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)