### PR TITLE
hotfix

### DIFF
--- a/VAT/management/commands/cerrar_comisiones_vencidas.py
+++ b/VAT/management/commands/cerrar_comisiones_vencidas.py
@@ -1,0 +1,86 @@
+"""
+Management command para cerrar comisiones cuya fecha de fin ya pasó.
+
+Cierra comisiones operativas (`ComisionCurso`) y de oferta institucional
+(`Comision`) en estado planificada/activa cuando `fecha_fin < hoy`.
+Las suspendidas no se tocan (decisión manual).
+
+Uso:
+    python manage.py cerrar_comisiones_vencidas --check    # muestra qué se cerraría
+    python manage.py cerrar_comisiones_vencidas --execute  # cierra las comisiones
+
+Cron (todos los días a la 01:00):
+    0 1 * * * cd /sisoc && python manage.py cerrar_comisiones_vencidas --execute
+"""
+
+import logging
+
+from django.core.management.base import BaseCommand
+from django.utils import timezone
+
+from VAT.services.comision_cierre_service import CierreComisionService
+
+logger = logging.getLogger("django")
+
+
+class Command(BaseCommand):
+    help = (
+        "Cierra comisiones (operativas y de oferta institucional) "
+        "con fecha de fin vencida."
+    )
+
+    def add_arguments(self, parser):
+        parser.add_argument(
+            "--check",
+            action="store_true",
+            help="Muestra qué se procesaría sin hacer cambios.",
+        )
+        parser.add_argument(
+            "--execute",
+            action="store_true",
+            help="Ejecuta el cierre.",
+        )
+
+    def handle(self, *args, **options):
+        check = options["check"]
+        execute = options["execute"]
+
+        if not check and not execute:
+            self.stdout.write(self.style.WARNING("Usá --check o --execute."))
+            return
+
+        hoy = timezone.localdate()
+
+        self._separador()
+        self.stdout.write(f"Cierre de comisiones vencidas — {hoy}")
+        self.stdout.write(f"Modo: {'VERIFICACIÓN' if check else 'EJECUCIÓN'}")
+        self._separador()
+
+        if check:
+            por_cerrar_curso = CierreComisionService.comisiones_curso_vencidas(hoy)
+            por_cerrar_oferta = CierreComisionService.comisiones_oferta_vencidas(hoy)
+            self.stdout.write(
+                f"→ {por_cerrar_curso.count()} comisiones de curso a cerrar"
+            )
+            self.stdout.write(
+                f"→ {por_cerrar_oferta.count()} comisiones de oferta a cerrar"
+            )
+            return
+
+        resultado = CierreComisionService.cerrar_comisiones_vencidas(hoy)
+
+        self._separador()
+        self.stdout.write(
+            self.style.SUCCESS(
+                f"Comisiones de curso cerradas: {resultado['comisiones_curso']}  |  "
+                f"Comisiones de oferta cerradas: {resultado['comisiones_oferta']}"
+            )
+        )
+        logger.info(
+            "cerrar_comisiones_vencidas: curso=%s oferta=%s",
+            resultado["comisiones_curso"],
+            resultado["comisiones_oferta"],
+        )
+
+    def _separador(self):
+        self.stdout.write("=" * 60)

--- a/VAT/serializers.py
+++ b/VAT/serializers.py
@@ -1515,6 +1515,7 @@ class VatWebInscripcionPrevalidacionVoucherSerializer(VatPlainSerializer):
 class VatWebInscripcionPrevalidacionResponseSerializer(VatPlainSerializer):
     puede_inscribirse = serializers.BooleanField()
     motivos = serializers.ListField(child=serializers.CharField())
+    avisos = serializers.ListField(child=serializers.CharField())
     ciudadano = VatWebInscripcionPrevalidacionCiudadanoSerializer()
     comision = VatWebInscripcionPrevalidacionComisionSerializer()
     voucher = VatWebInscripcionPrevalidacionVoucherSerializer()

--- a/VAT/services/comision_cierre_service.py
+++ b/VAT/services/comision_cierre_service.py
@@ -1,0 +1,53 @@
+"""Cierre automático de comisiones cuya fecha de fin ya pasó.
+
+Las comisiones no cambian de estado solas: este servicio concentra la regla
+que usa el management command `cerrar_comisiones_vencidas` (pensado para
+correr por cron diario) para cerrar las que quedaron con fecha de fin
+vencida. Complementa el bloqueo de inscripciones de
+`InscripcionService._comision_vencida`.
+"""
+
+from django.utils import timezone
+
+from VAT.models import Comision, ComisionCurso
+
+# "suspendida" es una decisión manual deliberada: no se cierra sola.
+ESTADOS_COMISION_CERRABLES = ("planificada", "activa")
+
+
+class CierreComisionService:
+    """Cierra comisiones operativas y de oferta institucional vencidas."""
+
+    @staticmethod
+    def comisiones_curso_vencidas(hoy=None):
+        hoy = hoy or timezone.localdate()
+        return ComisionCurso.objects.filter(
+            estado__in=ESTADOS_COMISION_CERRABLES,
+            fecha_fin__lt=hoy,
+        )
+
+    @staticmethod
+    def comisiones_oferta_vencidas(hoy=None):
+        hoy = hoy or timezone.localdate()
+        return Comision.objects.filter(
+            estado__in=ESTADOS_COMISION_CERRABLES,
+            fecha_fin__lt=hoy,
+        )
+
+    @staticmethod
+    def cerrar_comisiones_vencidas(hoy=None):
+        hoy = hoy or timezone.localdate()
+        # .update() no dispara auto_now: fecha_modificacion se setea explícito.
+        ahora = timezone.now()
+        cerradas_curso = CierreComisionService.comisiones_curso_vencidas(hoy).update(
+            estado="cerrada",
+            fecha_modificacion=ahora,
+        )
+        cerradas_oferta = CierreComisionService.comisiones_oferta_vencidas(hoy).update(
+            estado="cerrada",
+            fecha_modificacion=ahora,
+        )
+        return {
+            "comisiones_curso": cerradas_curso,
+            "comisiones_oferta": cerradas_oferta,
+        }

--- a/VAT/services/inscripcion_service.py
+++ b/VAT/services/inscripcion_service.py
@@ -25,6 +25,52 @@ ESTADOS_INSCRIPCION_OCUPAN_CUPO = (
     "validada_presencial",
 )
 
