### PR TITLE
Fix insumos categoria

### DIFF
--- a/insumos/forms.py
+++ b/insumos/forms.py
@@ -7,6 +7,28 @@ from .models import Insumo, InsumoCategoria
 from .validators import INSUMO_ACCEPT_ATTR
 
 
+class CategoriaSelect(forms.Select):
+    """Select de categoría que expone en cada opción su programa.
+
+    El atributo ``data-programa`` permite filtrar las categorías en el cliente
+    según el programa elegido, para que una categoría solo esté disponible en el
+    programa al que fue asociada.
+    """
+
+    # pylint: disable=too-many-arguments  # firma impuesta por forms.Select
+    def create_option(
+        self, name, value, label, selected, index, subindex=None, attrs=None
+    ):
+        option = super().create_option(
+            name, value, label, selected, index, subindex, attrs
+        )
+        instance = getattr(value, "instance", None)
+        programa_id = getattr(instance, "programa_id", None)
+        if programa_id:
+            option["attrs"]["data-programa"] = str(programa_id)
+        return option
+
+
 class InsumoCategoriaForm(forms.ModelForm):
     class Meta:
         model = InsumoCategoria
@@ -49,6 +71,7 @@ class InsumoForm(forms.ModelForm):
         widgets = {
             "descripcion": forms.Textarea(attrs={"rows": 3}),
             "archivo": forms.ClearableFileInput(attrs={"accept": INSUMO_ACCEPT_ATTR}),
+            "categoria": CategoriaSelect,
         }
 
     def __init__(self, *args, **kwargs):

--- a/insumos/templates/insumos/insumos_form.html
+++ b/insumos/templates/insumos/insumos_form.html
@@ -1,5 +1,5 @@
 {% extends "includes/main.html" %}
-{% load crispy_forms_tags %}
+{% load crispy_forms_tags static %}
 {% block title %}
     {% if form.instance.pk %}
         Editar insumo
@@ -30,7 +30,10 @@
 
                     <div class="row">
                         <div class="col-md-6">{{ form.programa|as_crispy_field }}</div>
-                        <div class="col-md-6">{{ form.categoria|as_crispy_field }}</div>
+                        <div class="col-md-6">
+                            {{ form.categoria|as_crispy_field }}
+                            <small class="text-muted d-block mb-3">Se muestran solo las categorías del programa seleccionado.</small>
+                        </div>
                     </div>
                     {{ form.titulo|as_crispy_field }}
                     {{ form.descripcion|as_crispy_field }}
@@ -57,4 +60,7 @@
             </div>
         </div>
     </div>
+{% endblock %}
+{% block customJS %}
+    <script src="{% static 'custom/js/insumoForm.js' %}"></script>
 {% endblock %}

--- a/insumos/tests/test_insumos_permisos.py
+++ b/insumos/tests/test_insumos_permisos.py
@@ -1,9 +1,12 @@
+import re
+
 import pytest
 from django.contrib.auth.models import Permission, User
 from django.core.files.uploadedfile import SimpleUploadedFile
 from django.urls import reverse
 
 from core.models import Programa
+from insumos.forms import InsumoForm
 from insumos.models import Insumo, InsumoCategoria
 
 
@@ -145,6 +148,33 @@ def test_gestion_puede_crear_categoria(client, user_gestion, programa):
     )
     assert response.status_code == 302
     assert InsumoCategoria.objects.filter(nombre="Rendiciones").exists()
+
+
+def _programa_de_la_opcion(html, categoria_pk):
+    """Devuelve el data-programa declarado por la opcion de una categoria."""
+    match = re.search(rf'<option[^>]*value="{categoria_pk}"[^>]*>', html)
+    assert match, f"No se encontro la opcion de la categoria {categoria_pk}"
+    data_programa = re.search(r'data-programa="(\d+)"', match.group(0))
+    return int(data_programa.group(1)) if data_programa else None
+
+
+@pytest.mark.django_db
+def test_cada_categoria_declara_su_programa_en_el_combo(programa):
+    """Regresion: la categoria de un programa no debe ofrecerse en los demas.
+
+    Cada opcion expone su ``data-programa`` para que el combo de categoria se
+    filtre segun el programa elegido.
+    """
+    otro = Programa.objects.create(nombre="Otro programa")
+    categoria_propia = InsumoCategoria.objects.create(
+        programa=programa, nombre="Manuales"
+    )
+    categoria_ajena = InsumoCategoria.objects.create(programa=otro, nombre="Ajena")
+
+    html = InsumoForm()["categoria"].as_widget()
+
+    assert _programa_de_la_opcion(html, categoria_propia.pk) == programa.pk
+    assert _programa_de_la_opcion(html, categoria_ajena.pk) == otro.pk
 
 
 @pytest.mark.django_db

