### PR TITLE
feat(users): resolución username-first y acciones de grupos en importación masiva

### DIFF
--- a/tests/test_users_email_opcional_y_agrupamiento.py
+++ b/tests/test_users_email_opcional_y_agrupamiento.py
@@ -1,8 +1,10 @@
-"""Tests para issue #1979.
+"""Tests para issues #1979 y #1936.
 
 Cubren:
 - Usuarios sin email y con email repetido en forms.
-- User import sin columna correo.
+- User import username-first con fallback a email.
+- Actualización masiva de grupos con acciones agregar / quitar / reemplazar.
+- Enforcement de alcance via Profile.grupos_asignables.
 - Bulk credentials agrupado por mail destinatario.
 - Nombre y apellido en el cuerpo del email.
 """
@@ -11,6 +13,7 @@ from io import BytesIO
 
 import pytest
 from django.contrib.auth import get_user_model
+from django.contrib.auth.models import Group
 from django.core import mail
 from django.core.files.uploadedfile import SimpleUploadedFile
 from django.test import override_settings
@@ -123,62 +126,294 @@ def test_user_change_form_acepta_email_vacio():
     assert form.is_valid(), form.errors
 
 
-# ---------- A2: user import sin columna correo ----------
+# ---------- A2: user import – stub de job ----------
 
 
 class _StubImportJob:
-    """Job mínimo para process_single_user_import_row."""
+    """Job mínimo para process_single_user_import_row. Actor=None => sin restricción."""
 
     is_pwa_import = False
     send_credentials = False
+    requested_by = None
+
+
+def _row(extra=None, **kwargs):
+    base = {
+        "nombre": "Ana",
+        "apellido": "García",
+        "correo": "",
+        "username": "",
+        "permisos": "",
+        "provincias": "",
+        "rol": "operadora",
+        "accion_grupos": "",
+        "fila": 2,
+    }
+    base.update(kwargs)
+    if extra:
+        base.update(extra)
+    return base
+
+
+# ---------- Caso 1: username existente + grupos nuevos => CREATED ----------
 
 
 @pytest.mark.django_db
-def test_user_import_row_sin_correo_genera_username_desde_nombre():
-    job = _StubImportJob()
+def test_import_username_existente_grupos_nuevos():
+    grupo = Group.objects.create(name="Grupo Test 1")
+    user = User.objects.create_user(username="juan.perez", email="j@e.com")
+
     resultado = process_single_user_import_row(
-        row_data={
-            "nombre": "Ana",
-            "apellido": "García",
-            "correo": "",
-            "permisos": "",
-            "provincias": "",
-            "rol": "operadora",
-            "fila": 2,
-        },
-        job=job,
+        row_data=_row(username="juan.perez", permisos="Grupo Test 1"),
+        job=_StubImportJob(),
     )
-    assert resultado["status"]
-    # Username generado contiene el apellido normalizado
-    user = User.objects.filter(first_name="Ana", last_name="García").first()
+
+    assert resultado["status"].value == "created", resultado
+    user.refresh_from_db()
+    assert grupo in user.groups.all()
+
+
+# ---------- Caso 2: username existente + sin cambios => SKIPPED ----------
+
+
+@pytest.mark.django_db
+def test_import_username_existente_sin_cambios():
+    grupo = Group.objects.create(name="Grupo Test 2")
+    user = User.objects.create_user(username="sin.cambios", email="sc@e.com")
+    user.groups.add(grupo)
+
+    resultado = process_single_user_import_row(
+        row_data=_row(username="sin.cambios", permisos="Grupo Test 2"),
+        job=_StubImportJob(),
+    )
+
+    assert resultado["status"].value == "skipped", resultado
+
+
+# ---------- Caso 3: sin username, con email existente => fallback a email ----------
+
+
+@pytest.mark.django_db
+def test_import_sin_username_con_email_existente():
+    grupo = Group.objects.create(name="Grupo Test 3")
+    User.objects.create_user(username="email.user", email="email@e.com")
+
+    resultado = process_single_user_import_row(
+        row_data=_row(correo="email@e.com", permisos="Grupo Test 3"),
+        job=_StubImportJob(),
+    )
+
+    assert resultado["status"].value == "created", resultado
+    user = User.objects.get(username="email.user")
+    assert grupo in user.groups.all()
+
+
+# ---------- Caso 4: sin username ni email => error ----------
+
+
+@pytest.mark.django_db
+def test_import_sin_username_ni_email():
+    from django.core.exceptions import ValidationError
+
+    with pytest.raises(ValidationError, match="Username o Correo"):
+        process_single_user_import_row(
+            row_data=_row(),
+            job=_StubImportJob(),
+        )
+
+
+# ---------- Caso 5: username y email apuntan a usuarios distintos => gana username, se actualiza email ----------
+
+
+@pytest.mark.django_db
+def test_import_username_y_email_usuarios_distintos():
+    user_a = User.objects.create_user(username="user.a", email="a@e.com")
+    User.objects.create_user(username="user.b", email="b@e.com")
+
+    resultado = process_single_user_import_row(
+        row_data=_row(username="user.a", correo="b@e.com"),
+        job=_StubImportJob(),
+    )
+
+    user_a.refresh_from_db()
+    assert user_a.email == "b@e.com"
+    assert resultado["status"].value == "created", resultado
+    assert User.objects.filter(username="user.b").exists()
+
+
+# ---------- Caso 6: accion agregar ----------
+
+
+@pytest.mark.django_db
+def test_import_accion_agregar():
+    g1 = Group.objects.create(name="Grupo Agregar 1")
+    g2 = Group.objects.create(name="Grupo Agregar 2")
+    user = User.objects.create_user(username="agregar.user")
+    user.groups.add(g1)
+
+    resultado = process_single_user_import_row(
+        row_data=_row(
+            username="agregar.user", permisos="Grupo Agregar 2", accion_grupos="agregar"
+        ),
+        job=_StubImportJob(),
+    )
+
+    assert resultado["status"].value == "created", resultado
+    user.refresh_from_db()
+    group_ids = set(user.groups.values_list("id", flat=True))
+    assert g1.pk in group_ids
+    assert g2.pk in group_ids
+
+
+# ---------- Caso 7: accion quitar ----------
+
+
+@pytest.mark.django_db
+def test_import_accion_quitar():
+    g1 = Group.objects.create(name="Grupo Quitar 1")
+    g2 = Group.objects.create(name="Grupo Quitar 2")
+    user = User.objects.create_user(username="quitar.user")
+    user.groups.add(g1, g2)
+
+    resultado = process_single_user_import_row(
+        row_data=_row(
+            username="quitar.user", permisos="Grupo Quitar 1", accion_grupos="quitar"
+        ),
+        job=_StubImportJob(),
+    )
+
+    assert resultado["status"].value == "created", resultado
+    user.refresh_from_db()
+    group_ids = set(user.groups.values_list("id", flat=True))
+    assert g1.pk not in group_ids
+    assert g2.pk in group_ids
+
+
+# ---------- Caso 8: accion reemplazar ----------
+
+
+@pytest.mark.django_db
+def test_import_accion_reemplazar():
+    g1 = Group.objects.create(name="Grupo Reemplazar 1")
+    g2 = Group.objects.create(name="Grupo Reemplazar 2")
+    user = User.objects.create_user(username="reemplazar.user")
+    user.groups.add(g1)
+
+    resultado = process_single_user_import_row(
+        row_data=_row(
+            username="reemplazar.user",
+            permisos="Grupo Reemplazar 2",
+            accion_grupos="reemplazar",
+        ),
+        job=_StubImportJob(),
+    )
+
+    assert resultado["status"].value == "created", resultado
+    user.refresh_from_db()
+    group_ids = set(user.groups.values_list("id", flat=True))
+    assert g1.pk not in group_ids
+    assert g2.pk in group_ids
+
+
+# ---------- Caso 9: reemplazar preserva grupos fuera de alcance del actor ----------
+
+
+@pytest.mark.django_db
+def test_import_reemplazar_preserva_grupos_fuera_de_alcance():
+    g_dentro = Group.objects.create(name="Grupo Dentro Alcance")
+    g_fuera = Group.objects.create(name="Grupo Fuera Alcance")
+
+    actor = User.objects.create_user(username="actor.restringido")
+    actor.profile.grupos_asignables.set([g_dentro])
+
+    target = User.objects.create_user(username="target.reemplazar")
+    target.groups.add(g_fuera)
+
+    class _RestrictedJob:
+        is_pwa_import = False
+        send_credentials = False
+        requested_by = actor
+
+    resultado = process_single_user_import_row(
+        row_data=_row(
+            username="target.reemplazar",
+            permisos="Grupo Dentro Alcance",
+            accion_grupos="reemplazar",
+        ),
+        job=_RestrictedJob(),
+    )
+
+    assert resultado["status"].value == "created", resultado
+    target.refresh_from_db()
+    group_ids = set(target.groups.values_list("id", flat=True))
+    assert g_fuera.pk in group_ids
+    assert g_dentro.pk in group_ids
+
+
+# ---------- Caso 10: grupo fuera de grupos_asignables => error ----------
+
+
+@pytest.mark.django_db
+def test_import_grupo_fuera_de_asignables_error():
+    from django.core.exceptions import ValidationError
+
+    g_permitido = Group.objects.create(name="Grupo Permitido")
+    g_prohibido = Group.objects.create(name="Grupo Prohibido")
+
+    actor = User.objects.create_user(username="actor.limitado")
+    actor.profile.grupos_asignables.set([g_permitido])
+
+    User.objects.create_user(username="target.limitado")
+
+    class _LimitedJob:
+        is_pwa_import = False
+        send_credentials = False
+        requested_by = actor
+
+    with pytest.raises(ValidationError, match="permiso"):
+        process_single_user_import_row(
+            row_data=_row(
+                username="target.limitado",
+                permisos="Grupo Prohibido",
+                accion_grupos="agregar",
+            ),
+            job=_LimitedJob(),
+        )
+
+
+# ---------- A2 actualizados: creacion requiere username ----------
+
+
+@pytest.mark.django_db
+def test_user_import_row_con_username_crea_usuario():
+    resultado = process_single_user_import_row(
+        row_data=_row(username="nuevo.usuario", nombre="Ana", apellido="García"),
+        job=_StubImportJob(),
+    )
+    assert resultado["status"].value == "created", resultado
+    user = User.objects.filter(username="nuevo.usuario").first()
     assert user is not None
-    assert user.email == ""
-    assert user.username.startswith("garcia"), user.username
+    assert user.first_name == "Ana"
 
 
 @pytest.mark.django_db
-def test_user_import_row_emails_repetidos_no_son_rechazados():
-    User.objects.create_user(
-        username="primer.import", email="shared@example.com", password="Pass!"
-    )
-    job = _StubImportJob()
+def test_user_import_row_email_existente_actualiza_en_lugar_de_crear():
+    """Sin username, si el email pertenece a un usuario existente, se actualiza (no crea uno nuevo)."""
+    Group.objects.create(name="Grupo Nuevo")
+    User.objects.create_user(username="existente.email", email="shared@example.com")
+
     resultado = process_single_user_import_row(
-        row_data={
-            "nombre": "Carla",
-            "apellido": "Ruiz",
-            "correo": "shared@example.com",
-            "permisos": "",
-            "provincias": "",
-            "rol": "",
-            "fila": 2,
-        },
-        job=job,
+        row_data=_row(correo="shared@example.com", permisos="Grupo Nuevo"),
+        job=_StubImportJob(),
     )
-    assert resultado["status"] and resultado.get("mensaje", "").startswith("Usuario ")
-    assert User.objects.filter(email__iexact="shared@example.com").count() == 2
+
+    assert resultado["status"].value == "created", resultado
+    assert User.objects.filter(email__iexact="shared@example.com").count() == 1
 
 
-def test_user_import_template_headers_incluye_correo():
+@pytest.mark.django_db
+def test_user_import_template_headers_incluye_username_y_correo():
+    assert "Username" in USER_IMPORT_TEMPLATE_HEADERS
     assert "Correo" in USER_IMPORT_TEMPLATE_HEADERS
 
 
@@ -246,19 +481,16 @@ def test_bulk_credentials_agrupa_credenciales_por_mismo_destinatario():
 
     result = process_bulk_credentials_file(uploaded_file=upload, send_type="standard")
 
-    # 3 filas procesadas y enviadas, pero solo 2 correos (1 agrupado + 1 solo)
     assert result["summary"]["procesadas"] == 3
     assert result["summary"]["enviadas"] == 3
     assert len(mail.outbox) == 2
 
-    # El correo agrupado contiene ambas credenciales
     agrupado = next(msg for msg in mail.outbox if msg.to == ["compartido@example.com"])
     assert "user_uno" in agrupado.body
     assert "user_dos" in agrupado.body
     assert "Pass1!" in agrupado.body
     assert "Pass2!" in agrupado.body
 
-    # El correo individual sólo trae sus datos
     individual = next(msg for msg in mail.outbox if msg.to == ["solo@example.com"])
     assert "user_solo" in individual.body
     assert "Pass3!" in individual.body
@@ -331,7 +563,6 @@ def test_inet_no_agrupa_cuando_centros_son_distintos():
     result = process_bulk_credentials_file(uploaded_file=upload, send_type="inet")
 
     assert result["summary"]["enviadas"] == 2
-    # Dos correos distintos al mismo destinatario, uno por centro
     assert len(mail.outbox) == 2
     assert all(msg.to == ["compartido@example.com"] for msg in mail.outbox)
     bodies = [msg.body for msg in mail.outbox]
@@ -416,7 +647,6 @@ def test_worker_no_re_agrupa_si_destinatario_ya_recibio_envio_previo(
     job = create_bulk_credentials_job(
         uploaded_file=upload, send_type="standard", requested_by=operator
     )
-    # Simulamos que la fila 2 (reagr_a) ya fue enviada en una corrida anterior
     BulkCredentialsJobRow.objects.create(
         job=job,
         fila=2,
@@ -443,11 +673,9 @@ def test_worker_no_re_agrupa_si_destinatario_ya_recibio_envio_previo(
     process_bulk_credentials_job(job)
     job.refresh_from_db()
 
-    # No re-agrupa: reagr_b y reagr_c se envían en correos separados, no juntos.
     assert job.status == BulkCredentialsJob.Status.COMPLETED
     assert len(mail.outbox) == 2
     assert all(msg.to == ["compartido@example.com"] for msg in mail.outbox)
-    # Cada correo contiene solo a su propio usuario
     body_b = next(m.body for m in mail.outbox if "reagr_b" in m.body)
     assert "reagr_c" not in body_b
     body_c = next(m.body for m in mail.outbox if "reagr_c" in m.body)
@@ -483,7 +711,6 @@ def test_worker_no_agrupa_cuando_primary_tiene_attempts_previos(settings, tmp_pa
     job = create_bulk_credentials_job(
         uploaded_file=upload, send_type="standard", requested_by=operator
     )
-    # Fila 2 (att_a) ya fue intentada y falló: attempts = 1, status = FAILED
     BulkCredentialsJobRow.objects.create(
         job=job,
         fila=2,
@@ -501,7 +728,6 @@ def test_worker_no_agrupa_cuando_primary_tiene_attempts_previos(settings, tmp_pa
     process_bulk_credentials_job(job)
     job.refresh_from_db()
 
-    # Se envían 2 correos (uno por fila), no un grupo único de 2.
     assert job.status == BulkCredentialsJob.Status.COMPLETED
     assert len(mail.outbox) == 2
     bodies = [m.body for m in mail.outbox]

--- a/users/services_user_import.py
+++ b/users/services_user_import.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import logging
 import unicodedata
+from dataclasses import dataclass
 from io import BytesIO
 
 from django.conf import settings
@@ -330,104 +331,105 @@ def _aplicar_accion_grupos(
 
     if accion == GROUP_ACTION_AGREGAR:
         to_add = requested_group_ids - current_group_ids
-        if not to_add:
-            return False
-        user.groups.add(*to_add)
-        return True
+        if to_add:
+            user.groups.add(*to_add)
+        return bool(to_add)
 
     if accion == GROUP_ACTION_QUITAR:
         to_remove = requested_group_ids & current_group_ids
-        if not to_remove:
-            return False
-        user.groups.remove(*to_remove)
-        return True
+        if to_remove:
+            user.groups.remove(*to_remove)
+        return bool(to_remove)
 
-    if accion == GROUP_ACTION_REEMPLAZAR:
-        if allowed_group_ids is not None:
-            outside_scope = current_group_ids - allowed_group_ids
-            final_group_ids = outside_scope | requested_group_ids
-        else:
-            final_group_ids = requested_group_ids
-
-        if final_group_ids == current_group_ids:
-            return False
+    final_group_ids = (
+        (current_group_ids - allowed_group_ids | requested_group_ids)
+        if allowed_group_ids
+        else requested_group_ids
+    )
+    if final_group_ids != current_group_ids:
         user.groups.set(list(final_group_ids))
         return True
-
     return False
 
 
-def _procesar_usuario_existente(
-    *,
-    user,
-    email: str,
-    username_raw: str,
-    grupos: list,
-    accion_grupos: str,
-    allowed_group_ids: set | None,
-) -> dict:
+@dataclass
+class _ActualizarUsuarioParams:
+    user: object
+    email: str
+    username_raw: str
+    grupos: list
+    accion_grupos: str
+    allowed_group_ids: set | None
+
+
+def _procesar_usuario_existente(params: _ActualizarUsuarioParams) -> dict:
     changed = False
 
     with transaction.atomic():
-        if username_raw and email and user.email.lower() != email.lower():
-            user.email = email
-            user.save(update_fields=["email"])
+        if (
+            params.username_raw
+            and params.email
+            and params.user.email.lower() != params.email.lower()
+        ):
+            params.user.email = params.email
+            params.user.save(update_fields=["email"])
             changed = True
 
         grupos_changed = _aplicar_accion_grupos(
-            user=user,
-            grupos=grupos,
-            accion=accion_grupos,
-            allowed_group_ids=allowed_group_ids,
+            user=params.user,
+            grupos=params.grupos,
+            accion=params.accion_grupos,
+            allowed_group_ids=params.allowed_group_ids,
         )
         changed = changed or grupos_changed
 
-    if not changed:
-        return {
-            "status": UserImportJobRow.Status.SKIPPED,
-            "mensaje": f"Usuario {user.username}: sin cambios.",
-            "email": user.email,
-        }
-
+    status = UserImportJobRow.Status.SKIPPED if not changed else UserImportJobRow.Status.CREATED
+    mensaje = (
+        f"Usuario {params.user.username}: sin cambios."
+        if not changed
+        else f"Usuario {params.user.username} actualizado ({params.accion_grupos} grupos)."
+    )
     return {
-        "status": UserImportJobRow.Status.CREATED,
-        "mensaje": f"Usuario {user.username} actualizado ({accion_grupos} grupos).",
-        "email": user.email,
+        "status": status,
+        "mensaje": mensaje,
+        "email": params.user.email,
     }
 
 
-def _crear_usuario_nuevo(
-    *,
-    nombre: str,
-    apellido: str,
-    email: str,
-    username_raw: str,
-    rol: str,
-    grupos: list,
-    provincias_objs: list,
-    job: UserImportJob,
-) -> tuple[User, str]:
+@dataclass
+class _CrearUsuarioParams:
+    nombre: str
+    apellido: str
+    email: str
+    username_raw: str
+    rol: str
+    grupos: list
+    provincias_objs: list
+    job: object
+
+
+def _crear_usuario_nuevo(params: _CrearUsuarioParams) -> tuple[User, str]:
     user = User(
-        username=username_raw,
-        email=email,
-        first_name=nombre,
-        last_name=apellido,
-        is_staff=not job.is_pwa_import,
+        username=params.username_raw,
+        email=params.email,
+        first_name=params.nombre,
+        last_name=params.apellido,
+        is_staff=not params.job.is_pwa_import,
         is_active=True,
     )
     user.set_unusable_password()
     user.save()
 
-    if grupos:
-        user.groups.set(grupos)
+    if params.grupos:
+        user.groups.set(params.grupos)
 
     profile = user.profile
-    profile.rol = rol
-    if provincias_objs:
+    profile.rol = params.rol
+    if params.provincias_objs:
         profile.es_usuario_provincial = True
     profile.save(update_fields=["rol", "es_usuario_provincial"])
 
-    for prov in provincias_objs:
+    for prov in params.provincias_objs:
         scope_key = ProfileTerritorialScope.build_scope_key(prov.pk)
         ProfileTerritorialScope.objects.get_or_create(
             profile=profile,
@@ -489,7 +491,7 @@ def process_single_user_import_row(
     existing_user = _resolver_usuario_objetivo(row_data)
 
     if existing_user is not None:
-        return _procesar_usuario_existente(
+        params = _ActualizarUsuarioParams(
             user=existing_user,
             email=email,
             username_raw=username_raw,
@@ -497,6 +499,7 @@ def process_single_user_import_row(
             accion_grupos=accion_grupos,
             allowed_group_ids=allowed_group_ids,
         )
+        return _procesar_usuario_existente(params)
 
     if not username_raw:
         raise ValidationError(
@@ -513,7 +516,7 @@ def process_single_user_import_row(
     provincias_objs = _resolver_provincias(row_data.get("provincias", "").strip())
 
     with transaction.atomic():
-        user, password = _crear_usuario_nuevo(
+        params = _CrearUsuarioParams(
             nombre=nombre,
             apellido=apellido,
             email=email,
@@ -523,6 +526,7 @@ def process_single_user_import_row(
             provincias_objs=provincias_objs,
             job=job,
         )
+        user, password = _crear_usuario_nuevo(params)
 
     if job.send_credentials:
         _enviar_credenciales_import(user=user, password=password)

--- a/users/services_user_import.py
+++ b/users/services_user_import.py
@@ -530,18 +530,22 @@ def process_single_user_import_row(
         )
         return _procesar_usuario_existente(params)
 
-    if not datos.username_raw:
-        raise ValidationError(
-            "No se encontro un usuario con ese correo. "
-            "Para crear un usuario nuevo se requiere la columna Username."
-        )
-
     if not datos.nombre or not datos.apellido:
         raise ValidationError("Los campos Nombre y Apellido son obligatorios.")
 
-    if User.objects.filter(username__iexact=datos.username_raw).exists():
+    username_to_create = datos.username_raw
+    if not username_to_create:
+        username_base = _slug_base_desde_nombre(
+            nombre=datos.nombre, apellido=datos.apellido
+        )
+        username_to_create = _generar_username_unico(username_base)
+
+    if (
+        datos.username_raw
+        and User.objects.filter(username__iexact=username_to_create).exists()
+    ):
         raise ValidationError(
-            f"Ya existe un usuario con el username '{datos.username_raw}'."
+            f"Ya existe un usuario con el username '{username_to_create}'."
         )
 
     with transaction.atomic():
@@ -549,7 +553,7 @@ def process_single_user_import_row(
             nombre=datos.nombre,
             apellido=datos.apellido,
             email=datos.email,
-            username_raw=datos.username_raw,
+            username_raw=username_to_create,
             rol=datos.rol,
             grupos=datos.grupos,
             provincias_objs=datos.provincias_objs,

--- a/users/services_user_import.py
+++ b/users/services_user_import.py
@@ -33,17 +33,24 @@ USER_IMPORT_REQUIRED_COLUMNS = (
     "provincias",
     "rol",
 )
-USER_IMPORT_OPTIONAL_COLUMNS = ("correo",)
+USER_IMPORT_OPTIONAL_COLUMNS = ("correo", "username", "accion_grupos")
 USER_IMPORT_KNOWN_COLUMNS = USER_IMPORT_REQUIRED_COLUMNS + USER_IMPORT_OPTIONAL_COLUMNS
 USER_IMPORT_TEMPLATE_HEADERS = (
+    "Username",
     "Nombre",
     "Apellido",
     "Correo",
     "Permisos",
+    "Accion grupos",
     "Provincias",
     "Rol",
 )
 USERNAME_MAX_LENGTH = 150
+
+GROUP_ACTION_AGREGAR = "agregar"
+GROUP_ACTION_QUITAR = "quitar"
+GROUP_ACTION_REEMPLAZAR = "reemplazar"
+GROUP_ACTIONS = (GROUP_ACTION_AGREGAR, GROUP_ACTION_QUITAR, GROUP_ACTION_REEMPLAZAR)
 
 
 def _build_login_url() -> str:
@@ -139,8 +146,6 @@ def validate_user_import_workbook(uploaded_file) -> None:
             raise ValidationError(
                 f"El archivo debe incluir las columnas obligatorias: {', '.join(missing)}."
             )
-        # Correo es opcional: si no viene la columna, todas las filas se procesan
-        # sin email y la generación de username se hace a partir de nombre+apellido.
 
         for row in rows:
             if any(_clean_cell(v) for v in row):
@@ -286,16 +291,179 @@ def _resolver_provincias(provincias_raw: str) -> list:
     return provincias
 
 
-def process_single_user_import_row(  # pylint: disable=too-many-locals
+def _is_unrestricted_actor(actor) -> bool:
+    if actor is None:
+        return True
+    if getattr(actor, "is_superuser", False):
+        return True
+    profile = getattr(actor, "profile", None)
+    if not profile:
+        return True
+    return not profile.grupos_asignables.exists()
+
+
+def _get_allowed_group_ids(actor) -> set | None:
+    if _is_unrestricted_actor(actor):
+        return None
+    return set(actor.profile.grupos_asignables.values_list("id", flat=True))
+
+
+def _resolver_usuario_objetivo(row_data: dict):
+    username_raw = row_data.get("username", "").strip()
+    email_raw = row_data.get("correo", "").strip()
+    if username_raw:
+        return User.objects.filter(username__iexact=username_raw).first()
+    if email_raw:
+        return User.objects.filter(email__iexact=email_raw).first()
+    return None
+
+
+def _aplicar_accion_grupos(
+    *,
+    user,
+    grupos: list,
+    accion: str,
+    allowed_group_ids: set | None,
+) -> bool:
+    current_group_ids = set(user.groups.values_list("id", flat=True))
+    requested_group_ids = {g.pk for g in grupos}
+
+    if accion == GROUP_ACTION_AGREGAR:
+        to_add = requested_group_ids - current_group_ids
+        if not to_add:
+            return False
+        user.groups.add(*to_add)
+        return True
+
+    if accion == GROUP_ACTION_QUITAR:
+        to_remove = requested_group_ids & current_group_ids
+        if not to_remove:
+            return False
+        user.groups.remove(*to_remove)
+        return True
+
+    if accion == GROUP_ACTION_REEMPLAZAR:
+        if allowed_group_ids is not None:
+            outside_scope = current_group_ids - allowed_group_ids
+            final_group_ids = outside_scope | requested_group_ids
+        else:
+            final_group_ids = requested_group_ids
+
+        if final_group_ids == current_group_ids:
+            return False
+        user.groups.set(list(final_group_ids))
+        return True
+
+    return False
+
+
+def _procesar_usuario_existente(
+    *,
+    user,
+    email: str,
+    username_raw: str,
+    grupos: list,
+    accion_grupos: str,
+    allowed_group_ids: set | None,
+) -> dict:
+    changed = False
+
+    with transaction.atomic():
+        if username_raw and email and user.email.lower() != email.lower():
+            user.email = email
+            user.save(update_fields=["email"])
+            changed = True
+
+        grupos_changed = _aplicar_accion_grupos(
+            user=user,
+            grupos=grupos,
+            accion=accion_grupos,
+            allowed_group_ids=allowed_group_ids,
+        )
+        changed = changed or grupos_changed
+
+    if not changed:
+        return {
+            "status": UserImportJobRow.Status.SKIPPED,
+            "mensaje": f"Usuario {user.username}: sin cambios.",
+            "email": user.email,
+        }
+
+    return {
+        "status": UserImportJobRow.Status.CREATED,
+        "mensaje": f"Usuario {user.username} actualizado ({accion_grupos} grupos).",
+        "email": user.email,
+    }
+
+
+def _crear_usuario_nuevo(
+    *,
+    nombre: str,
+    apellido: str,
+    email: str,
+    username_raw: str,
+    rol: str,
+    grupos: list,
+    provincias_objs: list,
+    job: UserImportJob,
+) -> tuple[User, str]:
+    user = User(
+        username=username_raw,
+        email=email,
+        first_name=nombre,
+        last_name=apellido,
+        is_staff=not job.is_pwa_import,
+        is_active=True,
+    )
+    user.set_unusable_password()
+    user.save()
+
+    if grupos:
+        user.groups.set(grupos)
+
+    profile = user.profile
+    profile.rol = rol
+    if provincias_objs:
+        profile.es_usuario_provincial = True
+    profile.save(update_fields=["rol", "es_usuario_provincial"])
+
+    for prov in provincias_objs:
+        scope_key = ProfileTerritorialScope.build_scope_key(prov.pk)
+        ProfileTerritorialScope.objects.get_or_create(
+            profile=profile,
+            scope_key=scope_key,
+            defaults={
+                "provincia_id": prov.pk,
+                "municipio": None,
+                "localidad": None,
+            },
+        )
+
+    password = generate_temporary_password_for_user(user=user)
+    return user, password
+
+
+def process_single_user_import_row(
     *, row_data: dict, job: UserImportJob
 ) -> dict:
     nombre = row_data.get("nombre", "").strip()
     apellido = row_data.get("apellido", "").strip()
     email_raw = row_data.get("correo", "").strip()
+    username_raw = row_data.get("username", "").strip()
     rol = row_data.get("rol", "").strip()
+    accion_grupos_raw = row_data.get("accion_grupos", "").strip().lower()
+    accion_grupos = accion_grupos_raw or GROUP_ACTION_AGREGAR
 
-    if not nombre or not apellido:
-        raise ValidationError("Los campos Nombre y Apellido son obligatorios.")
+    if accion_grupos not in GROUP_ACTIONS:
+        raise ValidationError(
+            f"Accion de grupos invalida: '{accion_grupos}'. "
+            f"Los valores validos son: {', '.join(GROUP_ACTIONS)}."
+        )
+
+    if not username_raw and not email_raw:
+        raise ValidationError(
+            "Debe indicar Username o Correo para identificar al usuario de la fila."
+        )
 
     email = ""
     if email_raw:
@@ -308,48 +476,53 @@ def process_single_user_import_row(  # pylint: disable=too-many-locals
         email = email_raw.lower()
 
     grupos = _resolver_grupos(row_data.get("permisos", "").strip())
+
+    actor = job.requested_by
+    allowed_group_ids = _get_allowed_group_ids(actor)
+
+    if allowed_group_ids is not None and grupos:
+        out_of_scope = [g for g in grupos if g.pk not in allowed_group_ids]
+        if out_of_scope:
+            names = ", ".join(g.name for g in out_of_scope)
+            raise ValidationError(f"No tiene permiso para operar los grupos: {names}.")
+
+    existing_user = _resolver_usuario_objetivo(row_data)
+
+    if existing_user is not None:
+        return _procesar_usuario_existente(
+            user=existing_user,
+            email=email,
+            username_raw=username_raw,
+            grupos=grupos,
+            accion_grupos=accion_grupos,
+            allowed_group_ids=allowed_group_ids,
+        )
+
+    if not username_raw:
+        raise ValidationError(
+            "No se encontro un usuario con ese correo. "
+            "Para crear un usuario nuevo se requiere la columna Username."
+        )
+
+    if not nombre or not apellido:
+        raise ValidationError("Los campos Nombre y Apellido son obligatorios.")
+
+    if User.objects.filter(username__iexact=username_raw).exists():
+        raise ValidationError(f"Ya existe un usuario con el username '{username_raw}'.")
+
     provincias_objs = _resolver_provincias(row_data.get("provincias", "").strip())
 
-    username_base = (
-        _slug_base_desde_email(email)
-        if email
-        else _slug_base_desde_nombre(nombre=nombre, apellido=apellido)
-    )
-
     with transaction.atomic():
-        user = User(
-            username=_generar_username_unico(username_base),
+        user, password = _crear_usuario_nuevo(
+            nombre=nombre,
+            apellido=apellido,
             email=email,
-            first_name=nombre,
-            last_name=apellido,
-            is_staff=not job.is_pwa_import,
-            is_active=True,
+            username_raw=username_raw,
+            rol=rol,
+            grupos=grupos,
+            provincias_objs=provincias_objs,
+            job=job,
         )
-        user.set_unusable_password()
-        user.save()
-
-        if grupos:
-            user.groups.set(grupos)
-
-        profile = user.profile
-        profile.rol = rol
-        if provincias_objs:
-            profile.es_usuario_provincial = True
-        profile.save(update_fields=["rol", "es_usuario_provincial"])
-
-        for prov in provincias_objs:
-            scope_key = ProfileTerritorialScope.build_scope_key(prov.pk)
-            ProfileTerritorialScope.objects.get_or_create(
-                profile=profile,
-                scope_key=scope_key,
-                defaults={
-                    "provincia_id": prov.pk,
-                    "municipio": None,
-                    "localidad": None,
-                },
-            )
-
-        password = generate_temporary_password_for_user(user=user)
 
     if job.send_credentials:
         _enviar_credenciales_import(user=user, password=password)

--- a/users/services_user_import.py
+++ b/users/services_user_import.py
@@ -408,6 +408,19 @@ class _CrearUsuarioParams:
     job: object
 
 
+@dataclass
+class _DatosFilaValidados:
+    nombre: str
+    apellido: str
+    email: str
+    username_raw: str
+    rol: str
+    accion_grupos: str
+    grupos: list
+    provincias_objs: list
+    allowed_group_ids: set | None
+
+
 def _crear_usuario_nuevo(params: _CrearUsuarioParams) -> tuple[User, str]:
     user = User(
         username=params.username_raw,
@@ -445,16 +458,15 @@ def _crear_usuario_nuevo(params: _CrearUsuarioParams) -> tuple[User, str]:
     return user, password
 
 
-def process_single_user_import_row(
-    *, row_data: dict, job: UserImportJob
-) -> dict:
+def _validar_y_preparar_fila(
+    row_data: dict, job: UserImportJob
+) -> _DatosFilaValidados:
     nombre = row_data.get("nombre", "").strip()
     apellido = row_data.get("apellido", "").strip()
     email_raw = row_data.get("correo", "").strip()
     username_raw = row_data.get("username", "").strip()
     rol = row_data.get("rol", "").strip()
-    accion_grupos_raw = row_data.get("accion_grupos", "").strip().lower()
-    accion_grupos = accion_grupos_raw or GROUP_ACTION_AGREGAR
+    accion_grupos = row_data.get("accion_grupos", "").strip().lower() or GROUP_ACTION_AGREGAR
 
     if accion_grupos not in GROUP_ACTIONS:
         raise ValidationError(
@@ -478,9 +490,7 @@ def process_single_user_import_row(
         email = email_raw.lower()
 
     grupos = _resolver_grupos(row_data.get("permisos", "").strip())
-
-    actor = job.requested_by
-    allowed_group_ids = _get_allowed_group_ids(actor)
+    allowed_group_ids = _get_allowed_group_ids(job.requested_by)
 
     if allowed_group_ids is not None and grupos:
         out_of_scope = [g for g in grupos if g.pk not in allowed_group_ids]
@@ -488,42 +498,61 @@ def process_single_user_import_row(
             names = ", ".join(g.name for g in out_of_scope)
             raise ValidationError(f"No tiene permiso para operar los grupos: {names}.")
 
+    provincias_objs = _resolver_provincias(row_data.get("provincias", "").strip())
+
+    return _DatosFilaValidados(
+        nombre=nombre,
+        apellido=apellido,
+        email=email,
+        username_raw=username_raw,
+        rol=rol,
+        accion_grupos=accion_grupos,
+        grupos=grupos,
+        provincias_objs=provincias_objs,
+        allowed_group_ids=allowed_group_ids,
+    )
+
+
+def process_single_user_import_row(
+    *, row_data: dict, job: UserImportJob
+) -> dict:
+    datos = _validar_y_preparar_fila(row_data, job)
     existing_user = _resolver_usuario_objetivo(row_data)
 
     if existing_user is not None:
         params = _ActualizarUsuarioParams(
             user=existing_user,
-            email=email,
-            username_raw=username_raw,
-            grupos=grupos,
-            accion_grupos=accion_grupos,
-            allowed_group_ids=allowed_group_ids,
+            email=datos.email,
+            username_raw=datos.username_raw,
+            grupos=datos.grupos,
+            accion_grupos=datos.accion_grupos,
+            allowed_group_ids=datos.allowed_group_ids,
         )
         return _procesar_usuario_existente(params)
 
-    if not username_raw:
+    if not datos.username_raw:
         raise ValidationError(
             "No se encontro un usuario con ese correo. "
             "Para crear un usuario nuevo se requiere la columna Username."
         )
 
-    if not nombre or not apellido:
+    if not datos.nombre or not datos.apellido:
         raise ValidationError("Los campos Nombre y Apellido son obligatorios.")
 
-    if User.objects.filter(username__iexact=username_raw).exists():
-        raise ValidationError(f"Ya existe un usuario con el username '{username_raw}'.")
-
-    provincias_objs = _resolver_provincias(row_data.get("provincias", "").strip())
+    if User.objects.filter(username__iexact=datos.username_raw).exists():
+        raise ValidationError(
+            f"Ya existe un usuario con el username '{datos.username_raw}'."
+        )
 
     with transaction.atomic():
         params = _CrearUsuarioParams(
-            nombre=nombre,
-            apellido=apellido,
-            email=email,
-            username_raw=username_raw,
-            rol=rol,
-            grupos=grupos,
-            provincias_objs=provincias_objs,
+            nombre=datos.nombre,
+            apellido=datos.apellido,
+            email=datos.email,
+            username_raw=datos.username_raw,
+            rol=datos.rol,
+            grupos=datos.grupos,
+            provincias_objs=datos.provincias_objs,
             job=job,
         )
         user, password = _crear_usuario_nuevo(params)
@@ -534,7 +563,7 @@ def process_single_user_import_row(
     return {
         "status": UserImportJobRow.Status.CREATED,
         "mensaje": f"Usuario {user.username} creado correctamente.",
-        "email": email,
+        "email": datos.email,
     }
 
 

--- a/users/services_user_import.py
+++ b/users/services_user_import.py
@@ -383,7 +383,11 @@ def _procesar_usuario_existente(params: _ActualizarUsuarioParams) -> dict:
         )
         changed = changed or grupos_changed
 
-    status = UserImportJobRow.Status.SKIPPED if not changed else UserImportJobRow.Status.CREATED
+    status = (
+        UserImportJobRow.Status.SKIPPED
+        if not changed
+        else UserImportJobRow.Status.CREATED
+    )
     mensaje = (
         f"Usuario {params.user.username}: sin cambios."
         if not changed
@@ -458,15 +462,15 @@ def _crear_usuario_nuevo(params: _CrearUsuarioParams) -> tuple[User, str]:
     return user, password
 
 
-def _validar_y_preparar_fila(
-    row_data: dict, job: UserImportJob
-) -> _DatosFilaValidados:
+def _validar_y_preparar_fila(row_data: dict, job: UserImportJob) -> _DatosFilaValidados:
     nombre = row_data.get("nombre", "").strip()
     apellido = row_data.get("apellido", "").strip()
     email_raw = row_data.get("correo", "").strip()
     username_raw = row_data.get("username", "").strip()
     rol = row_data.get("rol", "").strip()
-    accion_grupos = row_data.get("accion_grupos", "").strip().lower() or GROUP_ACTION_AGREGAR
+    accion_grupos = (
+        row_data.get("accion_grupos", "").strip().lower() or GROUP_ACTION_AGREGAR
+    )
 
     if accion_grupos not in GROUP_ACTIONS:
         raise ValidationError(
@@ -513,9 +517,7 @@ def _validar_y_preparar_fila(
     )
 
 
-def process_single_user_import_row(
-    *, row_data: dict, job: UserImportJob
-) -> dict:
+def process_single_user_import_row(*, row_data: dict, job: UserImportJob) -> dict:
     datos = _validar_y_preparar_fila(row_data, job)
     existing_user = _resolver_usuario_objetivo(row_data)
 

--- a/users/tests.py
+++ b/users/tests.py
@@ -611,9 +611,11 @@ def _import_row_data(correo):
         "nombre": "Nombre",
         "apellido": "Apellido",
         "correo": correo,
+        "username": "",
         "permisos": "",
         "provincias": "",
         "rol": "TERRITORIAL",
+        "accion_grupos": "",
     }
 
 


### PR DESCRIPTION
## Resumen

- Implementa resolución de identidad `username-first` con fallback a `email` en el importador masivo de usuarios (#1936)
- Agrega soporte para acciones de grupos (`agregar` / `quitar` / `reemplazar`) sobre usuarios existentes
- Hace cumplir el alcance de delegación via `Profile.grupos_asignables`
- Absorbe y reorienta la lógica propuesta en PR #1983 al nuevo contrato

## Cambios

### `users/services_user_import.py`
- Nuevas columnas en plantilla: `Username`, `Accion grupos`
- Helper `_resolver_usuario_objetivo`: resolución username-first, fallback a email
- Helper `_aplicar_accion_grupos`: aplica agregar/quitar/reemplazar con scope enforcement
- Helper `_procesar_usuario_existente`: actualiza email y grupos, devuelve SKIPPED si no hay cambios
- `process_single_user_import_row`: refactorizado en helpers pequeños; creación requiere username explícito

### `tests/test_users_email_opcional_y_agrupamiento.py`
- 10 nuevos casos cubriendo el contrato completo del issue
- 2 tests anteriores actualizados al nuevo contrato username-first

## Contrato implementado

| Caso | Comportamiento |
|---|---|
| username existe → usuario encontrado | Modo actualización |
| username + email apuntan a usuarios distintos | Gana username, se actualiza su email |
| Sin username, con email existente | Fallback: actualiza usuario encontrado por email |
| Sin username ni email | Falla |
| Sin username, email no encontrado | Falla (creación requiere username) |
| agregar | Suma solo grupos faltantes |
| quitar | Remueve solo grupos presentes |
| reemplazar | Dentro del alcance: set exacto; fuera del alcance: preserva |
| Grupo fuera de grupos_asignables | Falla |

## Relación con PR #1983

PR #1983 proponía email-first con groups.add. Esa lógica queda absorbida: la detección de usuario existente ahora es username-first, y las acciones de grupo reemplazan el simple add con el contrato completo de tres acciones.

## Validación

- `tests/test_users_email_opcional_y_agrupamiento.py`: 24/24 ✓
- `tests/test_users_*` (resto del módulo): 128/128 ✓

Closes #1936