+MENSAJE_COMISION_VENCIDA = "La comisión ya finalizó y no admite nuevas inscripciones."
+
+# Mensajes expeditivos por estado de la unidad formativa (Curso u Oferta).
+MENSAJES_UNIDAD_FORMATIVA_NO_INSCRIBIBLE = {
+    "planificado": "El curso todavía no abrió la inscripción.",
+    "finalizado": "El curso ya finalizó: la inscripción está cerrada.",
+    "cancelado": "El curso fue cancelado: no admite inscripciones.",
+    "cerrada": "La oferta está cerrada: no admite inscripciones.",
+    "cancelada": "La oferta fue cancelada: no admite inscripciones.",
+}
+MENSAJE_UNIDAD_FORMATIVA_NO_ACTIVA = (
+    "El curso no se encuentra activo para nuevas inscripciones."
+)
+
+MENSAJES_COMISION_NO_INSCRIBIBLE = {
+    "planificada": "La comisión todavía no abrió la inscripción.",
+    "cerrada": "La inscripción a esta comisión está cerrada.",
+    "suspendida": (
+        "La comisión está suspendida: no admite inscripciones por el momento."
+    ),
+}
+MENSAJE_COMISION_NO_ACTIVA = (
+    "La comisión no se encuentra activa para nuevas inscripciones."
+)
+
+# Estados que bloquean el alta también en crear_inscripcion. "planificada"/
+# "planificado" solo bloquea la prevalidación pública: el backoffice permite
+# pre-inscribir en comisiones planificadas.
+ESTADOS_UNIDAD_FORMATIVA_CERRADOS = ("finalizado", "cancelado", "cerrada", "cancelada")
+ESTADOS_COMISION_CERRADOS = ("cerrada", "suspendida")
+
+MENSAJE_CUPO_COMPLETO_SIN_ESPERA = (
+    "No es posible inscribirse: el cupo está completo y la comisión "
+    "no tiene lista de espera."
+)
+MENSAJE_CUPO_Y_ESPERA_COMPLETOS = (
+    "No es posible inscribirse: el cupo está completo y la lista de espera también."
+)
+MENSAJE_LISTA_ESPERA_COMPLETA = (
+    "La lista de espera está completa: no es posible anotarse."
+)
+MENSAJE_CUPO_COMPLETO = "El cupo de la comisión está completo."
+AVISO_INGRESA_LISTA_ESPERA = (
+    "El cupo está completo: la inscripción ingresa en lista de espera."
+)
+
 
 class InscripcionService:
     """Orquesta altas de inscripción con validaciones de voucher."""
@@ -130,6 +176,11 @@ class InscripcionService:
     @staticmethod
     def _acepta_lista_espera(comision) -> bool:
         return bool(getattr(comision, "acepta_lista_espera", False))
+
+    @staticmethod
+    def _comision_vencida(comision) -> bool:
+        fecha_fin = getattr(comision, "fecha_fin", None)
+        return bool(fecha_fin) and fecha_fin < timezone.localdate()
 
     @staticmethod
     def _resolver_cupo_lista_espera(comision) -> int:
@@ -350,25 +401,38 @@ class InscripcionService:
             and cupos_lista_espera_disponibles > 0
         )
         motivos: list[str] = []
+        avisos: list[str] = []
 
         if unidad_formativa.estado != "activo":
-            motivos.append("El curso no se encuentra activo para nuevas inscripciones.")
+            motivos.append(
+                MENSAJES_UNIDAD_FORMATIVA_NO_INSCRIBIBLE.get(
+                    unidad_formativa.estado, MENSAJE_UNIDAD_FORMATIVA_NO_ACTIVA
+                )
+            )
 
         if comision.estado != "activa":
             motivos.append(
-                "La comisión no se encuentra activa para nuevas inscripciones."
+                MENSAJES_COMISION_NO_INSCRIBIBLE.get(
+                    comision.estado, MENSAJE_COMISION_NO_ACTIVA
+                )
             )
+
+        if InscripcionService._comision_vencida(comision):
+            motivos.append(MENSAJE_COMISION_VENCIDA)
+
+        if pasa_a_lista_espera:
+            avisos.append(AVISO_INGRESA_LISTA_ESPERA)
 
         if cupos_disponibles <= 0 and not InscripcionService._acepta_lista_espera(
             comision
         ):
-            motivos.append("La comisión no tiene cupos disponibles.")
+            motivos.append(MENSAJE_CUPO_COMPLETO_SIN_ESPERA)
         elif (
             cupos_disponibles <= 0
             and InscripcionService._acepta_lista_espera(comision)
             and cupos_lista_espera_disponibles <= 0
         ):
-            motivos.append("La lista de espera no tiene cupos disponibles.")
+            motivos.append(MENSAJE_CUPO_Y_ESPERA_COMPLETOS)
 
         if programa is None:
             motivos.append(
@@ -450,6 +514,7 @@ class InscripcionService:
         return {
             "puede_inscribirse": not motivos,
             "motivos": motivos,
+            "avisos": avisos,
             "ciudadano": {
                 "id": ciudadano.id,
                 "documento": ciudadano.documento,
@@ -498,6 +563,19 @@ class InscripcionService:
         )
         programa = programa or unidad_formativa.programa
 
+        if InscripcionService._comision_vencida(comision):
+            raise ValueError(MENSAJE_COMISION_VENCIDA)
+
+        estado_unidad_formativa = getattr(unidad_formativa, "estado", None)
+        if estado_unidad_formativa in ESTADOS_UNIDAD_FORMATIVA_CERRADOS:
+            raise ValueError(
+                MENSAJES_UNIDAD_FORMATIVA_NO_INSCRIBIBLE[estado_unidad_formativa]
+            )
+
+        estado_comision = getattr(comision, "estado", None)
+        if estado_comision in ESTADOS_COMISION_CERRADOS:
+            raise ValueError(MENSAJES_COMISION_NO_INSCRIBIBLE[estado_comision])
+
         if programa is None and not getattr(
             unidad_formativa, "inscripcion_libre", False
         ):
@@ -544,12 +622,10 @@ class InscripcionService:
                             )
                             <= 0
                         ):
-                            raise ValueError(
-                                "La lista de espera no tiene cupos disponibles."
-                            )
+                            raise ValueError(MENSAJE_CUPO_Y_ESPERA_COMPLETOS)
                         estado_final = "en_espera"
                     else:
-                        raise ValueError("La comisión no tiene cupos disponibles.")
+                        raise ValueError(MENSAJE_CUPO_COMPLETO_SIN_ESPERA)
             elif estado == "en_espera" and not InscripcionService._acepta_lista_espera(
                 comision_locked
             ):
@@ -561,7 +637,7 @@ class InscripcionService:
                     )
                     <= 0
                 ):
-                    raise ValueError("La lista de espera no tiene cupos disponibles.")
+                    raise ValueError(MENSAJE_LISTA_ESPERA_COMPLETA)
 
             inscripcion_kwargs = {
                 "ciudadano": ciudadano,
@@ -635,7 +711,7 @@ class InscripcionService:
                     comision_locked
                 )
                 if cupos_disponibles <= 0:
-                    raise ValueError("La comisión no tiene cupos disponibles.")
+                    raise ValueError(MENSAJE_CUPO_COMPLETO)
 
             if unidad_formativa.usa_voucher and pasa_a_ocupar_cupo and not ocupaba_cupo:
                 cantidad_debito = InscripcionService._resolver_cantidad_debito(
@@ -676,6 +752,18 @@ class InscripcionService:
         inscrito_por=None,
     ):
         oferta = comision.oferta
