### PR TITLE
fix(pwa): corrige hallazgos de review de #1996 (tope=0, race vigente_pwa, gating, CI)

### DIFF
--- a/.importlinter
+++ b/.importlinter
@@ -87,6 +87,7 @@ ignore_imports =
     core.services.favorite_filters.config -> centrodefamilia.services.responsables_filter_config
     core.services.favorite_filters.config -> dispositivos.dispositivos_filter_config
     core.services.favorite_filters.config -> duplas.dupla_filter_config
+    core.services.favorite_filters.config -> rendicioncuentasmensual.filter_config
     core.services.favorite_filters.config -> VAT.services.centro_filter_config
     core.soft_delete.state_sync -> VAT.cache_utils
     core.templatetags.custom_filters -> VAT.services.access_scope
@@ -165,6 +166,7 @@ ignore_imports =
     users.forms -> comedores.models
     users.forms -> duplas.models
     users.forms -> organizaciones.models
+    users.services_pwa -> comedores.models
     users.services_user_import -> comedores.models
     users.services_user_import -> organizaciones.models
     users.signals -> duplas.models

--- a/admisiones/migrations/0065_admision_vigente_pwa.py
+++ b/admisiones/migrations/0065_admision_vigente_pwa.py
@@ -29,8 +29,17 @@ def marcar_admisiones_vigentes_pwa(apps, schema_editor):
             vigente or admisiones.filter(activa=True).first() or admisiones.first()
         )
         if vigente:
-            Admision.objects.filter(comedor_id=comedor_id).update(vigente_pwa=False)
-            Admision.objects.filter(pk=vigente.pk).update(vigente_pwa=True)
+            vigentes_actuales = list(
+                admisiones.filter(vigente_pwa=True).values_list("pk", flat=True)
+            )
+            if vigentes_actuales == [vigente.pk]:
+                continue
+            Admision.objects.filter(
+                comedor_id=comedor_id,
+                vigente_pwa=True,
+            ).exclude(pk=vigente.pk).update(vigente_pwa=False)
+            if not vigente.vigente_pwa:
+                Admision.objects.filter(pk=vigente.pk).update(vigente_pwa=True)
 
 
 class Migration(migrations.Migration):

--- a/admisiones/migrations/0065_admision_vigente_pwa.py
+++ b/admisiones/migrations/0065_admision_vigente_pwa.py
@@ -37,7 +37,9 @@ def marcar_admisiones_vigentes_pwa(apps, schema_editor):
             Admision.objects.filter(
                 comedor_id=comedor_id,
                 vigente_pwa=True,
-            ).exclude(pk=vigente.pk).update(vigente_pwa=False)
+            ).exclude(
+                pk=vigente.pk
+            ).update(vigente_pwa=False)
             if not vigente.vigente_pwa:
                 Admision.objects.filter(pk=vigente.pk).update(vigente_pwa=True)
 

--- a/admisiones/migrations/0066_repair_informetecnico_missing_columns.py
+++ b/admisiones/migrations/0066_repair_informetecnico_missing_columns.py
@@ -3,35 +3,22 @@
 from django.db import migrations
 
 
