### PR TITLE
ci(deploy): automatizar deploy por entorno con self-hosted runners

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,82 @@
+name: Despliegue automatizado
+
+on:
+    push:
+        branches:
+            - development
+            - homologacion
+            - main
+
+permissions: { contents: read }
+
+concurrency: { group: "deploy-${{ github.ref }}", cancel-in-progress: false }
+
+jobs:
+    deploy-qa:
+        if: github.ref == 'refs/heads/development'
+        environment: qa
+        runs-on: [self-hosted, sisoc-qa]
+
+        steps:
+            - name: Ejecutar deploy local de QA
+              shell: bash
+              env:
+                  GH_APP_ROOT: "${{ vars.APP_ROOT }}"
+              run: |
+                  set -Eeuo pipefail
+
+                  APP_ROOT="${GH_APP_ROOT:-${APP_ROOT:-}}"
+                  if [[ -z "$APP_ROOT" ]]; then
+                      echo "::error::APP_ROOT no esta configurado. Definir vars.APP_ROOT en el Environment qa o APP_ROOT en el servicio del runner."
+                      exit 1
+                  fi
+
+                  cd "$APP_ROOT"
+                  echo "Commit previo al deploy para rollback: $(git rev-parse HEAD)"
+                  ./scripts/operacion/deploy_refresh.sh --yes
+
+    deploy-homologacion:
+        if: github.ref == 'refs/heads/homologacion'
+        environment: homologacion
+        runs-on: [self-hosted, sisoc-homologacion]
+
+        steps:
+            - name: Ejecutar deploy local de homologacion
+              shell: bash
+              env:
+                  GH_APP_ROOT: "${{ vars.APP_ROOT }}"
+              run: |
+                  set -Eeuo pipefail
+
+                  APP_ROOT="${GH_APP_ROOT:-${APP_ROOT:-}}"
+                  if [[ -z "$APP_ROOT" ]]; then
+                      echo "::error::APP_ROOT no esta configurado. Definir vars.APP_ROOT en el Environment homologacion o APP_ROOT en el servicio del runner."
+                      exit 1
+                  fi
+
+                  cd "$APP_ROOT"
+                  echo "Commit previo al deploy para rollback: $(git rev-parse HEAD)"
+                  ./scripts/operacion/deploy_refresh.sh --yes
+
+    deploy-produccion:
+        if: github.ref == 'refs/heads/main'
+        environment: production
+        runs-on: [self-hosted, sisoc-produccion]
+
+        steps:
+            - name: Ejecutar deploy local de produccion
+              shell: bash
+              env:
+                  GH_APP_ROOT: "${{ vars.APP_ROOT }}"
+              run: |
+                  set -Eeuo pipefail
+
+                  APP_ROOT="${GH_APP_ROOT:-${APP_ROOT:-}}"
+                  if [[ -z "$APP_ROOT" ]]; then
+                      echo "::error::APP_ROOT no esta configurado. Definir vars.APP_ROOT en el Environment production o APP_ROOT en el servicio del runner."
+                      exit 1
+                  fi
+
+                  cd "$APP_ROOT"
+                  echo "Commit previo al deploy para rollback: $(git rev-parse HEAD)"
+                  ./scripts/operacion/deploy_refresh.sh --yes

