### PR TITLE
feat(users): email opcional, username como clave, envío masivo agrupado

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,19 +1,61 @@
 # CLAUDE.md
 
-Instrucciones especificas para Claude en SISOC.
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
 
-Fuente de verdad:
-- `AGENTS.md`
+Fuente de verdad para comportamiento de IA: `AGENTS.md`.
 
-Arranque minimo:
+## Arranque mínimo
+
 1. `AGENTS.md`
 2. `docs/indice.md`
-3. archivo objetivo + tests
-4. una guia relevante de `docs/ia/`
-5. ampliar solo con evidencia
+3. archivo objetivo + tests cercanos
+4. una guía relevante de `docs/ia/` según la tarea
+5. ampliar solo con evidencia concreta
 
-Reglas cortas:
-- no inventar modelos, endpoints ni permisos,
-- mantener cambios pequenos y revisables,
-- respetar `docs/ia/CONTEXT_HYGIENE.md`,
-- documentar cambios o decisiones importantes en `docs/`.
+## Comandos
+
+```bash
+# Levantar el stack local
+docker compose up
+
+# Ejecutar todos los tests (paralelo)
+docker compose exec django pytest -n auto
+
+# Ejecutar un archivo de tests específico
+docker compose exec django pytest tests/test_<modulo>.py -v
+
+# Solo tests smoke (sin DB real)
+docker compose exec django pytest -m smoke
+
+# Tests que requieren MySQL real (CI)
+docker compose exec django pytest -m mysql_compat
+
+# Formatear Python
+black .
+
+# Lint Python
+pylint <app>/
+
+# Lint templates Django
+djlint templates/ --check
+```
+
+## Arquitectura
+
+Django 4.2 + MySQL 8.4, desplegado con Docker Compose. Python 3.11+.
+
+**Organización de apps:** cada dominio de negocio es una Django app propia (`comedores/`, `admisiones/`, `users/`, etc.). La lógica de negocio vive en `<app>/services/`, nunca en views ni modelos. Las views son CBVs sin lógica. DRF coexiste con las views tradicionales; los serializers van en `api_serializers.py` y las API views en `api_views.py`.
+
+**Core compartido:** `core/` expone utilidades reutilizables (soft delete, permisos, cache, auth de API, validadores). No duplicar lo que ya existe ahí.
+
+**Configuración central:** `config/settings.py` centraliza DB, cache, middleware, apps instaladas, logging custom e integraciones externas (GESTIONAR, RENAPER, Sentry, PWA). El stack de middleware define contexto de seguridad, sesión, auditoría y thread-locals en ese orden — el orden importa.
+
+**Tests:** centralizados en `/tests/` (con algunos tests locales por app). SQLite in-memory por defecto; el marker `mysql_compat` activa MySQL real. `pytest --reuse-db` reutiliza el schema entre corridas para acelerar.
+
+**Registro de cambios:** todo cambio funcional visible, decisión de arquitectura o trade-off importante debe registrarse en `docs/registro/` (ver `docs/registro/README.md`).
+
+## Reglas cortas
+
+- No inventar modelos, endpoints, permisos ni settings sin evidencia en el repo o pedido explícito.
+- Cambios pequeños y revisables; no mezclar feature + refactor + formateo masivo.
+- Respetar `docs/ia/CONTEXT_HYGIENE.md` para decidir cuánto contexto cargar.

--- a/docs/registro/cambios/2026-06-30-usuarios-email-opcional-y-bulk-agrupado.md
+++ b/docs/registro/cambios/2026-06-30-usuarios-email-opcional-y-bulk-agrupado.md
@@ -1,0 +1,61 @@
+# Usuarios: email opcional, username como clave, envío masivo agrupado
+
+Issue: #1979.
+
+## Cambios funcionales
+
+- **Email opcional y no único en usuarios.** `UserCreationForm` y `CustomUserChangeForm`
+  ya no exigen `email`, ni rechazan emails repetidos. El `username` sigue siendo el
+  identificador único (constraint a nivel BD de `auth.User`). Se quitó la validación
+  equivalente en `services_pwa.crear_operador_pwa` y `services_generate_user._validar_email`
+  (en este último solo el check de duplicado; el email continúa siendo obligatorio
+  para enviar credenciales del referente).
+- **Importación masiva sin columna `Correo`.** `services_user_import` ahora trata
+  `correo` como columna opcional. Si la fila no trae email, el username se genera
+  desde `apellido.nombre` normalizado; si la fila trae email pero ya está en uso,
+  el usuario se crea igual (sin marcar `SKIPPED`). Si la fila no tiene email y
+  `send_credentials=True`, el envío se omite silenciosamente.
+- **Envío masivo agrupa por destinatario.** Cuando dos o más filas comparten el
+  mismo mail destinatario (informado en la planilla o resuelto desde `user.email`),
+  `process_bulk_credentials_file` y el worker `process_bulk_credentials_job` envían
+  un único correo al destinatario con la lista de credenciales. Cada fila del grupo
+  queda persistida individualmente como `SENT` para preservar el detalle del lote.
+- **Datos personales en el email.** Los templates `bulk_credentials_email.txt` y
+  `bulk_credentials_email_inet.txt` ahora muestran `Nombre y apellido` (`first_name`
+  + `last_name`) además de usuario y contraseña. En el modo agrupado se itera
+  sobre la lista de credenciales mostrando nombre/apellido por cada usuario.
+
+## Compatibilidad
+
+- `services_bulk_credentials.process_bulk_credentials_row` se mantiene como wrapper
+  fino sobre `process_bulk_credentials_group` para no romper consumidores externos.
+- `services_generate_user._enviar_credenciales` y
+  `services_user_import._enviar_credenciales_import` arman un `BulkCredentialEntry`
+  singular para reutilizar el mismo template con el contexto nuevo (`entries`,
+  `is_grouped`).
+- `services_auth.request_password_reset_for_email` ya iteraba sobre las coincidencias
+  de email, por lo que sigue siendo correcto con emails repetidos.
+
+## Defensas implementadas
+
+- **INET con centros distintos no se agrupa.** `_row_grouping_key` usa el par
+  `(recipient, nombre_del_centro)` como clave cuando el send_type requiere el
+  centro. Dos filas con mismo mail destinatario pero centros distintos viajan
+  en correos separados, evitando mezclar datos de centros en un mismo cuerpo.
+- **Cache de destinatarios.** `_build_recipient_cache(rows)` pre-carga
+  `username -> email` en una sola query antes de procesar el lote, eliminando
+  el O(N) de lookups del flujo anterior.
+- **Resume sin duplicar correos.** El worker aplica dos reglas defensivas en
+  `_select_group_for_row`:
+  1. Si la fila primaria ya tiene `attempts > 0` (resume tras fallo posible
+     post-envío SMTP exitoso), se procesa SOLA — no se re-arma el grupo.
+  2. Si existe alguna fila SENT en este mismo job con `mail_destino` igual al
+     destinatario candidato, no se agrupan filas pendientes con él: cada una
+     se envía por separado para no volver a entregar las credenciales que el
+     destinatario ya recibió en el correo agrupado original.
+
+## Pendientes
+
+- El template INET en modo agrupado mantiene el saludo con
+  `nombre_del_centro` del primer entry; con la nueva regla R3 esto siempre
+  coincide para todas las filas del grupo.

--- a/tests/test_users_bulk_credentials.py
+++ b/tests/test_users_bulk_credentials.py
@@ -454,7 +454,9 @@ def test_process_bulk_credentials_rejects_user_without_visible_password():
 
 @pytest.mark.django_db
 @override_settings(EMAIL_BACKEND="django.core.mail.backends.locmem.EmailBackend")
-def test_process_bulk_credentials_allows_shared_recipient_email():
+def test_process_bulk_credentials_groups_shared_recipient_into_one_email():
+    """Cuando varias filas comparten destinatario, se envía un solo correo
+    con todas las credenciales (issue #1979)."""
     first_user = User.objects.create_user(
         username="bulk_shared_one",
         email="one@example.com",
@@ -492,10 +494,9 @@ def test_process_bulk_credentials_allows_shared_recipient_email():
     assert second_user.email == "two@example.com"
     assert first_user.check_password("Inicial123!") is True
     assert second_user.check_password("Inicial123!") is True
-    assert [email.to for email in mail.outbox] == [
-        ["shared@example.com"],
-        ["shared@example.com"],
-    ]
+    assert [email.to for email in mail.outbox] == [["shared@example.com"]]
+    assert "bulk_shared_one" in mail.outbox[0].body
+    assert "bulk_shared_two" in mail.outbox[0].body
 
 
 @pytest.mark.django_db
@@ -824,8 +825,8 @@ def test_process_bulk_credentials_job_stops_on_first_failure_and_tracks_checkpoi
     )
 
     def _send_side_effect(*args, **kwargs):
-        user = kwargs["user"]
-        if user.username == "bulk_job_second":
+        first_username = kwargs["entries"][0].username
+        if first_username == "bulk_job_second":
             raise smtplib.SMTPAuthenticationError(535, b"auth failed")
         return None
 
