### PR TITLE
chore(arch): agregar ratchet import-linter (Fase 0, PR 1)

### DIFF
--- a/.github/workflows/architecture.yml
+++ b/.github/workflows/architecture.yml
@@ -1,0 +1,40 @@
+name: Arquitectura (imports)
+
+on:
+    pull_request:
+        branches:
+            - main
+            - development
+    push:
+        branches:
+            - main
+            - development
+
+permissions:
+    contents: read
+
+concurrency:
+    group: architecture-${{ github.event.pull_request.number || github.ref }}
+    cancel-in-progress: true
+
+jobs:
+    architecture_imports:
+        runs-on: ubuntu-latest
+        steps:
+            - name: Checkout code
+              uses: actions/checkout@v6.0.2
+
+            - name: Set up Python
+              uses: actions/setup-python@v6.2.0
+              with:
+                  python-version: '3.11.15'
+                  cache: 'pip'
+                  cache-dependency-path: requirements/arch.txt
+
+            - name: Install architecture tooling
+              run: |
+                  python -m pip install --upgrade pip
+                  pip install -r requirements/arch.txt
+
+            - name: Run import-linter
+              run: lint-imports

--- a/.importlinter
+++ b/.importlinter
@@ -1,0 +1,169 @@
+# Contratos de arquitectura (import-linter) - Fase 0 monolito modular.
+#
+# Objetivo: ratchet de dependencias. Las violaciones actuales se permiten via
+# baseline (ignore_imports) y CI falla ante NUEVAS dependencias prohibidas.
+# Cada PR posterior que corte una dependencia debe borrar su linea del baseline
+# (import-linter falla si una linea de ignore_imports no matchea ningun import).
+#
+# Alcance Fase 0: imports directos (allow_indirect_imports = True). El tooling de
+# soporte (debug_queries, benchmarks) y los tests se excluyen para enfocarse en
+# runtime; se ampliara cobertura en fases posteriores.
+#
+# Limitacion conocida: import-linter/grimp solo analiza paquetes regulares (con
+# __init__.py). Los namespace packages sin __init__.py (p. ej. historial.services)
+# quedan fuera del grafo y no se chequean por ahora.
+#
+# Como correr localmente:
+#   python -m venv .venv-arch
+#   .venv-arch\Scripts\pip install -r requirements/arch.txt   (Windows)
+#   .venv-arch\Scripts\lint-imports
+# o via Docker:
+#   docker run --rm -v "${PWD}:/sisoc" -w /sisoc python:3.11.15-slim-bookworm \
+#     sh -lc "pip install -q -r requirements/arch.txt && lint-imports"
+
+[importlinter]
+root_packages =
+    core
+    users
+    ciudadanos
+    comedores
+    organizaciones
+    duplas
+    admisiones
+    intervenciones
+    historial
+    acompanamientos
+    expedientespagos
+    relevamientos
+    rendicioncuentasfinal
+    rendicioncuentasmensual
+    centrodefamilia
+    VAT
+    celiaquia
+    importarexpediente
+    comunicados
+    centrodeinfancia
+    ver_para_ser_libre
+    dispositivos
+    pwa
+    ticketera
+
+[importlinter:contract:core-no-domains]
+name = core no debe importar apps de dominio
+type = forbidden
+allow_indirect_imports = True
+source_modules =
+    core
+forbidden_modules =
+    ciudadanos
+    comedores
+    organizaciones
+    duplas
+    admisiones
+    intervenciones
+    historial
+    acompanamientos
+    expedientespagos
+    relevamientos
+    rendicioncuentasfinal
+    rendicioncuentasmensual
+    centrodefamilia
+    VAT
+    celiaquia
+    importarexpediente
+    comunicados
+    centrodeinfancia
+    ver_para_ser_libre
+    dispositivos
+    pwa
+    ticketera
+ignore_imports =
+    core.api_views -> centrodefamilia.services.consulta_renaper.impl
+    core.management.commands.load_fixtures -> intervenciones.services_catalogo
+    core.services.favorite_filters.config -> admisiones.services.admisiones_filter_config
+    core.services.favorite_filters.config -> admisiones.services.legales_filter_config
+    core.services.favorite_filters.config -> centrodefamilia.services.beneficiarios_filter_config
+    core.services.favorite_filters.config -> centrodefamilia.services.centro_filter_config
+    core.services.favorite_filters.config -> centrodefamilia.services.responsables_filter_config
+    core.services.favorite_filters.config -> dispositivos.dispositivos_filter_config
+    core.services.favorite_filters.config -> duplas.dupla_filter_config
+    core.services.favorite_filters.config -> VAT.services.centro_filter_config
+    core.soft_delete.state_sync -> VAT.cache_utils
+    core.templatetags.custom_filters -> VAT.services.access_scope
+    core.views -> organizaciones.models
+    core.debug_queries -> **
+    core.benchmarks.** -> **
+
+[importlinter:contract:ciudadanos-no-domains]
+name = ciudadanos no debe importar otras apps de dominio
+type = forbidden
+allow_indirect_imports = True
+source_modules =
+    ciudadanos
+forbidden_modules =
+    comedores
+    organizaciones
+    duplas
+    admisiones
+    intervenciones
+    historial
+    acompanamientos
+    expedientespagos
+    relevamientos
+    rendicioncuentasfinal
+    rendicioncuentasmensual
+    centrodefamilia
+    VAT
+    celiaquia
+    importarexpediente
+    comunicados
+    centrodeinfancia
+    ver_para_ser_libre
+    dispositivos
+    pwa
+    ticketera
+ignore_imports =
+    ciudadanos.services_importacion_masiva -> centrodefamilia.services.consulta_renaper
+    ciudadanos.views -> celiaquia.models
+    ciudadanos.views -> centrodefamilia.models
+    ciudadanos.views -> comedores.models
+    ciudadanos.views -> pwa.models
+    ciudadanos.views -> VAT.models
+
+[importlinter:contract:users-no-domains]
+name = users no debe importar apps de dominio
+type = forbidden
+allow_indirect_imports = True
+source_modules =
+    users
+forbidden_modules =
+    ciudadanos
+    comedores
+    organizaciones
+    duplas
+    admisiones
+    intervenciones
+    historial
+    acompanamientos
+    expedientespagos
+    relevamientos
+    rendicioncuentasfinal
+    rendicioncuentasmensual
+    centrodefamilia
+    VAT
+    celiaquia
+    importarexpediente
+    comunicados
+    centrodeinfancia
+    ver_para_ser_libre
+    dispositivos
+    pwa
+    ticketera
+ignore_imports =
+    users.api_views -> pwa.models
+    users.api_views -> pwa.services.auditoria_service
+    users.forms -> comedores.models
+    users.forms -> duplas.models
+    users.forms -> organizaciones.models
+    users.signals -> duplas.models
+    users.tests -> **

