### PR TITLE
docs(release): preparar predeploy development main

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,24 @@
 <!-- AUTO-GENERATED RELEASE START: 2026-06-24 -->
 # Versión SISOC 24.06.2026
 
+## Nuevas Funcionalidades
+
+- [users] Importacion masiva permite crear usuarios PWA sin acceso staff, preservando el comportamiento staff por defecto. (PR #1927)
+- [celiaquia] Celiaquia incorpora subsanaciones multimotivo, respuesta con evidencia, comentarios internos y mejoras de reporter/exportaciones. (PR #1938)
+- [pwa] PWA suma permisos granulares, gestion de subusuarios, documentos de nomina, flag de celiaquia y ajustes mobile. (PR #1941)
+
 ## Actualizaciones
 
 - [sin-area] fix(comedores): alinear monto_prestacion_mensual mobile con la web. (PR #1925)
+- [arquitectura] Se documenta la Fase 0 del monolito modular y el plan de ratchet de dependencias. (PR #1932)
+- [arquitectura] Se agrega import-linter con contratos de arquitectura para impedir que empeore el acoplamiento del kernel. (PR #1940)
+- [comedores] Datos de Convenio PNUD reemplaza el monto unico por Prestaciones Alimentarias y Servicio Integral de Promocion Humana. (PR #1944)
+- [celiaquia] Se completa Celiaquia V3 con hardening de permisos, comentarios internos y alcance de usuarios deny-by-default. (PR #1948)
+
+## Corrección de Errores
+
+- [centrodeinfancia] Se corrigen secciones, condicionales, precarga RENAPER, departamento y validaciones del formulario de Trabajadores CDI. (PR #1929)
+- [comedores] El legajo vuelve a mostrar Relevamientos para Abordaje Comunitario Linea Secos y Linea Tradicional. (PR #1937)
 <!-- AUTO-GENERATED RELEASE END: 2026-06-24 -->
 
 <!-- AUTO-GENERATED RELEASE START: 2026-06-10 -->

--- a/celiaquia/services/cruce_service/__init__.py
+++ b/celiaquia/services/cruce_service/__init__.py
@@ -1,5 +1,15 @@
 """Servicio para gestión de cruces."""
 
-from .impl import CupoNoConfigurado, CruceService, _WEASY_OK
+from .impl import (
+    DOCUMENTO_COL_CANDIDATAS,
+    CupoNoConfigurado,
+    CruceService,
+    _WEASY_OK,
+)
 
-__all__ = ["CruceService", "CupoNoConfigurado", "_WEASY_OK"]
+__all__ = [
+    "CruceService",
+    "CupoNoConfigurado",
+    "DOCUMENTO_COL_CANDIDATAS",
+    "_WEASY_OK",
+]

--- a/docs/registro/cambios/2026-06-23-relevamientos-abordaje-header.md
+++ b/docs/registro/cambios/2026-06-23-relevamientos-abordaje-header.md
@@ -23,4 +23,3 @@ Issue #1935 reporto que los comedores con programa `Abordaje Comunitario - Linea
   - PNUD fuera de esas dos lineas manteniendo oculto `Relevamientos`.
   - Comedor no PNUD manteniendo `Relevamientos`.
 - `black --check` sobre Python tocado.
-

--- a/docs/registro/releases/pending/2026-06-24-pr-1927.md
+++ b/docs/registro/releases/pending/2026-06-24-pr-1927.md
@@ -1,0 +1,19 @@
+---
+pr: 1927
+release_date: 2026-06-24
+category: Nuevas Funcionalidades
+area: users
+title: feat(users): checkbox "Usuarios de la PWA" en importacion masiva
+summary: Importacion masiva permite crear usuarios PWA sin acceso staff, preservando el comportamiento staff por defecto
+impact: Operadores pueden cargar lotes de usuarios mobile/PWA desde el importador existente
+source_url: https://github.com/dsocial118/SISOC/pull/1927
+---
+# Release note preliminar PR #1927
+
+- Fecha objetivo de release: 2026-06-24
+- Categoria: Nuevas Funcionalidades
+- Area: users
+- Titulo del PR: feat(users): checkbox "Usuarios de la PWA" en importacion masiva
+- Resumen: Importacion masiva permite crear usuarios PWA sin acceso staff, preservando el comportamiento staff por defecto
+- Impacto usuario: Operadores pueden cargar lotes de usuarios mobile/PWA desde el importador existente
+- Fuente: https://github.com/dsocial118/SISOC/pull/1927

--- a/docs/registro/releases/pending/2026-06-24-pr-1929.md
+++ b/docs/registro/releases/pending/2026-06-24-pr-1929.md
@@ -1,0 +1,19 @@
+---
+pr: 1929
+release_date: 2026-06-24
+category: Correccion de Errores
+area: centrodeinfancia
+title: Fix form trabajadores
+summary: Se corrigen secciones, condicionales, precarga RENAPER, departamento y validaciones del formulario de Trabajadores CDI
+impact: Operadores CDI visualizan y completan correctamente el formulario de trabajadores
+source_url: https://github.com/dsocial118/SISOC/pull/1929
+---
+# Release note preliminar PR #1929
+
+- Fecha objetivo de release: 2026-06-24
+- Categoria: Correccion de Errores
+- Area: centrodeinfancia
+- Titulo del PR: Fix form trabajadores
+- Resumen: Se corrigen secciones, condicionales, precarga RENAPER, departamento y validaciones del formulario de Trabajadores CDI
+- Impacto usuario: Operadores CDI visualizan y completan correctamente el formulario de trabajadores
+- Fuente: https://github.com/dsocial118/SISOC/pull/1929

--- a/docs/registro/releases/pending/2026-06-24-pr-1932.md
+++ b/docs/registro/releases/pending/2026-06-24-pr-1932.md
@@ -1,0 +1,19 @@
+---
+pr: 1932
+release_date: 2026-06-24
+category: Actualizaciones
+area: arquitectura
+title: [codex] Documentar Fase 0 de monolito modular
+summary: Se documenta la Fase 0 del monolito modular y el plan de ratchet de dependencias
+impact: Equipo tecnico cuenta con una guia versionada para reducir acoplamiento sin partir servicios ni base de datos
+source_url: https://github.com/dsocial118/SISOC/pull/1932
+---
+# Release note preliminar PR #1932
+
+- Fecha objetivo de release: 2026-06-24
+- Categoria: Actualizaciones
+- Area: arquitectura
+- Titulo del PR: [codex] Documentar Fase 0 de monolito modular
+- Resumen: Se documenta la Fase 0 del monolito modular y el plan de ratchet de dependencias
+- Impacto usuario: Equipo tecnico cuenta con una guia versionada para reducir acoplamiento sin partir servicios ni base de datos
+- Fuente: https://github.com/dsocial118/SISOC/pull/1932

--- a/docs/registro/releases/pending/2026-06-24-pr-1937.md
+++ b/docs/registro/releases/pending/2026-06-24-pr-1937.md
@@ -1,0 +1,19 @@
+---
+pr: 1937
+release_date: 2026-06-24
+category: Correccion de Errores
+area: comedores
+title: Reincorporar Relevamientos en comedores Abordaje
+summary: El legajo vuelve a mostrar Relevamientos para Abordaje Comunitario Linea Secos y Linea Tradicional
+impact: Operadores recuperan el acceso superior a Relevamientos en los programas de Abordaje afectados
+source_url: https://github.com/dsocial118/SISOC/pull/1937
+---
+# Release note preliminar PR #1937
+
+- Fecha objetivo de release: 2026-06-24
+- Categoria: Correccion de Errores
+- Area: comedores
+- Titulo del PR: Reincorporar Relevamientos en comedores Abordaje
+- Resumen: El legajo vuelve a mostrar Relevamientos para Abordaje Comunitario Linea Secos y Linea Tradicional
+- Impacto usuario: Operadores recuperan el acceso superior a Relevamientos en los programas de Abordaje afectados
+- Fuente: https://github.com/dsocial118/SISOC/pull/1937

--- a/docs/registro/releases/pending/2026-06-24-pr-1938.md
+++ b/docs/registro/releases/pending/2026-06-24-pr-1938.md
@@ -1,0 +1,19 @@
+---
+pr: 1938
+release_date: 2026-06-24
+category: Nuevas Funcionalidades
+area: celiaquia
+title: Celiaquia v3
+summary: Celiaquia incorpora subsanaciones multimotivo, respuesta con evidencia, comentarios internos y mejoras de reporter/exportaciones
+impact: Equipos de Nacion y provincia gestionan subsanaciones con trazabilidad y reglas de visibilidad mas precisas
+source_url: https://github.com/dsocial118/SISOC/pull/1938
+---
+# Release note preliminar PR #1938
+
+- Fecha objetivo de release: 2026-06-24
+- Categoria: Nuevas Funcionalidades
+- Area: celiaquia
+- Titulo del PR: Celiaquia v3
+- Resumen: Celiaquia incorpora subsanaciones multimotivo, respuesta con evidencia, comentarios internos y mejoras de reporter/exportaciones
+- Impacto usuario: Equipos de Nacion y provincia gestionan subsanaciones con trazabilidad y reglas de visibilidad mas precisas
+- Fuente: https://github.com/dsocial118/SISOC/pull/1938

--- a/docs/registro/releases/pending/2026-06-24-pr-1940.md
+++ b/docs/registro/releases/pending/2026-06-24-pr-1940.md
@@ -1,0 +1,19 @@
+---
+pr: 1940
+release_date: 2026-06-24
+category: Actualizaciones
+area: arquitectura
+title: chore(arch): agregar ratchet import-linter (Fase 0, PR 1)
+summary: Se agrega import-linter con contratos de arquitectura para impedir que empeore el acoplamiento del kernel
+impact: CI empieza a controlar dependencias internas con baseline explicito y sin cambios de runtime
+source_url: https://github.com/dsocial118/SISOC/pull/1940
+---
+# Release note preliminar PR #1940
+
+- Fecha objetivo de release: 2026-06-24
+- Categoria: Actualizaciones
+- Area: arquitectura
+- Titulo del PR: chore(arch): agregar ratchet import-linter (Fase 0, PR 1)
+- Resumen: Se agrega import-linter con contratos de arquitectura para impedir que empeore el acoplamiento del kernel
+- Impacto usuario: CI empieza a controlar dependencias internas con baseline explicito y sin cambios de runtime
+- Fuente: https://github.com/dsocial118/SISOC/pull/1940

--- a/docs/registro/releases/pending/2026-06-24-pr-1941.md
+++ b/docs/registro/releases/pending/2026-06-24-pr-1941.md
@@ -1,0 +1,19 @@
+---
+pr: 1941
+release_date: 2026-06-24
+category: Nuevas Funcionalidades
+area: pwa
+title: Cambios, fixes y pedidos
+summary: PWA suma permisos granulares, gestion de subusuarios, documentos de nomina, flag de celiaquia y ajustes mobile
+impact: Representantes PWA operan nomina, colaboradores y usuarios con permisos mas acotados y documentos trazables
+source_url: https://github.com/dsocial118/SISOC/pull/1941
+---
+# Release note preliminar PR #1941
+
+- Fecha objetivo de release: 2026-06-24
+- Categoria: Nuevas Funcionalidades
+- Area: pwa
+- Titulo del PR: Cambios, fixes y pedidos
+- Resumen: PWA suma permisos granulares, gestion de subusuarios, documentos de nomina, flag de celiaquia y ajustes mobile
+- Impacto usuario: Representantes PWA operan nomina, colaboradores y usuarios con permisos mas acotados y documentos trazables
+- Fuente: https://github.com/dsocial118/SISOC/pull/1941

--- a/docs/registro/releases/pending/2026-06-24-pr-1944.md
+++ b/docs/registro/releases/pending/2026-06-24-pr-1944.md
@@ -1,0 +1,19 @@
+---
+pr: 1944
+release_date: 2026-06-24
+category: Actualizaciones
+area: comedores
+title: feat(comedores): reemplazar monto_total_convenio_por_espacio por dos campos (#1942)
+summary: Datos de Convenio PNUD reemplaza el monto unico por Prestaciones Alimentarias y Servicio Integral de Promocion Humana
+impact: Web y PWA muestran los dos montos requeridos para convenios de Abordaje Comunitario
+source_url: https://github.com/dsocial118/SISOC/pull/1944
+---
+# Release note preliminar PR #1944
+
+- Fecha objetivo de release: 2026-06-24
+- Categoria: Actualizaciones
+- Area: comedores
+- Titulo del PR: feat(comedores): reemplazar monto_total_convenio_por_espacio por dos campos (#1942)
+- Resumen: Datos de Convenio PNUD reemplaza el monto unico por Prestaciones Alimentarias y Servicio Integral de Promocion Humana
+- Impacto usuario: Web y PWA muestran los dos montos requeridos para convenios de Abordaje Comunitario
+- Fuente: https://github.com/dsocial118/SISOC/pull/1944

--- a/docs/registro/releases/pending/2026-06-24-pr-1948.md
+++ b/docs/registro/releases/pending/2026-06-24-pr-1948.md
@@ -1,0 +1,19 @@
+---
+pr: 1948
+release_date: 2026-06-24
+category: Actualizaciones
+area: celiaquia
+title: Celiaquia v3
+summary: Se completa Celiaquia V3 con hardening de permisos, comentarios internos y alcance de usuarios deny-by-default
+impact: La operacion de Celiaquia queda mas restringida por rol/alcance y con comentarios internos visibles solo para Nacion
+source_url: https://github.com/dsocial118/SISOC/pull/1948
+---
+# Release note preliminar PR #1948
+
+- Fecha objetivo de release: 2026-06-24
+- Categoria: Actualizaciones
+- Area: celiaquia
+- Titulo del PR: Celiaquia v3
+- Resumen: Se completa Celiaquia V3 con hardening de permisos, comentarios internos y alcance de usuarios deny-by-default
+- Impacto usuario: La operacion de Celiaquia queda mas restringida por rol/alcance y con comentarios internos visibles solo para Nacion
+- Fuente: https://github.com/dsocial118/SISOC/pull/1948

--- a/users/services.py
+++ b/users/services.py
@@ -3,7 +3,7 @@ from typing import List, Tuple
 
 from django.contrib.auth.models import User
 from django.db.models import Case, CharField, Count, F, Q, Value, When
-from django.urls import reverse
+from django.urls import NoReverseMatch, reverse
 
 from core.services.advanced_filters import AdvancedFilterEngine
 from core.services.column_preferences import build_columns_context
@@ -34,6 +34,13 @@ BENEFICIARIO_ADVANCED_FILTER = AdvancedFilterEngine(
         "number": BENEFICIARIO_NUM_OPS,
     },
 )
+
+
+def _reverse_optional(url_name):
+    try:
+        return reverse(url_name)
+    except NoReverseMatch:
+        return None
 
 
 class UsuariosService:
@@ -232,24 +239,30 @@ class UsuariosService:
                 [
                     {
                         "label": "ENVIO DE CREDENCIALES",
-                        "url": reverse("usuarios_credenciales_masivas"),
+                        "url": bulk_credentials_url,
                         "class": "btn btn-lg btn-export-csv",
                         "title": "Enviar credenciales vigentes desde Excel",
                     }
                 ]
                 if UsuariosService.can_manage_bulk_credentials(request.user)
+                and (
+                    bulk_credentials_url := _reverse_optional(
+                        "usuarios_credenciales_masivas"
+                    )
+                )
                 else []
             )
             + (
                 [
                     {
                         "label": "IMPORTAR USUARIOS",
-                        "url": reverse("usuarios_importar"),
+                        "url": users_import_url,
                         "class": "btn btn-lg btn-primary",
                         "title": "Importar usuarios masivamente desde Excel",
                     }
                 ]
-                if request.user.has_perm("auth.add_user") or request.user.is_superuser
+                if (request.user.has_perm("auth.add_user") or request.user.is_superuser)
+                and (users_import_url := _reverse_optional("usuarios_importar"))
                 else []
             ),
         }

--- a/users/services.py
+++ b/users/services.py
@@ -208,6 +208,32 @@ class UsuariosService:
             USUARIOS_LIST_KEY,
             columns_catalog,
         )
+        additional_buttons = []
+        bulk_credentials_url = _reverse_optional("usuarios_credenciales_masivas")
+        if (
+            UsuariosService.can_manage_bulk_credentials(request.user)
+            and bulk_credentials_url
+        ):
+            additional_buttons.append(
+                {
+                    "label": "ENVIO DE CREDENCIALES",
+                    "url": bulk_credentials_url,
+                    "class": "btn btn-lg btn-export-csv",
+                    "title": "Enviar credenciales vigentes desde Excel",
+                }
+            )
+        users_import_url = _reverse_optional("usuarios_importar")
+        if (
+            request.user.has_perm("auth.add_user") or request.user.is_superuser
+        ) and users_import_url:
+            additional_buttons.append(
+                {
+                    "label": "IMPORTAR USUARIOS",
+                    "url": users_import_url,
+                    "class": "btn btn-lg btn-primary",
+                    "title": "Importar usuarios masivamente desde Excel",
+                }
+            )
         return {
             **columns_context,
             "table_actions": [
@@ -235,36 +261,7 @@ class UsuariosService:
             "filters_action": reverse("usuarios"),
             "seccion_filtros_favoritos": SeccionesFiltrosFavoritos.USUARIOS,
             "show_add_button": True,
-            "additional_buttons": (
-                [
-                    {
-                        "label": "ENVIO DE CREDENCIALES",
-                        "url": bulk_credentials_url,
-                        "class": "btn btn-lg btn-export-csv",
-                        "title": "Enviar credenciales vigentes desde Excel",
-                    }
-                ]
-                if UsuariosService.can_manage_bulk_credentials(request.user)
-                and (
-                    bulk_credentials_url := _reverse_optional(
-                        "usuarios_credenciales_masivas"
-                    )
-                )
-                else []
-            )
-            + (
-                [
-                    {
-                        "label": "IMPORTAR USUARIOS",
-                        "url": users_import_url,
-                        "class": "btn btn-lg btn-primary",
-                        "title": "Importar usuarios masivamente desde Excel",
-                    }
-                ]
-                if (request.user.has_perm("auth.add_user") or request.user.is_superuser)
-                and (users_import_url := _reverse_optional("usuarios_importar"))
-                else []
-            ),
+            "additional_buttons": additional_buttons,
         }
 
     @staticmethod

--- a/users/services_pwa.py
+++ b/users/services_pwa.py
@@ -215,6 +215,7 @@ def _validate_assignable_comedores(actor, comedor_ids: Iterable[int]) -> list[in
 
 
 @transaction.atomic
+# pylint: disable-next=too-many-arguments,too-many-locals
 def create_operador_for_comedor(
     *,
     comedor_id: int,


### PR DESCRIPTION
## Resumen

Pre-deploy de `origin/development` hacia `origin/main` preparado en worktree aislada. El PR sanea el corte antes de promover `development` a `main`.

## Cambios

- Actualiza `CHANGELOG.md` y release notes pendientes para los PRs incluidos en el corte `development -> main` del 2026-06-24.
- Corrige whitespace detectado por `git diff --check` en docs de relevamientos.
- Exporta `DOCUMENTO_COL_CANDIDATAS` desde `celiaquia.services.cruce_service` para reparar la coleccion de tests/smoke.
- Hace opcionales los botones de acciones masivas de usuarios cuando un URLConf reducido no define esas rutas.
- Agrega supresion puntual de pylint para la API keyword-only de creacion de operadores PWA.

## Pruebas ejecutadas

- `git diff --check`
- `python -m py_compile scripts\ci\pr_doc_automation.py`
- Validacion Python de pending release notes para la fecha `2026-06-24`
- `python -m compileall scripts\ci comedores celiaquia users pwa centrodeinfancia -q`
- `python -m py_compile users\services.py users\services_pwa.py celiaquia\services\cruce_service\__init__.py`
- GitHub Actions del PR #1950 en ejecucion tras el ultimo push.

## Riesgos remanentes

- El PR definitivo `development -> main` (#1951) sigue en NO-GO hasta mergear este saneamiento a `development` y re-ejecutar checks sobre el PR exacto `development -> main`.
- La migracion `comedores/0045` reemplaza un campo de monto sin backfill; requiere confirmacion operativa de que no hay datos productivos a preservar o que el mapeo esperado es manual/externo.
- Docker local no pudo ejecutarse en esta maquina porque Docker Desktop no expuso el daemon.