### PR TITLE
feat(users): unificar grupos y permisos PWA en el importador masivo

### DIFF
--- a/users/services.py
+++ b/users/services.py
@@ -228,7 +228,7 @@ class UsuariosService:
         ) and users_import_url:
             additional_buttons.append(
                 {
-                    "label": "IMPORTAR USUARIOS",
+                    "label": "GESTOR DE USUARIOS",
                     "url": users_import_url,
                     "class": "btn btn-lg btn-primary",
                     "title": "Importar usuarios masivamente desde Excel",

--- a/users/services_user_import.py
+++ b/users/services_user_import.py
@@ -289,16 +289,6 @@ def _enviar_credenciales_import(*, user, password: str) -> bool:
         return False
 
 
-def _resolver_grupos(permisos_raw: str) -> list:
-    grupos = []
-    for nombre_grupo in _parse_semicolon_field(permisos_raw):
-        grupo = Group.objects.filter(name=nombre_grupo).first()
-        if grupo is None:
-            raise ValidationError(f"El grupo '{nombre_grupo}' no existe en el sistema.")
-        grupos.append(grupo)
-    return grupos
-
-
 def _resolver_provincias(provincias_raw: str) -> list:
     provincias = []
     for nombre_prov in _parse_semicolon_field(provincias_raw):
@@ -392,17 +382,25 @@ def _get_pwa_permission_ids(codes: set) -> set:
     return permission_ids
 
 
-def _resolver_permisos_pwa(permisos_raw: str, *, actor) -> list:
+def _resolver_grupos_y_permisos(permisos_raw: str, *, actor) -> tuple[list, list]:
+    """Resuelve cada token de 'Permisos' como Group o, si no existe, como
+    Permission PWA delegable por el actor. Aplica igual sea o no import PWA."""
     allowed_codes = set(get_assignable_pwa_permission_codes(actor))
     allowed_by_codename = {code.split(".", 1)[1]: code for code in allowed_codes}
 
+    grupos = []
     permisos = []
     for token in _parse_semicolon_field(permisos_raw):
+        grupo = Group.objects.filter(name=token).first()
+        if grupo is not None:
+            grupos.append(grupo)
+            continue
+
         matched_code = allowed_by_codename.get(token)
         if matched_code is None:
             raise ValidationError(
-                f"El permiso PWA '{token}' no existe o no tiene autorizacion "
-                "para asignarlo."
+                f"'{token}' no es un grupo existente ni un permiso PWA "
+                "autorizado para asignar."
             )
         app_label, codename = matched_code.split(".", 1)
         permission = Permission.objects.filter(
@@ -411,7 +409,7 @@ def _resolver_permisos_pwa(permisos_raw: str, *, actor) -> list:
         if permission is None:
             raise ValidationError(f"El permiso PWA '{token}' no existe en el sistema.")
         permisos.append(permission)
-    return permisos
+    return grupos, permisos
 
 
 @dataclass
@@ -424,42 +422,38 @@ class _PermisosFila:
     comedores: list
 
 
-def _resolver_permisos_fila_pwa(row_data: dict, job: UserImportJob) -> _PermisosFila:
-    permisos_pwa = _resolver_permisos_pwa(
+def _resolver_permisos_fila(row_data: dict, job: UserImportJob) -> _PermisosFila:
+    grupos, permisos_pwa = _resolver_grupos_y_permisos(
         row_data.get("permisos", "").strip(), actor=job.requested_by
     )
-    allowed_permiso_ids = _get_pwa_permission_ids(
-        set(get_assignable_pwa_permission_codes(job.requested_by))
-    )
-    return _PermisosFila(
-        grupos=[],
-        allowed_group_ids=None,
-        permisos_pwa=permisos_pwa,
-        allowed_permiso_ids=allowed_permiso_ids,
-        organizaciones=_resolver_organizaciones(
-            row_data.get("organizaciones", "").strip()
-        ),
-        comedores=_resolver_comedores(row_data.get("comedores", "").strip()),
-    )
 
-
-def _resolver_permisos_fila_grupos(row_data: dict, job: UserImportJob) -> _PermisosFila:
-    grupos = _resolver_grupos(row_data.get("permisos", "").strip())
     allowed_group_ids = _get_allowed_group_ids(job.requested_by)
-
     if allowed_group_ids is not None and grupos:
         out_of_scope = [g for g in grupos if g.pk not in allowed_group_ids]
         if out_of_scope:
             names = ", ".join(g.name for g in out_of_scope)
             raise ValidationError(f"No tiene permiso para operar los grupos: {names}.")
 
+    allowed_permiso_ids = _get_pwa_permission_ids(
+        set(get_assignable_pwa_permission_codes(job.requested_by))
+    )
+
+    if job.is_pwa_import:
+        organizaciones = _resolver_organizaciones(
+            row_data.get("organizaciones", "").strip()
+        )
+        comedores = _resolver_comedores(row_data.get("comedores", "").strip())
+    else:
+        organizaciones = []
+        comedores = []
+
     return _PermisosFila(
         grupos=grupos,
         allowed_group_ids=allowed_group_ids,
-        permisos_pwa=[],
-        allowed_permiso_ids=None,
-        organizaciones=[],
-        comedores=[],
+        permisos_pwa=permisos_pwa,
+        allowed_permiso_ids=allowed_permiso_ids,
+        organizaciones=organizaciones,
+        comedores=comedores,
     )
 
 
@@ -579,34 +573,33 @@ def _procesar_usuario_existente(params: _ActualizarUsuarioParams) -> dict:
             params.user.save(update_fields=["email"])
             changed = True
 
-        if params.is_pwa_import:
-            permisos_changed = _aplicar_accion_permisos_pwa(
-                user=params.user,
-                permisos=params.permisos_pwa,
-                accion=params.accion_grupos,
-                allowed_permiso_ids=params.allowed_permiso_ids,
-            )
-            changed = changed or permisos_changed
+        permisos_changed = _aplicar_accion_permisos_pwa(
+            user=params.user,
+            permisos=params.permisos_pwa,
+            accion=params.accion_grupos,
+            allowed_permiso_ids=params.allowed_permiso_ids,
+        )
+        changed = changed or permisos_changed
 
-            if params.organizaciones or params.comedores:
-                access_specs = _build_pwa_access_specs(
-                    organizaciones=params.organizaciones,
-                    comedores=params.comedores,
-                )
-                sync_representante_accesses(
-                    user=params.user,
-                    access_specs=access_specs,
-                    actor=params.actor,
-                )
-                changed = True
-        else:
-            grupos_changed = _aplicar_accion_grupos(
-                user=params.user,
-                grupos=params.grupos,
-                accion=params.accion_grupos,
-                allowed_group_ids=params.allowed_group_ids,
+        grupos_changed = _aplicar_accion_grupos(
+            user=params.user,
+            grupos=params.grupos,
+            accion=params.accion_grupos,
+            allowed_group_ids=params.allowed_group_ids,
+        )
+        changed = changed or grupos_changed
+
+        if params.is_pwa_import and (params.organizaciones or params.comedores):
+            access_specs = _build_pwa_access_specs(
+                organizaciones=params.organizaciones,
+                comedores=params.comedores,
             )
-            changed = changed or grupos_changed
+            sync_representante_accesses(
+                user=params.user,
+                access_specs=access_specs,
+                actor=params.actor,
+            )
+            changed = True
 
     status = (
         UserImportJobRow.Status.SKIPPED
@@ -669,21 +662,21 @@ def _crear_usuario_nuevo(params: _CrearUsuarioParams) -> tuple[User, str]:
     user.set_unusable_password()
     user.save()
 
-    if params.job.is_pwa_import:
-        if params.permisos_pwa:
-            user.user_permissions.set(params.permisos_pwa)
-        if params.organizaciones or params.comedores:
-            access_specs = _build_pwa_access_specs(
-                organizaciones=params.organizaciones,
-                comedores=params.comedores,
-            )
-            sync_representante_accesses(
-                user=user,
-                access_specs=access_specs,
-                actor=params.job.requested_by,
-            )
-    elif params.grupos:
+    if params.permisos_pwa:
+        user.user_permissions.set(params.permisos_pwa)
+    if params.grupos:
         user.groups.set(params.grupos)
+
+    if params.job.is_pwa_import and (params.organizaciones or params.comedores):
+        access_specs = _build_pwa_access_specs(
+            organizaciones=params.organizaciones,
+            comedores=params.comedores,
+        )
+        sync_representante_accesses(
+            user=user,
+            access_specs=access_specs,
+            actor=params.job.requested_by,
+        )
 
     profile = user.profile
     profile.rol = params.rol
@@ -738,11 +731,7 @@ def _validar_y_preparar_fila(row_data: dict, job: UserImportJob) -> _DatosFilaVa
             ) from exc
         email = email_raw.lower()
 
-    permisos_fila = (
-        _resolver_permisos_fila_pwa(row_data, job)
-        if job.is_pwa_import
-        else _resolver_permisos_fila_grupos(row_data, job)
-    )
+    permisos_fila = _resolver_permisos_fila(row_data, job)
     provincias_objs = _resolver_provincias(row_data.get("provincias", "").strip())
 
     return _DatosFilaValidados(

--- a/users/templates/user/user_import_form.html
+++ b/users/templates/user/user_import_form.html
@@ -60,9 +60,15 @@
                                 columna <code>Permisos</code> cuando la fila actualiza un usuario
                                 existente:
                                 <ul class="mb-0">
-                                    <li><code>agregar</code>: suma los grupos/permisos indicados a los que ya tiene.</li>
-                                    <li><code>quitar</code>: remueve los indicados, conserva el resto.</li>
-                                    <li><code>reemplazar</code>: deja exactamente los indicados (salvo los que usted no pueda delegar, que se preservan).</li>
+                                    <li>
+                                        <code>agregar</code>: suma los grupos/permisos indicados a los que ya tiene.
+                                    </li>
+                                    <li>
+                                        <code>quitar</code>: remueve los indicados, conserva el resto.
+                                    </li>
+                                    <li>
+                                        <code>reemplazar</code>: deja exactamente los indicados (salvo los que usted no pueda delegar, que se preservan).
+                                    </li>
                                 </ul>
                             </li>
                             <li>

--- a/users/templates/user/user_import_form.html
+++ b/users/templates/user/user_import_form.html
@@ -1,14 +1,14 @@
 {% extends "includes/main.html" %}
 {% load crispy_forms_tags %}
-{% block title %}Importacion masiva de usuarios{% endblock %}
-{% block titulo-pagina %}Importacion masiva de usuarios{% endblock %}
+{% block title %}Gestor masivo de usuarios{% endblock %}
+{% block titulo-pagina %}Gestor masivo de usuarios{% endblock %}
 {% block breadcrumb %}
     <ol class="breadcrumb float-sm-right">
         <li class="breadcrumb-item">Administracion</li>
         <li class="breadcrumb-item">
             <a href="{% url 'usuarios' %}">Usuarios</a>
         </li>
-        <li class="breadcrumb-item active">Importacion masiva</li>
+        <li class="breadcrumb-item active">Gestor masivo</li>
     </ol>
 {% endblock %}
 {% block content %}
@@ -16,7 +16,7 @@
         <div class="col-12 col-lg-8">
             <div class="card shadow-sm">
                 <div class="card-header">
-                    <h3 class="mb-0">Importacion masiva de usuarios</h3>
+                    <h3 class="mb-0">Gestor masivo de usuarios</h3>
                 </div>
                 <div class="card-body">
                     <p class="text-muted">
@@ -47,12 +47,23 @@
                                 <code>Correo</code> — email (se usara como identificador unico)
                             </li>
                             <li>
-                                <code>Permisos</code> — nombres de grupos separados por <code>;</code>
-                                (o codenames de permisos PWA si se marca "Usuarios de la PWA")
+                                <code>Permisos</code> — nombres de grupos y/o codenames de permisos PWA
+                                delegables, separados por <code>;</code>. Cada valor se busca primero
+                                como nombre de grupo; si no existe, se busca como permiso PWA que usted
+                                pueda delegar. Aplica igual con o sin "Usuarios de la PWA" marcado.
                                 <br />
-                                <small class="text-muted">Ej SISOC: <code>Comedores Ver;Comedores Listar;Comedores Crear</code></small>
-                                <br />
-                                <small class="text-muted">Ej PWA: <code>manage_nomina_pwa;manage_mobile_rendicion</code></small>
+                                <small class="text-muted">Ej: <code>Comedores Ver;Comedores Listar;manage_nomina_pwa</code></small>
+                            </li>
+                            <li>
+                                <code>Accion grupos</code> — opcional (si se deja en blanco se usa
+                                <code>agregar</code>). Define que hacer con los grupos y permisos de la
+                                columna <code>Permisos</code> cuando la fila actualiza un usuario
+                                existente:
+                                <ul class="mb-0">
+                                    <li><code>agregar</code>: suma los grupos/permisos indicados a los que ya tiene.</li>
+                                    <li><code>quitar</code>: remueve los indicados, conserva el resto.</li>
+                                    <li><code>reemplazar</code>: deja exactamente los indicados (salvo los que usted no pueda delegar, que se preservan).</li>
+                                </ul>
                             </li>
                             <li>
                                 <code>Provincias</code> — nombres de provincias separados por <code>;</code>

--- a/users/templates/user/user_import_job_detail.html
+++ b/users/templates/user/user_import_job_detail.html
@@ -8,7 +8,7 @@
             <a href="{% url 'usuarios' %}">Usuarios</a>
         </li>
         <li class="breadcrumb-item">
-            <a href="{{ upload_url }}">Importacion masiva</a>
+            <a href="{{ upload_url }}">Gestor masivo</a>
         </li>
         <li class="breadcrumb-item active">Lote #{{ job.id }}</li>
     </ol>

--- a/users/tests.py
+++ b/users/tests.py
@@ -871,3 +871,182 @@ def test_import_pwa_username_configurable_se_usa_tal_cual():
 
     creado = User.objects.get(email="pwa.con.username@example.com")
     assert creado.username == "usuario.pwa.manual"
+
+
+@pytest.mark.django_db
+def test_import_pwa_grupo_autorizado_se_asigna():
+    """En un import PWA, un token de 'Permisos' que matchea un grupo existente
+    se resuelve como grupo, igual que en import no-PWA."""
+    from comedores.models import Comedor
+    from users.models import UserImportJob
+    from users.services_user_import import process_single_user_import_row
+
+    admin = User.objects.create_superuser(
+        username="import_admin_pwa_grupo",
+        password="x",
+        email="admin_pwa_grupo@example.com",
+    )
+    grupo = Group.objects.create(name="Grupo PWA Test")
+    comedor = Comedor.objects.create(nombre="Comedor PWA Grupo")
+
+    job = UserImportJob(
+        requested_by=admin,
+        original_filename="usuarios.xlsx",
+        send_credentials=False,
+        is_pwa_import=True,
+    )
+
+    row_data = _import_row_data("pwa.grupo@example.com")
+    row_data["permisos"] = "Grupo PWA Test"
+    row_data["comedores"] = str(comedor.pk)
+
+    process_single_user_import_row(row_data=row_data, job=job)
+
+    creado = User.objects.get(email="pwa.grupo@example.com")
+    assert grupo in creado.groups.all()
+
+
+@pytest.mark.django_db
+def test_import_no_pwa_permiso_autorizado_se_asigna_directo():
+    """En un import no-PWA, un token de 'Permisos' que matchea un permiso PWA
+    delegable por el actor se asigna como permiso directo (no requiere grupo)."""
+    from users.models import UserImportJob
+    from users.services_user_import import process_single_user_import_row
+
+    admin = User.objects.create_superuser(
+        username="import_admin_staff_perm",
+        password="x",
+        email="admin_staff_perm@example.com",
+    )
+
+    job = UserImportJob(
+        requested_by=admin,
+        original_filename="usuarios.xlsx",
+        send_credentials=False,
+        is_pwa_import=False,
+    )
+
+    row_data = _import_row_data("staff.permiso@example.com")
+    row_data["permisos"] = "manage_nomina_pwa"
+
+    process_single_user_import_row(row_data=row_data, job=job)
+
+    creado = User.objects.get(email="staff.permiso@example.com")
+    assert creado.has_perm("pwa.manage_nomina_pwa")
+    assert creado.groups.count() == 0
+    assert creado.is_staff is True
+
+
+@pytest.mark.django_db
+def test_import_pwa_mezcla_grupo_y_permiso():
+    """Un mismo token 'Permisos' puede mezclar nombre de grupo y codename de
+    permiso PWA separados por ';', tambien en filas PWA."""
+    from comedores.models import Comedor
+    from users.models import UserImportJob
+    from users.services_user_import import process_single_user_import_row
+
+    admin = User.objects.create_superuser(
+        username="import_admin_pwa_mix", password="x", email="admin_pwa_mix@example.com"
+    )
+    grupo = Group.objects.create(name="Grupo Mix PWA")
+    comedor = Comedor.objects.create(nombre="Comedor Mix PWA")
+
+    job = UserImportJob(
+        requested_by=admin,
+        original_filename="usuarios.xlsx",
+        send_credentials=False,
+        is_pwa_import=True,
+    )
+
+    row_data = _import_row_data("pwa.mix@example.com")
+    row_data["permisos"] = "Grupo Mix PWA;manage_nomina_pwa"
+    row_data["comedores"] = str(comedor.pk)
+
+    process_single_user_import_row(row_data=row_data, job=job)
+
+    creado = User.objects.get(email="pwa.mix@example.com")
+    assert grupo in creado.groups.all()
+    assert creado.has_perm("pwa.manage_nomina_pwa")
+
+
+@pytest.mark.django_db
+def test_import_no_pwa_mezcla_grupo_y_permiso():
+    """Igual que en PWA, una fila no-PWA puede mezclar grupo y permiso en el
+    mismo token 'Permisos'."""
+    from users.models import UserImportJob
+    from users.services_user_import import process_single_user_import_row
+
+    admin = User.objects.create_superuser(
+        username="import_admin_staff_mix",
+        password="x",
+        email="admin_staff_mix@example.com",
+    )
+    grupo = Group.objects.create(name="Grupo Mix Staff")
+
+    job = UserImportJob(
+        requested_by=admin,
+        original_filename="usuarios.xlsx",
+        send_credentials=False,
+        is_pwa_import=False,
+    )
+
+    row_data = _import_row_data("staff.mix@example.com")
+    row_data["permisos"] = "Grupo Mix Staff;manage_nomina_pwa"
+
+    process_single_user_import_row(row_data=row_data, job=job)
+
+    creado = User.objects.get(email="staff.mix@example.com")
+    assert grupo in creado.groups.all()
+    assert creado.has_perm("pwa.manage_nomina_pwa")
+
+
+@pytest.mark.django_db
+def test_import_no_pwa_permiso_no_autorizado_lanza_error():
+    """Igual que en import PWA: si el actor no puede delegar el permiso PWA
+    solicitado, la fila falla aunque no sea import PWA."""
+    from django.core.exceptions import ValidationError
+    from users.models import UserImportJob
+    from users.services_user_import import process_single_user_import_row
+
+    admin = User.objects.create_user(
+        username="import_admin_staff_sin_perm", password="x"
+    )
+
+    job = UserImportJob(
+        requested_by=admin,
+        original_filename="usuarios.xlsx",
+        send_credentials=False,
+        is_pwa_import=False,
+    )
+
+    row_data = _import_row_data("staff.denegado@example.com")
+    row_data["permisos"] = "manage_nomina_pwa"
+
+    with pytest.raises(ValidationError):
+        process_single_user_import_row(row_data=row_data, job=job)
+
+
+@pytest.mark.django_db
+def test_import_token_no_matchea_grupo_ni_permiso_lanza_error():
+    """Un token que no es ni un grupo existente ni un permiso PWA delegable
+    lanza un error claro identificando el token."""
+    from django.core.exceptions import ValidationError
+    from users.models import UserImportJob
+    from users.services_user_import import process_single_user_import_row
+
+    admin = User.objects.create_user(
+        username="import_admin_token_invalido", password="x"
+    )
+
+    job = UserImportJob(
+        requested_by=admin,
+        original_filename="usuarios.xlsx",
+        send_credentials=False,
+        is_pwa_import=False,
+    )
+
+    row_data = _import_row_data("token.invalido@example.com")
+    row_data["permisos"] = "Grupo Que No Existe"
+
+    with pytest.raises(ValidationError, match="no es un grupo existente ni un permiso"):
+        process_single_user_import_row(row_data=row_data, job=job)


### PR DESCRIPTION
# Información de la Tarea
Vincular el #ISSUE

### **Resumen de la Solución:**
- La columna `Permisos` del importador masivo de usuarios ahora resuelve cada token (separado por `;`) como nombre de grupo primero, y si no existe, como permiso PWA delegable por el actor — indistintamente de si el lote es de import PWA o no.
- La columna `Accion grupos` (agregar/quitar/reemplazar) ahora aplica de forma conjunta tanto a grupos como a permisos PWA resueltos desde `Permisos`.
- Se documenta en la UI la columna `Accion grupos` (antes no explicada) y se actualiza el texto de `Permisos` para reflejar el nuevo comportamiento dual.
- Se renombra el botón "IMPORTAR USUARIOS" a "GESTOR DE USUARIOS" y los títulos/breadcrumbs de "Importacion masiva de usuarios" a "Gestor masivo de usuarios" (solo texto visible, sin tocar identificadores internos, verbose_name ni URLs).

### **Información Adicional:**
- El allow-list de permisos PWA delegables (`get_assignable_pwa_permission_codes`) no se amplió: sigue siendo el único mecanismo de scoping para permisos directos, tanto en filas PWA como no-PWA.
- El scope de grupos (`_get_allowed_group_ids`) ahora tambien se valida en filas PWA (antes solo aplicaba a filas no-PWA, ya que estas nunca resolvian grupos).
- Consecuencia esperada: con `accion_grupos=reemplazar` en una fila cuya columna `Permisos` no trae tokens, se puede limpiar cualquiera de los 4 permisos PWA delegables que el usuario ya tuviera asignado directamente (los permisos fuera de ese allow-list siempre se preservan). Es el comportamiento esperado de unificar la columna, no un bug.

# Descripción de los Cambios

### **Cambios:**
- `users/services_user_import.py`: se reemplazan `_resolver_permisos_fila_pwa` / `_resolver_permisos_fila_grupos` por un único `_resolver_permisos_fila`, y `_resolver_grupos` / `_resolver_permisos_pwa` por `_resolver_grupos_y_permisos` (resuelve grupo primero, permiso PWA delegable despues). `_crear_usuario_nuevo` y `_procesar_usuario_existente` aplican grupos y permisos PWA juntos via `accion_grupos`, sin importar `is_pwa_import` (organizaciones/comedores/is_staff siguen igual que antes).
- `users/tests.py`: nuevos tests para grupo-solo en PWA, permiso-solo en no-PWA, mezcla de ambos en PWA y no-PWA, permiso no autorizado en no-PWA, y token que no matchea ni grupo ni permiso.
- `users/templates/user/user_import_form.html`: nuevo `<li>` documentando `Accion grupos`, texto de `Permisos` actualizado, renombrado a "Gestor masivo de usuarios".
- `users/templates/user/user_import_job_detail.html`: breadcrumb renombrado a "Gestor masivo".
- `users/services.py`: label del botón renombrado a "GESTOR DE USUARIOS".

# Cómo Testear los Cambios

### **Pruebas Automáticas:**
- `docker compose exec django pytest users/tests.py -q` → 35 passed
- `docker compose exec django pytest tests/test_users_email_opcional_y_agrupamiento.py -q` → 24 passed (incluye los tests preexistentes de scope de grupos, sin modificar sus asserts)
- `black --check users/services_user_import.py users/tests.py` → limpio

### **Prubeas Manuales:**
- Cargar un Excel de importación con la columna `Permisos` mezclando un nombre de grupo y un codename de permiso PWA (ej: `Comedores Ver;manage_nomina_pwa`) tanto con "Usuarios de la PWA" marcado como sin marcar, y verificar que el usuario resultante recibe el grupo y el permiso directo correspondientes.

# Metadata para documentación automática

- Contexto funcional: Importador masivo de usuarios (SISOC + PWA)
- Tipo de cambio: Refactor de lógica de negocio + mejora de UI/UX
- Área principal: `users` (importador de usuarios)
- Resumen para changelog: El importador masivo de usuarios ahora permite asignar grupos y permisos PWA delegables desde la misma columna "Permisos", sin importar el tipo de import.
- Impacto usuario: Los administradores que usan el importador ganan flexibilidad (mezclar grupos y permisos PWA en una sola columna) sin perder ninguna restricción de seguridad existente.
- Riesgos / rollback: Cambio acotado a `users/services_user_import.py` y templates de UI; revertible con `git revert` del commit. Riesgo principal: filas con `accion_grupos=reemplazar` y columna `Permisos` vacía pueden limpiar permisos PWA delegables que el usuario ya tuviera (comportamiento esperado, documentado arriba).

🤖 Generated with [Claude Code](https://claude.com/claude-code)