+INFORME_TECNICO_REPAIR_COMIDAS = ("desayuno", "almuerzo", "merienda", "cena")
+INFORME_TECNICO_REPAIR_DIAS = (
+    "lunes",
+    "martes",
+    "miercoles",
+    "jueves",
+    "viernes",
+    "sabado",
+    "domingo",
+)
 INFORME_TECNICO_REPAIR_FIELDS = (
-    "aprobadas_ultimo_convenio_desayuno_lunes",
-    "aprobadas_ultimo_convenio_desayuno_martes",
-    "aprobadas_ultimo_convenio_desayuno_miercoles",
-    "aprobadas_ultimo_convenio_desayuno_jueves",
-    "aprobadas_ultimo_convenio_desayuno_viernes",
-    "aprobadas_ultimo_convenio_desayuno_sabado",
-    "aprobadas_ultimo_convenio_desayuno_domingo",
-    "aprobadas_ultimo_convenio_almuerzo_lunes",
-    "aprobadas_ultimo_convenio_almuerzo_martes",
-    "aprobadas_ultimo_convenio_almuerzo_miercoles",
-    "aprobadas_ultimo_convenio_almuerzo_jueves",
-    "aprobadas_ultimo_convenio_almuerzo_viernes",
-    "aprobadas_ultimo_convenio_almuerzo_sabado",
-    "aprobadas_ultimo_convenio_almuerzo_domingo",
-    "aprobadas_ultimo_convenio_merienda_lunes",
-    "aprobadas_ultimo_convenio_merienda_martes",
-    "aprobadas_ultimo_convenio_merienda_miercoles",
-    "aprobadas_ultimo_convenio_merienda_jueves",
-    "aprobadas_ultimo_convenio_merienda_viernes",
-    "aprobadas_ultimo_convenio_merienda_sabado",
-    "aprobadas_ultimo_convenio_merienda_domingo",
-    "aprobadas_ultimo_convenio_cena_lunes",
-    "aprobadas_ultimo_convenio_cena_martes",
-    "aprobadas_ultimo_convenio_cena_miercoles",
-    "aprobadas_ultimo_convenio_cena_jueves",
-    "aprobadas_ultimo_convenio_cena_viernes",
-    "aprobadas_ultimo_convenio_cena_sabado",
-    "aprobadas_ultimo_convenio_cena_domingo",
+    *(
+        f"aprobadas_ultimo_convenio_{comida}_{dia}"
+        for comida in INFORME_TECNICO_REPAIR_COMIDAS
+        for dia in INFORME_TECNICO_REPAIR_DIAS
+    ),
     "observaciones_subsanacion",
 )
 

--- a/admisiones/migrations/0068_admision_vigente_pwa_unique_constraint.py
+++ b/admisiones/migrations/0068_admision_vigente_pwa_unique_constraint.py
@@ -1,0 +1,21 @@
+# Generated manually in FAST mode.
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ("admisiones", "0067_repair_informetecnicopdf_missing_columns"),
+    ]
+
+    operations = [
+        migrations.AddConstraint(
+            model_name="admision",
+            constraint=models.UniqueConstraint(
+                fields=("comedor",),
+                condition=models.Q(vigente_pwa=True),
+                name="uniq_admision_vigente_pwa_por_comedor",
+            ),
+        ),
+    ]

--- a/admisiones/models/admisiones.py
+++ b/admisiones/models/admisiones.py
@@ -279,11 +279,6 @@ class Admision(models.Model):
             kwargs["update_fields"] = list(update_fields)
 
         super().save(*args, **kwargs)
-        if self.vigente_pwa and self.comedor_id:
-            Admision.objects.filter(
-                comedor_id=self.comedor_id,
-                vigente_pwa=True,
-            ).exclude(pk=self.pk).update(vigente_pwa=False)
         self._estado_mostrar_inicial = self.estado_mostrar
 
     @property
@@ -295,6 +290,13 @@ class Admision(models.Model):
         return None
 
     class Meta:
+        constraints = [
+            models.UniqueConstraint(
+                fields=["comedor"],
+                condition=models.Q(vigente_pwa=True),
+                name="uniq_admision_vigente_pwa_por_comedor",
+            )
+        ]
         indexes = [
             models.Index(fields=["comedor"]),
         ]

--- a/admisiones/services/admisiones_service/impl.py
+++ b/admisiones/services/admisiones_service/impl.py
@@ -40,6 +40,9 @@ from admisiones.services.admisiones_filter_config import (
     DATE_OPS as ADMISION_DATE_OPS,
     CHOICE_OPS as ADMISION_CHOICE_OPS,
 )
+from comedores.services.capacitaciones_certificados_service import (
+    is_alimentar_comunidad_program,
+)
 from comedores.utils import comedor_usa_admision_para_nomina
 from organizaciones.models import ArchivoOrganizacion, DocumentacionOrganizacion
 
@@ -863,11 +866,7 @@ class AdmisionService:
 
     @staticmethod
     def _admision_es_alimentar_comunidad(admision):
-        programa = getattr(getattr(admision, "comedor", None), "programa", None)
-        return (
-            AdmisionService._normalizar_nombre_tipo(getattr(programa, "nombre", ""))
-            == "alimentar comunidad"
-        )
+        return is_alimentar_comunidad_program(getattr(admision, "comedor", None))
 
     @staticmethod
     def _build_objetos_update_context(admision):
@@ -2905,12 +2904,25 @@ class AdmisionService:
                     "error": "No tiene permisos para editar esta admision.",
                 }
 
