### PR TITLE
fix(comedores):formatear montos de expedientes de pago

### DIFF
--- a/comedores/templates/comedor/comedor_mes_ejecucion_card.html
+++ b/comedores/templates/comedor/comedor_mes_ejecucion_card.html
@@ -1,3 +1,4 @@
+{% load custom_filters %}
 <div class="card bg-card h-100" id="card-mes-ejecucion">
     <div class="card-header py-1">
         <h6 class="fw-bold my-1 text-center">Mes de ejecuci&oacute;n</h6>
@@ -15,7 +16,7 @@
                     Cantidad de prestaciones: <strong>{{ mes_ejecucion_resumen.cantidad_prestaciones|default:"0" }}</strong>
                 </p>
                 <p class="mb-0 fs-7">
-                    Monto total de prestaciones: <strong>${{ mes_ejecucion_resumen.monto_total|default:"0" }}</strong>
+                    Monto total de prestaciones: <strong>${{ mes_ejecucion_resumen.monto_total|monto_sin_decimales }}</strong>
                 </p>
                 <p class="mb-0 fs-7">
                     Mes de pago: <strong>{{ expediente.mes_pago|default:"Sin informaci&oacute;n" }}</strong>

--- a/core/templatetags/custom_filters.py
+++ b/core/templatetags/custom_filters.py
@@ -1,6 +1,6 @@
 import builtins as python_builtins
 from datetime import date
-from decimal import Decimal, InvalidOperation
+from decimal import Decimal, InvalidOperation, ROUND_HALF_UP
 from urllib.parse import quote_plus
 
 from django import template
@@ -22,6 +22,23 @@ _DAYS = (
     "domingo",
 )
 _MEALS = ("desayuno", "almuerzo", "merienda", "merienda_reforzada", "cena")
+
+
+@register.filter
+def monto_sin_decimales(value):
+    if value in (None, ""):
+        return "-"
+
+    try:
+        amount = Decimal(str(value))
+    except (InvalidOperation, ValueError):
+        return "-"
+
+    if amount.is_nan() or amount.is_infinite():
+        return "-"
+
+    whole_amount = int(amount.quantize(Decimal("1"), rounding=ROUND_HALF_UP))
+    return f"{whole_amount:,}".replace(",", ".")
 
 
 @register.filter

--- a/docs/registro/cambios/2026-07-13-formato-montos-expedientes-pago.md
+++ b/docs/registro/cambios/2026-07-13-formato-montos-expedientes-pago.md
@@ -1,0 +1,18 @@
+# Formato de montos en expedientes de pago
+
+## Contexto
+
+Los totales de expedientes de pago se mostraban con decimales o sin separadores de miles, lo que dificultaba la lectura de montos altos.
+
+## Cambio
+
+- Se agrega el filtro `monto_sin_decimales` para mostrar montos con separador de miles `.` y sin centavos.
+- Se aplica el formato al campo `Total` del listado y detalle de expedientes de pago.
+- Se aplica el formato a la columna `Monto Mensual` del detalle de expedientes de pago.
+- Se aplica el formato a `Monto total de prestaciones` en el contenedor de mes de ejecucion del legajo de comedor.
+
+## Validacion
+
+- Tests unitarios del filtro y del item de listado de expedientes de pago.
+- `djlint --check` sobre los templates modificados.
+- `manage.py check`.

--- a/expedientespagos/templates/expedientespagos_detail.html
+++ b/expedientespagos/templates/expedientespagos_detail.html
@@ -1,5 +1,5 @@
 {% extends "includes/main.html" %}
-{% load static %}
+{% load static custom_filters %}
 
 {% block title %}Expediente de Pago{% endblock %}
 
@@ -64,7 +64,7 @@
                     </div>
                     <div class="col-md-4">
                         <small class="text-muted d-block">Total</small>