@@ -921,8 +922,8 @@ def test_process_bulk_credentials_job_can_resume_from_failed_row(
     failure_state = {"enabled": True}
 
     def _send_side_effect(*args, **kwargs):
-        user = kwargs["user"]
-        if failure_state["enabled"] and user.username == "bulk_resume_second":
+        first_username = kwargs["entries"][0].username
+        if failure_state["enabled"] and first_username == "bulk_resume_second":
             raise smtplib.SMTPAuthenticationError(535, b"auth failed")
         return None
 
@@ -1073,7 +1074,7 @@ def test_bulk_credentials_job_detail_view_shows_failure_context(
     )
 
     def _send_side_effect(*args, **kwargs):
-        if kwargs["user"].username == "bulk_detail_second":
+        if kwargs["entries"][0].username == "bulk_detail_second":
             raise smtplib.SMTPAuthenticationError(535, b"auth failed")
         return None
 

--- a/tests/test_users_email_opcional_y_agrupamiento.py
+++ b/tests/test_users_email_opcional_y_agrupamiento.py
@@ -1,0 +1,569 @@
+"""Tests para issue #1979.
+
+Cubren:
+- Usuarios sin email y con email repetido en forms.
+- User import sin columna correo.
+- Bulk credentials agrupado por mail destinatario.
+- Nombre y apellido en el cuerpo del email.
+"""
+
+from io import BytesIO
+
+import pytest
+from django.contrib.auth import get_user_model
+from django.core import mail
+from django.core.files.uploadedfile import SimpleUploadedFile
+from django.test import override_settings
+from openpyxl import Workbook
+
+from users.forms import CustomUserChangeForm, UserCreationForm
+from users.models import (
+    BulkCredentialsJob,
+    BulkCredentialsJobRow,
+)
+from users.services_bulk_credentials import (
+    process_bulk_credentials_file,
+)
+from users.services_bulk_credentials_jobs import (
+    create_bulk_credentials_job,
+    process_bulk_credentials_job,
+)
+from users.services_user_import import (
+    USER_IMPORT_TEMPLATE_HEADERS,
+    process_single_user_import_row,
+)
+
+User = get_user_model()
+
+
+def _build_excel_file(rows, headers=("usuario", "mail")):
+    workbook = Workbook()
+    worksheet = workbook.active
+    worksheet.title = "credenciales"
+    worksheet.append(list(headers))
+    for row in rows:
+        worksheet.append(list(row))
+    output = BytesIO()
+    workbook.save(output)
+    return SimpleUploadedFile(
+        "credenciales.xlsx",
+        output.getvalue(),
+        content_type=(
+            "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet"
+        ),
+    )
+
+
+def _set_visible_temporary_password(user, plain_password):
+    profile = user.profile
+    profile.must_change_password = True
+    profile.temporary_password_plaintext = plain_password
+    profile.save(
+        update_fields=["must_change_password", "temporary_password_plaintext"]
+    )
+    return user
+
+
+# ---------- A1: forms permiten email vacío y repetido ----------
+
+
+@pytest.mark.django_db
+def test_user_creation_form_acepta_email_vacio():
+    form = UserCreationForm(
+        data={
+            "username": "sin_email_user",
+            "email": "",
+            "password": "Inicial123!",
+            "first_name": "Juan",
+            "last_name": "Pérez",
+        },
+    )
+    assert form.is_valid(), form.errors
+    user = form.save()
+    assert user.email == ""
+    assert user.username == "sin_email_user"
+
+
+@pytest.mark.django_db
+def test_user_creation_form_acepta_email_repetido():
+    User.objects.create_user(
+        username="primer_usuario",
+        email="repetido@example.com",
+        password="Pass123!",
+    )
+    form = UserCreationForm(
+        data={
+            "username": "segundo_usuario",
+            "email": "repetido@example.com",
+            "password": "Pass123!",
+            "first_name": "Ana",
+            "last_name": "García",
+        },
+    )
+    assert form.is_valid(), form.errors
+    nuevo = form.save()
+    assert nuevo.email == "repetido@example.com"
+    assert (
+        User.objects.filter(email__iexact="repetido@example.com").count() == 2
+    )
+
+
+@pytest.mark.django_db
+def test_user_change_form_acepta_email_vacio():
+    existing = User.objects.create_user(
+        username="cambia_email",
+        email="viejo@example.com",
+        password="Pass123!",
+    )
+    form = CustomUserChangeForm(
+        data={
+            "username": "cambia_email",
+            "email": "",
+            "first_name": "Pedro",
+            "last_name": "Lopez",
+        },
+        instance=existing,
+    )
+    assert form.is_valid(), form.errors
+
+
+# ---------- A2: user import sin columna correo ----------
+
+
+class _StubImportJob:
+    """Job mínimo para process_single_user_import_row."""
+
+    is_pwa_import = False
+    send_credentials = False
+
+
+@pytest.mark.django_db
+def test_user_import_row_sin_correo_genera_username_desde_nombre():
+    job = _StubImportJob()
+    resultado = process_single_user_import_row(
+        row_data={
+            "nombre": "Ana",
+            "apellido": "García",
+            "correo": "",
+            "permisos": "",
+            "provincias": "",
+            "rol": "operadora",
+            "fila": 2,
+        },
+        job=job,
+    )
+    assert resultado["status"]
+    # Username generado contiene el apellido normalizado
+    user = User.objects.filter(first_name="Ana", last_name="García").first()
+    assert user is not None
+    assert user.email == ""
+    assert user.username.startswith("garcia"), user.username
+
+
+@pytest.mark.django_db
+def test_user_import_row_emails_repetidos_no_son_rechazados():
+    User.objects.create_user(
+        username="primer.import", email="shared@example.com", password="Pass!"
+    )
+    job = _StubImportJob()
+    resultado = process_single_user_import_row(
+        row_data={
+            "nombre": "Carla",
+            "apellido": "Ruiz",
+            "correo": "shared@example.com",
+            "permisos": "",
+            "provincias": "",
+            "rol": "",
+            "fila": 2,
+        },
+        job=job,
+    )
+    assert (
+        resultado["status"]
+        and resultado.get("mensaje", "").startswith("Usuario ")
+    )
+    assert (
+        User.objects.filter(email__iexact="shared@example.com").count() == 2
+    )
+
+
+def test_user_import_template_headers_incluye_correo():
+    assert "Correo" in USER_IMPORT_TEMPLATE_HEADERS
+
+
+# ---------- C: nombre y apellido en el email ----------
+
+
+@pytest.mark.django_db
+@override_settings(EMAIL_BACKEND="django.core.mail.backends.locmem.EmailBackend")
+def test_bulk_credentials_email_incluye_nombre_y_apellido():
+    user = User.objects.create_user(
+        username="con_datos",
+        email="con_datos@example.com",
+        password="Inicial123!",
+        first_name="Lucía",
+        last_name="Fernández",
+    )
+    _set_visible_temporary_password(user, "Inicial123!")
+
+    upload = _build_excel_file([("con_datos", "con_datos@example.com")])
+    process_bulk_credentials_file(uploaded_file=upload, send_type="standard")
+
+    assert len(mail.outbox) == 1
+    body = mail.outbox[0].body
+    assert "Lucía Fernández" in body
+
+
+# ---------- D: agrupamiento por destinatario ----------
+
+
+@pytest.mark.django_db
+@override_settings(EMAIL_BACKEND="django.core.mail.backends.locmem.EmailBackend")
+def test_bulk_credentials_agrupa_credenciales_por_mismo_destinatario():
+    user1 = User.objects.create_user(
+        username="user_uno",
+        email="x@example.com",
+        password="Pass1!",
+        first_name="Uno",
+        last_name="Apellido",
+    )
+    user2 = User.objects.create_user(
+        username="user_dos",
+        email="x@example.com",
+        password="Pass2!",
+        first_name="Dos",
+        last_name="Apellido",
+    )
+    user3 = User.objects.create_user(
+        username="user_solo",
+        email="z@example.com",
+        password="Pass3!",
+        first_name="Solo",
+        last_name="Otra",
+    )
+    _set_visible_temporary_password(user1, "Pass1!")
+    _set_visible_temporary_password(user2, "Pass2!")
+    _set_visible_temporary_password(user3, "Pass3!")
+
+    upload = _build_excel_file(
+        [
+            ("user_uno", "compartido@example.com"),
+            ("user_dos", "compartido@example.com"),
+            ("user_solo", "solo@example.com"),
+        ]
+    )
+
+    result = process_bulk_credentials_file(
+        uploaded_file=upload, send_type="standard"
+    )
+
+    # 3 filas procesadas y enviadas, pero solo 2 correos (1 agrupado + 1 solo)
+    assert result["summary"]["procesadas"] == 3
+    assert result["summary"]["enviadas"] == 3
+    assert len(mail.outbox) == 2
+
+    # El correo agrupado contiene ambas credenciales
+    agrupado = next(
+        msg for msg in mail.outbox if msg.to == ["compartido@example.com"]
+    )
+    assert "user_uno" in agrupado.body
+    assert "user_dos" in agrupado.body
+    assert "Pass1!" in agrupado.body
+    assert "Pass2!" in agrupado.body
+
+    # El correo individual sólo trae sus datos
+    individual = next(
+        msg for msg in mail.outbox if msg.to == ["solo@example.com"]
+    )
+    assert "user_solo" in individual.body
+    assert "Pass3!" in individual.body
+    assert "user_uno" not in individual.body
+
+
+@pytest.mark.django_db
+@override_settings(EMAIL_BACKEND="django.core.mail.backends.locmem.EmailBackend")
+def test_bulk_credentials_agrupa_cuando_destinatario_se_resuelve_desde_user_email():
+    """Si la columna mail está vacía, se usa user.email y debe agruparse igual."""
+    user1 = User.objects.create_user(
+        username="vacio_uno",
+        email="comp@example.com",
+        password="Aaa1!",
+        first_name="A",
+        last_name="A",
+    )
+    user2 = User.objects.create_user(
+        username="vacio_dos",
+        email="comp@example.com",
+        password="Bbb2!",
+        first_name="B",
+        last_name="B",
+    )
+    _set_visible_temporary_password(user1, "Aaa1!")
+    _set_visible_temporary_password(user2, "Bbb2!")
+
+    upload = _build_excel_file(
+        [("vacio_uno", ""), ("vacio_dos", "")]
+    )
+    result = process_bulk_credentials_file(
+        uploaded_file=upload, send_type="standard"
+    )
+
+    assert result["summary"]["enviadas"] == 2
+    assert len(mail.outbox) == 1
+    assert mail.outbox[0].to == ["comp@example.com"]
+    assert "vacio_uno" in mail.outbox[0].body
+    assert "vacio_dos" in mail.outbox[0].body
+
+
+# ---------- Defensivos R3: INET no agrupa con centros distintos ----------
+
+
+@pytest.mark.django_db
+@override_settings(EMAIL_BACKEND="django.core.mail.backends.locmem.EmailBackend")
+def test_inet_no_agrupa_cuando_centros_son_distintos():
+    """Aunque dos filas INET compartan destinatario, no se agrupan si los
+    nombres de centro difieren: evita mezclar datos en el correo."""
+    user_a = User.objects.create_user(
+        username="inet_a",
+        email="inet_a@example.com",
+        password="Pass!",
+        first_name="A",
+        last_name="A",
+    )
+    user_b = User.objects.create_user(
+        username="inet_b",
+        email="inet_b@example.com",
+        password="Pass!",
+        first_name="B",
+        last_name="B",
+    )
+    _set_visible_temporary_password(user_a, "Pass!")
+    _set_visible_temporary_password(user_b, "Pass!")
+
+    upload = _build_excel_file(
+        [
+            ("inet_a", "compartido@example.com", "CFP 401"),
+            ("inet_b", "compartido@example.com", "CFP 402"),
+        ],
+        headers=("usuario", "mail", "Nombre del Centro"),
+    )
+    result = process_bulk_credentials_file(
+        uploaded_file=upload, send_type="inet"
+    )
+
+    assert result["summary"]["enviadas"] == 2
+    # Dos correos distintos al mismo destinatario, uno por centro
+    assert len(mail.outbox) == 2
+    assert all(msg.to == ["compartido@example.com"] for msg in mail.outbox)
+    bodies = [msg.body for msg in mail.outbox]
+    assert any("CFP 401" in body and "inet_a" in body for body in bodies)
+    assert any("CFP 402" in body and "inet_b" in body for body in bodies)
+
+
+@pytest.mark.django_db
+@override_settings(EMAIL_BACKEND="django.core.mail.backends.locmem.EmailBackend")
+def test_inet_agrupa_cuando_centro_y_destinatario_coinciden():
+    user_a = User.objects.create_user(
+        username="inet_mismo_a",
+        email="a@example.com",
+        password="Pass!",
+        first_name="A",
+        last_name="A",
+    )
+    user_b = User.objects.create_user(
+        username="inet_mismo_b",
+        email="b@example.com",
+        password="Pass!",
+        first_name="B",
+        last_name="B",
+    )
+    _set_visible_temporary_password(user_a, "Pass!")
+    _set_visible_temporary_password(user_b, "Pass!")
+
+    upload = _build_excel_file(
+        [
+            ("inet_mismo_a", "centro@example.com", "CFP 401"),
+            ("inet_mismo_b", "centro@example.com", "CFP 401"),
+        ],
+        headers=("usuario", "mail", "Nombre del Centro"),
+    )
+    result = process_bulk_credentials_file(
+        uploaded_file=upload, send_type="inet"
+    )
+
+    assert result["summary"]["enviadas"] == 2
+    assert len(mail.outbox) == 1
+    body = mail.outbox[0].body
+    assert "inet_mismo_a" in body
+    assert "inet_mismo_b" in body
+    assert "CFP 401" in body
+
+
+# ---------- Defensivos R1: resume no duplica correos al destinatario ----------
+
+
+@pytest.mark.django_db
+@override_settings(EMAIL_BACKEND="django.core.mail.backends.locmem.EmailBackend")
+def test_worker_no_re_agrupa_si_destinatario_ya_recibio_envio_previo(
+    settings, tmp_path
+):
+    """Si en un job ya hay una fila SENT con cierto destinatario y se reanuda
+    con filas pendientes para el mismo destinatario, no se vuelve a agrupar:
+    el destinatario ya recibió un correo, no debe recibir uno repetido con
+    todas las credenciales."""
+    settings.MEDIA_ROOT = tmp_path
+    operator = User.objects.create_user(
+        username="bulk_operator_r1",
+        email="op@example.com",
+        password="Pass!",
+    )
+    user_a = User.objects.create_user(
+        username="reagr_a", email="reagr_a@x.com", password="Pass!"
+    )
+    user_b = User.objects.create_user(
+        username="reagr_b", email="reagr_b@x.com", password="Pass!"
+    )
+    user_c = User.objects.create_user(
+        username="reagr_c", email="reagr_c@x.com", password="Pass!"
+    )
+    for user in (user_a, user_b, user_c):
+        _set_visible_temporary_password(user, "Pass!")
+
+    upload = _build_excel_file(
+        [
+            ("reagr_a", "compartido@example.com"),
+            ("reagr_b", "compartido@example.com"),
+            ("reagr_c", "compartido@example.com"),
+        ]
+    )
+    job = create_bulk_credentials_job(
+        uploaded_file=upload, send_type="standard", requested_by=operator
+    )
+    # Simulamos que la fila 2 (reagr_a) ya fue enviada en una corrida anterior
+    BulkCredentialsJobRow.objects.create(
+        job=job,
+        fila=2,
+        usuario="reagr_a",
+        mail_destino="compartido@example.com",
+        status=BulkCredentialsJobRow.Status.SENT,
+        password_actualizada=False,
+        mensaje="OK previo",
+        attempts=1,
+    )
+    job.next_row_index = 1
+    job.sent_rows = 1
+    job.unchanged_password_rows = 1
+    job.processed_rows = 1
+    job.save(
+        update_fields=[
+            "next_row_index",
+            "sent_rows",
+            "unchanged_password_rows",
+            "processed_rows",
+        ]
+    )
+
+    process_bulk_credentials_job(job)
+    job.refresh_from_db()
+
+    # No re-agrupa: reagr_b y reagr_c se envían en correos separados, no juntos.
+    assert job.status == BulkCredentialsJob.Status.COMPLETED
+    assert len(mail.outbox) == 2
+    assert all(msg.to == ["compartido@example.com"] for msg in mail.outbox)
+    # Cada correo contiene solo a su propio usuario
+    body_b = next(m.body for m in mail.outbox if "reagr_b" in m.body)
+    assert "reagr_c" not in body_b
+    body_c = next(m.body for m in mail.outbox if "reagr_c" in m.body)
+    assert "reagr_b" not in body_c
+
+
+@pytest.mark.django_db
+@override_settings(EMAIL_BACKEND="django.core.mail.backends.locmem.EmailBackend")
+def test_worker_no_agrupa_cuando_primary_tiene_attempts_previos(
+    settings, tmp_path
+):
+    """Si la fila primaria ya tenía attempts > 0 (resume tras fallo posible
+    post-envío), debe procesarse sola para acotar duplicación al destinatario."""
+    settings.MEDIA_ROOT = tmp_path
+    operator = User.objects.create_user(
+        username="bulk_operator_attempts",
+        email="op2@example.com",
+        password="Pass!",
+    )
+    user_a = User.objects.create_user(
+        username="att_a", email="att_a@x.com", password="Pass!"
+    )
+    user_b = User.objects.create_user(
+        username="att_b", email="att_b@x.com", password="Pass!"
+    )
+    _set_visible_temporary_password(user_a, "Pass!")
+    _set_visible_temporary_password(user_b, "Pass!")
+
+    upload = _build_excel_file(
+        [
+            ("att_a", "compartido2@example.com"),
+            ("att_b", "compartido2@example.com"),
+        ]
+    )
+    job = create_bulk_credentials_job(
+        uploaded_file=upload, send_type="standard", requested_by=operator
+    )
+    # Fila 2 (att_a) ya fue intentada y falló: attempts = 1, status = FAILED
+    BulkCredentialsJobRow.objects.create(
+        job=job,
+        fila=2,
+        usuario="att_a",
+        mail_destino="compartido2@example.com",
+        status=BulkCredentialsJobRow.Status.FAILED,
+        password_actualizada=False,
+        mensaje="fallo previo",
+        attempts=1,
+    )
+    job.rejected_rows = 1
+    job.processed_rows = 1
+    job.save(update_fields=["rejected_rows", "processed_rows"])
+
+    process_bulk_credentials_job(job)
+    job.refresh_from_db()
+
+    # Se envían 2 correos (uno por fila), no un grupo único de 2.
+    assert job.status == BulkCredentialsJob.Status.COMPLETED
+    assert len(mail.outbox) == 2
+    bodies = [m.body for m in mail.outbox]
+    assert any("att_a" in b and "att_b" not in b for b in bodies)
+    assert any("att_b" in b and "att_a" not in b for b in bodies)
+
+
+# ---------- Defensivos R2: el cache evita N queries por destinatario ----------
+
+
+@pytest.mark.django_db
+@override_settings(EMAIL_BACKEND="django.core.mail.backends.locmem.EmailBackend")
+def test_recipient_cache_resuelve_destinatarios_con_una_query(
+    django_assert_num_queries,
+):
+    """Cuando las filas no informan mail explícito, todos los emails de los
+    usuarios se resuelven en una sola query, no una por fila."""
+    from users.services_bulk_credentials import _build_recipient_cache
+    from users.services_bulk_credentials import (
+        _load_workbook_rows,
+        get_bulk_credentials_send_type_config,
+    )
+
+    for index in range(5):
+        User.objects.create_user(
+            username=f"cache_user_{index}",
+            email=f"cache_user_{index}@example.com",
+            password="Pass!",
+        )
+    upload = _build_excel_file(
+        [(f"cache_user_{i}", "") for i in range(5)]
+    )
+    config = get_bulk_credentials_send_type_config("standard")
+    rows = _load_workbook_rows(upload, send_type_config=config)
+
+    with django_assert_num_queries(1):
+        cache = _build_recipient_cache(rows)
+
+    assert len(cache) == 5
+    assert cache["cache_user_0"] == "cache_user_0@example.com"

--- a/tests/test_users_email_opcional_y_agrupamiento.py
+++ b/tests/test_users_email_opcional_y_agrupamiento.py
@@ -58,9 +58,7 @@ def _set_visible_temporary_password(user, plain_password):
     profile = user.profile
     profile.must_change_password = True
     profile.temporary_password_plaintext = plain_password
-    profile.save(
-        update_fields=["must_change_password", "temporary_password_plaintext"]
-    )
+    profile.save(update_fields=["must_change_password", "temporary_password_plaintext"])
     return user
 
 
@@ -103,9 +101,7 @@ def test_user_creation_form_acepta_email_repetido():
     assert form.is_valid(), form.errors
     nuevo = form.save()
     assert nuevo.email == "repetido@example.com"
-    assert (
-        User.objects.filter(email__iexact="repetido@example.com").count() == 2
-    )
+    assert User.objects.filter(email__iexact="repetido@example.com").count() == 2
 
 
 @pytest.mark.django_db
@@ -178,13 +174,8 @@ def test_user_import_row_emails_repetidos_no_son_rechazados():
         },
         job=job,
     )
