### PR TITLE
fix(users): respetar username y evitar accesos PWA fantasma en el importador masivo

### DIFF
--- a/users/services_user_import.py
+++ b/users/services_user_import.py
@@ -432,6 +432,7 @@ class _PermisosFila:
     allowed_permiso_ids: set | None
     organizaciones: list
     comedores: list
+    access_specs: list
 
 
 def _resolver_permisos_fila(row_data: dict, job: UserImportJob) -> _PermisosFila:
@@ -444,6 +445,15 @@ def _resolver_permisos_fila(row_data: dict, job: UserImportJob) -> _PermisosFila
         organizaciones = []
         comedores = []
     comedor_id = _comedor_id_alimentar_comunidad_en_lista(comedores)
+
+    access_specs = _build_pwa_access_specs(
+        organizaciones=organizaciones, comedores=comedores
+    )
+    if job.is_pwa_import and (organizaciones or comedores) and not access_specs:
+        raise ValidationError(
+            "Las organizaciones o comedores indicados no tienen comedores "
+            "asociados; el usuario quedaria sin ningun acceso PWA activo."
+        )
 
     grupos, permisos_pwa = _resolver_grupos_y_permisos(
         row_data.get("permisos", "").strip(),
@@ -469,6 +479,7 @@ def _resolver_permisos_fila(row_data: dict, job: UserImportJob) -> _PermisosFila
         allowed_permiso_ids=allowed_permiso_ids,
         organizaciones=organizaciones,
         comedores=comedores,
+        access_specs=access_specs,
     )
 
 
@@ -493,7 +504,9 @@ def _resolver_usuario_objetivo(row_data: dict):
     username_raw = row_data.get("username", "").strip()
     email_raw = row_data.get("correo", "").strip()
     if username_raw:
-        return User.objects.filter(username__iexact=username_raw).first()
+        user = User.objects.filter(username__iexact=username_raw).first()
+        if user is not None:
+            return user
     if email_raw:
         return User.objects.filter(email__iexact=email_raw).first()
     return None
@@ -567,11 +580,9 @@ class _ActualizarUsuarioParams:
     grupos: list
     accion_grupos: str
     allowed_group_ids: set | None
-    is_pwa_import: bool
     permisos_pwa: list
     allowed_permiso_ids: set | None
-    organizaciones: list
-    comedores: list
+    access_specs: list
     actor: object
 
 
@@ -579,6 +590,22 @@ def _procesar_usuario_existente(params: _ActualizarUsuarioParams) -> dict:
     changed = False
 
     with transaction.atomic():
+        if (
+            params.username_raw
+            and params.user.username.lower() != params.username_raw.lower()
+        ):
+            if (
+                User.objects.filter(username__iexact=params.username_raw)
+                .exclude(pk=params.user.pk)
+                .exists()
+            ):
+                raise ValidationError(
+                    f"Ya existe un usuario con el username '{params.username_raw}'."
+                )
+            params.user.username = params.username_raw
+            params.user.save(update_fields=["username"])
+            changed = True
+
         if (
             params.username_raw
             and params.email
@@ -604,14 +631,10 @@ def _procesar_usuario_existente(params: _ActualizarUsuarioParams) -> dict:
         )
         changed = changed or grupos_changed
 
-        if params.is_pwa_import and (params.organizaciones or params.comedores):
-            access_specs = _build_pwa_access_specs(
-                organizaciones=params.organizaciones,
-                comedores=params.comedores,
-            )
+        if params.access_specs:
             sync_representante_accesses(
                 user=params.user,
-                access_specs=access_specs,
+                access_specs=params.access_specs,
                 actor=params.actor,
             )
             changed = True
@@ -644,8 +667,7 @@ class _CrearUsuarioParams:
     provincias_objs: list
     job: object
     permisos_pwa: list
-    organizaciones: list
-    comedores: list
+    access_specs: list
 
 
 @dataclass
@@ -663,6 +685,7 @@ class _DatosFilaValidados:
     allowed_permiso_ids: set | None
     organizaciones: list
     comedores: list
+    access_specs: list
 
 
 def _crear_usuario_nuevo(params: _CrearUsuarioParams) -> tuple[User, str]:
@@ -682,14 +705,10 @@ def _crear_usuario_nuevo(params: _CrearUsuarioParams) -> tuple[User, str]:
     if params.grupos:
         user.groups.set(params.grupos)
 
