### PR TITLE
feat(comedores): reemplazar monto_total_convenio_por_espacio por dos campos (#1942)

### DIFF
--- a/comedores/api_serializers.py
+++ b/comedores/api_serializers.py
@@ -1051,7 +1051,9 @@ class ComedorDetailSerializer(serializers.ModelSerializer):
             "id_externo": obj.id_externo,
             "domicilio_completo_espacio": self._build_domicilio_convenio(obj),
             "monto_convenio_prestaciones_alimentarias": (
-                datos_pnud.monto_convenio_prestaciones_alimentarias if datos_pnud else None
+                datos_pnud.monto_convenio_prestaciones_alimentarias
+                if datos_pnud
+                else None
             ),
             "monto_convenio_siph": (
                 datos_pnud.monto_convenio_siph if datos_pnud else None

--- a/comedores/api_serializers.py
+++ b/comedores/api_serializers.py
@@ -1050,8 +1050,11 @@ class ComedorDetailSerializer(serializers.ModelSerializer):
             "nombre_espacio_comunitario": obj.nombre,
             "id_externo": obj.id_externo,
             "domicilio_completo_espacio": self._build_domicilio_convenio(obj),
-            "monto_total_convenio_por_espacio": (
-                datos_pnud.monto_total_convenio_por_espacio if datos_pnud else None
+            "monto_convenio_prestaciones_alimentarias": (
+                datos_pnud.monto_convenio_prestaciones_alimentarias if datos_pnud else None
+            ),
+            "monto_convenio_siph": (
+                datos_pnud.monto_convenio_siph if datos_pnud else None
             ),
             "prestaciones_financiadas_mensuales": (
                 datos_pnud.prestaciones_financiadas_mensuales if datos_pnud else None

--- a/comedores/forms/convenio_pnud_form.py
+++ b/comedores/forms/convenio_pnud_form.py
@@ -9,7 +9,8 @@ class ComedorDatosConvenioPnudForm(forms.ModelForm):
         fields = [
             "monto_total_conveniado",
             "nro_convenio",
-            "monto_total_convenio_por_espacio",
+            "monto_convenio_prestaciones_alimentarias",
+            "monto_convenio_siph",
             "prestaciones_financiadas_mensuales",
             "personas_conveniadas",
             "cantidad_modulos",
@@ -17,7 +18,8 @@ class ComedorDatosConvenioPnudForm(forms.ModelForm):
         labels = {
             "monto_total_conveniado": "Monto total conveniado",
             "nro_convenio": "Nro convenio",
-            "monto_total_convenio_por_espacio": "Monto total de convenio por espacio",
+            "monto_convenio_prestaciones_alimentarias": "Monto total de convenio por Espacio - Prestaciones Alimentarias",
+            "monto_convenio_siph": "Monto total de convenio por Espacio - Servicio Integral de Promoción Humana",
             "prestaciones_financiadas_mensuales": "Prestaciones financiadas mensuales",
             "personas_conveniadas": "Personas conveniadas",
             "cantidad_modulos": "Cantidad modulos",

--- a/comedores/migrations/0045_split_monto_convenio_por_espacio.py
+++ b/comedores/migrations/0045_split_monto_convenio_por_espacio.py
@@ -1,0 +1,25 @@
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ("comedores", "0044_nomina_derivacion"),
+    ]
+
+    operations = [
+        migrations.RemoveField(
+            model_name="comedordatosconveniopnud",
+            name="monto_total_convenio_por_espacio",
+        ),
+        migrations.AddField(
+            model_name="comedordatosconveniopnud",
+            name="monto_convenio_prestaciones_alimentarias",
+            field=models.DecimalField(blank=True, decimal_places=2, max_digits=14, null=True),
+        ),
+        migrations.AddField(
+            model_name="comedordatosconveniopnud",
+            name="monto_convenio_siph",
+            field=models.DecimalField(blank=True, decimal_places=2, max_digits=14, null=True),
+        ),
+    ]

--- a/comedores/migrations/0045_split_monto_convenio_por_espacio.py
+++ b/comedores/migrations/0045_split_monto_convenio_por_espacio.py
@@ -15,11 +15,15 @@ class Migration(migrations.Migration):
         migrations.AddField(
             model_name="comedordatosconveniopnud",
             name="monto_convenio_prestaciones_alimentarias",
-            field=models.DecimalField(blank=True, decimal_places=2, max_digits=14, null=True),
+            field=models.DecimalField(
+                blank=True, decimal_places=2, max_digits=14, null=True
+            ),
         ),
         migrations.AddField(
             model_name="comedordatosconveniopnud",
             name="monto_convenio_siph",
-            field=models.DecimalField(blank=True, decimal_places=2, max_digits=14, null=True),
+            field=models.DecimalField(
+                blank=True, decimal_places=2, max_digits=14, null=True
+            ),
         ),
     ]

--- a/comedores/models.py
+++ b/comedores/models.py
@@ -481,7 +481,13 @@ class ComedorDatosConvenioPnud(models.Model):
         blank=True,
     )
     nro_convenio = models.CharField(max_length=120, null=True, blank=True)
-    monto_total_convenio_por_espacio = models.DecimalField(
+    monto_convenio_prestaciones_alimentarias = models.DecimalField(
+        max_digits=14,
+        decimal_places=2,
+        null=True,
+        blank=True,
+    )
+    monto_convenio_siph = models.DecimalField(
         max_digits=14,
         decimal_places=2,
         null=True,

--- a/comedores/templates/comedor/comedor_convenio_pnud_form.html
+++ b/comedores/templates/comedor/comedor_convenio_pnud_form.html
@@ -38,7 +38,8 @@
                 <div class="row">
                     <div class="col-md-6">{{ form.monto_total_conveniado|as_crispy_field }}</div>
                     <div class="col-md-6">{{ form.nro_convenio|as_crispy_field }}</div>
-                    <div class="col-md-6">{{ form.monto_total_convenio_por_espacio|as_crispy_field }}</div>
+                    <div class="col-md-6">{{ form.monto_convenio_prestaciones_alimentarias|as_crispy_field }}</div>
+                    <div class="col-md-6">{{ form.monto_convenio_siph|as_crispy_field }}</div>
                     <div class="col-md-6">{{ form.prestaciones_financiadas_mensuales|as_crispy_field }}</div>
                     <div class="col-md-6">{{ form.personas_conveniadas|as_crispy_field }}</div>
                     <div class="col-md-6">{{ form.cantidad_modulos|as_crispy_field }}</div>

--- a/comedores/templates/comedor/comedor_detail.html
+++ b/comedores/templates/comedor/comedor_detail.html
@@ -1151,7 +1151,10 @@
                                 Domicilio completo: <strong>{{ domicilio_completo_comedor|default_if_none:"Sin informaci&oacute;n" }}</strong>
                             </p>
                             <p class="mb-0 fs-7">
-                                Monto total de convenio por espacio: <strong>{{ datos_convenio_pnud.monto_total_convenio_por_espacio|default_if_none:"Sin informaci&oacute;n" }}</strong>
+                                Monto total de convenio por Espacio - Prestaciones Alimentarias: <strong>{{ datos_convenio_pnud.monto_convenio_prestaciones_alimentarias|default_if_none:"Sin informaci&oacute;n" }}</strong>
+                            </p>
+                            <p class="mb-0 fs-7">
+                                Monto total de convenio por Espacio - Servicio Integral de Promoci&oacute;n Humana: <strong>{{ datos_convenio_pnud.monto_convenio_siph|default_if_none:"Sin informaci&oacute;n" }}</strong>
                             </p>
                             <p class="mb-0 fs-7">
                                 Prestaciones financiadas mensuales: <strong>{{ datos_convenio_pnud.prestaciones_financiadas_mensuales|default_if_none:"Sin informaci&oacute;n" }}</strong>


### PR DESCRIPTION
## Resumen

- Elimina el campo `monto_total_convenio_por_espacio` del modelo `ComedorDatosConvenioPnud`
- Agrega dos campos separados con el mismo tipo (`DecimalField`, 14 dígitos, 2 decimales, nullable):
  - `monto_convenio_prestaciones_alimentarias` → "Monto total de convenio por Espacio - Prestaciones Alimentarias"
  - `monto_convenio_siph` → "Monto total de convenio por Espacio - Servicio Integral de Promoción Humana"
- Actualiza el formulario, templates de detalle y edición, serializer de API (PWA) y agrega la migración correspondiente

Closes #1942

## Test plan

- [ ] Ejecutar `python manage.py migrate` y verificar que la migración `0045` aplica sin errores
- [ ] Abrir el formulario "Datos del Convenio" de un comedor PNUD y confirmar que aparecen los dos nuevos campos y desapareció el anterior
- [ ] Guardar valores y verificar que se persisten correctamente
- [ ] Verificar la vista de detalle del comedor muestra los dos nuevos campos
- [ ] Verificar el endpoint de API devuelve `monto_convenio_prestaciones_alimentarias` y `monto_convenio_siph` en lugar del campo anterior

🤖 Generated with [Claude Code](https://claude.com/claude-code)