### PR TITLE
feat(users): actualizar grupos de usuario existente en importación masiva

### DIFF
--- a/tests/test_users_email_opcional_y_agrupamiento.py
+++ b/tests/test_users_email_opcional_y_agrupamiento.py
@@ -157,8 +157,11 @@ def test_user_import_row_sin_correo_genera_username_desde_nombre():
 
 
 @pytest.mark.django_db
-def test_user_import_row_emails_repetidos_no_son_rechazados():
-    User.objects.create_user(
+def test_user_import_row_email_existente_actualiza_grupos():
+    from django.contrib.auth.models import Group
+
+    grupo_nuevo = Group.objects.create(name="GrupoNuevo")
+    existing = User.objects.create_user(
         username="primer.import", email="shared@example.com", password="Pass!"
     )
     job = _StubImportJob()
@@ -167,15 +170,47 @@ def test_user_import_row_emails_repetidos_no_son_rechazados():
             "nombre": "Carla",
             "apellido": "Ruiz",
             "correo": "shared@example.com",
-            "permisos": "",
+            "permisos": "GrupoNuevo",
             "provincias": "",
             "rol": "",
             "fila": 2,
         },
         job=job,
     )
-    assert resultado["status"] and resultado.get("mensaje", "").startswith("Usuario ")
-    assert User.objects.filter(email__iexact="shared@example.com").count() == 2
+    from users.models import UserImportJobRow
+
+    assert resultado["status"] == UserImportJobRow.Status.CREATED
+    assert resultado.get("mensaje", "").startswith("Usuario primer.import actualizado")
+    assert User.objects.filter(email__iexact="shared@example.com").count() == 1
+    assert existing.groups.filter(pk=grupo_nuevo.pk).exists()
+
+
+@pytest.mark.django_db
+def test_user_import_row_email_existente_sin_grupos_nuevos_marca_skipped():
+    from django.contrib.auth.models import Group
+
+    grupo = Group.objects.create(name="GrupoExistente")
+    existing = User.objects.create_user(
+        username="primer.import2", email="shared2@example.com", password="Pass!"
+    )
+    existing.groups.add(grupo)
+    job = _StubImportJob()
+    resultado = process_single_user_import_row(
+        row_data={
+            "nombre": "Carla",
+            "apellido": "Ruiz",
+            "correo": "shared2@example.com",
+            "permisos": "GrupoExistente",
+            "provincias": "",
+            "rol": "",
+            "fila": 3,
+        },
+        job=job,
+    )
+    from users.models import UserImportJobRow
+
+    assert resultado["status"] == UserImportJobRow.Status.SKIPPED
+    assert resultado.get("mensaje", "").startswith("Usuario primer.import2 ya existe")
 
 
 def test_user_import_template_headers_incluye_correo():

--- a/users/services_user_import.py
+++ b/users/services_user_import.py
@@ -308,6 +308,25 @@ def process_single_user_import_row(  # pylint: disable=too-many-locals
         email = email_raw.lower()
 
     grupos = _resolver_grupos(row_data.get("permisos", "").strip())
+
+    if email:
+        existing_user = User.objects.filter(email__iexact=email).first()
+        if existing_user:
+            grupos_actuales = set(existing_user.groups.all())
+            nuevos = [g for g in grupos if g not in grupos_actuales]
+            if nuevos:
+                existing_user.groups.add(*nuevos)
+                return {
+                    "status": UserImportJobRow.Status.CREATED,
+                    "mensaje": f"Usuario {existing_user.username} actualizado: {len(nuevos)} grupo(s) añadido(s).",
+                    "email": email,
+                }
+            return {
+                "status": UserImportJobRow.Status.SKIPPED,
+                "mensaje": f"Usuario {existing_user.username} ya existe y ya tiene todos los grupos indicados.",
+                "email": email,
+            }
+
     provincias_objs = _resolver_provincias(row_data.get("provincias", "").strip())
 
     username_base = (


### PR DESCRIPTION
## ¿Qué cambia?

`process_single_user_import_row` ahora detecta si el email de la fila ya corresponde a un usuario registrado. En ese caso, en lugar de saltar la fila:

- Resuelve los grupos del Excel con `_resolver_grupos()`
- Calcula la diferencia: grupos del Excel que el usuario **aún no tiene**
- Si hay grupos nuevos → `user.groups.add(*nuevos)` y devuelve `CREATED` con mensaje `"actualizado: N grupo(s) añadido(s)"`
- Si ya tiene todos → devuelve `SKIPPED` con mensaje `"ya existe y ya tiene todos los grupos indicados"`

El resto del flujo (provincias, rol, credenciales, creación de usuarios sin email) **no se toca**.

## Archivos modificados

- `users/services_user_import.py` — bloque de detección de usuario existente insertado entre `_resolver_grupos` y `_resolver_provincias`; `_resolver_provincias` sólo se llama para el flujo de creación
- `tests/test_users_email_opcional_y_agrupamiento.py` — reemplaza el test anterior (que esperaba 2 usuarios con el mismo email) por dos tests específicos: uno para el path "grupos añadidos → CREATED" y otro para "sin grupos nuevos → SKIPPED"

## Decisiones de diseño

| Decisión | Razón |
|---|---|
| `groups.add` en lugar de `groups.set` | No pisar grupos que el usuario ya tiene |
| Status `CREATED` para "actualizado" | El dispatcher de `services_user_import_jobs` ya enruta cualquier non-SKIPPED a `_record_row_created`, que incrementa `created_rows` — no se necesita status nuevo ni cambios en el dispatcher |
| Status `SKIPPED` para "sin cambios" | Semánticamente correcto: la fila no produjo ningún cambio |
| Check sólo cuando `email != ""` | Usuarios sin email no tienen identidad única por email; el flujo de creación se mantiene intacto |
| `_resolver_provincias` movida después del check | Evita validar provincias para filas que van a salir por el path de usuario existente |

## Validación

Los tests cubren los tres caminos:
1. Usuario nuevo (tests preexistentes sin cambios)
2. Usuario existente + grupos nuevos → CREATED
3. Usuario existente + todos los grupos ya presentes → SKIPPED