--- a/static/custom/js/insumoForm.js
+++ b/static/custom/js/insumoForm.js
@@ -1,0 +1,46 @@
+(function () {
+    "use strict";
+
+    document.addEventListener("DOMContentLoaded", function () {
+        var programaSelect = document.getElementById("id_programa");
+        var categoriaSelect = document.getElementById("id_categoria");
+
+        if (!programaSelect || !categoriaSelect) {
+            return;
+        }
+
+        // El filtrado quita opciones del DOM, así que hay que conservar la lista
+        // completa para poder restaurarlas al cambiar de programa.
+        var todasLasOpciones = Array.prototype.slice.call(categoriaSelect.options);
+
+        function sincronizarCategorias() {
+            var programaId = programaSelect.value;
+            var seleccionActual = categoriaSelect.value;
+            var seleccionSigueValida = false;
+
+            categoriaSelect.innerHTML = "";
+
+            todasLasOpciones.forEach(function (opcion) {
+                var programaDeLaOpcion = opcion.getAttribute("data-programa");
+
+                // La opción vacía ("Sin categoría") no tiene programa: siempre disponible.
+                if (!programaDeLaOpcion) {
+                    categoriaSelect.appendChild(opcion);
+                    return;
+                }
+
+                if (programaId && programaDeLaOpcion === programaId) {
+                    categoriaSelect.appendChild(opcion);
+                    if (opcion.value === seleccionActual) {
+                        seleccionSigueValida = true;
+                    }
+                }
+            });
+
+            categoriaSelect.value = seleccionSigueValida ? seleccionActual : "";
+        }
+
+        programaSelect.addEventListener("change", sincronizarCategorias);
+        sincronizarCategorias();
+    });
+})();


### PR DESCRIPTION
# Información de la Tarea
Vincular el #ISSUE

### **Resumen de la Solución:**
- Se corrige el bug reportado por QA: al dar de alta un insumo, el combo de **Categoría** mostraba las categorías de **todos los programas**. Ahora el combo es dependiente del **Programa** seleccionado y solo ofrece las categorías asociadas a ese programa (más la opción "Sin categoría", siempre disponible).

### **Información Adicional:**
- **No hubo datos corruptos en HML.** La validación del servidor (`InsumoForm.clean()` + `Insumo.clean()`) ya rechazaba guardar una categoría de otro programa, por lo que el problema era exclusivamente de **visualización del desplegable**: se podían *ver* categorías ajenas, pero no *guardarlas*.
- **Causa raíz:** en `InsumoForm.__init__` el queryset del campo era `InsumoCategoria.objects.filter(activo=True)`, sin filtrar por programa.
- Se resolvió con **filtrado en el cliente** (sin endpoint nuevo ni llamadas AJAX): las categorías son pocas, se envían todas y el JS oculta las que no corresponden. La validación del servidor se mantiene como red de seguridad.

# Descripción de los Cambios

### **Cambios:**
- **`insumos/forms.py`**: nuevo widget `CategoriaSelect` (subclase de `forms.Select`) que agrega el atributo `data-programa="<id>"` a cada opción del combo, declarando a qué programa pertenece cada categoría. Se asigna como widget del campo `categoria` en `InsumoForm`.
- **`static/custom/js/insumoForm.js`** (nuevo): al cargar la página y ante cada cambio de **Programa**, deja disponibles únicamente las categorías de ese programa. Si la categoría seleccionada deja de pertenecer al programa elegido, se resetea a "Sin categoría".
- **`insumos/templates/insumos/insumos_form.html`**: carga el script y suma la leyenda de ayuda *"Se muestran solo las categorías del programa seleccionado."*
- **`insumos/tests/test_insumos_permisos.py`**: nuevo test de regresión `test_cada_categoria_declara_su_programa_en_el_combo`.

# Cómo Testear los Cambios

### **Pruebas Automáticas:**
- Nuevo test de regresión: `test_cada_categoria_declara_su_programa_en_el_combo` — verifica que cada opción del combo expone el `data-programa` correcto (es decir, que la categoría del Programa A no se puede ofrecer como si fuera del Programa B).
- Se mantiene `test_categoria_de_otro_programa_es_invalida` (la validación del servidor sigue rechazando el guardado inconsistente).
- Suite completa de `insumos`: **10/10 en verde**.
- Comando: `docker exec sisoc_2-django-1 python -m pytest insumos/tests/ -q`
- Calidad: `black`, `pylint` (10.00/10) y `djlint` sin observaciones.

### **Pruebas Manuales:**
1. Crear dos categorías en programas distintos: una en el **Programa A** y otra en el **Programa B** (`/insumos/categorias/crear`).
2. Ir a **Nuevo insumo** (`/insumos/crear`) y seleccionar el **Programa A** → el combo **Categoría** debe mostrar **solo** la categoría de A (más "Sin categoría"). **La de B no debe aparecer.**
3. Cambiar el Programa a **B** sin recargar → el combo debe actualizarse solo y mostrar únicamente la categoría de B.
4. Si había una categoría de A seleccionada y se cambia el programa a B, la selección debe volver a **"Sin categoría"** (no debe quedar una categoría inválida).
5. **Editar** un insumo existente que tenga categoría → debe abrir con su programa y su categoría correctamente preseleccionados.
6. Guardar un insumo con categoría → debe persistir bien; guardar sin categoría → debe quedar como "Sin categoría".

# Metadata para documentación automática

- **Contexto funcional:** Comedores — submódulo Insumos (alta/edición de insumos).
- **Tipo de cambio:** Bugfix (corrección de bug reportado por QA).
- **Área principal:** `insumos` — formulario de Insumo (combo Categoría dependiente de Programa).
- **Resumen para changelog:** El combo de Categoría en el alta/edición de insumos ahora muestra únicamente las categorías del programa seleccionado, en lugar de las de todos los programas.
- **Impacto usuario:** Mejora de usabilidad y consistencia — el usuario ya no ve categorías de otros programas al cargar un insumo. Sin impacto en datos existentes ni en permisos.
- **Riesgos / rollback:** Riesgo bajo. No hay cambios de modelo ni migraciones, y la validación del servidor ya existía (no había datos inconsistentes). Rollback: revertir el commit (widget `CategoriaSelect`, el JS y el template). **Atención al deploy:** incorpora un archivo estático nuevo (`insumoForm.js`), por lo que hay que correr `collectstatic`.


# Capturas de Pantalla