-    if params.job.is_pwa_import and (params.organizaciones or params.comedores):
-        access_specs = _build_pwa_access_specs(
-            organizaciones=params.organizaciones,
-            comedores=params.comedores,
-        )
+    if params.access_specs:
         sync_representante_accesses(
             user=user,
-            access_specs=access_specs,
+            access_specs=params.access_specs,
             actor=params.job.requested_by,
         )
 
@@ -763,6 +782,7 @@ def _validar_y_preparar_fila(row_data: dict, job: UserImportJob) -> _DatosFilaVa
         allowed_permiso_ids=permisos_fila.allowed_permiso_ids,
         organizaciones=permisos_fila.organizaciones,
         comedores=permisos_fila.comedores,
+        access_specs=permisos_fila.access_specs,
     )
 
 
@@ -778,11 +798,9 @@ def process_single_user_import_row(*, row_data: dict, job: UserImportJob) -> dic
             grupos=datos.grupos,
             accion_grupos=datos.accion_grupos,
             allowed_group_ids=datos.allowed_group_ids,
-            is_pwa_import=job.is_pwa_import,
             permisos_pwa=datos.permisos_pwa,
             allowed_permiso_ids=datos.allowed_permiso_ids,
-            organizaciones=datos.organizaciones,
-            comedores=datos.comedores,
+            access_specs=datos.access_specs,
             actor=job.requested_by,
         )
         return _procesar_usuario_existente(params)
@@ -822,8 +840,7 @@ def process_single_user_import_row(*, row_data: dict, job: UserImportJob) -> dic
             provincias_objs=datos.provincias_objs,
             job=job,
             permisos_pwa=datos.permisos_pwa,
-            organizaciones=datos.organizaciones,
-            comedores=datos.comedores,
+            access_specs=datos.access_specs,
         )
         user, password = _crear_usuario_nuevo(params)
 

--- a/users/tests.py
+++ b/users/tests.py
@@ -719,6 +719,35 @@ def test_import_username_vacio_se_autogenera():
 
 
 @pytest.mark.django_db