--- a/docs/registro/decisiones/2026-06-23-import-linter-ratchet-fase-0.md
+++ b/docs/registro/decisiones/2026-06-23-import-linter-ratchet-fase-0.md
@@ -1,0 +1,118 @@
+# 2026-06-23 - Ratchet de imports con import-linter (Fase 0 monolito modular)
+
+## Estado
+
+Implementada. Corresponde al "Primer PR esperado" de la Fase 0 documentada en el
+PR #1932 (`docs/plans/2026-06-22-monolito-modular-fase-0.md`).
+
+## Contexto
+
+SISOC es un monolito Django modular por apps de dominio. Hoy existen imports
+directos desde capas compartidas (kernel) hacia dominios concretos, por ejemplo:
+
+- `core/services/favorite_filters/config.py` importa configuraciones de
+  `admisiones`, `centrodefamilia`, `VAT`, `comedores`, `duplas` y `dispositivos`.
+- `core/views.py`, `core/api_views.py`, `core/templatetags/custom_filters.py` y
+  `core/soft_delete/state_sync.py` importan modelos/servicios de dominio.
+- `ciudadanos/views.py` importa modelos de `comedores`, `celiaquia`,
+  `centrodefamilia`, `pwa` y `VAT` para la vista 360.
+- `users/api_views.py` importa `pwa`; `users/signals.py` y `users/forms.py`
+  importan `duplas`/`comedores`/`organizaciones`.
+
+El objetivo de Fase 0 no es extraer servicios ni partir la base: es **impedir que
+el grafo empeore** y empezar a mover dependencias hacia contratos explicitos.
+
+## Decision
+
+Instalar un *ratchet* de dependencias con `import-linter`, aislado del runtime y
+con su propio job de CI. Caracteristicas:
+
+1. **Contratos `forbidden`** para los modulos kernel/criticos: `core`,
+   `ciudadanos` y `users` no deben importar apps de dominio.
+2. **Imports directos** (`allow_indirect_imports = True`). Se chequea el import
+   directo, no las cadenas transitivas, para que el baseline sea estable y
+   mantenible en Fase 0.
+3. **Baseline** de las violaciones runtime actuales via `ignore_imports`. CI
+   queda verde hoy y **falla ante cualquier NUEVA** dependencia prohibida.
+4. **Tooling y tests fuera de alcance**: `core/debug_queries.py`,
+   `core/benchmarks/` y `users/tests.py` se excluyen para enfocarse en runtime.
+
+No se cortan imports en este PR (incluido `favorite_filters/config.py`); eso queda
+para los PRs siguientes de la Fase 0.
+
+## Implementacion
+
+Archivos agregados (cambio docs+tooling, sin tocar runtime, modelos, migraciones,
+permisos, endpoints ni templates):
+
+- `requirements/arch.txt`: dependencia aislada `import-linter==2.12` (+`grimp==3.14`).
+- `.importlinter`: `root_packages`, los 3 contratos `forbidden` y el baseline.
+- `.github/workflows/architecture.yml`: workflow independiente con el job
+  `architecture_imports` (Python 3.11.15, instala `requirements/arch.txt` y corre
+  `lint-imports`), disparado en `pull_request` y `push` a `development`/`main`.
+
+### Como reduce el baseline cada PR posterior
+
+`import-linter` falla si una linea de `ignore_imports` no matchea ningun import
+real. Por eso, cuando un PR corta una dependencia (p. ej. el registro de filtros
+favoritos por app), debe **borrar la linea correspondiente del baseline**, o el
+check quedara rojo. Asi el baseline solo puede bajar.
+
+## Como correr el check localmente
+
+Con venv (Python 3.11 recomendado para igualar CI):
+
+```powershell
+python -m venv .venv-arch
+.venv-arch\Scripts\pip install -r requirements/arch.txt
+.venv-arch\Scripts\lint-imports
+```
+
+Con Docker (replica exacta de CI):
+
+```powershell
+docker run --rm -v "${PWD}:/sisoc" -w /sisoc python:3.11.15-slim-bookworm `
+  sh -lc "pip install -q -r requirements/arch.txt && lint-imports"
+```
+
+`lint-imports` no ejecuta la app (grimp hace analisis estatico de AST), por lo que
+no requiere instalar las dependencias de Django ni levantar servicios.
+
+## Limitaciones conocidas
+
+- **Solo imports directos**: las cadenas transitivas no se chequean en Fase 0.
+- **Namespace packages parciales**: `import-linter`/`grimp` analizan paquetes
+  regulares (con `__init__.py`). Rutas servidas por namespace packages sin
+  `__init__.py` (p. ej. `historial.services`, `comedores.services.filter_config`)
+  pueden no entrar al grafo y no chequearse todavia. El baseline refleja solo los
+  edges efectivamente detectados.
+- **Tooling/tests excluidos**: `core/debug_queries.py`, `core/benchmarks/` y
+  `users/tests.py` no estan cubiertos por ahora.
+- **No es gate de merge todavia**: el job corre y se ve rojo ante violaciones,
+  pero no se agrego a `deploy_guard` (`.github/workflows/tests.yml`). Ver proximos
+  pasos.
+
+## Validacion ejecutada
+
+- `lint-imports` en `python:3.11.15-slim-bookworm` (misma base que CI):
+  `Contracts: 3 kept, 0 broken` (exit 0).
+- Prueba negativa: inyectado un import `core -> comedores.models` temporal, el
+  contrato rompe con exit 1 y el reporte lo identifica. Archivo de prueba removido.
+- `git diff --check` sin warnings de whitespace.
+
+## Proximos pasos
+
+1. **Promover a gate**: una vez verde unos PRs, agregar `architecture_imports` a la
+   lista `required` de `deploy_guard` en `.github/workflows/tests.yml`.
+2. **PR 2**: registro de filtros favoritos por app para cortar
+   `core/services/favorite_filters/config.py -> dominios` y bajar el baseline.
+3. **PR 3**: registro de paneles de ciudadano 360 para cortar imports directos en
+   `ciudadanos/views.py`.
+4. **PR 4**: aislar `users -> pwa/duplas` con servicios o eventos de app.
+
+## Referencias
+
+- `docs/plans/2026-06-22-monolito-modular-fase-0.md` (PR #1932)
+- `.importlinter`
+- `.github/workflows/architecture.yml`
+- `AGENTS.md`, `docs/ia/ARCHITECTURE.md`, `docs/registro/README.md`

--- a/requirements/arch.txt
+++ b/requirements/arch.txt
@@ -1,0 +1,5 @@
+# Dependencias del check de arquitectura (import-linter / grimp).
+# Aisladas del runtime: solo se instalan en el job de CI architecture_imports
+# y al correr `lint-imports` localmente.
+import-linter==2.12
+grimp==3.14


### PR DESCRIPTION
## Resumen

Implementar el *Primer PR esperado* del plan Fase 0 documentado en el PR #1932.
Agregar un ratchet de dependencias con `import-linter` para impedir que el grafo
de acoplamiento en el kernel empeore y empezar a mover dependencias hacia
contratos explícitos.

## Impacto

Tooling + CI + docs-only. No cambia runtime, modelos, migraciones, permisos,
endpoints, templates ni comportamiento observable.

Nuevos archivos:
- `requirements/arch.txt`: dependencia aislada `import-linter==2.12` + `grimp==3.14`.
- `.importlinter`: 3 contratos `forbidden` (core, ciudadanos, users no deben importar
  dominios) + baseline de las violaciones runtime actuales.
- `.github/workflows/architecture.yml`: job `architecture_imports` independiente
  (Python 3.11.15, corre `lint-imports` en cada PR y push).
- `docs/registro/decisiones/2026-06-23-import-linter-ratchet-fase-0.md`: documentación
  de la implementación, modo de uso local y próximos pasos.

## Validación

- `lint-imports` en `python:3.11.15-slim-bookworm` (misma base que CI):
  **Contracts: 3 kept, 0 broken** (exit 0).
- Prueba negativa: inyectar un import prohibido rompe el contrato con exit 1.
- `git diff --check`: sin warnings de whitespace.

## Nota operativa

El job corre pero no está en `deploy_guard` todavía (no es check requerido).
Recomendación: promoverlo tras unos PRs verdes.

El baseline refleja solo imports detectados por `grimp` (paquetes regulares con
`__init__.py`). Algunas rutas bajo namespace packages sin `__init__.py`
(p. ej. `historial.services`, `comedores.services.filter_config`) pueden no
estar cubiertas; se ampliará en fases posteriores.

Próximos PRs:
1. Registro de filtros favoritos para cortar `core/services/favorite_filters/config.py → dominios`.
2. Registro de paneles 360 para aislar `ciudadanos/views.py`.
3. Servicios/eventos para aislar `users → pwa/duplas`.

Co-Authored-By: Claude Haiku 4.5 <noreply@anthropic.com>