### PR TITLE
ci(deploy): habilitar CD self-hosted en main

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,82 @@
+name: Despliegue automatizado
+
+on:
+    push:
+        branches:
+            - development
+            - homologacion
+            - main
+
+permissions: { contents: read }
+
+concurrency: { group: "deploy-${{ github.ref }}", cancel-in-progress: false }
+
+jobs:
+    deploy-qa:
+        if: github.ref == 'refs/heads/development'
+        environment: qa
+        runs-on: [self-hosted, sisoc-qa]
+
+        steps:
+            - name: Ejecutar deploy local de QA
+              shell: bash
+              env:
+                  GH_APP_ROOT: "${{ vars.APP_ROOT }}"
+              run: |
+                  set -Eeuo pipefail
+
+                  APP_ROOT="${GH_APP_ROOT:-${APP_ROOT:-}}"
+                  if [[ -z "$APP_ROOT" ]]; then
+                      echo "::error::APP_ROOT no esta configurado. Definir vars.APP_ROOT en el Environment qa o APP_ROOT en el servicio del runner."
+                      exit 1
+                  fi
+
+                  cd "$APP_ROOT"
+                  echo "Commit previo al deploy para rollback: $(git rev-parse HEAD)"
+                  ./scripts/operacion/deploy_refresh.sh --yes
+
+    deploy-homologacion:
+        if: github.ref == 'refs/heads/homologacion'
+        environment: homologacion
+        runs-on: [self-hosted, sisoc-homologacion]
+
+        steps:
+            - name: Ejecutar deploy local de homologacion
+              shell: bash
+              env:
+                  GH_APP_ROOT: "${{ vars.APP_ROOT }}"
+              run: |
+                  set -Eeuo pipefail
+
+                  APP_ROOT="${GH_APP_ROOT:-${APP_ROOT:-}}"
+                  if [[ -z "$APP_ROOT" ]]; then
+                      echo "::error::APP_ROOT no esta configurado. Definir vars.APP_ROOT en el Environment homologacion o APP_ROOT en el servicio del runner."
+                      exit 1
+                  fi
+
+                  cd "$APP_ROOT"
+                  echo "Commit previo al deploy para rollback: $(git rev-parse HEAD)"
+                  ./scripts/operacion/deploy_refresh.sh --yes
+
+    deploy-produccion:
+        if: github.ref == 'refs/heads/main'
+        environment: production
+        runs-on: [self-hosted, sisoc-produccion]
+
+        steps:
+            - name: Ejecutar deploy local de produccion
+              shell: bash
+              env:
+                  GH_APP_ROOT: "${{ vars.APP_ROOT }}"
+              run: |
+                  set -Eeuo pipefail
+
+                  APP_ROOT="${GH_APP_ROOT:-${APP_ROOT:-}}"
+                  if [[ -z "$APP_ROOT" ]]; then
+                      echo "::error::APP_ROOT no esta configurado. Definir vars.APP_ROOT en el Environment production o APP_ROOT en el servicio del runner."
+                      exit 1
+                  fi
+
+                  cd "$APP_ROOT"
+                  echo "Commit previo al deploy para rollback: $(git rev-parse HEAD)"
+                  ./scripts/operacion/deploy_refresh.sh --yes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+<!-- AUTO-GENERATED RELEASE START: 2026-07-15 -->
+# Versión SISOC 15.07.2026
+
+## Actualizaciones
+
+- [sin-area] ci(deploy): habilitar CD self-hosted en main. (PR #2024)
+<!-- AUTO-GENERATED RELEASE END: 2026-07-15 -->
+
 <!-- AUTO-GENERATED RELEASE START: 2026-07-08 -->
 # Versión SISOC 08.07.2026
 

--- a/docs/contexto/features/pr-2024-ci-deploy-habilitar-cd-self-hosted-en-main.md
+++ b/docs/contexto/features/pr-2024-ci-deploy-habilitar-cd-self-hosted-en-main.md
@@ -1,0 +1,43 @@
+# Contexto de feature PR #2024 - ci(deploy): habilitar CD self-hosted en main
+
+## Resumen
+
+- PR: https://github.com/dsocial118/SISOC/pull/2024
+- Base: `main`
+- Rama origen: `codex/deploy-workflow-main-20260708-220442`
+- Autor: `juanikitro`
+
+## Contexto funcional
+
+- No informado explícitamente; inferir desde el título del PR y el diff.
+
+## Arquitectura tocada
+
+- El alcance incluye automatización o tooling de CI/CD.
+
+## Decisiones y supuestos detectados
+
+- Tipo de cambio declarado: No informado
+- Área principal declarada: No informada
+- Impacto usuario declarado: No informado
+- Riesgos / rollback: No informado
+
+## Design system y UI
+
+- Sin cambios visibles de UI o design system detectados en el diff.
+
+## Memoria operativa para agentes
+
+- Empezar por `docs/registro/prs/PR-2024.md` para contexto resumido del PR.
+- Revisar primero estos archivos del diff:
+- `.github/workflows/deploy.yml`
+- Documentación sugerida para ampliar contexto:
+- `docs/indice.md`
+- `docs/ia/CONTEXT_HYGIENE.md`
+- `docs/ia/ARCHITECTURE.md`
+- `docs/ia/TESTING.md`
+
+## Trazabilidad
+
+- Documento generado automáticamente desde el evento de `pull_request`.
+- Si este PR cambia de título, el archivo se renombrará para mantener el slug alineado.

--- a/docs/registro/prs/PR-2024.md
+++ b/docs/registro/prs/PR-2024.md
@@ -1,0 +1,46 @@
+# PR #2024 - ci(deploy): habilitar CD self-hosted en main
+
+## Metadata
+
+- PR: https://github.com/dsocial118/SISOC/pull/2024
+- Base: `main`
+- Rama origen: `codex/deploy-workflow-main-20260708-220442`
+- Autor: `juanikitro`
+- Última actualización: `2026-07-09T01:04:55Z`
+
+## Resumen operativo
+
+- Tipo de cambio: No informado
+- Área principal: No informada
+- Contexto funcional: No informado explícitamente; revisar título, diff y documentación relacionada.
+- Resumen para changelog: No informado
+- Impacto usuario: No informado
+
+## Áreas afectadas
+
+- `.github/workflows`
+
+## Archivos relevantes del diff
+
+- `.github/workflows/deploy.yml`
+
+## Validación declarada
+
+- Pruebas automáticas: No informado en el PR.
+- Pruebas manuales: No informado en el PR.
+
+## Riesgos y rollback
+
+- No informado explícitamente en el PR.
+
+## Documentación sugerida para lectura
+
+- `docs/indice.md`
+- `docs/ia/CONTEXT_HYGIENE.md`
+- `docs/ia/ARCHITECTURE.md`
+- `docs/ia/TESTING.md`
+
+## Notas para continuidad
+
+- Este documento es generado automáticamente desde el contexto del PR y sirve como índice rápido para revisión y futuras sesiones de agentes.
+- Si la metadata del body del PR está incompleta, varias secciones usarán fallbacks derivados del título o del diff.

--- a/docs/registro/releases/pending/2026-07-15-pr-2024.md
+++ b/docs/registro/releases/pending/2026-07-15-pr-2024.md
@@ -1,0 +1,19 @@
+---
+pr: 2024
+release_date: 2026-07-15
+category: Actualizaciones
+area: sin-area
+title: ci(deploy): habilitar CD self-hosted en main
+summary: ci(deploy): habilitar CD self-hosted en main
+impact: No informado
+source_url: https://github.com/dsocial118/SISOC/pull/2024
+---
+# Release note preliminar PR #2024
+
+- Fecha objetivo de release: 2026-07-15
+- Categoría: Actualizaciones
+- Área: sin-area
+- Título del PR: ci(deploy): habilitar CD self-hosted en main
+- Resumen: ci(deploy): habilitar CD self-hosted en main
+- Impacto usuario: No informado
+- Fuente: https://github.com/dsocial118/SISOC/pull/2024


### PR DESCRIPTION
Agrega el workflow de deploy self-hosted ya validado en development para habilitar CD del environment main. No toca codigo de negocio.