-    assert (
-        resultado["status"]
-        and resultado.get("mensaje", "").startswith("Usuario ")
-    )
-    assert (
-        User.objects.filter(email__iexact="shared@example.com").count() == 2
-    )
+    assert resultado["status"] and resultado.get("mensaje", "").startswith("Usuario ")
+    assert User.objects.filter(email__iexact="shared@example.com").count() == 2
 
 
 def test_user_import_template_headers_incluye_correo():
@@ -253,9 +244,7 @@ def test_bulk_credentials_agrupa_credenciales_por_mismo_destinatario():
         ]
     )
 
-    result = process_bulk_credentials_file(
-        uploaded_file=upload, send_type="standard"
-    )
+    result = process_bulk_credentials_file(uploaded_file=upload, send_type="standard")
 
     # 3 filas procesadas y enviadas, pero solo 2 correos (1 agrupado + 1 solo)
     assert result["summary"]["procesadas"] == 3
@@ -263,18 +252,14 @@ def test_bulk_credentials_agrupa_credenciales_por_mismo_destinatario():
     assert len(mail.outbox) == 2
 
     # El correo agrupado contiene ambas credenciales
-    agrupado = next(
-        msg for msg in mail.outbox if msg.to == ["compartido@example.com"]
-    )
+    agrupado = next(msg for msg in mail.outbox if msg.to == ["compartido@example.com"])
     assert "user_uno" in agrupado.body
     assert "user_dos" in agrupado.body
     assert "Pass1!" in agrupado.body
     assert "Pass2!" in agrupado.body
 
     # El correo individual sólo trae sus datos