-                        <span class="fw-semibold">${{ expediente.total|floatformat:2 }}</span>
+                        <span class="fw-semibold">${{ expediente.total|monto_sin_decimales }}</span>
                     </div>
                     <div class="col-md-4">
                         <small class="text-muted d-block">Mes de Pago</small>
@@ -140,22 +140,22 @@
                         <tr>
                             <td>Desayuno</td>
                             <td class="text-end">{{ expediente.prestaciones_mensuales_desayuno|default:"-" }}</td>
-                            <td class="text-end">${{ expediente.monto_mensual_desayuno|floatformat:2 }}</td>
+                            <td class="text-end">${{ expediente.monto_mensual_desayuno|monto_sin_decimales }}</td>
                         </tr>
                         <tr>
                             <td>Almuerzo</td>
                             <td class="text-end">{{ expediente.prestaciones_mensuales_almuerzo|default:"-" }}</td>
-                            <td class="text-end">${{ expediente.monto_mensual_almuerzo|floatformat:2 }}</td>
+                            <td class="text-end">${{ expediente.monto_mensual_almuerzo|monto_sin_decimales }}</td>
                         </tr>
                         <tr>
                             <td>Merienda</td>
                             <td class="text-end">{{ expediente.prestaciones_mensuales_merienda|default:"-" }}</td>
-                            <td class="text-end">${{ expediente.monto_mensual_merienda|floatformat:2 }}</td>
+                            <td class="text-end">${{ expediente.monto_mensual_merienda|monto_sin_decimales }}</td>
                         </tr>
                         <tr>
                             <td>Cena</td>
                             <td class="text-end">{{ expediente.prestaciones_mensuales_cena|default:"-" }}</td>
-                            <td class="text-end">${{ expediente.monto_mensual_cena|floatformat:2 }}</td>
+                            <td class="text-end">${{ expediente.monto_mensual_cena|monto_sin_decimales }}</td>
                         </tr>
                     </tbody>
                     <tfoot>
@@ -171,7 +171,7 @@
                                 class="text-end"
                                 style="background-color: #3d4f63 !important;
                                        border-bottom: 2px solid #e7ba61 !important">
-                                ${{ expediente.total|floatformat:2 }}
+                                ${{ expediente.total|monto_sin_decimales }}
                             </th>
                         </tr>
                     </tfoot>

--- a/expedientespagos/views.py
+++ b/expedientespagos/views.py
@@ -9,9 +9,11 @@ from django.views.generic import (
 )
 from django.urls import reverse_lazy, reverse
 from django.utils.decorators import method_decorator
+from django.utils.html import format_html
 from django.views.decorators.csrf import ensure_csrf_cookie
 from core.soft_delete.view_helpers import SoftDeleteDeleteViewMixin