+
+        if InscripcionService._comision_vencida(comision):
+            raise ValueError(MENSAJE_COMISION_VENCIDA)
+
+        estado_oferta = getattr(oferta, "estado", None)
+        if estado_oferta in ESTADOS_UNIDAD_FORMATIVA_CERRADOS:
+            raise ValueError(MENSAJES_UNIDAD_FORMATIVA_NO_INSCRIBIBLE[estado_oferta])
+
+        estado_comision = getattr(comision, "estado", None)
+        if estado_comision in ESTADOS_COMISION_CERRADOS:
+            raise ValueError(MENSAJES_COMISION_NO_INSCRIBIBLE[estado_comision])
+
         usuario_inscribe = InscripcionService._resolver_usuario_auditoria(inscrito_por)
         if usuario_inscribe is None:
             raise ValueError("No hay usuario disponible para registrar la inscripción.")

--- a/VAT/tests.py
+++ b/VAT/tests.py
@@ -67,6 +67,14 @@ from VAT.services.access_scope import (
     is_vat_sse,
 )
 from VAT.services import nomina_export
+from VAT.services.inscripcion_service import (
+    AVISO_INGRESA_LISTA_ESPERA,
+    MENSAJE_COMISION_VENCIDA,
+    MENSAJE_CUPO_COMPLETO_SIN_ESPERA,
+    MENSAJES_COMISION_NO_INSCRIBIBLE,
+    MENSAJES_UNIDAD_FORMATIVA_NO_INSCRIBIBLE,
+    InscripcionService,
+)
 from ciudadanos.models import Ciudadano
 from core.models import Dia, Localidad, Municipio, Provincia, Programa, Sexo
 from users.models import Profile, ProfileTerritorialScope