--- a/docs/operacion/deploy_automatizado.md
+++ b/docs/operacion/deploy_automatizado.md
@@ -1,0 +1,128 @@
+# Deploy automatizado con self-hosted runners
+
+Estado: runbook operativo para automatizar el deploy de SISOC en QA, homologacion y produccion usando GitHub Actions con runners self-hosted instalados en cada servidor de aplicacion.
+
+El workflow no usa runners cloud ni `actions/checkout`: cada runner ejecuta el script local `scripts/operacion/deploy_refresh.sh` dentro del checkout ya provisionado en el servidor.
+
+## Flujo operativo
+
+| Entorno | Branch | GitHub Environment | Runner labels | Variable requerida |
+| --- | --- | --- | --- | --- |
+| QA | `development` | `qa` | `self-hosted`, `sisoc-qa` | `APP_ROOT` |
+| Homologacion | `homologacion` | `homologacion` | `self-hosted`, `sisoc-homologacion` | `APP_ROOT` |
+| Produccion | `main` | `production` | `self-hosted`, `sisoc-produccion` | `APP_ROOT` |
+
+En cada push a la branch del entorno, GitHub agenda el job correspondiente. El runner local:
+
+1. resuelve `APP_ROOT` desde la variable del Environment;
+2. entra al checkout provisionado en el servidor;
+3. registra `git rev-parse HEAD` como referencia previa de rollback;
+4. ejecuta `./scripts/operacion/deploy_refresh.sh --yes`.
+
+El script existente conserva las validaciones operativas: lee `ENVIRONMENT` desde `.env`, valida branch esperada, ejecuta `docker compose config -q`, baja el stack sin volumenes, hace `git pull --ff-only` y levanta con `up -d --build`.
+
+## Instalar runner por entorno
+
+Ejecutar en el servidor de aplicacion de cada entorno con el usuario operativo del deploy, por ejemplo `sisoc-deploy`. Reemplazar `<TOKEN_REGISTRO>` por un token de registro nuevo generado en GitHub para el repositorio `dsocial118/SISOC`.
+
+```bash
+sudo -iu sisoc-deploy
+mkdir -p ~/actions-runner
+cd ~/actions-runner
+
+RUNNER_VERSION=<version-vigente>
+curl -o actions-runner-linux-x64.tar.gz -L \
+  "https://github.com/actions/runner/releases/download/v${RUNNER_VERSION}/actions-runner-linux-x64-${RUNNER_VERSION}.tar.gz"
+tar xzf actions-runner-linux-x64.tar.gz
+
+./config.sh \
+  --url https://github.com/dsocial118/SISOC \
+  --token <TOKEN_REGISTRO> \
+  --name sisoc-<entorno> \
+  --labels sisoc-<entorno> \
+  --unattended
+```
+
+Usar el label final segun entorno:
+
+| Entorno | `--name` sugerido | `--labels` |
+| --- | --- | --- |
+| QA | `sisoc-qa` | `sisoc-qa` |
+| Homologacion | `sisoc-homologacion` | `sisoc-homologacion` |
+| Produccion | `sisoc-produccion` | `sisoc-produccion` |
+
+Instalar y arrancar como servicio:
+
+```bash
+sudo ./svc.sh install sisoc-deploy
+sudo ./svc.sh start
+sudo ./svc.sh status
+```
+
+## Permisos locales del runner
+
+El usuario del runner debe tener:
+
+- pertenencia al grupo `docker` o permisos equivalentes para ejecutar `docker compose`;
+- permisos de lectura/escritura sobre `APP_ROOT`;
+- acceso Git al remoto con la deploy key `github-sisoc`;
+- `.env` real del entorno presente en `APP_ROOT` con permisos `600`;
+- branch correcta para el entorno (`development`, `homologacion` o `main`).
+
+Validacion minima en cada servidor:
+
+```bash
+id sisoc-deploy
+docker compose version
+git -C "$APP_ROOT" branch --show-current
+git -C "$APP_ROOT" rev-parse --short HEAD
+git -C "$APP_ROOT" remote -v
+test -f "$APP_ROOT/.env" && ls -l "$APP_ROOT/.env"
+```
+
+## Configurar GitHub
+
+Crear los Environments del repositorio:
+
+- `qa`
+- `homologacion`
+- `production`
+
+En cada Environment, crear la variable:
+
+```text
+APP_ROOT=<ruta-real-del-checkout>
+```
+
+No hardcodear una ruta global: los servidores existentes pueden usar rutas distintas, por ejemplo `/opt/sisoc/SISOC` o `/opt/ssies/SISOC-Backoffice`.
+
+En `production`, configurar Required reviewers. Esa regla materializa la aprobacion manual antes de que el job de produccion corra en el runner self-hosted.
+
+## Seguridad
+
+- Solo `.github/workflows/deploy.yml` debe usar estos runners self-hosted.
+- No correr workflows de PR ni jobs que ejecuten codigo no confiable en los runners de deploy.
+- Registrar cada runner solo en el repositorio `dsocial118/SISOC`, no a nivel organizacion, salvo decision explicita de infraestructura.
+- No commitear secretos ni `.env` reales. Los `.env` viven en cada servidor con `chmod 600`.
+- Rotar tokens de registro inmediatamente si se exponen durante la instalacion.
+- Mantener el acceso SSH/VPN segun el modelo actual; el runner elimina la necesidad de SSH manual desde GitHub, no abre los servidores a Internet.
+
+## Rollback
+
+El rollback sigue el procedimiento actual documentado en `docs/operacion/infraestructura.md`, seccion 9:
+
+- volver al ultimo tag estable o commit acordado;
+- restaurar backup de DB si el cambio lo requiere;
+- ejecutar el deploy operativo del entorno.
+
+Cada ejecucion del workflow registra el commit que estaba desplegado antes del refresh (`git rev-parse HEAD`). Ese valor sirve como referencia rapida para volver al commit previo si el tag estable no alcanza o si se necesita reconstruir la secuencia del incidente.
+
+## Fallas frecuentes
+
+| Sintoma | Causa probable | Accion |
+| --- | --- | --- |
+| El job queda en cola | Runner offline o label incorrecto | Revisar `svc.sh status`, conectividad VPN/local y labels del runner |
+| Falla `APP_ROOT no esta configurado` | Falta variable del Environment | Definir `APP_ROOT` en `qa`, `homologacion` o `production` |
+| Falla por branch esperada | Checkout local en branch equivocada | Corregir branch en el servidor o revisar el mapping del entorno |
+| Falla `git pull --ff-only` | Historial local divergio | Resolver manualmente en el servidor; no usar merge automatico en el runner |
+| Falla Docker | Usuario sin grupo `docker` o daemon detenido | Revisar `id`, `systemctl status docker` y `docker compose version` |