-            if vigente and admision.comedor_id:
-                Admision.objects.filter(comedor_id=admision.comedor_id).update(
-                    vigente_pwa=False
-                )
-            admision.vigente_pwa = vigente
-            admision.save(update_fields=["vigente_pwa"])
+            with transaction.atomic():
+                if admision.comedor_id:
+                    admisiones_comedor = (
+                        Admision.objects.select_for_update()
+                        .filter(comedor_id=admision.comedor_id)
+                        .order_by("id")
+                    )
+                    admisiones_bloqueadas = list(admisiones_comedor)
+                    admision = next(
+                        item for item in admisiones_bloqueadas if item.pk == admision.pk
+                    )
+                    if vigente:
+                        admisiones_comedor.exclude(pk=admision.pk).filter(
+                            vigente_pwa=True
+                        ).update(vigente_pwa=False)
+                else:
+                    admision = Admision.objects.select_for_update().get(pk=admision.pk)
+                admision.vigente_pwa = vigente
+                admision.save(update_fields=["vigente_pwa"])
             return {"success": True, "vigente_pwa": admision.vigente_pwa}
         except Exception as exc:
             logger.exception("Error en actualizar_vigente_pwa_ajax")

--- a/comedores/forms/convenio_pnud_form.py
+++ b/comedores/forms/convenio_pnud_form.py
@@ -3,35 +3,20 @@ from django import forms
 from comedores.models import ComedorDatosConvenioPnud
 
 
+PRESTACIONES_APROBADAS_DIAS = (
+    "lunes",
+    "martes",
+    "miercoles",
+    "jueves",
+    "viernes",
+    "sabado",
+    "domingo",
+)
+PRESTACIONES_APROBADAS_COMIDAS = ("desayuno", "almuerzo", "merienda", "cena")
 PRESTACIONES_APROBADAS_FIELDS = [
-    "aprobadas_desayuno_lunes",
-    "aprobadas_almuerzo_lunes",
-    "aprobadas_merienda_lunes",
-    "aprobadas_cena_lunes",
-    "aprobadas_desayuno_martes",
-    "aprobadas_almuerzo_martes",
-    "aprobadas_merienda_martes",
-    "aprobadas_cena_martes",
-    "aprobadas_desayuno_miercoles",
-    "aprobadas_almuerzo_miercoles",
-    "aprobadas_merienda_miercoles",
-    "aprobadas_cena_miercoles",
-    "aprobadas_desayuno_jueves",
-    "aprobadas_almuerzo_jueves",
-    "aprobadas_merienda_jueves",
-    "aprobadas_cena_jueves",
-    "aprobadas_desayuno_viernes",
-    "aprobadas_almuerzo_viernes",
-    "aprobadas_merienda_viernes",
-    "aprobadas_cena_viernes",
-    "aprobadas_desayuno_sabado",
-    "aprobadas_almuerzo_sabado",
-    "aprobadas_merienda_sabado",
-    "aprobadas_cena_sabado",
-    "aprobadas_desayuno_domingo",
-    "aprobadas_almuerzo_domingo",
-    "aprobadas_merienda_domingo",
-    "aprobadas_cena_domingo",
+    f"aprobadas_{comida}_{dia}"
+    for dia in PRESTACIONES_APROBADAS_DIAS
+    for comida in PRESTACIONES_APROBADAS_COMIDAS
 ]
 
 

--- a/comedores/views/comedor.py
+++ b/comedores/views/comedor.py
@@ -51,7 +51,6 @@ from comedores.utils import (
     is_abordaje_comunitario_relevamientos_header_program,
     is_abordaje_comunitario_linea_secos_program,
     is_pnud_comedor,
-    is_prestacion_alimentaria_conformidad_program,
     usa_datos_convenio_pnud,
 )
 from core.pagination import NoCountPaginator, build_no_count_page_range
@@ -1377,8 +1376,6 @@ class ComedorDetailView(LoginRequiredMixin, DetailView):
         }
 
     def _build_conformidad_prestacion_context(self):
-        if not is_prestacion_alimentaria_conformidad_program(self.object):
-            return {"pendiente": False, "periodo": None}
         pending_period = get_prestacion_conformidad_pending_period(self.object)
         return {"pendiente": pending_period is not None, "periodo": pending_period}
 

