### PR TITLE
fix(users): exigir organizacion o comedor al importar usuarios PWA

### DIFF
--- a/users/services_user_import.py
+++ b/users/services_user_import.py
@@ -786,6 +786,12 @@ def process_single_user_import_row(*, row_data: dict, job: UserImportJob) -> dic
     if not datos.nombre or not datos.apellido:
         raise ValidationError("Los campos Nombre y Apellido son obligatorios.")
 
+    if job.is_pwa_import and not (datos.organizaciones or datos.comedores):
+        raise ValidationError(
+            "Los usuarios PWA deben tener al menos una organizacion o comedor "
+            "asignado en las columnas Organizaciones/Comedores del archivo."
+        )
+
     username_to_create = datos.username_raw
     if not username_to_create:
         username_base = _slug_base_desde_nombre(

--- a/users/tests.py
+++ b/users/tests.py
@@ -621,10 +621,12 @@ def _import_row_data(correo):
 
 @pytest.mark.django_db
 def test_import_pwa_crea_usuario_sin_staff():
+    from comedores.models import Comedor
     from users.models import UserImportJob
     from users.services_user_import import process_single_user_import_row
 
     admin = User.objects.create_user(username="import_admin_pwa", password="x")
+    comedor = Comedor.objects.create(nombre="Comedor PWA Staff")
     job = UserImportJob(
         requested_by=admin,
         original_filename="usuarios.xlsx",
@@ -632,8 +634,11 @@ def test_import_pwa_crea_usuario_sin_staff():
         is_pwa_import=True,
     )
 
+    row_data = _import_row_data("pwa.user@example.com")
+    row_data["comedores"] = str(comedor.pk)
+
     result = process_single_user_import_row(
-        row_data=_import_row_data("pwa.user@example.com"),
+        row_data=row_data,
         job=job,
     )
 
@@ -765,12 +770,14 @@ def test_import_pwa_asigna_organizaciones_y_comedores():
 def test_import_pwa_permiso_autorizado_se_asigna_directo():
     """Un permiso de gestion PWA que el actor puede delegar se asigna como
     permiso directo del usuario, no como grupo."""
+    from comedores.models import Comedor
     from users.models import UserImportJob
     from users.services_user_import import process_single_user_import_row
 
     admin = User.objects.create_superuser(
         username="import_admin_pwa_perm", password="x", email="admin@example.com"
     )
+    comedor = Comedor.objects.create(nombre="Comedor PWA Permiso")
 
     job = UserImportJob(
         requested_by=admin,
@@ -781,6 +788,7 @@ def test_import_pwa_permiso_autorizado_se_asigna_directo():
 
     row_data = _import_row_data("pwa.permiso@example.com")
     row_data["permisos"] = "manage_nomina_pwa"
+    row_data["comedores"] = str(comedor.pk)
 
     process_single_user_import_row(row_data=row_data, job=job)
 
@@ -810,3 +818,56 @@ def test_import_pwa_permiso_no_autorizado_lanza_error():
 
     with pytest.raises(ValidationError):
         process_single_user_import_row(row_data=row_data, job=job)
+
+
+@pytest.mark.django_db
+def test_import_pwa_sin_organizaciones_ni_comedores_lanza_error():
+    """Un usuario PWA nuevo sin Organizaciones ni Comedores en la fila no debe
+    crearse, porque quedaria sin ningun acceso PWA activo (no podria loguear)."""
+    from django.core.exceptions import ValidationError
+    from users.models import UserImportJob
+    from users.services_user_import import process_single_user_import_row
+
+    admin = User.objects.create_user(username="import_admin_sin_espacio", password="x")
+
+    job = UserImportJob(
+        requested_by=admin,
+        original_filename="usuarios.xlsx",
+        send_credentials=False,
+        is_pwa_import=True,
+    )
+
+    row_data = _import_row_data("pwa.sin.espacio@example.com")
+
+    with pytest.raises(ValidationError):
+        process_single_user_import_row(row_data=row_data, job=job)
+
+    assert not User.objects.filter(email="pwa.sin.espacio@example.com").exists()
+
+
+@pytest.mark.django_db
+def test_import_pwa_username_configurable_se_usa_tal_cual():
+    """Igual que en la importacion no-PWA: si la fila trae Username, se usa
+    ese valor tal cual y no se autogenera a partir de nombre/apellido."""
+    from comedores.models import Comedor
+    from users.models import UserImportJob
+    from users.services_user_import import process_single_user_import_row
+
+    admin = User.objects.create_user(username="import_admin_pwa_username", password="x")
+    comedor = Comedor.objects.create(nombre="Comedor PWA Username")
+
+    job = UserImportJob(
+        requested_by=admin,
+        original_filename="usuarios.xlsx",
+        send_credentials=False,
+        is_pwa_import=True,
+    )
+
+    row_data = _import_row_data("pwa.con.username@example.com")
+    row_data["username"] = "usuario.pwa.manual"
+    row_data["comedores"] = str(comedor.pk)
+
+    process_single_user_import_row(row_data=row_data, job=job)
+
+    creado = User.objects.get(email="pwa.con.username@example.com")
+    assert creado.username == "usuario.pwa.manual"


### PR DESCRIPTION
## Summary
- El importador masivo de usuarios PWA permitía crear usuarios sin ninguna Organización/Comedor asignado en el Excel. Sin esa asociación no se crea ningún `AccesoComedorPWA`, y `is_pwa_user()` (el gate de login mobile) siempre devuelve `False` — el usuario queda creado pero bloqueado con "Este usuario no tiene acceso PWA activo" al intentar loguear en la PWA.
- Se agrega la misma validación que ya existe en el alta manual web (un usuario mobile siempre debe tener al menos un espacio visible) para que la fila del Excel falle con un mensaje claro en vez de crear un usuario inutilizable.
- Se investigó también el reporte de que el `Username` del Excel no se respetaba: se agregó un test que reproduce el caso exacto (import PWA + username explícito) y pasa correctamente — el importador ya respeta el username cuando se lo pasa. Todo indica que la fila de esa prueba puntual nunca llegó a crearse por un error de columnas en el Excel (el valor de Permisos estaba tipeado en la columna "Accion grupos").

Closes #1926

## Test plan
- [x] `docker compose exec django pytest users/tests.py -q` (29 passed)
- [x] `docker compose exec django pytest tests/test_users_email_opcional_y_agrupamiento.py -q` (24 passed)
- [x] `black --check users/services_user_import.py users/tests.py`

🤖 Generated with [Claude Code](https://claude.com/claude-code)