--- a/docs/registro/cambios/2026-07-08-deploy-automatizado-selfhosted.md
+++ b/docs/registro/cambios/2026-07-08-deploy-automatizado-selfhosted.md
@@ -1,0 +1,41 @@
+# Deploy automatizado con self-hosted runners
+
+Fecha: 2026-07-08
+
+## Cambio
+
+Se agrego un workflow de GitHub Actions para desplegar automaticamente QA, homologacion y produccion desde runners self-hosted instalados en cada servidor de aplicacion.
+
+El flujo queda atado a las branches operativas:
+
+- `development` despliega `qa`;
+- `homologacion` despliega `homologacion`;
+- `main` despliega `production`.
+
+Cada job corre con labels estaticos del entorno y delega en `scripts/operacion/deploy_refresh.sh --yes` dentro del checkout local del servidor.
+
+## Decision
+
+No se usa `actions/checkout` porque el deploy debe operar sobre el checkout provisionado del servidor, con su `.env`, deploy key y permisos locales.
+
+`APP_ROOT` se resuelve desde una variable del GitHub Environment para no fijar una ruta unica de servidor. Si no existe, el workflow falla antes de ejecutar el deploy.
+
+La aprobacion manual de produccion se traslada a GitHub Environments mediante Required reviewers en `production`.
+
+## Impacto operativo
+
+- El deploy manual por SSH queda reemplazado por push a la branch del entorno y, en produccion, aprobacion del Environment.
+- Los servidores siguen sin exponerse a runners cloud: cada runner ejecuta localmente dentro de la red/VPN existente.
+- El rollback conserva el procedimiento actual: tag estable y backup de DB, con el commit previo al refresh logueado por el workflow.
+
+## Validacion esperada
+
+- Sintaxis YAML del workflow.
+- Primer deploy controlado en `qa` validando que el runner tenga permisos Docker, acceso a `APP_ROOT`, deploy key `github-sisoc` y variable `APP_ROOT` definida.
+
+## Riesgos
+
+- Si el checkout local no esta en la branch esperada para el `ENVIRONMENT`, `deploy_refresh.sh` bloquea el deploy.
+- Si un runner esta offline o mal etiquetado, el job queda en cola.
+- Si `APP_ROOT` apunta a un checkout incorrecto, el deploy puede operar sobre otro repo; revisar la variable por Environment antes de habilitarlo.
+- Si se habilitan workflows de PR sobre estos runners, codigo no confiable podria ejecutarse en servidores internos; mantenerlos exclusivos para `deploy.yml`.


### PR DESCRIPTION
## Contexto

El deploy a QA/homologación/producción hoy es **100% manual por SSH** (ver `docs/operacion/infraestructura.md` §9). Los servidores son self-hosted, con IPs internas detrás de VPN (GlobalProtect), inalcanzables desde los runners cloud de GitHub. Ese es el bloqueo que impedía automatizar.

## Solución

Un **self-hosted runner por servidor de entorno**. El runner abre conexión **saliente** a GitHub (HTTPS 443), así que **no requiere acceso entrante** — la VPN/firewall dejan de importar, sin credenciales de GlobalProtect en GitHub ni SSH expuesto. Al mergear a la rama del entorno, el workflow corre `runs-on: self-hosted` y ejecuta localmente el `scripts/operacion/deploy_refresh.sh` que ya existe.

## Cambios

- **`.github/workflows/deploy.yml`** — 3 jobs por rama/label:
  - `development` → `qa` (`self-hosted, sisoc-qa`)
  - `homologacion` → `homologacion` (`self-hosted, sisoc-homologacion`)
  - `main` → `production` (`self-hosted, sisoc-produccion`, con aprobación manual vía Environment)
  - Sin `actions/checkout` (usa el checkout provisionado del server); `APP_ROOT` desde `vars.APP_ROOT`; `concurrency` por ref; loguea el commit previo para rollback.
- **`docs/operacion/deploy_automatizado.md`** — runbook: instalación del runner, permisos, Environments, seguridad, rollback, fallas frecuentes.
- **`docs/registro/cambios/2026-07-08-deploy-automatizado-selfhosted.md`** — registro del cambio de arquitectura.

## Requisitos operativos (post-merge, no incluidos en el diff)

1. Definir `APP_ROOT` real por Environment (unificar `/opt/sisoc/SISOC` vs `/opt/ssies/...`).
2. Instalar el runner en cada server (usuario en grupo `docker`, deploy key `github-sisoc`) con su label.
3. Crear Environments `qa`/`homologacion`/`production`, con **Required reviewer en `production`**.
4. Validar primero en **QA** antes de habilitar prod.

## Notas

- Solo `deploy.yml` usa self-hosted; el resto del CI sigue en runners cloud.
- No modifica `deploy_refresh.sh` ni workflows existentes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)