@@ -5306,8 +5314,8 @@ def test_api_vat_inscripciones_curso_crea_inscripcion_en_comision_curso(
         codigo_comision="API-INS-CURSO-01",
         nombre="Comisión API Inscripción",
         cupo_total=20,
-        fecha_inicio=date(2026, 5, 1),
-        fecha_fin=date(2026, 6, 1),
+        fecha_inicio=timezone.localdate() - timedelta(days=30),
+        fecha_fin=timezone.localdate() + timedelta(days=30),
         estado="activa",
     )
     ciudadano = Ciudadano.objects.create(
@@ -5338,6 +5346,458 @@ def test_api_vat_inscripciones_curso_crea_inscripcion_en_comision_curso(
         ciudadano=ciudadano,
         comision_curso=comision,
     ).exists()
+
+
+@pytest.mark.django_db
+def test_api_vat_inscripciones_curso_rechaza_comision_con_fecha_vencida(
+    vat_api_client, vat_curso_base
+):
+    centro, ubicacion, modalidad = vat_curso_base
+    sexo = Sexo.objects.create(sexo="No Binario")
+    curso = Curso.objects.create(
+        centro=centro,
+        nombre="Curso Comisión Vencida",
+        modalidad=modalidad,
+        estado="activo",
+        inscripcion_libre=True,
+    )
+    comision = ComisionCurso.objects.create(
+        curso=curso,
+        ubicacion=ubicacion,
+        codigo_comision="API-INS-VENC-01",
+        nombre="Comisión Vencida",
+        cupo_total=20,
+        fecha_inicio=timezone.localdate() - timedelta(days=60),
+        fecha_fin=timezone.localdate() - timedelta(days=1),
+        estado="activa",
+    )
+    ciudadano = Ciudadano.objects.create(
+        apellido="API",
+        nombre="Vencida",
+        fecha_nacimiento=date(2000, 1, 1),
+        tipo_documento=Ciudadano.DOCUMENTO_DNI,
+        documento=40111333,
+        sexo=sexo,
+    )
+
+    response = vat_api_client.post(
+        "/api/vat/inscripciones-curso/",
+        {
+            "ciudadano": ciudadano.id,
+            "comision_curso": comision.id,
+            "estado": "inscripta",
+            "origen_canal": "api",
+        },
+        format="json",
+    )
+
+    assert response.status_code == 400
+    assert response.json() == {"error": [MENSAJE_COMISION_VENCIDA]}
+    assert not Inscripcion.objects.filter(
+        ciudadano=ciudadano,
+        comision_curso=comision,
+    ).exists()
+
+
+@pytest.mark.django_db
+def test_prevalidar_inscripcion_informa_comision_con_fecha_vencida(vat_curso_base):
+    centro, ubicacion, modalidad = vat_curso_base
+    sexo = Sexo.objects.create(sexo="No Binario")
+    curso = Curso.objects.create(
+        centro=centro,
+        nombre="Curso Prevalidar Vencida",
+        modalidad=modalidad,
+        estado="activo",
+        inscripcion_libre=True,
+    )
+    comision = ComisionCurso.objects.create(
+        curso=curso,
+        ubicacion=ubicacion,
+        codigo_comision="PREV-VENC-01",
+        nombre="Comisión Prevalidar Vencida",
+        cupo_total=20,
+        fecha_inicio=timezone.localdate() - timedelta(days=60),
+        fecha_fin=timezone.localdate() - timedelta(days=1),
+        estado="activa",
+    )
+    ciudadano = Ciudadano.objects.create(
+        apellido="Prevalidar",
+        nombre="Vencida",
+        fecha_nacimiento=date(2000, 1, 1),
+        tipo_documento=Ciudadano.DOCUMENTO_DNI,
+        documento=40111444,
+        sexo=sexo,
+    )
+
+    resultado = InscripcionService.prevalidar_inscripcion(
+        ciudadano=ciudadano,
+        comision=comision,
+    )
+
+    assert resultado["puede_inscribirse"] is False
+    assert MENSAJE_COMISION_VENCIDA in resultado["motivos"]
+
+
+@pytest.mark.django_db
+def test_crear_inscripcion_permite_comision_que_finaliza_hoy(vat_curso_base):
+    centro, ubicacion, modalidad = vat_curso_base
+    sexo = Sexo.objects.create(sexo="No Binario")
+    curso = Curso.objects.create(
+        centro=centro,
+        nombre="Curso Finaliza Hoy",
+        modalidad=modalidad,
+        estado="activo",
+        inscripcion_libre=True,
+    )
+    comision = ComisionCurso.objects.create(
+        curso=curso,
+        ubicacion=ubicacion,
+        codigo_comision="FIN-HOY-01",
+        nombre="Comisión Finaliza Hoy",
+        cupo_total=20,
+        fecha_inicio=timezone.localdate() - timedelta(days=60),
+        fecha_fin=timezone.localdate(),
+        estado="activa",
+    )
+    ciudadano = Ciudadano.objects.create(
+        apellido="Finaliza",
+        nombre="Hoy",
+        fecha_nacimiento=date(2000, 1, 1),
+        tipo_documento=Ciudadano.DOCUMENTO_DNI,
+        documento=40111555,
+        sexo=sexo,
+    )
+
+    inscripcion = InscripcionService.crear_inscripcion(
+        ciudadano=ciudadano,
+        comision=comision,
+        estado="inscripta",
+    )
+
+    assert inscripcion.pk is not None
+    assert inscripcion.estado == "inscripta"
+
+
+def _crear_ciudadano_mensajes(documento):
+    sexo = Sexo.objects.create(sexo=f"Sexo Mensajes {documento}")
+    return Ciudadano.objects.create(
+        apellido="Mensajes",
+        nombre="Expeditivos",
+        fecha_nacimiento=date(2000, 1, 1),
+        tipo_documento=Ciudadano.DOCUMENTO_DNI,
+        documento=documento,
+        sexo=sexo,
+    )
+
+
+def _crear_comision_mensajes(
+    curso, ubicacion, codigo, estado="activa", cupo_total=10, **kwargs
+):
+    return ComisionCurso.objects.create(
+        curso=curso,
+        ubicacion=ubicacion,
+        codigo_comision=codigo,
+        nombre=f"Comisión {codigo}",
+        cupo_total=cupo_total,
+        fecha_inicio=timezone.localdate() - timedelta(days=30),
+        fecha_fin=timezone.localdate() + timedelta(days=30),
+        estado=estado,
+        **kwargs,
+    )
+
+
+@pytest.mark.django_db
+def test_prevalidar_inscripcion_mensajes_expeditivos_por_estado(vat_curso_base):
+    centro, ubicacion, modalidad = vat_curso_base
+    curso = Curso.objects.create(
+        centro=centro,
+        nombre="Curso Finalizado Mensajes",
+        modalidad=modalidad,
+        estado="finalizado",
+        inscripcion_libre=True,
+    )
+    comision = _crear_comision_mensajes(
+        curso, ubicacion, "MSJ-EST-01", estado="cerrada"
+    )
+    ciudadano = _crear_ciudadano_mensajes(40222111)
+
+    resultado = InscripcionService.prevalidar_inscripcion(
+        ciudadano=ciudadano,
+        comision=comision,
+    )
+
+    assert resultado["puede_inscribirse"] is False
+    assert (
+        MENSAJES_UNIDAD_FORMATIVA_NO_INSCRIBIBLE["finalizado"] in resultado["motivos"]
+    )
+    assert MENSAJES_COMISION_NO_INSCRIBIBLE["cerrada"] in resultado["motivos"]
+
+
+@pytest.mark.django_db
+def test_prevalidar_inscripcion_avisa_ingreso_a_lista_espera(vat_curso_base):
+    centro, ubicacion, modalidad = vat_curso_base
+    curso = Curso.objects.create(
+        centro=centro,
+        nombre="Curso Aviso Espera",
+        modalidad=modalidad,
+        estado="activo",
+        inscripcion_libre=True,
+    )
+    comision = _crear_comision_mensajes(
+        curso,
+        ubicacion,
+        "MSJ-AVISO-01",
+        cupo_total=1,
+        acepta_lista_espera=True,
+        cupo_lista_espera=5,
+    )
+    programa = Programa.objects.create(nombre="Programa Aviso Espera")
+    titular = _crear_ciudadano_mensajes(40222112)
+    aspirante = _crear_ciudadano_mensajes(40222113)
+    Inscripcion.objects.create(
+        ciudadano=titular,
+        comision_curso=comision,
+        programa=programa,
+        estado="inscripta",
+        origen_canal="backoffice",
+    )
+
+    resultado = InscripcionService.prevalidar_inscripcion(
+        ciudadano=aspirante,
+        comision=comision,
+        programa=programa,
+    )
+
+    assert resultado["puede_inscribirse"] is True
+    assert resultado["motivos"] == []
+    assert resultado["avisos"] == [AVISO_INGRESA_LISTA_ESPERA]
+    assert resultado["comision"]["ingresa_a_lista_espera"] is True
+
+
+@pytest.mark.django_db
+def test_inscripcion_cupo_completo_sin_lista_espera_mensaje_expeditivo(vat_curso_base):
+    centro, ubicacion, modalidad = vat_curso_base
+    curso = Curso.objects.create(
+        centro=centro,
+        nombre="Curso Cupo Completo",
+        modalidad=modalidad,
+        estado="activo",
+        inscripcion_libre=True,
+    )
+    comision = _crear_comision_mensajes(curso, ubicacion, "MSJ-CUPO-01", cupo_total=1)
+    titular = _crear_ciudadano_mensajes(40222114)
+    aspirante = _crear_ciudadano_mensajes(40222115)
+    Inscripcion.objects.create(
+        ciudadano=titular,
+        comision_curso=comision,
+        estado="inscripta",
+        origen_canal="backoffice",
+    )
+
+    resultado = InscripcionService.prevalidar_inscripcion(
+        ciudadano=aspirante,
+        comision=comision,
+    )
+
+    assert resultado["puede_inscribirse"] is False
+    assert MENSAJE_CUPO_COMPLETO_SIN_ESPERA in resultado["motivos"]
+
+    with pytest.raises(ValueError) as exc_info:
+        InscripcionService.crear_inscripcion(
+            ciudadano=aspirante,
+            comision=comision,
+            estado="inscripta",
+        )
+
+    assert str(exc_info.value) == MENSAJE_CUPO_COMPLETO_SIN_ESPERA
+
+
+@pytest.mark.django_db
+def test_crear_inscripcion_rechaza_comision_cerrada_o_suspendida(vat_curso_base):
+    centro, ubicacion, modalidad = vat_curso_base
+    curso = Curso.objects.create(
+        centro=centro,
+        nombre="Curso Estados Cerrados",
+        modalidad=modalidad,
+        estado="activo",
+        inscripcion_libre=True,
+    )
+    cerrada = _crear_comision_mensajes(
+        curso, ubicacion, "MSJ-CERR-01", estado="cerrada"
+    )
+    suspendida = _crear_comision_mensajes(
+        curso, ubicacion, "MSJ-SUSP-01", estado="suspendida"
+    )
+    ciudadano = _crear_ciudadano_mensajes(40222116)
+
+    with pytest.raises(ValueError) as exc_cerrada:
+        InscripcionService.crear_inscripcion(
+            ciudadano=ciudadano,
+            comision=cerrada,
+            estado="inscripta",
+        )
+    assert str(exc_cerrada.value) == MENSAJES_COMISION_NO_INSCRIBIBLE["cerrada"]
+
+    with pytest.raises(ValueError) as exc_suspendida:
+        InscripcionService.crear_inscripcion(
+            ciudadano=ciudadano,
+            comision=suspendida,
+            estado="inscripta",
+        )
+    assert str(exc_suspendida.value) == MENSAJES_COMISION_NO_INSCRIBIBLE["suspendida"]
+
+    assert not Inscripcion.objects.filter(ciudadano=ciudadano).exists()
+
+
+@pytest.mark.django_db
+def test_crear_inscripcion_permite_comision_planificada(vat_curso_base):
+    centro, ubicacion, modalidad = vat_curso_base
+    curso = Curso.objects.create(
+        centro=centro,
+        nombre="Curso Planificado Preinscripcion",
+        modalidad=modalidad,
+        estado="activo",
+        inscripcion_libre=True,
+    )
+    comision = _crear_comision_mensajes(
+        curso, ubicacion, "MSJ-PLAN-01", estado="planificada"
+    )
+    ciudadano = _crear_ciudadano_mensajes(40222117)
+
+    inscripcion = InscripcionService.crear_inscripcion(
+        ciudadano=ciudadano,
+        comision=comision,
+        estado="pre_inscripta",
+    )
+
+    assert inscripcion.pk is not None
+    assert inscripcion.estado == "pre_inscripta"
+
+
+@pytest.mark.django_db
+def test_cerrar_comisiones_vencidas_cierra_solo_las_vencidas(
+    vat_geo_data, vat_curso_base
+):
+    provincia, _, _ = vat_geo_data
+    centro, ubicacion, modalidad = vat_curso_base
+    hoy = timezone.localdate()
+    curso = Curso.objects.create(
+        centro=centro,
+        nombre="Curso Cierre Automático",
+        modalidad=modalidad,
+        estado="activo",
+    )
+
+    def _comision_curso(codigo, estado, fecha_fin):
+        return ComisionCurso.objects.create(
+            curso=curso,
+            ubicacion=ubicacion,
+            codigo_comision=codigo,
+            nombre=f"Comisión {codigo}",
+            cupo_total=10,
+            fecha_inicio=fecha_fin - timedelta(days=30),
+            fecha_fin=fecha_fin,
+            estado=estado,
+        )
+
+    vencida_activa = _comision_curso(
+        "CIERRE-VENC-ACT", "activa", hoy - timedelta(days=1)
+    )
+    vencida_planificada = _comision_curso(
+        "CIERRE-VENC-PLAN", "planificada", hoy - timedelta(days=10)
+    )
+    vencida_suspendida = _comision_curso(
+        "CIERRE-VENC-SUSP", "suspendida", hoy - timedelta(days=1)
+    )
+    termina_hoy = _comision_curso("CIERRE-HOY", "activa", hoy)
+    vigente = _comision_curso("CIERRE-VIGENTE", "activa", hoy + timedelta(days=30))
+
+    sector = Sector.objects.create(nombre="Sector Cierre")
+    plan = PlanVersionCurricular.objects.create(
+        nombre="Plan Cierre",
+        provincia=provincia,
+        sector=sector,
+        modalidad_cursada=modalidad,
+        normativa="Resolución 1/2026",
+        horas_reloj=100,
+        nivel_requerido="sin_requisito",
+        nivel_certifica="nivel_1",
+        activo=True,
+    )
+    programa = Programa.objects.create(nombre="Programa Cierre")
+    oferta = OfertaInstitucional.objects.create(
+        centro=centro,
+        plan_curricular=plan,
+        programa=programa,
+        nombre_local="Oferta Cierre",
+        ciclo_lectivo=2026,
+        estado="publicada",
+    )
+    legacy_vencida = Comision.objects.create(
+        oferta=oferta,
+        ubicacion=ubicacion,
+        codigo_comision="CIERRE-LEG-VENC",
+        nombre="Comisión Legacy Vencida",
+        cupo=10,
+        fecha_inicio=hoy - timedelta(days=40),
+        fecha_fin=hoy - timedelta(days=1),
+        estado="activa",
+    )
+    legacy_vigente = Comision.objects.create(
+        oferta=oferta,
+        ubicacion=ubicacion,
+        codigo_comision="CIERRE-LEG-VIG",
+        nombre="Comisión Legacy Vigente",
+        cupo=10,
+        fecha_inicio=hoy - timedelta(days=10),
+        fecha_fin=hoy + timedelta(days=30),
+        estado="activa",
+    )
+
+    call_command("cerrar_comisiones_vencidas", "--execute")
+
+    vencida_activa.refresh_from_db()
+    vencida_planificada.refresh_from_db()
+    vencida_suspendida.refresh_from_db()
+    termina_hoy.refresh_from_db()
+    vigente.refresh_from_db()
+    legacy_vencida.refresh_from_db()
+    legacy_vigente.refresh_from_db()
+
+    assert vencida_activa.estado == "cerrada"
+    assert vencida_planificada.estado == "cerrada"
+    assert vencida_suspendida.estado == "suspendida"
+    assert termina_hoy.estado == "activa"
+    assert vigente.estado == "activa"
+    assert legacy_vencida.estado == "cerrada"
+    assert legacy_vigente.estado == "activa"
+
+
+@pytest.mark.django_db
+def test_cerrar_comisiones_vencidas_check_no_modifica(vat_curso_base):
+    centro, ubicacion, modalidad = vat_curso_base
+    hoy = timezone.localdate()
+    curso = Curso.objects.create(
+        centro=centro,
+        nombre="Curso Cierre Check",
+        modalidad=modalidad,
+        estado="activo",
+    )
+    comision = ComisionCurso.objects.create(
+        curso=curso,
+        ubicacion=ubicacion,
+        codigo_comision="CIERRE-CHECK-01",
+        nombre="Comisión Cierre Check",
+        cupo_total=10,
+        fecha_inicio=hoy - timedelta(days=40),
+        fecha_fin=hoy - timedelta(days=1),
+        estado="activa",
+    )
+
+    call_command("cerrar_comisiones_vencidas", "--check")
+
+    comision.refresh_from_db()
+    assert comision.estado == "activa"
 
 
 @pytest.mark.django_db
@@ -5564,8 +6024,8 @@ def test_api_vat_web_mi_argentina_flujo_completo_prevalidar_e_inscribir(
         codigo_comision="MIARG-01",
         nombre="Comisión Mi Argentina",
         cupo_total=12,
-        fecha_inicio=date(2026, 6, 1),
-        fecha_fin=date(2026, 7, 1),
+        fecha_inicio=timezone.localdate() - timedelta(days=30),
+        fecha_fin=timezone.localdate() + timedelta(days=30),
         estado="activa",
     )
     ciudadano = Ciudadano.objects.create(
@@ -5851,8 +6311,8 @@ def test_api_vat_web_inscripcion_libre_crea_inscripcion_operativa_sin_ciudadano(
         codigo_comision="LIBRE-01",
         nombre="Comisión Libre",
         cupo_total=20,
-        fecha_inicio=date(2026, 6, 1),
-        fecha_fin=date(2026, 7, 1),
+        fecha_inicio=timezone.localdate() - timedelta(days=30),
+        fecha_fin=timezone.localdate() + timedelta(days=30),
         estado="activa",
     )
 
@@ -5933,8 +6393,8 @@ def test_api_vat_web_inscripcion_libre_usa_cuil_como_documento_si_no_viene_docum
         codigo_comision="LIBRE-CUIL-01",
         nombre="Comisión Libre con CUIL",
         cupo_total=20,
-        fecha_inicio=date(2026, 6, 1),
-        fecha_fin=date(2026, 7, 1),
+        fecha_inicio=timezone.localdate() - timedelta(days=30),
+        fecha_fin=timezone.localdate() + timedelta(days=30),
         estado="activa",
     )
 
@@ -6081,8 +6541,8 @@ def test_api_vat_web_inscripciones_informa_lista_espera_si_no_hay_cupo(
         cupo_total=1,
         acepta_lista_espera=True,
         cupo_lista_espera=5,
-        fecha_inicio=date(2026, 6, 1),
-        fecha_fin=date(2026, 7, 1),
+        fecha_inicio=timezone.localdate() - timedelta(days=30),
+        fecha_fin=timezone.localdate() + timedelta(days=30),
         estado="activa",
     )
     titular = Ciudadano.objects.create(
@@ -6169,8 +6629,8 @@ def test_api_vat_web_inscripciones_crea_sobre_comision_curso(
         codigo_comision="WEB-INSC-01",
         nombre="Comisión Web Inscripción",
         cupo_total=10,
-        fecha_inicio=date(2026, 5, 10),
-        fecha_fin=date(2026, 6, 10),
+        fecha_inicio=timezone.localdate() - timedelta(days=30),
+        fecha_fin=timezone.localdate() + timedelta(days=30),
         estado="activa",
     )
     ciudadano = Ciudadano.objects.create(
@@ -8447,8 +8907,8 @@ def test_api_vat_inscripciones_curso_envia_a_lista_espera_si_no_hay_cupo(
         cupo_total=1,
         acepta_lista_espera=True,
         cupo_lista_espera=2,
-        fecha_inicio=date(2026, 5, 1),
-        fecha_fin=date(2026, 6, 1),
+        fecha_inicio=timezone.localdate() - timedelta(days=30),
+        fecha_fin=timezone.localdate() + timedelta(days=30),
         estado="activa",
     )
     titular = Ciudadano.objects.create(
@@ -8531,8 +8991,8 @@ def test_api_vat_inscripciones_curso_rechaza_lista_espera_sin_cupo_disponible(
         cupo_total=1,
         acepta_lista_espera=True,
         cupo_lista_espera=1,
-        fecha_inicio=date(2026, 5, 1),
-        fecha_fin=date(2026, 6, 1),
+        fecha_inicio=timezone.localdate() - timedelta(days=30),
+        fecha_fin=timezone.localdate() + timedelta(days=30),
         estado="activa",
     )
     titular = Ciudadano.objects.create(
@@ -8629,8 +9089,8 @@ def test_api_vat_web_prevalidar_permite_lista_espera_si_no_hay_cupo(
         cupo_total=1,
         acepta_lista_espera=True,
         cupo_lista_espera=5,
-        fecha_inicio=date(2026, 5, 10),
-        fecha_fin=date(2026, 6, 10),
+        fecha_inicio=timezone.localdate() - timedelta(days=30),
+        fecha_fin=timezone.localdate() + timedelta(days=30),
         estado="activa",
     )
     titular = Ciudadano.objects.create(
@@ -8672,6 +9132,7 @@ def test_api_vat_web_prevalidar_permite_lista_espera_si_no_hay_cupo(
     assert response.status_code == 200
     assert payload["puede_inscribirse"] is True
     assert payload["motivos"] == []
+    assert payload["avisos"] == [AVISO_INGRESA_LISTA_ESPERA]
     assert payload["comision"]["acepta_lista_espera"] is True
     assert payload["comision"]["ingresa_a_lista_espera"] is True
     assert payload["comision"]["cupos_disponibles"] == 0
@@ -8713,8 +9174,8 @@ def test_api_vat_web_prevalidar_permite_lista_espera_sin_voucher_si_no_hay_cupo(
         cupo_total=1,
         acepta_lista_espera=True,
         cupo_lista_espera=5,
-        fecha_inicio=date(2026, 5, 10),
-        fecha_fin=date(2026, 6, 10),
+        fecha_inicio=timezone.localdate() - timedelta(days=30),
+        fecha_fin=timezone.localdate() + timedelta(days=30),
         estado="activa",
     )
     titular = Ciudadano.objects.create(
@@ -8756,6 +9217,7 @@ def test_api_vat_web_prevalidar_permite_lista_espera_sin_voucher_si_no_hay_cupo(
     assert response.status_code == 200
     assert payload["puede_inscribirse"] is True
     assert payload["motivos"] == []
+    assert payload["avisos"] == [AVISO_INGRESA_LISTA_ESPERA]
     assert payload["comision"]["acepta_lista_espera"] is True
     assert payload["comision"]["ingresa_a_lista_espera"] is True
     assert payload["comision"]["cupos_disponibles"] == 0
@@ -8822,8 +9284,8 @@ def test_inscripcion_curso_no_permite_mover_de_inscripta_a_lista_espera(
         nombre="Comisión Bloqueo Espera",
         cupo_total=1,
         acepta_lista_espera=True,
-        fecha_inicio=date(2026, 4, 1),
-        fecha_fin=date(2026, 4, 30),
+        fecha_inicio=timezone.localdate() - timedelta(days=30),
+        fecha_fin=timezone.localdate() + timedelta(days=30),
         estado="activa",
     )
     ciudadano = Ciudadano.objects.create(
@@ -9069,8 +9531,8 @@ def test_inscripcion_rapida_comision_curso_crea_inscripcion(client, vat_geo_data
         codigo_comision="INSC-01",
         nombre="Comisión Inscriptos",
         cupo_total=20,
-        fecha_inicio=date(2026, 4, 1),
-        fecha_fin=date(2026, 4, 30),
+        fecha_inicio=timezone.localdate() - timedelta(days=30),
+        fecha_fin=timezone.localdate() + timedelta(days=30),
         estado="activa",
     )
     ciudadano = Ciudadano.objects.create(
@@ -9166,8 +9628,8 @@ def test_inscripcion_rapida_comision_curso_envia_a_lista_espera(client, vat_geo_
         cupo_total=1,
         acepta_lista_espera=True,
         cupo_lista_espera=5,
-        fecha_inicio=date(2026, 4, 1),
-        fecha_fin=date(2026, 4, 30),
+        fecha_inicio=timezone.localdate() - timedelta(days=30),
+        fecha_fin=timezone.localdate() + timedelta(days=30),
         estado="activa",
     )
     titular = Ciudadano.objects.create(
@@ -9270,8 +9732,8 @@ def test_inscripcion_rapida_comision_curso_libre_sin_programa_crea_inscripcion(
         codigo_comision="LIBRE-FAST-01",
         nombre="Comisión Libre Fast",
         cupo_total=20,
-        fecha_inicio=date(2026, 4, 1),
-        fecha_fin=date(2026, 4, 30),
+        fecha_inicio=timezone.localdate() - timedelta(days=30),
+        fecha_fin=timezone.localdate() + timedelta(days=30),
         estado="activa",
     )
     ciudadano = Ciudadano.objects.create(
@@ -9373,8 +9835,8 @@ def test_inscripcion_rapida_comision_legacy_envia_a_lista_espera(client, vat_geo
         nombre="Comisión Legacy Espera",
         cupo=1,
         acepta_lista_espera=True,
-        fecha_inicio=date(2026, 4, 1),
-        fecha_fin=date(2026, 4, 30),
+        fecha_inicio=timezone.localdate() - timedelta(days=30),
+        fecha_fin=timezone.localdate() + timedelta(days=30),
         estado="activa",
     )
     titular = Ciudadano.objects.create(
@@ -9480,8 +9942,8 @@ def test_comision_curso_detail_administra_lista_espera_desde_el_detalle(
         nombre="Comisión Gestión Espera",
         cupo_total=1,
         acepta_lista_espera=True,
-        fecha_inicio=date(2026, 4, 1),
-        fecha_fin=date(2026, 4, 30),
+        fecha_inicio=timezone.localdate() - timedelta(days=30),
+        fecha_fin=timezone.localdate() + timedelta(days=30),
         estado="activa",
     )
     titular = Ciudadano.objects.create(

--- a/docs/registro/cambios/2026-07-06-vat-centro-cascada-municipio-localidad.md
+++ b/docs/registro/cambios/2026-07-06-vat-centro-cascada-municipio-localidad.md
@@ -1,0 +1,40 @@
+# VAT: cascada Municipio → Localidad rota en crear/editar centro
+
+## Contexto (bug reportado)
+
+En el formulario de alta/edicion de centro, al cambiar el Municipio el select
+de Localidad no actualizaba sus opciones: seguia mostrando las localidades del
+municipio anterior. Mas visible en edicion, donde el form filtra las
+localidades por el municipio original de la instancia.
+
+## Diagnostico
+
+Bug clasico de Select2 + JS vanilla:
+
+- Los selects de provincia/municipio/localidad llevan clase `select2`
+  (`_select2_attrs` en `VAT/forms.py`) y `custom.js` los inicializa
+  globalmente.
+- Al elegir una opcion, Select2 dispara un evento `change` **de jQuery**, que
+  no ejecuta listeners nativos registrados con `addEventListener`.
+- `static/custom/js/centro_create_form.js` bindeaba la cascada
+  (provincia→municipio y municipio→localidad) con `addEventListener("change")`
+  → los handlers nunca corrian y las opciones no se recargaban.
+
+## Cambio
+
+`centro_create_form.js`: nuevo helper `bindSelectChange()` que bindea via
+jQuery cuando esta disponible (los handlers jQuery reciben tanto el change de
+Select2 como el nativo) con fallback a `addEventListener`. Se aplica a ambos
+eslabones de la cascada.
+
+## Validacion
+
+Verificacion E2E con Playwright sobre la pagina real de edicion
+(`/vat/centros/<id>/editar/` en el stack local, sesion autenticada):
+
+- Antes del cambio de municipio: opciones de localidad = las del municipio
+  original.
+- Se simula la seleccion de otro municipio exactamente como lo hace Select2
+  (`$('#id_municipio').val(x).trigger('change')`).
+- Resultado: el select de Localidad recarga con las localidades del municipio
+  nuevo y desaparecen las del anterior (`CASCADA OK`).

--- a/docs/registro/cambios/2026-07-12-vat-inscripciones-bloqueo-comision-vencida.md
+++ b/docs/registro/cambios/2026-07-12-vat-inscripciones-bloqueo-comision-vencida.md
@@ -1,0 +1,96 @@
+# VAT: bloquear inscripciones y cerrar comisiones con fecha de fin vencida
+
+## Contexto (bug reportado)
+
+Las comisiones (`ComisionCurso` y `Comision`) no cambian de estado
+automaticamente cuando pasa su `fecha_fin`: el estado es 100% manual.
+Como la validacion de inscripciones solo miraba `estado` (`curso activo` +
+`comision activa`), una comision terminada hace meses seguia aceptando
+inscripciones nuevas por API, web publica (Mi Argentina / inscripcion libre)
+y backoffice mientras nadie la cerrara a mano.
+
+## Cambio
+
+`VAT/services/inscripcion_service.py`:
+
+- Nuevo helper `InscripcionService._comision_vencida()`: una comision esta
+  vencida cuando `fecha_fin < timezone.localdate()`. El dia de `fecha_fin`
+  inclusive todavia admite inscripciones; el bloqueo empieza al dia
+  siguiente. Si el objeto no tiene `fecha_fin` (mocks o instancias sin
+  persistir) el chequeo se saltea.
+- `prevalidar_inscripcion()` suma el motivo `MENSAJE_COMISION_VENCIDA`
+  ("La comisión ya finalizó y no admite nuevas inscripciones.").
+- `crear_inscripcion()` y `crear_inscripcion_oferta()` lanzan `ValueError`
+  con el mismo mensaje. Como todos los puntos de entrada (API
+  `/api/vat/inscripciones*`, API web publica, views de persona/curso/oferta,
+  serializers de inscripcion libre) confunden en estos dos metodos, el
+  bloqueo cubre todos los canales, incluida la lista de espera.
+
+### Cierre automatico de estado (segunda parte)
+
+`VAT/services/comision_cierre_service.py` + management command
+`cerrar_comisiones_vencidas` (mismo patron que `recargar_vouchers`,
+con `--check` / `--execute`):
+
+- Cierra (`estado="cerrada"`) las `ComisionCurso` y `Comision` en estado
+  `planificada` o `activa` con `fecha_fin < hoy`. Las `suspendida` no se
+  tocan: es una decision manual deliberada.
+- Usa el manager default de soft delete, asi que las comisiones borradas
+  logicamente no se reprocesan.
+- `queryset.update()` no dispara `auto_now`, por eso el servicio setea
+  `fecha_modificacion` explicitamente.
+- Pensado para cron diario en el servidor (no hay scheduler en el repo,
+  igual que `recargar_vouchers`):
+  `0 1 * * * cd /sisoc && python manage.py cerrar_comisiones_vencidas --execute`
+
+El bloqueo de inscripciones del service es la red de seguridad para la
+ventana entre el vencimiento y la proxima corrida del cron.
+
+Fuera de alcance (decision pendiente): pasar `Curso` a `finalizado` cuando
+todas sus comisiones esten cerradas — el curso no tiene fechas propias.
+
+### Mensajes expeditivos y bloqueo por estado (tercera parte)
+
+Los mensajes de "no se puede inscribir" pasan a ser especificos por causa,
+centralizados como constantes en `inscripcion_service.py`:
+
+- Por estado del curso: `finalizado` ("El curso ya finalizo: la inscripcion
+  esta cerrada."), `cancelado`, `planificado` ("todavia no abrio la
+  inscripcion"); idem oferta institucional (`cerrada`/`cancelada`).
+- Por estado de la comision: `cerrada` ("La inscripcion a esta comision esta
+  cerrada."), `suspendida`, `planificada`.
+- Por cupo: "No es posible inscribirse: el cupo esta completo y la comision
+  no tiene lista de espera." / "...y la lista de espera tambien.".
+- Cupo completo con lista de espera disponible: la prevalidacion agrega el
+  campo nuevo `avisos` (no bloqueante) con "El cupo esta completo: la
+  inscripcion ingresa en lista de espera." — el front puede mostrarlo antes
+  de confirmar. Campo agregado tambien al serializer de respuesta OpenAPI.
+
+Ademas `crear_inscripcion` y `crear_inscripcion_oferta` ahora bloquean por
+estado (antes solo la prevalidacion lo miraba, la API directa ignoraba el
+estado): comision `cerrada`/`suspendida` y curso `finalizado`/`cancelado`
+(oferta `cerrada`/`cancelada`) rechazan el alta con el mismo mensaje.
+Decision deliberada: `planificada`/`planificado` NO bloquea el alta directa,
+porque el backoffice permite pre-inscribir en comisiones planificadas
+(`InscripcionForm` las ofrece); si bloquea la prevalidacion publica.
+
+Las views de backoffice muestran `str(exc)` del service, asi que los textos
+nuevos llegan a todos los canales sin cambios adicionales.
+
+## Tests
+
+- Nuevos en `VAT/tests.py`: rechazo por API con comision vencida (400 +
+  mensaje), motivo en `prevalidar_inscripcion`, caso borde que permite
+  inscribir cuando `fecha_fin` es hoy, y dos tests del command
+  `cerrar_comisiones_vencidas` (cierra solo vencidas planificadas/activas
+  en ambos modelos, respeta suspendidas y vigentes; `--check` no modifica).
+- Fixtures de tests de inscripcion que usaban fechas hardcodeadas ya
+  vencidas (`date(2026, 4, 30)`, etc.) pasaron a fechas relativas
+  (`timezone.localdate() +/- timedelta`) para que no vuelvan a caducar.
+
+## Validacion
+
+En Docker (entorno canonico): `pytest VAT/tests.py` 199 passed / 3 skipped,
+mas `VAT/test_reporte_inscripciones_asistencia.py` y los unit tests
+`tests/test_vat_api_web_unit.py`, `tests/test_vat_api_views_unit.py`,
+`tests/test_vat_persona_views_unit.py` (18 passed). `black --check` limpio.


### PR DESCRIPTION
# Información de la Tarea
Vincular el #ISSUE

### **Resumen de la Solución:**
- Las comisiones con fecha de fin vencida dejan de aceptar inscripciones en todos los canales (APIs, web pública/Mi Argentina y backoffice).
- Nuevo management command `cerrar_comisiones_vencidas` (cron diario) que pasa automáticamente a estado `cerrada` las comisiones planificadas/activas cuya `fecha_fin` ya pasó, tanto operativas (`ComisionCurso`) como de oferta institucional (`Comision`).
- Mensajes de rechazo expeditivos y específicos por causa: cupo completo (con o sin lista de espera), inscripción cerrada, comisión suspendida, curso finalizado/cancelado, comisión que todavía no abrió.
- La prevalidación devuelve un campo nuevo `avisos` (no bloqueante): cuando el cupo está completo pero hay lista de espera, informa que la inscripción ingresa en espera antes de confirmar.

### **Información Adicional:**
- Los estados de comisiones/cursos eran 100% manuales: una comisión terminada hacía meses seguía aceptando inscripciones si nadie la cerraba a mano.
- El alta directa por API no validaba el estado de la comisión (solo la prevalidación lo hacía): se podía inscribir en una comisión cerrada salteando la prevalidación. Este PR cierra ese agujero.
- Decisión deliberada: las comisiones `planificada` siguen permitiendo el alta directa (pre-inscripciones desde backoffice/API), pero la prevalidación pública las rechaza con mensaje propio.
- El día de la `fecha_fin` inclusive todavía se puede inscribir; el bloqueo arranca al día siguiente.
- Registro de cambios: `docs/registro/cambios/2026-07-12-vat-inscripciones-bloqueo-comision-vencida.md`.

# Descripción de los Cambios

### **Cambios:**
- `VAT/services/inscripcion_service.py`:
  - Helper `_comision_vencida()` (fecha_fin < hoy) y bloqueo en `prevalidar_inscripcion`, `crear_inscripcion` y `crear_inscripcion_oferta`.
  - Bloqueo por estado en el alta directa: comisión `cerrada`/`suspendida` y curso `finalizado`/`cancelado` (oferta `cerrada`/`cancelada`) rechazan con `ValueError` → HTTP 400 en las APIs.
  - Catálogo de mensajes expeditivos centralizado en constantes (por estado y por cupo).
  - `prevalidar_inscripcion` devuelve `avisos` con el aviso de ingreso a lista de espera.
- `VAT/services/comision_cierre_service.py` (nuevo): `CierreComisionService` con la regla de cierre por fecha vencida. No toca comisiones `suspendida` ni borradas lógicamente; setea `fecha_modificacion` explícito porque `update()` no dispara `auto_now`.
- `VAT/management/commands/cerrar_comisiones_vencidas.py` (nuevo): command con `--check` / `--execute`, mismo patrón que `recargar_vouchers`. Cron sugerido: `0 1 * * * cd /sisoc && python manage.py cerrar_comisiones_vencidas --execute`.
- `VAT/serializers.py`: campo `avisos` en el serializer de respuesta de prevalidación (schema OpenAPI).
- `VAT/tests.py`: 10 tests nuevos y fixtures de inscripción migrados de fechas hardcodeadas (ya vencidas) a fechas relativas a hoy para que no vuelvan a caducar.

# Cómo Testear los Cambios

### **Pruebas Automáticas:**
- `docker compose exec django pytest VAT/tests.py` → 206 passed, 3 skipped.
- `docker compose exec django pytest VAT/test_reporte_inscripciones_asistencia.py tests/test_vat_api_web_unit.py tests/test_vat_api_views_unit.py tests/test_vat_persona_views_unit.py` → 18 passed.
- Tests nuevos clave: rechazo por API con comisión vencida (400 + mensaje), motivo en prevalidación, borde "finaliza hoy" permitido, rechazo de cerrada/suspendida en alta directa, pre-inscripción en planificada permitida, aviso de lista de espera, mensajes de cupo completo, y cierre automático (solo vencidas, respeta suspendidas/vigentes, `--check` no modifica).

### **Prubeas Manuales:**
- `python manage.py cerrar_comisiones_vencidas --check`: lista cuántas comisiones se cerrarían sin modificar nada; con `--execute` verificar que pasan a `cerrada` y las suspendidas/vigentes quedan igual.
- `POST /api/vat/web/inscripciones/prevalidar/` contra una comisión con cupo lleno y lista de espera: `puede_inscribirse: true` y `avisos` con el mensaje de ingreso a espera.
- `POST /api/vat/inscripciones-curso/` contra una comisión vencida o cerrada: HTTP 400 con `{"error": ["<mensaje específico>"]}`.
- Desde backoffice, intentar inscribir en una comisión cerrada/suspendida: el mensaje específico aparece en pantalla.

# Metadata para documentación automática

- Contexto funcional: VAT — inscripciones a comisiones de cursos y oferta institucional.
- Tipo de cambio: fix + feature (validación de negocio + automatización de estados).
- Área principal: `VAT/services/` + management command + API de inscripciones.
- Resumen para changelog: Las comisiones vencidas se cierran automáticamente (cron diario) y las inscripciones se rechazan en todos los canales con mensajes específicos por causa (cupo completo, lista de espera, inscripción cerrada, curso finalizado/cancelado, comisión suspendida).
- Impacto usuario: los ciudadanos y operadores ven mensajes claros del motivo de rechazo; deja de ser posible inscribirse en comisiones terminadas; las inscripciones con cupo lleno avisan el pase a lista de espera antes de confirmar.
- Riesgos / rollback: el command es idempotente y tiene modo `--check`; si un cierre automático fuera incorrecto, el estado se corrige manualmente desde backoffice. Rollback: revertir el PR y quitar la línea de cron; no hay migraciones de base de datos.

# Capturas de Pantalla