--- a/pwa/services/nomina_service.py
+++ b/pwa/services/nomina_service.py
@@ -139,7 +139,7 @@ def _tope_nomina_alimentaria_cubierto(
     *, comedor_id: int, exclude_nomina_id: int | None = None
 ) -> bool:
     tope = _get_tope_nomina_alimentaria(comedor_id)
-    if not tope:
+    if tope is None:
         return False
     return (
         _count_nomina_alimentaria_activa(
@@ -223,10 +223,16 @@ def validar_asistencia_nomina_habilitada():
 def _resolve_admision_para_comedor(*, comedor_id: int):
     from admisiones.models.admisiones import Admision
 
-    admision = ComedorService.get_admision_vigente_pwa(comedor_id)
-    if admision:
-        return admision
-    return Admision.objects.create(comedor_id=comedor_id, activa=True, vigente_pwa=True)
+    with transaction.atomic():
+        Comedor.objects.select_for_update().get(pk=comedor_id)
+        admision = ComedorService.get_admision_vigente_pwa(comedor_id)
+        if admision:
+            return admision
+        return Admision.objects.create(
+            comedor_id=comedor_id,
+            activa=True,
+            vigente_pwa=True,
+        )
 
 
 def _build_nomina_link_fields(*, comedor_id: int) -> dict:

--- a/tests/test_admisiones_service_botones_characterization_db.py
+++ b/tests/test_admisiones_service_botones_characterization_db.py
@@ -187,7 +187,7 @@ def test_get_botones_disponibles_preserva_orden_en_combinacion_tecnica():
         num_expediente="EXP-33",
         enviado_legales=False,
     )
-    informe_tecnico = _informe(estado="Validado")
+    informe_tecnico = _informe(estado="Validado", estado_formulario="finalizado")
 
     botones = module.AdmisionService._get_botones_disponibles(
         admision,

--- a/tests/test_admisiones_service_helpers_unit.py
+++ b/tests/test_admisiones_service_helpers_unit.py
@@ -1108,7 +1108,8 @@ def test_generar_documento_admision_and_update_context(mocker):
     mocker.patch(
         "admisiones.services.admisiones_service.InformeTecnico.objects.filter",
         return_value=SimpleNamespace(
-            order_by=lambda *_: SimpleNamespace(first=lambda: None)
+            order_by=lambda *_: SimpleNamespace(first=lambda: None),
+            exists=lambda: False,
         ),
     )
     mocker.patch(

--- a/tests/test_comedor_service_renaper_helpers_unit.py
+++ b/tests/test_comedor_service_renaper_helpers_unit.py
@@ -676,6 +676,12 @@ class _FakeQS:
     def order_by(self, *_args, **_kwargs):
         return self
 
+    def select_related(self, *_args, **_kwargs):
+        return self
+
+    def defer(self, *_args, **_kwargs):
+        return self
+
     def first(self):
         return self._result
 
@@ -691,6 +697,11 @@ def test_get_prestaciones_aprobadas_resumen_usa_aprobadas(mocker):
         aprobadas_cena_lunes=4,
     )
     mocker.patch.object(
+        impl_module.Comedor,
+        "objects",
+        SimpleNamespace(filter=lambda **k: _FakeQS(SimpleNamespace())),
+    )
+    mocker.patch.object(
         impl_module.Admision,
         "objects",
         SimpleNamespace(filter=lambda **k: _FakeQS(admision)),
@@ -699,6 +710,11 @@ def test_get_prestaciones_aprobadas_resumen_usa_aprobadas(mocker):
         impl_module.InformeTecnico,
         "objects",
         SimpleNamespace(filter=lambda **k: _FakeQS(informe)),
+    )
+    mocker.patch.object(
+        impl_module.InformeComplementario,
+        "objects",
+        SimpleNamespace(filter=lambda **k: _FakeQS(None)),
     )
 
     resumen = impl_module.ComedorService.get_prestaciones_aprobadas_resumen(123)
@@ -711,6 +727,11 @@ def test_get_prestaciones_aprobadas_resumen_usa_aprobadas(mocker):
 def test_get_prestaciones_aprobadas_resumen_sin_admision(mocker):
     from comedores.services.comedor_service import impl as impl_module
 
+    mocker.patch.object(
+        impl_module.Comedor,
+        "objects",
+        SimpleNamespace(filter=lambda **k: _FakeQS(SimpleNamespace())),
+    )
     mocker.patch.object(
         impl_module.Admision,
         "objects",

--- a/users/services_user_import.py
+++ b/users/services_user_import.py
@@ -17,6 +17,9 @@ from django.urls import reverse
 from openpyxl import Workbook, load_workbook
 
 from comedores.models import Comedor
+from comedores.services.capacitaciones_certificados_service import (
+    is_alimentar_comunidad_program,
+)
 from core.models import Provincia
 from organizaciones.models import Organizacion
 from users.models import (
@@ -335,6 +338,13 @@ def _resolver_comedores(comedores_raw: str) -> list:
     return comedores
 
 
+def _comedor_id_alimentar_comunidad_en_lista(comedores: list) -> int | None:
+    for comedor in comedores:
+        if is_alimentar_comunidad_program(comedor):
+            return comedor.pk
+    return None
+
+
 def _build_pwa_access_specs(*, organizaciones: list, comedores: list) -> list[dict]:
     """Arma los accesos PWA a partir de organizaciones y comedores de la fila.
 
@@ -382,10 +392,12 @@ def _get_pwa_permission_ids(codes: set) -> set:
     return permission_ids
 
 
-def _resolver_grupos_y_permisos(permisos_raw: str, *, actor) -> tuple[list, list]:
+def _resolver_grupos_y_permisos(
+    permisos_raw: str, *, actor, comedor_id: int | None = None
+) -> tuple[list, list]:
     """Resuelve cada token de 'Permisos' como Group o, si no existe, como
     Permission PWA delegable por el actor. Aplica igual sea o no import PWA."""
-    allowed_codes = set(get_assignable_pwa_permission_codes(actor))
+    allowed_codes = set(get_assignable_pwa_permission_codes(actor, comedor_id))
     allowed_by_codename = {code.split(".", 1)[1]: code for code in allowed_codes}
 
     grupos = []
@@ -423,8 +435,20 @@ class _PermisosFila:
 
 
 def _resolver_permisos_fila(row_data: dict, job: UserImportJob) -> _PermisosFila:
+    if job.is_pwa_import:
+        organizaciones = _resolver_organizaciones(
+            row_data.get("organizaciones", "").strip()
+        )
+        comedores = _resolver_comedores(row_data.get("comedores", "").strip())
+    else:
+        organizaciones = []
+        comedores = []
+    comedor_id = _comedor_id_alimentar_comunidad_en_lista(comedores)
+
     grupos, permisos_pwa = _resolver_grupos_y_permisos(
-        row_data.get("permisos", "").strip(), actor=job.requested_by
+        row_data.get("permisos", "").strip(),
+        actor=job.requested_by,
+        comedor_id=comedor_id,
     )
 
     allowed_group_ids = _get_allowed_group_ids(job.requested_by)
@@ -435,17 +459,8 @@ def _resolver_permisos_fila(row_data: dict, job: UserImportJob) -> _PermisosFila
             raise ValidationError(f"No tiene permiso para operar los grupos: {names}.")
 
     allowed_permiso_ids = _get_pwa_permission_ids(
-        set(get_assignable_pwa_permission_codes(job.requested_by))
+        set(get_assignable_pwa_permission_codes(job.requested_by, comedor_id))
     )
-
-    if job.is_pwa_import:
-        organizaciones = _resolver_organizaciones(
-            row_data.get("organizaciones", "").strip()
-        )
-        comedores = _resolver_comedores(row_data.get("comedores", "").strip())
-    else:
-        organizaciones = []
-        comedores = []
 
     return _PermisosFila(
         grupos=grupos,


### PR DESCRIPTION
## Contexto

El [PR #1996](https://github.com/dsocial118/SISOC/pull/1996) ya se mergeó a `development` (necesitaba estar en HML). Este PR corrige los hallazgos detectados en la review posterior de ese PR y arregla los checks de CI que habían quedado en rojo.

## Cambios

**Bugs de lógica**
- `pwa/services/nomina_service.py`: `_tope_nomina_alimentaria_cubierto` trataba `tope=0` igual que `tope=None` (sin tope), permitiendo nómina ilimitada cuando el tope estaba explícitamente en cero. Ahora solo `None` mantiene el bypass.
- `pwa/services/nomina_service.py`: `_resolve_admision_para_comedor` creaba una admisión con `vigente_pwa=True` sin ningún lock; dos requests concurrentes para un comedor sin admisión vigente podían crear dos filas vigentes. Ahora serializa con `select_for_update()` sobre el comedor y vuelve a chequear dentro de la sección bloqueada.

**Concurrencia / integridad de datos**
- `admisiones/models/admisiones.py` + `admisiones/services/admisiones_service/impl.py`: la regla "una sola admisión `vigente_pwa=True` por comedor" vivía en `Admision.save()` (lógica de negocio en el modelo) aplicada con un `.update()` posterior sin transacción ni lock. Se movió a `actualizar_vigente_pwa_ajax`, envuelta en `transaction.atomic()` + `select_for_update()`.
- Migración nueva `0068`: agrega `UniqueConstraint(condition=Q(vigente_pwa=True))` como red de seguridad adicional a nivel de modelo. **Nota**: MySQL no soporta índices únicos parciales, así que esta constraint no se enforce en la base real (sí en SQLite, que es lo que usan los tests) — la protección real en producción es el `select_for_update()`.
- `admisiones/migrations/0065_admision_vigente_pwa.py`: evita los dos `UPDATE` redundantes cuando el comedor ya tiene la admisión vigente correcta (antes se reescribían siempre, aunque no hiciera falta).

**Comportamiento inconsistente**
- `comedores/views/comedor.py`: la vista de legajo (web) todavía gateaba "conformidad pendiente" por tipo de programa, mientras que la API PWA ya había liberado ese gate para todos los programas en el PR original. Ahora ambas superficies se comportan igual.

**Duplicación**
- `admisiones/services/admisiones_service/impl.py`: `_admision_es_alimentar_comunidad` reimplementaba a mano la normalización de nombre de programa; ahora reusa `is_alimentar_comunidad_program` (ya usado en este mismo alcance por `users/services_pwa.py`).
- `comedores/forms/convenio_pnud_form.py` y `admisiones/migrations/0066`: listas de ~28 campos hardcodeadas a mano (con riesgo de typo silencioso) ahora se generan por comprehension.
- `users/services_user_import.py`: el importador masivo de usuarios PWA no aplicaba el filtro de comedor a `get_assignable_pwa_permission_codes`, por lo que la restricción "sin permiso de Rendición de Cuentas para Alimentar Comunidad" (agregada en #1996) no se respetaba en el alta masiva. Ahora resuelve los comedores de la fila primero y propaga el `comedor_id` correspondiente.

**CI**
- `.importlinter`: baseline de los dos imports cross-dominio nuevos que introdujo #1996 (`core.services.favorite_filters.config -> rendicioncuentasmensual.filter_config`, `users.services_pwa -> comedores.models`), siguiendo el mismo patrón ya aceptado para otros dominios.
- `tests/`: actualiza mocks/fixtures desalineados con los cambios de contrato de #1996 (`Comedor`/`InformeComplementario` sin mockear en `get_prestaciones_aprobadas_resumen`, falta `.exists()` en el mock de `InformeTecnico.objects.filter` usado por `get_admision_update_context`, characterization test con `estado_formulario` desactualizado tras el cambio de gate de `informe_tecnico_complementario`).

## Riesgos conocidos / pendientes

- La `UniqueConstraint` de la migración `0068` no se enforce en MySQL 8.4 (limitación de la base, no de Django). La protección real contra la condición de carrera es el `select_for_update()` agregado en el service; si se quiere enforcement real a nivel de DB en MySQL haría falta un mecanismo distinto (columna generada + índice único), no incluido acá.

## Validación

- `python -m py_compile` sobre todos los archivos tocados: OK.
- No se corrió el suite completo de tests ni `manage.py check` en este entorno (sandbox sin acceso a Docker/DB). Recomendado antes de mergear:
  - `docker compose exec django pytest tests/test_admisiones_service_botones_characterization_db.py tests/test_admisiones_service_helpers_unit.py tests/test_comedor_service_renaper_helpers_unit.py tests/test_pwa_comedores_api.py -v`
  - `lint-imports` (chequeo de `.importlinter`)
  - `python manage.py makemigrations --check --dry-run`
  - `python manage.py sqlmigrate admisiones 0068` contra la config real de MySQL, para confirmar que la constraint efectivamente no se aplica (documentar si aplica)

🤖 Generated with [Claude Code](https://claude.com/claude-code)