-from core.services.column_preferences import build_columns_context_from_fields
+from core.services.column_preferences import build_columns_context_for_custom_cells
+from core.templatetags.custom_filters import monto_sin_decimales
 from expedientespagos.models import ExpedientePago
 from expedientespagos.forms import ExpedientePagoForm
 from expedientespagos.services import (
@@ -20,6 +22,26 @@ from expedientespagos.services import (
 )
 from comedores.models import Comedor
 from iam.services import user_has_any_permission_codes
+
+
+def _build_expediente_pago_list_item(expediente):
+    return {
+        "pk": expediente.pk,
+        "cells": [
+            {"content": expediente.mes_pago or "-"},
+            {"content": expediente.ano or "-"},
+            {"content": expediente.expediente_pago or "-"},
+            {"content": expediente.expediente_convenio or "-"},
+            {"content": format_html("${}", monto_sin_decimales(expediente.total))},
+            {
+                "content": (
+                    expediente.fecha_creacion.strftime("%d/%m/%Y")
+                    if expediente.fecha_creacion
+                    else "-"
+                )
+            },
+        ],
+    }
 
 
 @method_decorator(ensure_csrf_cookie, name="dispatch")
@@ -36,37 +58,37 @@ class ExpedientesPagosListView(LoginRequiredMixin, ListView):
     def get_context_data(self, **kwargs):
         context = super().get_context_data(**kwargs)
         comedor_id = self.kwargs.get("pk")
-        context["expedientes_pagos"] = (
-            ExpedientesPagosService.obtener_expedientes_pagos(comedor_id)
+        expedientes_pagos = ExpedientesPagosService.obtener_expedientes_pagos(
+            comedor_id
         )
+        context["expedientes_pagos"] = [
+            _build_expediente_pago_list_item(expediente)
+            for expediente in expedientes_pagos
+        ]
         context["comedorid"] = comedor_id
 
         headers = [
-            {"title": "Mes de Pago"},
+            {"key": "mes_pago", "title": "Mes de Pago"},
             {"title": "Año"},
-            {"title": "Expediente de Pago"},
-            {"title": "Expediente del Convenio"},
-            {"title": "Total"},
+            {"key": "expediente_pago", "title": "Expediente de Pago"},
+            {"key": "expediente_convenio", "title": "Expediente del Convenio"},
+            {"key": "total", "title": "Total"},
             {"title": "Fecha de creación"},
         ]
 
-        fields = [
-            {"name": "mes_pago"},
-            {"name": "ano"},
-            {"name": "expediente_pago"},
-            {"name": "expediente_convenio"},
-            {"name": "total"},
-            {"name": "fecha_creacion"},
-        ]
+        headers[1]["key"] = "ano"
+        headers[5]["key"] = "fecha_creacion"
 
         context.update(
-            build_columns_context_from_fields(
+            build_columns_context_for_custom_cells(
                 self.request,
                 "expedientes_pagos_list",
                 headers,
-                fields,
+                context["expedientes_pagos"],
+                items_key="expedientes_pagos",
             )
         )
+        context["custom_cells"] = True
 
         context["table_actions"] = [
             {"label": "Ver", "url_name": "expedientespagos_detail", "type": "info"}

--- a/expedientespagos/views.py
+++ b/expedientespagos/views.py
@@ -9,7 +9,7 @@ from django.views.generic import (
 )
 from django.urls import reverse_lazy, reverse
 from django.utils.decorators import method_decorator
-from django.utils.html import format_html
+from django.utils.html import escape, format_html
 from django.views.decorators.csrf import ensure_csrf_cookie
 from core.soft_delete.view_helpers import SoftDeleteDeleteViewMixin
 from core.services.column_preferences import build_columns_context_for_custom_cells
@@ -28,10 +28,10 @@ def _build_expediente_pago_list_item(expediente):
     return {
         "pk": expediente.pk,
         "cells": [
-            {"content": expediente.mes_pago or "-"},
-            {"content": expediente.ano or "-"},
-            {"content": expediente.expediente_pago or "-"},
-            {"content": expediente.expediente_convenio or "-"},
+            {"content": escape(expediente.mes_pago or "-")},
+            {"content": escape(expediente.ano or "-")},
+            {"content": escape(expediente.expediente_pago or "-")},
+            {"content": escape(expediente.expediente_convenio or "-")},
             {"content": format_html("${}", monto_sin_decimales(expediente.total))},
             {
                 "content": (
@@ -69,15 +69,12 @@ class ExpedientesPagosListView(LoginRequiredMixin, ListView):
 
         headers = [
             {"key": "mes_pago", "title": "Mes de Pago"},
-            {"title": "Año"},
+            {"key": "ano", "title": "Año"},
             {"key": "expediente_pago", "title": "Expediente de Pago"},
             {"key": "expediente_convenio", "title": "Expediente del Convenio"},
             {"key": "total", "title": "Total"},
-            {"title": "Fecha de creación"},
+            {"key": "fecha_creacion", "title": "Fecha de creación"},
         ]
-
-        headers[1]["key"] = "ano"
-        headers[5]["key"] = "fecha_creacion"
 
         context.update(
             build_columns_context_for_custom_cells(

--- a/tests/test_expedientespagos_views_unit.py
+++ b/tests/test_expedientespagos_views_unit.py
@@ -21,3 +21,22 @@ def test_build_expediente_pago_list_item_formatea_total_sin_decimales():
     assert item["pk"] == 3058
     assert item["cells"][4]["content"] == "$110.000.001"
     assert item["cells"][5]["content"] == "13/07/2026"
+
+
+def test_build_expediente_pago_list_item_escapa_campos_de_texto():
+    expediente = SimpleNamespace(
+        pk=1,
+        mes_pago="<script>alert(1)</script>",
+        ano="2026",
+        expediente_pago="EX&1",
+        expediente_convenio='"><img src=x onerror=alert(1)>',
+        total=Decimal("100.00"),
+        fecha_creacion=date(2026, 7, 13),
+    )
+
+    item = _build_expediente_pago_list_item(expediente)
+
+    assert "<script>" not in item["cells"][0]["content"]
+    assert item["cells"][0]["content"] == "&lt;script&gt;alert(1)&lt;/script&gt;"
+    assert item["cells"][2]["content"] == "EX&amp;1"
+    assert "<img" not in item["cells"][3]["content"]

--- a/tests/test_expedientespagos_views_unit.py
+++ b/tests/test_expedientespagos_views_unit.py
@@ -1,0 +1,23 @@
+from datetime import date
+from decimal import Decimal
+from types import SimpleNamespace
+
+from expedientespagos.views import _build_expediente_pago_list_item
+
+
+def test_build_expediente_pago_list_item_formatea_total_sin_decimales():
+    expediente = SimpleNamespace(
+        pk=3058,
+        mes_pago="Marzo",
+        ano=2026,
+        expediente_pago="EX-1",
+        expediente_convenio="CONV-1",
+        total=Decimal("110000000.75"),
+        fecha_creacion=date(2026, 7, 13),
+    )
+
+    item = _build_expediente_pago_list_item(expediente)
+
+    assert item["pk"] == 3058
+    assert item["cells"][4]["content"] == "$110.000.001"
+    assert item["cells"][5]["content"] == "13/07/2026"

--- a/tests/test_monto_sin_decimales_filter.py
+++ b/tests/test_monto_sin_decimales_filter.py
@@ -1,0 +1,20 @@
+from decimal import Decimal
+
+import pytest
+
+from core.templatetags.custom_filters import monto_sin_decimales
+
+
+@pytest.mark.parametrize(
+    ("value", "expected"),
+    [
+        (Decimal("110000000.00"), "110.000.000"),
+        (Decimal("1234.56"), "1.235"),
+        ("9876543.21", "9.876.543"),
+        (None, "-"),
+        ("", "-"),
+        ("no-es-monto", "-"),
+    ],
+)
+def test_monto_sin_decimales_formatea_pesos_sin_centavos(value, expected):
+    assert monto_sin_decimales(value) == expected


### PR DESCRIPTION
# Información de la Tarea
https://github.com/dsocial118/SISOC/issues/2029

Los totales de expedientes de pago se mostraban con decimales o sin separadores de miles, lo que dificultaba la lectura de montos altos.

### **Resumen de la Solución:** 
-

### **Información Adicional:**
-

# Descripción de los Cambios

### **Cambios:**
- Se agrega el filtro `monto_sin_decimales` para mostrar montos con separador de miles `.` y sin centavos.
- Se aplica el formato al campo `Total` del listado y detalle de expedientes de pago.
- Se aplica el formato a la columna `Monto Mensual` del detalle de expedientes de pago.
- Se aplica el formato a `Monto total de prestaciones` en el contenedor de mes de ejecucion del legajo de comedor.

# Cómo Testear los Cambios

### **Pruebas Automáticas:**
-

### **Prubeas Manuales:**
-

# Metadata para documentación automática

- Contexto funcional:
- Tipo de cambio:
- Área principal:
- Resumen para changelog:
- Impacto usuario:
- Riesgos / rollback:

# Capturas de Pantalla
