### PR TITLE
ci(deploy): desplegar SISOC-Mobile con HML y PRD

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -56,7 +56,7 @@ jobs:
 
                   cd "$APP_ROOT"
                   echo "Commit previo al deploy para rollback: $(git rev-parse HEAD)"
-                  ./scripts/operacion/deploy_refresh.sh --yes
+                  ./scripts/operacion/deploy_refresh.sh --yes --with-mobile --mobile-dir /sisoc/SISOC-Mobile
 
     deploy-produccion:
         if: github.ref == 'refs/heads/main'
@@ -79,4 +79,4 @@ jobs:
 
                   cd "$APP_ROOT"
                   echo "Commit previo al deploy para rollback: $(git rev-parse HEAD)"
-                  ./scripts/operacion/deploy_refresh.sh --yes
+                  ./scripts/operacion/deploy_refresh.sh --yes --with-mobile --mobile-dir /sisoc/SISOC-Mobile

--- a/scripts/operacion/deploy_refresh.sh
+++ b/scripts/operacion/deploy_refresh.sh
@@ -36,6 +36,7 @@ Opciones:
   --mobile-dir PATH         Ruta del checkout SISOC-Mobile.
                             Default: ../SISOC-Mobile desde la raiz de SISOC.
                             Ejecuta scripts/operacion/deploy_refresh.sh de ese repo.
+                            SISOC-Mobile debe estar en branch main.
   -h, --help                Muestra esta ayuda.
 
 Mapeo por entorno:
@@ -219,7 +220,7 @@ configure_mobile() {
   [[ "$ALLOW_BRANCH_MISMATCH" -eq 1 ]] && MOBILE_ARGS+=(--allow-branch-mismatch)
   [[ "$SKIP_PULL" -eq 1 ]] && MOBILE_ARGS+=(--skip-pull)
 
-  ensure_clean_branch "$MOBILE_DIR" "" MOBILE_BRANCH "SISOC-Mobile"
+  ensure_clean_branch "$MOBILE_DIR" "${MOBILE_BRANCH:-main}" MOBILE_BRANCH "SISOC-Mobile"
 }
 
 main() {


### PR DESCRIPTION
Activa el deploy de /sisoc/SISOC-Mobile cuando corren los jobs self-hosted de homologacion y production. SISOC-Mobile se valida en branch main antes de ejecutar su deploy_refresh. QA queda sin cambios.