### PR TITLE
docs(predeploy): preparar corte development main 2026-07-08

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -215,7 +215,9 @@ jobs:
                       const passConclusions = new Set(["success", "neutral", "skipped"]);
 
                       const sleep = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
-                      const maxAttempts = 40;
+                      // PRs hacia main esperan workflows externos (lint y release_sanity)
+                      // que pueden durar mas que los jobs propios de este workflow.
+                      const maxAttempts = 120;
                       const waitMs = 15000;
 
                       let checkRuns = [];

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,31 @@
 <!-- AUTO-GENERATED RELEASE START: 2026-07-08 -->
 # Versión SISOC 08.07.2026
 
+## Nuevas Funcionalidades
+
+- [ocr] Se incorpora el módulo OCR con carga de documentos, jobs de procesamiento, pre/postprocesamiento, métricas de evaluación, opciones de orientación/capa de texto y cobertura de servicios/vistas. (PR #2019)
+- [insumos] Se agrega el submódulo de insumos para comedores, con ABM de categorías e insumos, permisos propios, validaciones y tests de acceso. (PR #1989)
+- [pwa] La PWA suma prestaciones/conformidad por períodos, comunicados segmentados por organizaciones y mejoras de nómina vigente. (PRs #1996, #2004)
+- [usuarios] El importador masivo pasa a resolver usuarios por username, email opcional y agrupamiento de credenciales, con asignación de organizaciones/comedores y permisos PWA. (PRs #1980, #1985, #1994, #1995, #2002, #2012)
+- [dashboard] Los tableros incorporan agrupación por programa y visibilidad de Espacios Comunitarios en el menú lateral. (PRs #2008, #2019)
+
 ## Actualizaciones
 
-- [sin-area] hotfix. (PR #1997)
-- [sin-area] hotfix. (PR #1998)
+- [infraestructura] Se agrega deploy automatizado por entorno con runners self-hosted, runbook operativo y ajustes Docker/entrypoint para ejecución por rol. (PR #2020)
+- [docs] Se incorpora `AGENT_REPO_MAP.md`, documentación OCR, registros spec-as-source y artefactos de continuidad para el corte. (PRs #1963, #2019, #2020)
+- [VAT] Se consolidan permisos/perfiles, restricciones INET_PROVINCIA, detalle de curso solo lectura, panel/modal de lista de espera y ocultamiento de datos administrativos para operadores CFP. (PRs #2007, #2019)
+- [Celiaquía] Se refuerza padrón final, reporter por provincias, soft-delete de cupos, señales y saneamiento operativo de expedientes. (PRs #1988, #2003)
+- [Comedores] Se ajustan prestaciones PNUD, exportación con permisos, serializers/API, convenio, listados y utilidades de RENAPER. (PRs #1964, #2019)
+- [Admisiones] Se agregan personas conveniadas, vigencia PWA, reparaciones de columnas históricas y mejoras de técnicos/rendiciones. (PR #2019)
+- [Ver para Ser Libre] Se actualizan permisos globales de itinerarios, UI de jornadas/sedes/itinerarios y flujos de eliminación. (PRs #1960, #2019)
+
+## Corrección de Errores
+
+- [predeploy] Se normaliza `docker-compose.produccion.yml` para eliminar una línea en blanco final que hacía fallar `git diff --check`.
+- [usuarios] Se evita crear accesos PWA fantasma al actualizar/importar usuarios y se preserva el username existente. (PR #2012)
+- [Celiaquía] La nómina de aprobados se genera desde base y se corrigen conflictos/regresiones detectadas en el flujo de padrón final. (PR #2003)
+- [PWA] Se corrigen hallazgos de review sobre tope cero, carrera de `vigente_pwa`, gating y CI. (PR #2004)
+- [sidebar] Se estabiliza el menú lateral y la limpieza de `grupo_menu` sin cambiar el algoritmo de agrupación. (PR #2008)
 <!-- AUTO-GENERATED RELEASE END: 2026-07-08 -->
 
 <!-- AUTO-GENERATED RELEASE START: 2026-06-24 -->

--- a/docker-compose.produccion.yml
+++ b/docker-compose.produccion.yml
@@ -54,4 +54,3 @@ services:
       - .:/sisoc/
     user: "${RUN_UID:-0}:${RUN_GID:-0}"
     restart: unless-stopped
-

--- a/docs/registro/cambios/2026-07-08-predeploy-development-main.md
+++ b/docs/registro/cambios/2026-07-08-predeploy-development-main.md
@@ -1,0 +1,48 @@
+# 2026-07-08 - Predeploy development a main
+
+## Contexto
+
+Se preparó el corte `development -> main` desde una worktree aislada basada en
+`origin/development`, comparando el diff real contra `origin/main`.
+
+El corte incluye 242 archivos modificados (+18.543 / -1.736) y cambios
+transversales en OCR, insumos, PWA, usuarios, VAT, Celiaquía, Comedores,
+Admisiones, Dashboard, Ver para Ser Libre, documentación e infraestructura de
+deploy.
+
+## Cambios de saneamiento
+
+- Se actualizó el bloque superior de `CHANGELOG.md` con fecha `2026-07-08` para
+  reflejar las implementaciones que viajan en el PR final `development -> main`,
+  en lugar de las notas incompletas de los hotfixes ya publicados en `main`.
+- Se eliminó una línea en blanco final de `docker-compose.produccion.yml` que
+  hacía fallar `git diff --check` para el rango `origin/main...origin/development`.
+
+## Impacto
+
+El saneamiento no agrega reglas de negocio nuevas. El release sí incorpora
+funcionalidad nueva y cambios operativos: módulo OCR, submódulo de insumos,
+prestaciones y comunicados PWA, mejoras del importador masivo de usuarios,
+permisos y vistas VAT, ajustes de Celiaquía, exportaciones de Comedores,
+tableros agrupados e infraestructura de deploy automatizado por entorno.
+
+## Riesgos operativos
+
+- El release incluye migraciones nuevas en `admisiones`, `comedores`,
+  `comunicados`, `dashboard`, `insumos`, `ocr`, `users` y
+  `ver_para_ser_libre`; ejecutar migraciones con backup y ventana controlada.
+- `users.0039_reconcile_vat_admin_groups` toca permisos/grupos VAT; validar
+  grupos operativos después del deploy.
+- La nueva infraestructura de deploy usa runners self-hosted y `APP_ROOT` por
+  environment; confirmar variables y permisos del runner antes de promover.
+- OCR agrega dependencias del sistema y procesamiento de archivos; validar
+  binarios/runtime del host productivo antes de habilitar operación intensiva.
+- PWA, usuarios y permisos tienen cambios acoplados; validar con usuarios reales
+  de organización, comedor, staff y perfiles provinciales.
+
+## Validación esperada
+
+- `git diff --check origin/main...HEAD`
+- `docker compose --env-file .env.example config --services`
+- Checks de GitHub Actions del PR final a `main`: lint, tests, architecture,
+  secrets, PR docs y release sanity.


### PR DESCRIPTION
## Resumen

Predeploy de saneamiento para dejar `development` en condiciones de promoción a `main`.

## Cambios

- Actualiza el bloque superior de `CHANGELOG.md` para representar el corte real `development -> main` del 2026-07-08, no sólo las notas incompletas de hotfixes ya publicados.
- Agrega registro spec-as-source del predeploy en `docs/registro/cambios/2026-07-08-predeploy-development-main.md`.
- Elimina una línea en blanco final en `docker-compose.produccion.yml` que hacía fallar el chequeo de whitespace del rango completo.
- Amplía la espera de `deploy_guard` de 10 a 30 minutos para PRs grandes a `main`, porque el guard depende de workflows externos como lint y `release_sanity`.

## Pruebas ejecutadas

- `git diff --check origin/main`
- `git diff --check origin/development`
- `docker compose --env-file .env.example config --services` -> `django`, `mysql`, `ocr_worker`
- Checks de GitHub Actions de este PR #2021 -> verdes: `architecture_imports`, `gitleaks`, `sync_pr_artifacts`, `autofix`, `encoding_check`, `black`, `djlint`, `pylint`, `smoke`, `migrations_check`, `mysql_compat`, `pytest`, `deploy_guard`, `CodeQL`.
- Verificación de #2022: `release_sanity` y `djlint` terminaron en `SUCCESS`; el `deploy_guard` inicial falló por timeout y el rerun pasó tras completar esos checks.

## Riesgos remanentes

- El PR final `development -> main` debe esperar que este PR sea mergeado para incluir el saneamiento y el fix de `deploy_guard`.
- El release completo incluye migraciones y cambios operativos; mantener validación post-merge en el PR draft `development -> main`.
- El chequeo estático local de migraciones por AST fue descartado como gate porque no interpreta correctamente migraciones squashed/replaced históricas del repo.