-    individual = next(
-        msg for msg in mail.outbox if msg.to == ["solo@example.com"]
-    )
+    individual = next(msg for msg in mail.outbox if msg.to == ["solo@example.com"])
     assert "user_solo" in individual.body
     assert "Pass3!" in individual.body
     assert "user_uno" not in individual.body
@@ -301,12 +286,8 @@ def test_bulk_credentials_agrupa_cuando_destinatario_se_resuelve_desde_user_emai
     _set_visible_temporary_password(user1, "Aaa1!")
     _set_visible_temporary_password(user2, "Bbb2!")
 
-    upload = _build_excel_file(
-        [("vacio_uno", ""), ("vacio_dos", "")]
-    )
-    result = process_bulk_credentials_file(
-        uploaded_file=upload, send_type="standard"
-    )
+    upload = _build_excel_file([("vacio_uno", ""), ("vacio_dos", "")])
+    result = process_bulk_credentials_file(uploaded_file=upload, send_type="standard")
 
     assert result["summary"]["enviadas"] == 2
     assert len(mail.outbox) == 1
@@ -347,9 +328,7 @@ def test_inet_no_agrupa_cuando_centros_son_distintos():
         ],
         headers=("usuario", "mail", "Nombre del Centro"),
     )
-    result = process_bulk_credentials_file(
-        uploaded_file=upload, send_type="inet"
-    )
+    result = process_bulk_credentials_file(uploaded_file=upload, send_type="inet")
 
     assert result["summary"]["enviadas"] == 2
     # Dos correos distintos al mismo destinatario, uno por centro
@@ -387,9 +366,7 @@ def test_inet_agrupa_cuando_centro_y_destinatario_coinciden():
         ],
         headers=("usuario", "mail", "Nombre del Centro"),
     )
-    result = process_bulk_credentials_file(
-        uploaded_file=upload, send_type="inet"
-    )
+    result = process_bulk_credentials_file(uploaded_file=upload, send_type="inet")
 
     assert result["summary"]["enviadas"] == 2
     assert len(mail.outbox) == 1
