### PR TITLE
feat(users): asignar organizaciones/comedores y permisos PWA en importador

### DIFF
--- a/.importlinter
+++ b/.importlinter
@@ -165,5 +165,7 @@ ignore_imports =
     users.forms -> comedores.models
     users.forms -> duplas.models
     users.forms -> organizaciones.models
+    users.services_user_import -> comedores.models
+    users.services_user_import -> organizaciones.models
     users.signals -> duplas.models
     users.tests -> **

--- a/users/forms.py
+++ b/users/forms.py
@@ -1062,7 +1062,10 @@ class UserImportForm(forms.Form):
         label="Archivo Excel",
         validators=[FileExtensionValidator(["xlsx"])],
         widget=forms.ClearableFileInput(attrs={"accept": ".xlsx"}),
-        help_text="Archivo .xlsx con columnas: Nombre, Apellido, Correo, Permisos, Provincias, Rol.",
+        help_text=(
+            "Archivo .xlsx con columnas: Username, Nombre, Apellido, Correo, "
+            "Permisos, Provincias, Rol, Organizaciones, Comedores."
+        ),
     )
     enviar_credenciales = forms.BooleanField(
         label="Enviar credenciales por email",

--- a/users/services_user_import.py
+++ b/users/services_user_import.py
@@ -7,7 +7,7 @@ from io import BytesIO
 
 from django.conf import settings
 from django.contrib.auth import get_user_model
-from django.contrib.auth.models import Group
+from django.contrib.auth.models import Group, Permission
 from django.core.exceptions import ValidationError
 from django.core.mail import send_mail
 from django.core.validators import validate_email
@@ -16,9 +16,20 @@ from django.template.loader import render_to_string
 from django.urls import reverse
 from openpyxl import Workbook, load_workbook
 
+from comedores.models import Comedor
 from core.models import Provincia
-from users.models import ProfileTerritorialScope, UserImportJob, UserImportJobRow
+from organizaciones.models import Organizacion
+from users.models import (
+    AccesoComedorPWA,
+    ProfileTerritorialScope,
+    UserImportJob,
+    UserImportJobRow,
+)
 from users.services_auth import generate_temporary_password_for_user
+from users.services_pwa import (
+    get_assignable_pwa_permission_codes,
+    sync_representante_accesses,
+)
 
 User = get_user_model()
 logger = logging.getLogger("django")
@@ -34,7 +45,13 @@ USER_IMPORT_REQUIRED_COLUMNS = (
     "provincias",
     "rol",
 )
-USER_IMPORT_OPTIONAL_COLUMNS = ("correo", "username", "accion_grupos")
+USER_IMPORT_OPTIONAL_COLUMNS = (
+    "correo",
+    "username",
+    "accion_grupos",
+    "organizaciones",
+    "comedores",
+)
 USER_IMPORT_KNOWN_COLUMNS = USER_IMPORT_REQUIRED_COLUMNS + USER_IMPORT_OPTIONAL_COLUMNS
 USER_IMPORT_TEMPLATE_HEADERS = (
     "Username",
@@ -45,6 +62,8 @@ USER_IMPORT_TEMPLATE_HEADERS = (
     "Accion grupos",
     "Provincias",
     "Rol",
+    "Organizaciones",
+    "Comedores",
 )
 USERNAME_MAX_LENGTH = 150
 
@@ -292,6 +311,158 @@ def _resolver_provincias(provincias_raw: str) -> list:
     return provincias
 
 
+def _resolver_organizaciones(organizaciones_raw: str) -> list:
+    organizaciones = []
+    for token in _parse_semicolon_field(organizaciones_raw):
+        try:
+            organizacion_id = int(token)
+        except ValueError as exc:
+            raise ValidationError(
+                f"El ID de organizacion '{token}' no es valido."
+            ) from exc
+        organizacion = Organizacion.objects.filter(pk=organizacion_id).first()
+        if organizacion is None:
+            raise ValidationError(
+                f"La organizacion con ID '{token}' no existe en el sistema."
+            )
+        organizaciones.append(organizacion)
+    return organizaciones
+
+
+def _resolver_comedores(comedores_raw: str) -> list:
+    comedores = []
+    for token in _parse_semicolon_field(comedores_raw):
+        try:
+            comedor_id = int(token)
+        except ValueError as exc:
+            raise ValidationError(f"El ID de comedor '{token}' no es valido.") from exc
+        comedor = Comedor.objects.filter(pk=comedor_id).first()
+        if comedor is None:
+            raise ValidationError(
+                f"El comedor con ID '{token}' no existe en el sistema."
+            )
+        comedores.append(comedor)
+    return comedores
+
+
+def _build_pwa_access_specs(*, organizaciones: list, comedores: list) -> list[dict]:
+    """Arma los accesos PWA a partir de organizaciones y comedores de la fila.
+
+    Un usuario asociado a una organizacion opera con todos los comedores de
+    esa organizacion; un comedor asignado explicitamente que no pertenezca a
+    ninguna organizacion seleccionada queda asociado como espacio individual.
+    """
+    specs_by_comedor_id: dict[int, dict] = {}
+
+    organizacion_ids = {organizacion.pk for organizacion in organizaciones}
+    if organizacion_ids:
+        for comedor in Comedor.objects.filter(organizacion_id__in=organizacion_ids):
+            specs_by_comedor_id[comedor.pk] = {
+                "comedor_id": comedor.pk,
+                "tipo_asociacion": AccesoComedorPWA.TIPO_ASOCIACION_ORGANIZACION,
+                "organizacion_id": comedor.organizacion_id,
+            }
+
+    for comedor in comedores:
+        specs_by_comedor_id.setdefault(
+            comedor.pk,
+            {
+                "comedor_id": comedor.pk,
+                "tipo_asociacion": AccesoComedorPWA.TIPO_ASOCIACION_ESPACIO,
+                "organizacion_id": None,
+            },
+        )
+
+    return list(specs_by_comedor_id.values())
+
+
+def _get_pwa_permission_ids(codes: set) -> set:
+    permission_ids = set()
+    for code in codes:
+        app_label, codename = code.split(".", 1)
+        permission_id = (
+            Permission.objects.filter(
+                content_type__app_label=app_label, codename=codename
+            )
+            .values_list("id", flat=True)
+            .first()
+        )
+        if permission_id:
+            permission_ids.add(permission_id)
+    return permission_ids
+
+
+def _resolver_permisos_pwa(permisos_raw: str, *, actor) -> list:
+    allowed_codes = set(get_assignable_pwa_permission_codes(actor))
+    allowed_by_codename = {code.split(".", 1)[1]: code for code in allowed_codes}
+
+    permisos = []
+    for token in _parse_semicolon_field(permisos_raw):
+        matched_code = allowed_by_codename.get(token)
+        if matched_code is None:
+            raise ValidationError(
+                f"El permiso PWA '{token}' no existe o no tiene autorizacion "
+                "para asignarlo."
+            )
+        app_label, codename = matched_code.split(".", 1)
+        permission = Permission.objects.filter(
+            content_type__app_label=app_label, codename=codename
+        ).first()
+        if permission is None:
+            raise ValidationError(f"El permiso PWA '{token}' no existe en el sistema.")
+        permisos.append(permission)
+    return permisos
+
+
+@dataclass
+class _PermisosFila:
+    grupos: list
+    allowed_group_ids: set | None
+    permisos_pwa: list
+    allowed_permiso_ids: set | None
+    organizaciones: list
+    comedores: list
+
+
+def _resolver_permisos_fila_pwa(row_data: dict, job: UserImportJob) -> _PermisosFila:
+    permisos_pwa = _resolver_permisos_pwa(
+        row_data.get("permisos", "").strip(), actor=job.requested_by
+    )
+    allowed_permiso_ids = _get_pwa_permission_ids(
+        set(get_assignable_pwa_permission_codes(job.requested_by))
+    )
+    return _PermisosFila(
+        grupos=[],
+        allowed_group_ids=None,
+        permisos_pwa=permisos_pwa,
+        allowed_permiso_ids=allowed_permiso_ids,
+        organizaciones=_resolver_organizaciones(
+            row_data.get("organizaciones", "").strip()
+        ),
+        comedores=_resolver_comedores(row_data.get("comedores", "").strip()),
+    )
+
+
+def _resolver_permisos_fila_grupos(row_data: dict, job: UserImportJob) -> _PermisosFila:
+    grupos = _resolver_grupos(row_data.get("permisos", "").strip())
+    allowed_group_ids = _get_allowed_group_ids(job.requested_by)
+
+    if allowed_group_ids is not None and grupos:
+        out_of_scope = [g for g in grupos if g.pk not in allowed_group_ids]
+        if out_of_scope:
+            names = ", ".join(g.name for g in out_of_scope)
+            raise ValidationError(f"No tiene permiso para operar los grupos: {names}.")
+
+    return _PermisosFila(
+        grupos=grupos,
+        allowed_group_ids=allowed_group_ids,
+        permisos_pwa=[],
+        allowed_permiso_ids=None,
+        organizaciones=[],
+        comedores=[],
+    )
+
+
 def _is_unrestricted_actor(actor) -> bool:
     if actor is None:
         return True
@@ -319,6 +490,36 @@ def _resolver_usuario_objetivo(row_data: dict):
     return None
 
 
+def _aplicar_accion_m2m(
+    *,
+    manager,
+    requested_ids: set,
+    accion: str,
+    allowed_ids: set | None,
+) -> bool:
+    current_ids = set(manager.values_list("id", flat=True))
+
+    if accion == GROUP_ACTION_AGREGAR:
+        to_add = requested_ids - current_ids
+        if to_add:
+            manager.add(*to_add)
+        return bool(to_add)
+
+    if accion == GROUP_ACTION_QUITAR:
+        to_remove = requested_ids & current_ids
+        if to_remove:
+            manager.remove(*to_remove)
+        return bool(to_remove)
+
+    final_ids = (
+        (current_ids - allowed_ids | requested_ids) if allowed_ids else requested_ids
+    )
+    if final_ids != current_ids:
+        manager.set(list(final_ids))
+        return True
+    return False
+
+
 def _aplicar_accion_grupos(
     *,
     user,
@@ -326,30 +527,27 @@ def _aplicar_accion_grupos(
     accion: str,
     allowed_group_ids: set | None,
 ) -> bool:
-    current_group_ids = set(user.groups.values_list("id", flat=True))
-    requested_group_ids = {g.pk for g in grupos}
-
-    if accion == GROUP_ACTION_AGREGAR:
-        to_add = requested_group_ids - current_group_ids
-        if to_add:
-            user.groups.add(*to_add)
-        return bool(to_add)
-
-    if accion == GROUP_ACTION_QUITAR:
-        to_remove = requested_group_ids & current_group_ids
-        if to_remove:
-            user.groups.remove(*to_remove)
-        return bool(to_remove)
-
-    final_group_ids = (
-        (current_group_ids - allowed_group_ids | requested_group_ids)
-        if allowed_group_ids
-        else requested_group_ids
+    return _aplicar_accion_m2m(
+        manager=user.groups,
+        requested_ids={g.pk for g in grupos},
+        accion=accion,
+        allowed_ids=allowed_group_ids,
     )
-    if final_group_ids != current_group_ids:
-        user.groups.set(list(final_group_ids))
-        return True
-    return False
+
+
+def _aplicar_accion_permisos_pwa(
+    *,
+    user,
+    permisos: list,
+    accion: str,
+    allowed_permiso_ids: set | None,
+) -> bool:
+    return _aplicar_accion_m2m(
+        manager=user.user_permissions,
+        requested_ids={p.pk for p in permisos},
+        accion=accion,
+        allowed_ids=allowed_permiso_ids,
+    )
 
 
 @dataclass
@@ -360,6 +558,12 @@ class _ActualizarUsuarioParams:
     grupos: list
     accion_grupos: str
     allowed_group_ids: set | None
+    is_pwa_import: bool
+    permisos_pwa: list
+    allowed_permiso_ids: set | None
+    organizaciones: list
+    comedores: list
+    actor: object
 
 
 def _procesar_usuario_existente(params: _ActualizarUsuarioParams) -> dict:
@@ -375,13 +579,34 @@ def _procesar_usuario_existente(params: _ActualizarUsuarioParams) -> dict:
             params.user.save(update_fields=["email"])
             changed = True
 
-        grupos_changed = _aplicar_accion_grupos(
-            user=params.user,
-            grupos=params.grupos,
-            accion=params.accion_grupos,
-            allowed_group_ids=params.allowed_group_ids,
-        )
-        changed = changed or grupos_changed
+        if params.is_pwa_import:
+            permisos_changed = _aplicar_accion_permisos_pwa(
+                user=params.user,
+                permisos=params.permisos_pwa,
+                accion=params.accion_grupos,
+                allowed_permiso_ids=params.allowed_permiso_ids,
+            )
+            changed = changed or permisos_changed
+
+            if params.organizaciones or params.comedores:
+                access_specs = _build_pwa_access_specs(
+                    organizaciones=params.organizaciones,
+                    comedores=params.comedores,
+                )
+                sync_representante_accesses(
+                    user=params.user,
+                    access_specs=access_specs,
+                    actor=params.actor,
+                )
+                changed = True
+        else:
+            grupos_changed = _aplicar_accion_grupos(
+                user=params.user,
+                grupos=params.grupos,
+                accion=params.accion_grupos,
+                allowed_group_ids=params.allowed_group_ids,
+            )
+            changed = changed or grupos_changed
 
     status = (
         UserImportJobRow.Status.SKIPPED
@@ -410,6 +635,9 @@ class _CrearUsuarioParams:
     grupos: list
     provincias_objs: list
     job: object
+    permisos_pwa: list
+    organizaciones: list
+    comedores: list
 
 
 @dataclass
@@ -423,6 +651,10 @@ class _DatosFilaValidados:
     grupos: list
     provincias_objs: list
     allowed_group_ids: set | None
+    permisos_pwa: list
+    allowed_permiso_ids: set | None
+    organizaciones: list
+    comedores: list
 
 
 def _crear_usuario_nuevo(params: _CrearUsuarioParams) -> tuple[User, str]:
@@ -437,7 +669,20 @@ def _crear_usuario_nuevo(params: _CrearUsuarioParams) -> tuple[User, str]:
     user.set_unusable_password()
     user.save()
 
-    if params.grupos:
+    if params.job.is_pwa_import:
+        if params.permisos_pwa:
+            user.user_permissions.set(params.permisos_pwa)
+        if params.organizaciones or params.comedores:
+            access_specs = _build_pwa_access_specs(
+                organizaciones=params.organizaciones,
+                comedores=params.comedores,
+            )
+            sync_representante_accesses(
+                user=user,
+                access_specs=access_specs,
+                actor=params.job.requested_by,
+            )
+    elif params.grupos:
         user.groups.set(params.grupos)
 
     profile = user.profile
@@ -493,15 +738,11 @@ def _validar_y_preparar_fila(row_data: dict, job: UserImportJob) -> _DatosFilaVa
             ) from exc
         email = email_raw.lower()
 
-    grupos = _resolver_grupos(row_data.get("permisos", "").strip())
-    allowed_group_ids = _get_allowed_group_ids(job.requested_by)
-
-    if allowed_group_ids is not None and grupos:
-        out_of_scope = [g for g in grupos if g.pk not in allowed_group_ids]
-        if out_of_scope:
-            names = ", ".join(g.name for g in out_of_scope)
-            raise ValidationError(f"No tiene permiso para operar los grupos: {names}.")
-
+    permisos_fila = (
+        _resolver_permisos_fila_pwa(row_data, job)
+        if job.is_pwa_import
+        else _resolver_permisos_fila_grupos(row_data, job)
+    )
     provincias_objs = _resolver_provincias(row_data.get("provincias", "").strip())
 
     return _DatosFilaValidados(
@@ -511,9 +752,13 @@ def _validar_y_preparar_fila(row_data: dict, job: UserImportJob) -> _DatosFilaVa
         username_raw=username_raw,
         rol=rol,
         accion_grupos=accion_grupos,
-        grupos=grupos,
+        grupos=permisos_fila.grupos,
         provincias_objs=provincias_objs,
-        allowed_group_ids=allowed_group_ids,
+        allowed_group_ids=permisos_fila.allowed_group_ids,
+        permisos_pwa=permisos_fila.permisos_pwa,
+        allowed_permiso_ids=permisos_fila.allowed_permiso_ids,
+        organizaciones=permisos_fila.organizaciones,
+        comedores=permisos_fila.comedores,
     )
 
 
@@ -529,6 +774,12 @@ def process_single_user_import_row(*, row_data: dict, job: UserImportJob) -> dic
             grupos=datos.grupos,
             accion_grupos=datos.accion_grupos,
             allowed_group_ids=datos.allowed_group_ids,
+            is_pwa_import=job.is_pwa_import,
+            permisos_pwa=datos.permisos_pwa,
+            allowed_permiso_ids=datos.allowed_permiso_ids,
+            organizaciones=datos.organizaciones,
+            comedores=datos.comedores,
+            actor=job.requested_by,
         )
         return _procesar_usuario_existente(params)
 
@@ -560,6 +811,9 @@ def process_single_user_import_row(*, row_data: dict, job: UserImportJob) -> dic
             grupos=datos.grupos,
             provincias_objs=datos.provincias_objs,
             job=job,
+            permisos_pwa=datos.permisos_pwa,
+            organizaciones=datos.organizaciones,
+            comedores=datos.comedores,
         )
         user, password = _crear_usuario_nuevo(params)
 

--- a/users/templates/user/user_import_form.html
+++ b/users/templates/user/user_import_form.html
@@ -34,6 +34,10 @@
                         </p>
                         <ul class="mb-2 pl-3">
                             <li>
+                                <code>Username</code> — opcional. Si se completa, se usa tal cual; si se deja en
+                                blanco, se genera automaticamente a partir del nombre y apellido.
+                            </li>
+                            <li>
                                 <code>Nombre</code> — nombre del usuario
                             </li>
                             <li>
@@ -44,20 +48,38 @@
                             </li>
                             <li>
                                 <code>Permisos</code> — nombres de grupos separados por <code>;</code>
+                                (o codenames de permisos PWA si se marca "Usuarios de la PWA")
                                 <br />
-                                <small class="text-muted">Ej: <code>Comedores Ver;Comedores Listar;Comedores Crear</code></small>
+                                <small class="text-muted">Ej SISOC: <code>Comedores Ver;Comedores Listar;Comedores Crear</code></small>
+                                <br />
+                                <small class="text-muted">Ej PWA: <code>manage_nomina_pwa;manage_mobile_rendicion</code></small>
                             </li>
                             <li>
                                 <code>Provincias</code> — nombres de provincias separados por <code>;</code>
+                                (no aplica a usuarios PWA)
                                 <br />
                                 <small class="text-muted">Ej: <code>CABA;BUENOS AIRES</code></small>
                             </li>
                             <li>
-                                <code>Rol</code> — descripcion textual del rol (ej: <code>TERRITORIAL</code>)
+                                <code>Rol</code> — descripcion textual del rol (ej: <code>TERRITORIAL</code>,
+                                no aplica a usuarios PWA)
+                            </li>
+                            <li>
+                                <code>Organizaciones</code> — IDs de organizaciones separados por <code>;</code>
+                                (solo para usuarios PWA). El usuario opera con todos los comedores de esas organizaciones.
+                                <br />
+                                <small class="text-muted">Ej: <code>3;7</code></small>
+                            </li>
+                            <li>
+                                <code>Comedores</code> — IDs de comedores separados por <code>;</code>
+                                (solo para usuarios PWA). Permite asignar comedores puntuales ademas o en lugar de organizaciones.
+                                <br />
+                                <small class="text-muted">Ej: <code>101;205</code></small>
                             </li>
                         </ul>
                         <p class="mb-0 text-muted small">
-                            Los nombres de grupos y provincias deben coincidir exactamente con los registros del sistema.
+                            Los nombres de grupos y provincias, y los IDs de organizaciones y comedores, deben
+                            coincidir exactamente con los registros del sistema.
                             Una fila invalida detiene el lote y puede reanudarse desde esa fila.
                         </p>
                     </div>

--- a/users/tests.py
+++ b/users/tests.py
@@ -666,3 +666,147 @@ def test_import_no_pwa_crea_usuario_staff():
     creado = User.objects.get(email="staff.user@example.com")
     assert creado.is_staff is True
     assert creado.is_active is True
+
+
+@pytest.mark.django_db
+def test_import_username_configurable_se_usa_tal_cual():
+    """Si la fila trae Username, se usa ese valor y no se autogenera."""
+    from users.models import UserImportJob
+    from users.services_user_import import process_single_user_import_row
+
+    admin = User.objects.create_user(username="import_admin_username", password="x")
+    job = UserImportJob(
+        requested_by=admin,
+        original_filename="usuarios.xlsx",
+        send_credentials=False,
+        is_pwa_import=False,
+    )
+
+    row_data = _import_row_data("con.username@example.com")
+    row_data["username"] = "usuario.manual"
+
+    process_single_user_import_row(row_data=row_data, job=job)
+
+    creado = User.objects.get(email="con.username@example.com")
+    assert creado.username == "usuario.manual"
+
+
+@pytest.mark.django_db
+def test_import_username_vacio_se_autogenera():
+    """Si la fila no trae Username, se genera automaticamente a partir del nombre."""
+    from users.models import UserImportJob
+    from users.services_user_import import process_single_user_import_row
+
+    admin = User.objects.create_user(username="import_admin_autouser", password="x")
+    job = UserImportJob(
+        requested_by=admin,
+        original_filename="usuarios.xlsx",
+        send_credentials=False,
+        is_pwa_import=False,
+    )
+
+    process_single_user_import_row(
+        row_data=_import_row_data("sin.username@example.com"), job=job
+    )
+
+    creado = User.objects.get(email="sin.username@example.com")
+    assert creado.username == "apellido.nombre"
+
+
+@pytest.mark.django_db
+def test_import_pwa_asigna_organizaciones_y_comedores():
+    """Un usuario PWA importado con Organizaciones y Comedores queda con
+    acceso a todos los comedores de esas organizaciones, mas los comedores
+    puntuales indicados."""
+    from organizaciones.models import Organizacion, TipoEntidad
+    from comedores.models import Comedor
+    from users.models import AccesoComedorPWA, UserImportJob
+    from users.services_user_import import process_single_user_import_row
+
+    admin = User.objects.create_user(username="import_admin_orgs", password="x")
+    tipo = TipoEntidad.objects.create(nombre="Personeria Juridica")
+    organizacion = Organizacion.objects.create(
+        nombre="Org Importada", tipo_entidad=tipo
+    )
+    comedor_de_org = Comedor.objects.create(
+        nombre="Comedor de Org", organizacion=organizacion
+    )
+    comedor_suelto = Comedor.objects.create(nombre="Comedor Suelto")
+
+    job = UserImportJob(
+        requested_by=admin,
+        original_filename="usuarios.xlsx",
+        send_credentials=False,
+        is_pwa_import=True,
+    )
+
+    row_data = _import_row_data("pwa.multi@example.com")
+    row_data["organizaciones"] = str(organizacion.pk)
+    row_data["comedores"] = str(comedor_suelto.pk)
+
+    process_single_user_import_row(row_data=row_data, job=job)
+
+    creado = User.objects.get(email="pwa.multi@example.com")
+    accesos = {
+        acceso.comedor_id: acceso
+        for acceso in AccesoComedorPWA.objects.filter(user=creado, activo=True)
+    }
+    assert accesos[comedor_de_org.pk].tipo_asociacion == (
+        AccesoComedorPWA.TIPO_ASOCIACION_ORGANIZACION
+    )
+    assert accesos[comedor_de_org.pk].organizacion_id == organizacion.pk
+    assert accesos[comedor_suelto.pk].tipo_asociacion == (
+        AccesoComedorPWA.TIPO_ASOCIACION_ESPACIO
+    )
+    assert accesos[comedor_suelto.pk].organizacion_id is None
+
+
+@pytest.mark.django_db
+def test_import_pwa_permiso_autorizado_se_asigna_directo():
+    """Un permiso de gestion PWA que el actor puede delegar se asigna como
+    permiso directo del usuario, no como grupo."""
+    from users.models import UserImportJob
+    from users.services_user_import import process_single_user_import_row
+
+    admin = User.objects.create_superuser(
+        username="import_admin_pwa_perm", password="x", email="admin@example.com"
+    )
+
+    job = UserImportJob(
+        requested_by=admin,
+        original_filename="usuarios.xlsx",
+        send_credentials=False,
+        is_pwa_import=True,
+    )
+
+    row_data = _import_row_data("pwa.permiso@example.com")
+    row_data["permisos"] = "manage_nomina_pwa"
+
+    process_single_user_import_row(row_data=row_data, job=job)
+
+    creado = User.objects.get(email="pwa.permiso@example.com")
+    assert creado.has_perm("pwa.manage_nomina_pwa")
+    assert creado.groups.count() == 0
+
+
+@pytest.mark.django_db
+def test_import_pwa_permiso_no_autorizado_lanza_error():
+    """Si el actor no puede delegar el permiso PWA solicitado, la fila falla."""
+    from django.core.exceptions import ValidationError
+    from users.models import UserImportJob
+    from users.services_user_import import process_single_user_import_row
+
+    admin = User.objects.create_user(username="import_admin_sin_perm", password="x")
+
+    job = UserImportJob(
+        requested_by=admin,
+        original_filename="usuarios.xlsx",
+        send_credentials=False,
+        is_pwa_import=True,
+    )
+
+    row_data = _import_row_data("pwa.denegado@example.com")
+    row_data["permisos"] = "manage_nomina_pwa"
+
+    with pytest.raises(ValidationError):
+        process_single_user_import_row(row_data=row_data, job=job)


### PR DESCRIPTION
# Información de la Tarea
Vincular el #1926

### **Resumen de la Solución:**
- Se extiende el importador masivo de usuarios (`services_user_import.py`) para soportar el alta de usuarios PWA con las asociaciones que pide el issue: N organizaciones y/o N comedores, y permisos de gestión PWA (nómina, prestaciones, colaboradores, rendición).

### **Información Adicional:**
- La columna `Username` configurable ya estaba implementada en PRs previos (#1980/#1985); se agregaron tests de regresión que la cubren.
- Se optó por un único set de columnas/plantilla para usuarios SISOC y PWA (en vez de dos plantillas separadas) para no complejizar la validación del archivo, tal como se sugirió evaluar en el issue.

# Descripción de los Cambios

### **Cambios:**
- Nuevas columnas opcionales `Organizaciones` y `Comedores` (IDs separados por `;`). Reutilizan `AccesoComedorPWA` / `sync_representante_accesses` (la misma lógica del alta manual de usuarios PWA): un comedor que pertenece a una organización listada queda asociado como `organizacion` (opera con todos los comedores de esa organización); un comedor listado individualmente queda como `espacio`. Ambos pueden convivir en la misma fila.
- La columna `Permisos`, para filas PWA, ahora también resuelve **codenames de permisos de gestión PWA** (`manage_nomina_pwa`, `manage_prestaciones_mensuales_pwa`, `manage_colaboradores_pwa`, `manage_mobile_rendicion`) y los asigna como permisos directos del usuario (no como grupos), respetando lo que el actor que corre la importación puede delegar (`services_pwa.get_assignable_pwa_permission_codes`). Esto resuelve el comentario del issue: "el check implementado para usuarios PWA no permite asignar los grupos específicos para la gestión dentro de la PWA".
- Para usuarios SISOC (no PWA) el comportamiento de `Permisos` (grupos Django) no cambia.
- Se refactorizó `_aplicar_accion_grupos` en un helper genérico `_aplicar_accion_m2m` reutilizado tanto para grupos como para permisos PWA (agregar/quitar/reemplazar).
- Se actualizó el formulario y el template de importación con la documentación de las nuevas columnas.

# Cómo Testear los Cambios

### **Pruebas Automáticas:**
- `users/tests.py`: se agregaron tests para username configurable/autogenerado, asignación combinada de organizaciones+comedores, asignación de permisos PWA autorizados y rechazo de permisos PWA no autorizados.
- Suite completa `users/tests.py`: 27/27 passed.
- `pylint users/services_user_import.py`: 10.00/10.
- `black --check` y `djlint --check`: sin cambios pendientes.

### **Pruebas Manuales:**
- Descargar la plantilla desde `/usuarios/importar/plantilla/`, completar una fila con `Organizaciones`/`Comedores` y `Permisos` con codenames PWA, marcar "Usuarios de la PWA" y crear el lote; verificar en el detalle del lote que la fila queda `Creado` y que el usuario resultante tiene los `AccesoComedorPWA` y permisos esperados.

# Metadata para documentación automática

- Contexto funcional: Importación masiva de usuarios / accesos PWA
- Tipo de cambio: Feature
- Área principal: users (importador de usuarios, accesos PWA)
- Resumen para changelog: El importador de usuarios ahora permite crear usuarios PWA asignando organizaciones, comedores y permisos específicos de gestión PWA.
- Impacto usuario: Administradores pueden dar de alta usuarios PWA masivamente sin pasos manuales adicionales.
- Riesgos / rollback: No hay restricción de scope sobre qué organizaciones/comedores puede asignar quien importa (igual que el alta manual, requiere permiso `auth.add_user`). Revertir el commit restaura el comportamiento previo.

# Capturas de Pantalla
-