+def test_import_username_renombra_usuario_existente_matcheado_por_correo():
+    """Si una fila matchea un usuario existente por correo y trae un Username
+    distinto al actual, el importador debe renombrar el usuario."""
+    from users.models import UserImportJob
+    from users.services_user_import import process_single_user_import_row
+
+    admin = User.objects.create_user(username="import_admin_rename", password="x")
+    existente = User.objects.create_user(
+        username="gonzalez.pedro",
+        email="pedro.gonzalez@example.com",
+        password="x",
+    )
+    job = UserImportJob(
+        requested_by=admin,
+        original_filename="usuarios.xlsx",
+        send_credentials=False,
+        is_pwa_import=False,
+    )
+
+    row_data = _import_row_data("pedro.gonzalez@example.com")
+    row_data["username"] = "pedrouser"
+
+    process_single_user_import_row(row_data=row_data, job=job)
+
+    existente.refresh_from_db()
+    assert existente.username == "pedrouser"
+
+
+@pytest.mark.django_db
 def test_import_pwa_asigna_organizaciones_y_comedores():
     """Un usuario PWA importado con Organizaciones y Comedores queda con
     acceso a todos los comedores de esas organizaciones, mas los comedores
@@ -843,6 +872,89 @@ def test_import_pwa_sin_organizaciones_ni_comedores_lanza_error():
         process_single_user_import_row(row_data=row_data, job=job)
 
     assert not User.objects.filter(email="pwa.sin.espacio@example.com").exists()
+
+
+@pytest.mark.django_db
+def test_import_pwa_organizacion_sin_comedores_lanza_error():
+    """Una Organizacion sin comedores asociados no otorga ningun acceso PWA
+    real; la fila debe fallar en vez de crear un usuario inutilizable."""
+    from django.core.exceptions import ValidationError
+    from organizaciones.models import Organizacion, TipoEntidad
+    from users.models import UserImportJob
+    from users.services_user_import import process_single_user_import_row
+
+    admin = User.objects.create_user(username="import_admin_org_vacia", password="x")
+    tipo = TipoEntidad.objects.create(nombre="Personeria Juridica")
+    organizacion_vacia = Organizacion.objects.create(
+        nombre="Org Sin Comedores", tipo_entidad=tipo
+    )
+
+    job = UserImportJob(
+        requested_by=admin,
+        original_filename="usuarios.xlsx",
+        send_credentials=False,
+        is_pwa_import=True,
+    )
+
+    row_data = _import_row_data("pwa.org.vacia@example.com")
+    row_data["organizaciones"] = str(organizacion_vacia.pk)
+
+    with pytest.raises(ValidationError):
+        process_single_user_import_row(row_data=row_data, job=job)
+
+    assert not User.objects.filter(email="pwa.org.vacia@example.com").exists()
+
+
+@pytest.mark.django_db
+def test_import_pwa_organizacion_sin_comedores_no_borra_accesos_existentes():
+    """Actualizar un usuario PWA existente con una Organizacion sin comedores
+    no debe desactivar silenciosamente sus accesos PWA activos previos."""
+    from django.core.exceptions import ValidationError
+    from comedores.models import Comedor
+    from organizaciones.models import Organizacion, TipoEntidad
+    from users.models import AccesoComedorPWA, UserImportJob
+    from users.services_pwa import sync_representante_accesses
+    from users.services_user_import import process_single_user_import_row
+
+    admin = User.objects.create_user(
+        username="import_admin_org_vacia_update", password="x"
+    )
+    tipo = TipoEntidad.objects.create(nombre="Personeria Juridica")
+    organizacion_vacia = Organizacion.objects.create(
+        nombre="Org Sin Comedores Update", tipo_entidad=tipo
+    )
+    comedor_suelto = Comedor.objects.create(nombre="Comedor Suelto Update")
+
+    existente = User.objects.create_user(
+        username="pwa.existente", email="pwa.existente@example.com", password="x"
+    )
+    sync_representante_accesses(
+        user=existente,
+        access_specs=[
+            {
+                "comedor_id": comedor_suelto.pk,
+                "tipo_asociacion": AccesoComedorPWA.TIPO_ASOCIACION_ESPACIO,
+                "organizacion_id": None,
+            }
+        ],
+        actor=admin,
+    )
+
+    job = UserImportJob(
+        requested_by=admin,
+        original_filename="usuarios.xlsx",
+        send_credentials=False,
+        is_pwa_import=True,
+    )
+
+    row_data = _import_row_data("pwa.existente@example.com")
+    row_data["organizaciones"] = str(organizacion_vacia.pk)
+
+    with pytest.raises(ValidationError):
+        process_single_user_import_row(row_data=row_data, job=job)
+
+    acceso = AccesoComedorPWA.objects.get(user=existente, comedor=comedor_suelto)
+    assert acceso.activo is True
 
 
 @pytest.mark.django_db


### PR DESCRIPTION
## Summary
- Cierra #1926: el gestor masivo de usuarios no respetaba el `Username` de una fila cuando esta matcheaba a un usuario existente por correo — `_resolver_usuario_objetivo` sólo buscaba por username y, si no encontraba coincidencia, devolvía `None` sin caer a buscar por correo, lo que terminaba creando una cuenta **duplicada** en vez de actualizar la existente.
- También corrige un acceso PWA "fantasma": si la fila asignaba una Organización sin comedores asociados (y sin comedores explícitos), el usuario se creaba/actualizaba "exitosamente" pero sin ningún `AccesoComedorPWA` real — no podía loguear en la PWA y, en el caso de actualizar un usuario PWA existente, el bug podía **desactivar silenciosamente sus accesos activos previos**.
- Probablemente relacionado con el reporte en #1936 (mismo mecanismo de matching).

## Changes
- `_resolver_usuario_objetivo`: ahora cae a buscar por correo si el `Username` de la fila no matchea a ningún usuario existente.
- `_procesar_usuario_existente`: si el `Username` de la fila difiere del actual, renombra al usuario (con guarda de colisión de username contra otro usuario).
- El cálculo de `access_specs` (organizaciones/comedores resueltos a accesos PWA) se centralizó en `_resolver_permisos_fila`, que corre tanto para creación como para actualización, y valida el resultado **resuelto** (no las listas crudas) — evita el caso de "organización sin comedores" tanto al crear como al actualizar usuarios PWA.

## Test plan
- [x] `pytest users/tests.py -q` → 38 passed
- [x] `pytest tests/ -k "pwa or user_import or users" -q` → 270 passed
- [x] `pytest -n auto -q` (suite completa) → 3199 passed, 8 skipped
- [x] `black --check users/services_user_import.py users/tests.py`
- [x] `pylint users/services_user_import.py` → 10.00/10

🤖 Generated with [Claude Code](https://claude.com/claude-code)