@@ -479,9 +456,7 @@ def test_worker_no_re_agrupa_si_destinatario_ya_recibio_envio_previo(
 
 @pytest.mark.django_db
 @override_settings(EMAIL_BACKEND="django.core.mail.backends.locmem.EmailBackend")
-def test_worker_no_agrupa_cuando_primary_tiene_attempts_previos(
-    settings, tmp_path
-):
+def test_worker_no_agrupa_cuando_primary_tiene_attempts_previos(settings, tmp_path):
     """Si la fila primaria ya tenía attempts > 0 (resume tras fallo posible
     post-envío), debe procesarse sola para acotar duplicación al destinatario."""
     settings.MEDIA_ROOT = tmp_path
@@ -556,9 +531,7 @@ def test_recipient_cache_resuelve_destinatarios_con_una_query(
             email=f"cache_user_{index}@example.com",
             password="Pass!",
         )
-    upload = _build_excel_file(
-        [(f"cache_user_{i}", "") for i in range(5)]
-    )
+    upload = _build_excel_file([(f"cache_user_{i}", "") for i in range(5)])
     config = get_bulk_credentials_send_type_config("standard")
     rows = _load_workbook_rows(upload, send_type_config=config)
 

--- a/users/forms.py
+++ b/users/forms.py
@@ -433,20 +433,11 @@ class PWAAccessMixin:
             return
         deactivate_representante_accesses(user)
 
-    def _validate_required_email(self, cleaned):
-        email = (cleaned.get("email") or "").strip()
-        if not email:
-            self.add_error("email", "Este campo es obligatorio.")
-            return cleaned
-
-        qs = User.objects.filter(email__iexact=email)
-        if getattr(self.instance, "pk", None):
-            qs = qs.exclude(pk=self.instance.pk)
-        if qs.exists():
-            self.add_error("email", "Ya existe un usuario con ese email.")
-            return cleaned
-
-        cleaned["email"] = email
+    def _clean_optional_email(self, cleaned):
+        # El email es opcional y puede repetirse entre usuarios; la unicidad
+        # vive en username. Solo normalizamos espacios para evitar registros
+        # inconsistentes.
+        cleaned["email"] = (cleaned.get("email") or "").strip()
         return cleaned
 
 
@@ -706,7 +697,7 @@ class UserCreationForm(
         self._setup_pwa_fields()
         self._setup_delegation_fields()
         self._scope_assignable_fields_for_actor()
-        self.fields["email"].required = True
+        self.fields["email"].required = False
         self.fields["password"].required = False
         self.generated_password = None
         self.password_was_auto_generated = False
@@ -714,7 +705,7 @@ class UserCreationForm(
 
     def clean(self):
         cleaned = super().clean()
-        cleaned = self._validate_required_email(cleaned)
+        cleaned = self._clean_optional_email(cleaned)
         if (
             not cleaned.get("es_representante_pwa")
             and not (cleaned.get("password") or "").strip()
@@ -894,7 +885,7 @@ class CustomUserChangeForm(
         self._setup_pwa_fields()
         self._setup_delegation_fields()
         self._scope_assignable_fields_for_actor()
-        self.fields["email"].required = True
+        self.fields["email"].required = False
         self._original_password_hash = self.instance.password
         self.fields["password"].initial = ""
         self._init_pwa_fields()
@@ -915,7 +906,7 @@ class CustomUserChangeForm(
 
     def clean(self):
         cleaned = super().clean()
-        cleaned = self._validate_required_email(cleaned)
+        cleaned = self._clean_optional_email(cleaned)
         cleaned = self._clean_territorial_scope_fields(cleaned)
         if cleaned.get("es_coordinador") and not cleaned.get("duplas_asignadas"):
             self.add_error("duplas_asignadas", "Seleccione al menos una dupla.")

--- a/users/services_bulk_credentials.py
+++ b/users/services_bulk_credentials.py
@@ -640,7 +640,9 @@ def _resolve_row_for_send(
     return user, recipient_email, entry
 
 
-def _row_success_result(*, row: ParsedCredentialRow, recipient_email: str, grouped: bool):
+def _row_success_result(
+    *, row: ParsedCredentialRow, recipient_email: str, grouped: bool
+):
     base_message = "Credenciales enviadas correctamente."
     if grouped:
         base_message = (
@@ -735,9 +737,9 @@ def _build_recipient_cache(
     }
     if not usernames_needed:
         return {}
-    user_qs = User.objects.filter(
-        username__in=list(usernames_needed)
-    ).only("username", "email")
+    user_qs = User.objects.filter(username__in=list(usernames_needed)).only(
+        "username", "email"
+    )
     cache = {
         (u.username or "").strip().lower(): (u.email or "").strip().lower()
         for u in user_qs
@@ -769,9 +771,7 @@ def _row_grouping_key(
         cached = (recipient_cache or {}).get(username_key)
         if cached is None and recipient_cache is None:
             user = (
-                User.objects.filter(username__iexact=row.usuario)
-                .only("email")
-                .first()
+                User.objects.filter(username__iexact=row.usuario).only("email").first()
             )
             cached = (user.email or "").strip().lower() if user else ""
         recipient = cached or ""
@@ -932,10 +932,7 @@ def process_bulk_credentials_file(
         except Exception as exc:
             message = build_bulk_credentials_error_message(exc)
             logger.exception(
-                (
-                    "Fallo procesando envio masivo de credenciales. "
-                    "tipo=%s filas=%s"
-                ),
+                ("Fallo procesando envio masivo de credenciales. " "tipo=%s filas=%s"),
                 send_type_config.key,
                 [rows[i].fila for i in group_indices],
             )

--- a/users/services_bulk_credentials.py
+++ b/users/services_bulk_credentials.py
@@ -160,6 +160,21 @@ class ParsedCredentialRow:
         return self.data.get("nombre_del_centro", "")
 
 
+@dataclass(frozen=True)
+class BulkCredentialEntry:
+    """Una credencial individual dentro de un envío (posiblemente agrupado)."""
+
+    username: str
+    plain_password: str
+    first_name: str
+    last_name: str
+    nombre_del_centro: str = ""
+
+    @property
+    def full_name(self) -> str:
+        return f"{self.first_name} {self.last_name}".strip()
+
+
 BULK_CREDENTIALS_SEND_TYPES = {
     "standard": BulkCredentialsSendTypeConfig(
         key="standard",
@@ -401,21 +416,27 @@ def get_bulk_credentials_template_filename(send_type: str | None = None) -> str:
     return send_type_config.template_filename
 
 
-def _send_bulk_credentials_email_once(  # pylint: disable=too-many-arguments
+def _send_bulk_credentials_email_once(
     *,
-    user,
     recipient_email: str,
-    plain_password: str,
+    entries: list[BulkCredentialEntry],
     login_url: str,
     send_type: str | None = None,
-    nombre_del_centro: str = "",
 ) -> None:
     send_type_config = get_bulk_credentials_send_type_config(send_type)
+    # nombre_del_centro y first_name/last_name del primer entry se exponen al
+    # template para mantener compatibilidad con los placeholders existentes
+    # cuando la lista tiene un solo elemento.
+    first = entries[0]
     context = {
-        "user": user,
-        "plain_password": plain_password,
+        "entries": entries,
         "login_url": login_url,
-        "nombre_del_centro": nombre_del_centro,
+        "is_grouped": len(entries) > 1,
+        # Compatibilidad: campos del primer (o único) usuario.
+        "user_username": first.username,
+        "user_full_name": first.full_name,
+        "plain_password": first.plain_password,
+        "nombre_del_centro": first.nombre_del_centro,
     }
     message = render_to_string(send_type_config.email_template_name, context)
     send_mail(
@@ -464,16 +485,16 @@ def _build_email_retry_failure_message(last_error: Exception | None) -> str:
     return f"{base_message} El envio se reintento sin exito."
 
 
-def send_bulk_credentials_email(  # pylint: disable=too-many-arguments
+def send_bulk_credentials_email(
     *,
-    user,
     recipient_email: str,
-    plain_password: str,
+    entries: list[BulkCredentialEntry],
     login_url: str,
     send_type: str | None = None,
-    nombre_del_centro: str = "",
     max_total_seconds: float | None = None,
 ) -> None:
+    if not entries:
+        raise ValidationError("No hay credenciales para enviar.")
     timeout_seconds = _get_bulk_credentials_email_attempt_timeout_seconds()
     total_deadline = (
         time.monotonic() + max_total_seconds
@@ -481,6 +502,7 @@ def send_bulk_credentials_email(  # pylint: disable=too-many-arguments
         else None
     )
     last_error = None
+    usernames_log = ",".join(entry.username for entry in entries)
 
     for attempt in range(1, BULK_CREDENTIALS_EMAIL_MAX_ATTEMPTS + 1):
         remaining_total_seconds = _get_remaining_processing_seconds(total_deadline)
@@ -497,12 +519,10 @@ def send_bulk_credentials_email(  # pylint: disable=too-many-arguments
         try:
             with _mail_send_timeout_guard(attempt_timeout_seconds):
                 _send_bulk_credentials_email_once(
-                    user=user,
                     recipient_email=recipient_email,
-                    plain_password=plain_password,
+                    entries=entries,
                     login_url=login_url,
                     send_type=send_type,
-                    nombre_del_centro=nombre_del_centro,
                 )
             return
         except (
@@ -515,9 +535,9 @@ def send_bulk_credentials_email(  # pylint: disable=too-many-arguments
             logger.warning(
                 (
                     "Fallo enviando credenciales por correo. "
-                    "usuario=%s intento=%s/%s tipo=%s"
+                    "usuarios=%s intento=%s/%s tipo=%s"
                 ),
-                user.username,
+                usernames_log,
                 attempt,
                 BULK_CREDENTIALS_EMAIL_MAX_ATTEMPTS,
                 send_type or DEFAULT_BULK_CREDENTIALS_SEND_TYPE,
@@ -590,6 +610,99 @@ def _get_user_plain_password(user) -> str:
     return plain_password
 
 
+def _resolve_row_for_send(
+    row: ParsedCredentialRow,
+    *,
+    send_type_config: BulkCredentialsSendTypeConfig,
+):
+    """Valida un row y resuelve user, destinatario y entry para el envío.
+
+    Levanta ValidationError si falta data, no existe el usuario, no hay mail
+    válido o el usuario no tiene contraseña temporal visible.
+    """
+    _validate_row_data(row, send_type_config=send_type_config)
+    user = (
+        User.objects.select_related("profile")
+        .filter(username__iexact=row.usuario)
+        .first()
+    )
+    if not user:
+        raise ValidationError("No existe un usuario con ese nombre.")
+    recipient_email = _get_recipient_email(row=row, user=user)
+    plain_password = _get_user_plain_password(user)
+    entry = BulkCredentialEntry(
+        username=user.username,
+        plain_password=plain_password,
+        first_name=user.first_name or "",
+        last_name=user.last_name or "",
+        nombre_del_centro=row.nombre_del_centro,
+    )
+    return user, recipient_email, entry
+
+
+def _row_success_result(*, row: ParsedCredentialRow, recipient_email: str, grouped: bool):
+    base_message = "Credenciales enviadas correctamente."
+    if grouped:
+        base_message = (
+            "Credenciales enviadas correctamente "
+            "(agrupadas con otras del mismo destinatario)."
+        )
+    return {
+        "fila": row.fila,
+        "usuario": row.usuario,
+        "mail_destino": recipient_email,
+        "estado": "enviada",
+        "mensaje": base_message,
+        "password_actualizada": False,
+    }
+
+
+def process_bulk_credentials_group(
+    *,
+    rows: list[ParsedCredentialRow],
+    send_type_config: BulkCredentialsSendTypeConfig,
+    login_url: str,
+    max_total_seconds: float | None = None,
+) -> list[dict[str, object]]:
+    """Envía un único correo con las credenciales de todas las filas del grupo.
+
+    Todas las filas deben compartir destinatario (ya resuelto). Si alguna falla
+    validación se levanta ValidationError sin enviar el correo: el caller debe
+    decidir cómo registrar el fallo por fila.
+    """
+    if not rows:
+        raise ValidationError("No hay filas para procesar en el grupo.")
+
+    resolved: list[tuple[ParsedCredentialRow, BulkCredentialEntry]] = []
+    recipient_email: str | None = None
+    with transaction.atomic():
+        for row in rows:
+            _user, row_recipient, entry = _resolve_row_for_send(
+                row, send_type_config=send_type_config
+            )
+            if recipient_email is None:
+                recipient_email = row_recipient
+            elif row_recipient.lower() != recipient_email.lower():
+                raise ValidationError(
+                    "Las filas del grupo no comparten el mismo destinatario."
+                )
+            resolved.append((row, entry))
+
+        send_bulk_credentials_email(
+            recipient_email=recipient_email,
+            entries=[entry for _row, entry in resolved],
+            login_url=login_url,
+            send_type=send_type_config.key,
+            max_total_seconds=max_total_seconds,
+        )
+
+    grouped = len(resolved) > 1
+    return [
+        _row_success_result(row=row, recipient_email=recipient_email, grouped=grouped)
+        for row, _entry in resolved
+    ]
+
+
 def process_bulk_credentials_row(
     *,
     row: ParsedCredentialRow,
@@ -597,37 +710,134 @@ def process_bulk_credentials_row(
     login_url: str,
     max_total_seconds: float | None = None,
 ) -> dict[str, object]:
-    _validate_row_data(row, send_type_config=send_type_config)
-    with transaction.atomic():
-        user = (
-            User.objects.select_related("profile")
-            .filter(username__iexact=row.usuario)
-            .first()
-        )
-        if not user:
-            raise ValidationError("No existe un usuario con ese nombre.")
+    """Procesa una sola fila sin agrupamiento. Mantenido para compatibilidad."""
+    results = process_bulk_credentials_group(
+        rows=[row],
+        send_type_config=send_type_config,
+        login_url=login_url,
+        max_total_seconds=max_total_seconds,
+    )
+    return results[0]
 
-        recipient_email = _get_recipient_email(row=row, user=user)
-        plain_password = _get_user_plain_password(user)
 
-        send_bulk_credentials_email(
-            user=user,
-            recipient_email=recipient_email,
-            plain_password=plain_password,
-            login_url=login_url,
-            send_type=send_type_config.key,
-            nombre_del_centro=row.nombre_del_centro,
-            max_total_seconds=max_total_seconds,
-        )
+def _build_recipient_cache(
+    rows: list[ParsedCredentialRow],
+) -> dict[str, str]:
+    """Pre-carga `username -> email` en una sola query para evitar N lookups.
 
-    return {
-        "fila": row.fila,
-        "usuario": row.usuario,
-        "mail_destino": recipient_email,
-        "estado": "enviada",
-        "mensaje": "Credenciales enviadas correctamente.",
-        "password_actualizada": False,
+    Solo se incluyen los usuarios efectivamente referenciados por filas que no
+    informan mail explícito. Devuelve un dict indexado por username en minúsculas.
+    """
+    usernames_needed = {
+        row.usuario.strip().lower()
+        for row in rows
+        if row.usuario and not row.mail.strip()
     }
+    if not usernames_needed:
+        return {}
+    user_qs = User.objects.filter(
+        username__in=list(usernames_needed)
+    ).only("username", "email")
+    cache = {
+        (u.username or "").strip().lower(): (u.email or "").strip().lower()
+        for u in user_qs
+    }
+    return cache
+
+
+def _row_grouping_key(
+    row: ParsedCredentialRow,
+    *,
+    send_type_config: BulkCredentialsSendTypeConfig,
+    recipient_cache: dict[str, str] | None = None,
+) -> tuple[str, str] | None:
+    """Devuelve la clave de agrupamiento (destinatario, centro) para una fila.
+
+    Si el send_type requiere `nombre_del_centro`, el centro forma parte de la
+    clave: dos filas con mismo destinatario pero distinto centro NO se agrupan
+    (evita mensajes mezclando datos de centros). Si la fila no puede resolver
+    destinatario, retorna None y el row se procesa solo.
+    """
+    if not row.data.get("usuario"):
+        return None
+
+    explicit_mail = row.mail.strip()
+    if explicit_mail:
+        recipient = explicit_mail.lower()
+    else:
+        username_key = row.usuario.strip().lower()
+        cached = (recipient_cache or {}).get(username_key)
+        if cached is None and recipient_cache is None:
+            user = (
+                User.objects.filter(username__iexact=row.usuario)
+                .only("email")
+                .first()
+            )
+            cached = (user.email or "").strip().lower() if user else ""
+        recipient = cached or ""
+
+    if not recipient:
+        return None
+
+    requires_centro = "nombre_del_centro" in send_type_config.required_columns
+    centro_key = ""
+    if requires_centro:
+        # Normalizamos para que diferencias de espacios/caso no fragmenten el grupo.
+        centro_key = " ".join(row.nombre_del_centro.lower().split())
+
+    return recipient, centro_key
+
+
+def _peek_recipient_email(
+    row: ParsedCredentialRow,
+    *,
+    send_type_config: BulkCredentialsSendTypeConfig,
+    recipient_cache: dict[str, str] | None = None,
+) -> str | None:
+    """Compatibilidad: devuelve solo el destinatario (sin el componente centro)."""
+    key = _row_grouping_key(
+        row,
+        send_type_config=send_type_config,
+        recipient_cache=recipient_cache,
+    )
+    return key[0] if key else None
+
+
+def _collect_group_indices(
+    *,
+    rows: list[ParsedCredentialRow],
+    start_index: int,
+    send_type_config: BulkCredentialsSendTypeConfig,
+    skip_indices: set[int],
+    recipient_cache: dict[str, str] | None = None,
+) -> tuple[list[int], str | None]:
+    """Identifica los índices de filas que comparten clave de agrupamiento con
+    rows[start_index]. Para INET, la clave incluye `nombre_del_centro`.
+
+    Retorna la lista de índices (incluido start_index) y el destinatario común.
+    Si el row inicial no puede resolver clave, retorna ([start_index], None).
+    """
+    primary_key = _row_grouping_key(
+        rows[start_index],
+        send_type_config=send_type_config,
+        recipient_cache=recipient_cache,
+    )
+    if primary_key is None:
+        return [start_index], None
+
+    primary_recipient = primary_key[0]
+    group = [start_index]
+    for index in range(start_index + 1, len(rows)):
+        if index in skip_indices:
+            continue
+        candidate_key = _row_grouping_key(
+            rows[index],
+            send_type_config=send_type_config,
+            recipient_cache=recipient_cache,
+        )
+        if candidate_key == primary_key:
+            group.append(index)
+    return group, primary_recipient
 
 
 def process_bulk_credentials_file(
@@ -651,66 +861,101 @@ def process_bulk_credentials_file(
     }
     login_url = _build_login_url(request=request)
     processing_deadline = _get_bulk_credentials_batch_deadline()
+    results_by_index: dict[int, dict[str, object]] = {}
+    handled_indices: set[int] = set()
+    recipient_cache = _build_recipient_cache(rows)
 
     for row_index, row in enumerate(rows):
+        if row_index in handled_indices:
+            continue
         if not _has_enough_batch_time(processing_deadline):
             timeout_message = _get_batch_timeout_message()
-            for pending_row in rows[row_index:]:
+            for pending_index in range(row_index, len(rows)):
+                if pending_index in handled_indices:
+                    continue
+                pending_row = rows[pending_index]
                 summary["procesadas"] += 1
                 summary["rechazadas"] += 1
-                results.append(
-                    {
-                        "fila": pending_row.fila,
-                        "usuario": pending_row.usuario,
-                        "mail_destino": pending_row.mail,
-                        "estado": "rechazada",
-                        "mensaje": timeout_message,
-                        "password_actualizada": False,
-                    }
-                )
+                results_by_index[pending_index] = {
+                    "fila": pending_row.fila,
+                    "usuario": pending_row.usuario,
+                    "mail_destino": pending_row.mail,
+                    "estado": "rechazada",
+                    "mensaje": timeout_message,
+                    "password_actualizada": False,
+                }
+                handled_indices.add(pending_index)
             break
 
-        summary["procesadas"] += 1
-        row_result = {
-            "fila": row.fila,
-            "usuario": row.usuario,
-            "mail_destino": row.mail,
-            "estado": "rechazada",
-            "mensaje": "",
-            "password_actualizada": False,
-        }
+        group_indices, _recipient = _collect_group_indices(
+            rows=rows,
+            start_index=row_index,
+            send_type_config=send_type_config,
+            skip_indices=handled_indices,
+            recipient_cache=recipient_cache,
+        )
+        group_rows = [rows[i] for i in group_indices]
 
         try:
-            row_result = process_bulk_credentials_row(
-                row=row,
+            group_results = process_bulk_credentials_group(
+                rows=group_rows,
                 send_type_config=send_type_config,
                 login_url=login_url,
                 max_total_seconds=_get_remaining_processing_seconds(
                     processing_deadline
                 ),
             )
-            if row_result["password_actualizada"]:
-                summary["actualizadas"] += 1
-            else:
-                summary["sin_cambios"] += 1
-            summary["enviadas"] += 1
+            for idx, group_result in zip(group_indices, group_results):
+                summary["procesadas"] += 1
+                if group_result.get("password_actualizada"):
+                    summary["actualizadas"] += 1
+                else:
+                    summary["sin_cambios"] += 1
+                summary["enviadas"] += 1
+                results_by_index[idx] = group_result
+                handled_indices.add(idx)
         except ValidationError as exc:
-            summary["rechazadas"] += 1
-            row_result["mensaje"] = build_bulk_credentials_error_message(exc)
+            message = build_bulk_credentials_error_message(exc)
+            for idx in group_indices:
+                fail_row = rows[idx]
+                summary["procesadas"] += 1
+                summary["rechazadas"] += 1
+                results_by_index[idx] = {
+                    "fila": fail_row.fila,
+                    "usuario": fail_row.usuario,
+                    "mail_destino": fail_row.mail,
+                    "estado": "rechazada",
+                    "mensaje": message,
+                    "password_actualizada": False,
+                }
+                handled_indices.add(idx)
         except Exception as exc:
-            summary["rechazadas"] += 1
-            row_result["mensaje"] = build_bulk_credentials_error_message(exc)
+            message = build_bulk_credentials_error_message(exc)
             logger.exception(
                 (
                     "Fallo procesando envio masivo de credenciales. "
-                    "tipo=%s fila=%s usuario=%s"
+                    "tipo=%s filas=%s"
                 ),
                 send_type_config.key,
-                row.fila,
-                row.usuario,
+                [rows[i].fila for i in group_indices],
             )
+            for idx in group_indices:
+                fail_row = rows[idx]
+                summary["procesadas"] += 1
+                summary["rechazadas"] += 1
+                results_by_index[idx] = {
+                    "fila": fail_row.fila,
+                    "usuario": fail_row.usuario,
+                    "mail_destino": fail_row.mail,
+                    "estado": "rechazada",
+                    "mensaje": message,
+                    "password_actualizada": False,
+                }
+                handled_indices.add(idx)
 
-        results.append(row_result)
+    for idx in range(len(rows)):
+        if idx in results_by_index:
+            results.append(results_by_index[idx])
 
     return {
         "summary": summary,

--- a/users/services_bulk_credentials_jobs.py
+++ b/users/services_bulk_credentials_jobs.py
@@ -13,10 +13,12 @@ from django.utils import timezone
 from users.models import BulkCredentialsJob, BulkCredentialsJobRow
 from users.services_bulk_credentials import (
     _build_login_url,
+    _build_recipient_cache,
+    _collect_group_indices,
     _load_workbook_rows,
     build_bulk_credentials_error_message,
     get_bulk_credentials_send_type_config,
-    process_bulk_credentials_row,
+    process_bulk_credentials_group,
     validate_bulk_credentials_workbook,
 )
 
@@ -344,6 +346,40 @@ def _record_row_failure(
     return job
 
 
+def _persist_grouped_row_success(
+    *,
+    job: BulkCredentialsJob,
+    row,
+    row_state,
+    result: dict[str, object],
+) -> BulkCredentialsJob:
+    """Persiste el éxito de UNA fila dentro de un envío agrupado.
+
+    A diferencia de _record_row_success, no toca next_row_index ni marca el job
+    como completado: el caller decide cuándo avanzar y cuándo cerrar el lote.
+    """
+    row_log = row_state["row_log"]
+    row_log.usuario = row.usuario
+    row_log.mail_destino = str(result["mail_destino"])
+    row_log.status = BulkCredentialsJobRow.Status.SENT
+    row_log.password_actualizada = bool(result["password_actualizada"])
+    row_log.mensaje = str(result["mensaje"])
+    row_log.attempts += 1
+    row_log.processed_at = timezone.now()
+    row_log.save()
+
+    _apply_row_outcome(
+        job=job,
+        old_status=row_state["old_status"],
+        old_password_updated=row_state["old_password_updated"],
+        new_status=row_log.status,
+        new_password_updated=row_log.password_actualizada,
+    )
+    job.last_successful_row = row.fila
+    job.last_successful_username = row.usuario
+    return job
+
+
 def _record_row_success(
     *,
     job: BulkCredentialsJob,
@@ -455,6 +491,99 @@ def _load_job_rows(job: BulkCredentialsJob, *, send_type_config):
     return None
 
 
+def _advance_job_pointer(
+    *,
+    job: BulkCredentialsJob,
+    row_index: int,
+    total_rows: int,
+) -> BulkCredentialsJob:
+    """Avanza next_row_index al row siguiente al `row_index` y persiste contadores."""
+    now = timezone.now()
+    job.next_row_index = row_index + 1
+    job.last_activity_at = now
+    update_fields = [
+        "processed_rows",
+        "sent_rows",
+        "updated_password_rows",
+        "unchanged_password_rows",
+        "rejected_rows",
+        "next_row_index",
+        "last_successful_row",
+        "last_successful_username",
+        "last_activity_at",
+    ]
+    if job.next_row_index >= total_rows:
+        job.status = BulkCredentialsJob.Status.COMPLETED
+        job.finished_at = now
+        job.last_error_message = ""
+        job.last_error_at = None
+        update_fields.extend(
+            [
+                "status",
+                "finished_at",
+                "last_error_message",
+                "last_error_at",
+            ]
+        )
+    job.save(update_fields=update_fields)
+    return job
+
+
+def _select_group_for_row(
+    *,
+    job: BulkCredentialsJob,
+    rows,
+    row_index: int,
+    send_type_config,
+    recipient_cache: dict[str, str] | None = None,
+    primary_attempts: int = 0,
+) -> tuple[list[int], list]:
+    """Identifica el grupo del row actual con defensas contra duplicación.
+
+    Reglas defensivas (issue #1979):
+    - Si la fila primaria ya tiene attempts > 0 (caso resume de un grupo que
+      ya pudo haber sido enviado), se procesa SOLA. Re-enviar el grupo entero
+      duplicaría el correo previo en el inbox del destinatario.
+    - Si el destinatario del grupo ya recibió un envío exitoso previo en este
+      mismo job (cualquier fila SENT con `mail_destino` igual), no se agrupa
+      con otras filas pendientes: cada una se envía sola.
+    - Las filas posteriores del grupo que ya están SENT en BD se excluyen.
+    """
+    if primary_attempts > 0:
+        return [row_index], [rows[row_index]]
+
+    group_indices, primary_recipient = _collect_group_indices(
+        rows=rows,
+        start_index=row_index,
+        send_type_config=send_type_config,
+        skip_indices=set(),
+        recipient_cache=recipient_cache,
+    )
+    if len(group_indices) == 1:
+        return group_indices, [rows[row_index]]
+
+    if primary_recipient and BulkCredentialsJobRow.objects.filter(
+        job=job,
+        status=BulkCredentialsJobRow.Status.SENT,
+        mail_destino__iexact=primary_recipient,
+    ).exists():
+        # Destinatario ya recibió un correo de este job; no re-agrupar.
+        return [row_index], [rows[row_index]]
+
+    candidate_filas = [rows[i].fila for i in group_indices]
+    already_sent_filas = set(
+        BulkCredentialsJobRow.objects.filter(
+            job=job,
+            status=BulkCredentialsJobRow.Status.SENT,
+            fila__in=candidate_filas,
+        ).values_list("fila", flat=True)
+    )
+    fresh = [i for i in group_indices if rows[i].fila not in already_sent_filas]
+    if not fresh:
+        fresh = [row_index]
+    return fresh, [rows[i] for i in fresh]
+
+
 def process_bulk_credentials_job(job: BulkCredentialsJob) -> BulkCredentialsJob:
     send_type_config = get_bulk_credentials_send_type_config(job.send_type)
     login_url = _build_login_url()
@@ -467,19 +596,40 @@ def process_bulk_credentials_job(job: BulkCredentialsJob) -> BulkCredentialsJob:
     if job.next_row_index >= total_rows:
         return _mark_job_completed(job=job)
 
+    recipient_cache = _build_recipient_cache(rows)
+
     for row_index in range(job.next_row_index, total_rows):
         row = rows[row_index]
         _start_job_row_attempt(job=job, row_index=row_index, row=row)
         row_log, old_status, old_password_updated = _get_job_row_log(job=job, row=row)
+
+        if row_log.status == BulkCredentialsJobRow.Status.SENT:
+            # Ya enviada por un agrupamiento anterior; solo avanzo el puntero.
+            job = _advance_job_pointer(
+                job=job, row_index=row_index, total_rows=total_rows
+            )
+            if job.status == BulkCredentialsJob.Status.COMPLETED:
+                return job
+            continue
+
         row_state = _build_row_processing_state(
             row_log=row_log,
             old_status=old_status,
             old_password_updated=old_password_updated,
         )
 
+        fresh_indices, group_rows = _select_group_for_row(
+            job=job,
+            rows=rows,
+            row_index=row_index,
+            send_type_config=send_type_config,
+            recipient_cache=recipient_cache,
+            primary_attempts=row_log.attempts,
+        )
+
         try:
-            result = process_bulk_credentials_row(
-                row=row,
+            results = process_bulk_credentials_group(
+                rows=group_rows,
                 send_type_config=send_type_config,
                 login_url=login_url,
                 max_total_seconds=None,
@@ -507,12 +657,28 @@ def process_bulk_credentials_job(job: BulkCredentialsJob) -> BulkCredentialsJob:
                 row_state=row_state,
                 message=build_bulk_credentials_error_message(exc),
             )
-        job = _record_row_success(
-            job=job,
-            row=row,
-            row_state=row_state,
-            result=result,
-            progress=_build_row_progress(row_index=row_index, total_rows=total_rows),
+
+        for fresh_idx, result in zip(fresh_indices, results):
+            fresh_row = rows[fresh_idx]
+            if fresh_idx == row_index:
+                _persist_grouped_row_success(
+                    job=job, row=fresh_row, row_state=row_state, result=result
+                )
+                continue
+            other_log, other_old_status, other_old_password = _get_job_row_log(
+                job=job, row=fresh_row
+            )
+            other_state = _build_row_processing_state(
+                row_log=other_log,
+                old_status=other_old_status,
+                old_password_updated=other_old_password,
+            )
+            _persist_grouped_row_success(
+                job=job, row=fresh_row, row_state=other_state, result=result
+            )
+
+        job = _advance_job_pointer(
+            job=job, row_index=row_index, total_rows=total_rows
         )
         if job.status == BulkCredentialsJob.Status.COMPLETED:
             return job

--- a/users/services_bulk_credentials_jobs.py
+++ b/users/services_bulk_credentials_jobs.py
@@ -562,11 +562,14 @@ def _select_group_for_row(
     if len(group_indices) == 1:
         return group_indices, [rows[row_index]]
 
-    if primary_recipient and BulkCredentialsJobRow.objects.filter(
-        job=job,
-        status=BulkCredentialsJobRow.Status.SENT,
-        mail_destino__iexact=primary_recipient,
-    ).exists():
+    if (
+        primary_recipient
+        and BulkCredentialsJobRow.objects.filter(
+            job=job,
+            status=BulkCredentialsJobRow.Status.SENT,
+            mail_destino__iexact=primary_recipient,
+        ).exists()
+    ):
         # Destinatario ya recibió un correo de este job; no re-agrupar.
         return [row_index], [rows[row_index]]
 
@@ -677,9 +680,7 @@ def process_bulk_credentials_job(job: BulkCredentialsJob) -> BulkCredentialsJob:
                 job=job, row=fresh_row, row_state=other_state, result=result
             )
 
-        job = _advance_job_pointer(
-            job=job, row_index=row_index, total_rows=total_rows
-        )
+        job = _advance_job_pointer(job=job, row_index=row_index, total_rows=total_rows)
         if job.status == BulkCredentialsJob.Status.COMPLETED:
             return job
 

--- a/users/services_generate_user.py
+++ b/users/services_generate_user.py
@@ -108,8 +108,6 @@ def _validar_email(datos: DatosUsuarioDelegado) -> str:
         validate_email(email)
     except ValidationError as exc:
         raise ValidationError("El email del referente no es válido.") from exc
-    if User.objects.filter(email__iexact=email).exists():
-        raise ValidationError("Ya existe un usuario con ese email.")
     return email
 
 
@@ -117,9 +115,23 @@ def _enviar_credenciales(*, user, password: str, request=None) -> bool:
     """Envía las credenciales por mail. Best-effort: loguea y no propaga."""
     if not user.email:
         return False
+    from users.services_bulk_credentials import (  # noqa: PLC0415
+        BulkCredentialEntry,
+    )
+
+    entry = BulkCredentialEntry(
+        username=user.username,
+        plain_password=password,
+        first_name=user.first_name or "",
+        last_name=user.last_name or "",
+    )
     context = {
-        "user": user,
+        "entries": [entry],
+        "is_grouped": False,
+        "user_username": entry.username,
+        "user_full_name": entry.full_name,
         "plain_password": password,
+        "nombre_del_centro": "",
         "login_url": _build_login_url(request=request),
     }
     message = render_to_string(CREDENTIALS_EMAIL_TEMPLATE, context)

--- a/users/services_pwa.py
+++ b/users/services_pwa.py
@@ -267,8 +267,6 @@ def create_operador_for_comedor(
 
     if User.objects.filter(username__iexact=username).exists():
         raise ValidationError({"username": "Ya existe un usuario con ese username."})
-    if User.objects.filter(email__iexact=email).exists():
-        raise ValidationError({"email": "Ya existe un usuario con ese email."})
 
     try:
         operador = User.objects.create_user(

--- a/users/services_user_import.py
+++ b/users/services_user_import.py
@@ -29,11 +29,12 @@ USER_IMPORT_SHEET_NAME = "usuarios"
 USER_IMPORT_REQUIRED_COLUMNS = (
     "nombre",
     "apellido",
-    "correo",
     "permisos",
     "provincias",
     "rol",
 )
+USER_IMPORT_OPTIONAL_COLUMNS = ("correo",)
+USER_IMPORT_KNOWN_COLUMNS = USER_IMPORT_REQUIRED_COLUMNS + USER_IMPORT_OPTIONAL_COLUMNS
 USER_IMPORT_TEMPLATE_HEADERS = (
     "Nombre",
     "Apellido",
@@ -86,6 +87,15 @@ def _slug_base_desde_email(email: str) -> str:
     return cleaned[:USERNAME_MAX_LENGTH] or "usuario"
 
 
+def _slug_base_desde_nombre(*, nombre: str, apellido: str) -> str:
+    raw = f"{apellido} {nombre}".strip()
+    normalized = unicodedata.normalize("NFKD", raw)
+    normalized = "".join(ch for ch in normalized if not unicodedata.combining(ch))
+    cleaned = "".join(ch if ch.isalnum() else "." for ch in normalized.lower())
+    cleaned = ".".join(part for part in cleaned.split(".") if part)
+    return cleaned[:USERNAME_MAX_LENGTH] or "usuario"
+
+
 def _generar_username_unico(base: str) -> str:
     if not User.objects.filter(username__iexact=base).exists():
         return base
@@ -129,6 +139,8 @@ def validate_user_import_workbook(uploaded_file) -> None:
             raise ValidationError(
                 f"El archivo debe incluir las columnas obligatorias: {', '.join(missing)}."
             )
+        # Correo es opcional: si no viene la columna, todas las filas se procesan
+        # sin email y la generación de username se hace a partir de nombre+apellido.
 
         for row in rows:
             if any(_clean_cell(v) for v in row):
@@ -155,7 +167,7 @@ def load_user_import_rows(uploaded_file) -> list[dict]:
         col_map = {
             col: idx
             for idx, col in enumerate(headers)
-            if col in USER_IMPORT_REQUIRED_COLUMNS
+            if col in USER_IMPORT_KNOWN_COLUMNS
         }
 
         parsed = []
@@ -217,9 +229,23 @@ def _enviar_credenciales_import(*, user, password: str) -> bool:
     if not user.email:
         return False
     try:
+        from users.services_bulk_credentials import (  # noqa: PLC0415
+            BulkCredentialEntry,
+        )
+
+        entry = BulkCredentialEntry(
+            username=user.username,
+            plain_password=password,
+            first_name=user.first_name or "",
+            last_name=user.last_name or "",
+        )
         context = {
-            "user": user,
+            "entries": [entry],
+            "is_grouped": False,
+            "user_username": entry.username,
+            "user_full_name": entry.full_name,
             "plain_password": password,
+            "nombre_del_centro": "",
             "login_url": _build_login_url(),
         }
         message = render_to_string(USER_IMPORT_CREDENTIALS_EMAIL_TEMPLATE, context)
@@ -266,29 +292,31 @@ def process_single_user_import_row(*, row_data: dict, job: UserImportJob) -> dic
     email_raw = row_data.get("correo", "").strip()
     rol = row_data.get("rol", "").strip()
 
-    if not email_raw:
-        raise ValidationError("El campo Correo es obligatorio.")
-    try:
-        validate_email(email_raw)
-    except ValidationError as exc:
-        raise ValidationError(
-            f"El correo '{email_raw}' no tiene formato valido."
-        ) from exc
+    if not nombre or not apellido:
+        raise ValidationError("Los campos Nombre y Apellido son obligatorios.")
 
-    email = email_raw.lower()
-
-    if User.objects.filter(email__iexact=email).exists():
-        return {
-            "status": UserImportJobRow.Status.SKIPPED,
-            "mensaje": f"Ya existe un usuario con el correo {email}.",
-        }
+    email = ""
+    if email_raw:
+        try:
+            validate_email(email_raw)
+        except ValidationError as exc:
+            raise ValidationError(
+                f"El correo '{email_raw}' no tiene formato valido."
+            ) from exc
+        email = email_raw.lower()
 
     grupos = _resolver_grupos(row_data.get("permisos", "").strip())
     provincias_objs = _resolver_provincias(row_data.get("provincias", "").strip())
 
+    username_base = (
+        _slug_base_desde_email(email)
+        if email
+        else _slug_base_desde_nombre(nombre=nombre, apellido=apellido)
+    )
+
     with transaction.atomic():
         user = User(
-            username=_generar_username_unico(_slug_base_desde_email(email)),
+            username=_generar_username_unico(username_base),
             email=email,
             first_name=nombre,
             last_name=apellido,

--- a/users/templates/user/bulk_credentials_email.txt
+++ b/users/templates/user/bulk_credentials_email.txt
@@ -1,11 +1,26 @@
-Hola {{ user.get_full_name|default:user.username }},
+{% if is_grouped %}Hola,
+
+Se generó un envío de credenciales para los siguientes usuarios de SISOC:
+{% for entry in entries %}
+- {{ entry.full_name|default:entry.username }}
+  Usuario: {{ entry.username }}
+  Contraseña: {{ entry.plain_password }}
+{% endfor %}
+Ingreso: {{ login_url }}
+
+Por seguridad, cada usuario deberá cambiar su contraseña en el primer ingreso.
+
+Si usted no esperaba este correo, comuníquese con el equipo administrador.
+{% else %}{% with entry=entries.0 %}Hola {{ entry.full_name|default:entry.username }},
 
 Se generó un envío de credenciales para su acceso a SISOC.
 
-Usuario: {{ user.username }}
-Contraseña: {{ plain_password }}
+Nombre y apellido: {{ entry.full_name }}
+Usuario: {{ entry.username }}
+Contraseña: {{ entry.plain_password }}
 Ingreso: {{ login_url }}
 
 Por seguridad, deberá cambiar esta contraseña en el primer ingreso.
 
 Si usted no esperaba este correo, comuníquese con el equipo administrador.
+{% endwith %}{% endif %}

--- a/users/templates/user/bulk_credentials_email_inet.txt
+++ b/users/templates/user/bulk_credentials_email_inet.txt
@@ -1,9 +1,15 @@
 Hola, {{ nombre_del_centro }},
 
 Estamos muy contentos de sumarlos a la nueva plataforma de cursos.
-Les compartimos sus datos de acceso:
-Usuario: {{ user.username }}
-Contrasena: {{ plain_password }}
+{% if is_grouped %}Les compartimos los datos de acceso de los usuarios del centro:
+{% for entry in entries %}
+- {{ entry.full_name|default:entry.username }}
+  Usuario: {{ entry.username }}
+  Contrasena: {{ entry.plain_password }}
+{% endfor %}{% else %}{% with entry=entries.0 %}Les compartimos sus datos de acceso:
+Nombre y apellido: {{ entry.full_name }}
+Usuario: {{ entry.username }}
+Contrasena: {{ entry.plain_password }}{% endwith %}{% endif %}
 Accedan a la plataforma aqui: {{ login_url }}
 
 Ademas, los invitamos a participar de una capacitacion virtual para aprovechar al maximo la plataforma.


### PR DESCRIPTION
## Resumen

Cierra #1979.

- **Email opcional y no único**: `UserCreationForm`, `CustomUserChangeForm`, `services_pwa` y `services_generate_user` ya no exigen ni validan unicidad de email. El `username` (constraint DB) es el único identificador único.
- **Importación masiva sin columna Correo**: `services_user_import` trata `correo` como columna opcional. Si la fila no tiene email, el username se genera desde `apellido.nombre` normalizado. Email repetido ya no produce `SKIPPED`.
- **Envío masivo agrupado**: `process_bulk_credentials_file` y el worker agrupan filas con el mismo mail destinatario en un único correo, evitando N correos al mismo inbox.
- **Datos personales en templates**: `bulk_credentials_email.txt` y `bulk_credentials_email_inet.txt` muestran nombre y apellido en modo individual y en modo agrupado (iterando la lista `entries`).

## Defensas implementadas

| Riesgo | Defensa |
|--------|---------|
| INET agrupa centros distintos en un correo | `_row_grouping_key` usa `(recipient, nombre_del_centro)` como clave compuesta |
| N+1 queries al resolver destinatarios | `_build_recipient_cache(rows)` pre-carga `username→email` en 1 sola query |
| Double-send en resume post-SMTP | `_select_group_for_row` procesa solo si `attempts > 0` o si el destinatario ya tiene una fila SENT en el job |

## Archivos modificados

- `users/forms.py` — email opcional en ambos formularios
- `users/services_pwa.py` — quitado check de email duplicado
- `users/services_generate_user.py` — quitado check de email duplicado; BulkCredentialEntry
- `users/services_user_import.py` — correo columna opcional; username desde nombre+apellido
- `users/services_bulk_credentials.py` — BulkCredentialEntry, grouping, recipient cache
- `users/services_bulk_credentials_jobs.py` — grouping en worker con defensas de resume
- `users/templates/user/bulk_credentials_email*.txt` — soporte entries + is_grouped
- `tests/test_users_bulk_credentials.py` — fixes de mocks post-refactor
- `tests/test_users_email_opcional_y_agrupamiento.py` — tests nuevos (email opcional, agrupamiento, defensas)
- `docs/registro/cambios/2026-06-30-usuarios-email-opcional-y-bulk-agrupado.md` — changelog

## Plan de validación

```bash
docker compose exec django pytest tests/test_users_bulk_credentials.py tests/test_users_email_opcional_y_agrupamiento.py -v
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)