### PR TITLE
docs(infra): registrar backup local de media en produccion

### DIFF
--- a/docs/infra/PROD_CHANGE_PROPOSALS.md
+++ b/docs/infra/PROD_CHANGE_PROPOSALS.md
@@ -1,13 +1,15 @@
 # Produccion - Propuestas de cambio
 
-Estado: propuestas solamente. Ningun comando de este documento fue ejecutado en
-produccion. Cada propuesta requiere aprobacion separada, ventana y responsable.
+Estado: propuestas solamente. Ningun comando propuesto en este documento fue
+ejecutado en produccion. El unico cambio aplicado fue el backup local de media
+aprobado y registrado en `PROD_INVENTORY.md`. Cada propuesta restante requiere
+aprobacion separada, ventana y responsable.
 
 No ejecutar bloques completos por copia/pega sin revisar nuevamente el estado.
 
 ## Prioridad sugerida
 
-1. demostrar backups/restores de DB y media antes de cualquier cambio;
+1. verificar backups/restores de DB y copiar media fuera del host;
 2. corregir cron root de forma acotada;
 3. agregar rotacion a logs NGINX;
 4. evaluar Stage 1 del MySQL local;
@@ -443,8 +445,11 @@ coordinado.
 ## Temas deliberadamente sin propuesta ejecutable
 
 - TLS: postergado por el responsable.
-- Backup DB/media: falta definir herramienta, storage, credenciales, RPO/RTO y
-  restore target; inventar comandos seria inseguro.
+- Backup DB: su existencia fue informada, pero falta verificar storage,
+  retencion, integridad, RPO/RTO y restore target.
+- Backup media: existe una copia local completa bajo `/sisoc/backups/media`,
+  pero falta definir destino externo, credenciales, checksum y restore target.
+  No se automatiza retencion ni borrado hasta contar con esa segunda copia.
 - Bind 8001/firewall: requiere conocer ACL y balanceo antes de editar Compose.
 - Retencion de logs Django/auditoria: requiere politica funcional/legal antes de
   eliminar archivos o registros.

--- a/docs/infra/PROD_INVENTORY.md
+++ b/docs/infra/PROD_INVENTORY.md
@@ -1,8 +1,9 @@
 # Produccion - Inventario inicial de infraestructura
 
-Estado: auditoria cerrada en modo exclusivamente read-only el 2026-07-13. No se
-modificaron archivos, servicios, cron, permisos, Git, Docker, MySQL, NGINX, TLS
-ni datos.
+Estado: auditoria inicial cerrada en modo exclusivamente read-only el
+2026-07-13. Luego, con aprobacion explicita, se creo una copia local de media.
+No se modificaron servicios, cron, permisos existentes, Git, Docker, MySQL,
+NGINX, TLS ni datos de origen.
 
 ## Alcance y fuente canonica
 
@@ -18,7 +19,7 @@ alcance y se conservan solo como referencia de una posible migracion.
 | Frontend | SISOC-Mobile en un segundo stack Docker Compose |
 | Proxy | NGINX con HTTP/HTTPS |
 | DB canonica | MySQL separado en `10.80.5.46:3306`, schema `sisoc_local` |
-| Filesystem raiz | 785 GB, 90 GB usados, 663 GB libres, 12% |
+| Filesystem raiz antes del backup local | 785 GB, 90 GB usados, 663 GB libres, 12% |
 | Inodos | 2% usados |
 | Uptime observado | 25 dias |
 
@@ -103,7 +104,8 @@ No habia conexiones establecidas al listener MySQL local 3306 en las muestras.
 | --- | --- |
 | `/sisoc/SISOC` | checkout backend activo, owner `sisoc-deploy`, modo 2775 |
 | `/sisoc/SISOC/.env` | configuracion real, `sisoc-deploy:sisoc-deploy`, modo 640 |
-| `/sisoc/SISOC/media` | 65 GiB, 68,455 archivos; dato critico no regenerable |
+| `/sisoc/SISOC/media` | 65 GiB; 68,548 archivos al copiar; dato critico no regenerable |
+| `/sisoc/backups/media/20260713_172352/media` | copia local aprobada, privada de root y en el mismo filesystem |
 | `/sisoc/SISOC/static_root` | 27 MiB, 894 archivos; regenerable |
 | `/sisoc/SISOC/logs` | 1.3 GiB, logs por fecha |
 | `/sisoc/SISOC/tmp` | 24 KiB, tres archivos no trackeados; contenido no leido |
@@ -129,6 +131,27 @@ Mobile activo:
 
 No se leyo ni borro contenido de `tmp/`, media, checkouts historicos o `.env`.
 
+## Backup local de media
+
+El 2026-07-13 se creo, con aprobacion explicita, el snapshot local
+`/sisoc/backups/media/20260713_172352/media`:
+
+- fuente `/sisoc/SISOC/media`, sin mover ni borrar el original;
+- fuente medida en 69,226,448,310 bytes mediante `du -sb`;
+- 68,548 archivos regulares en fuente y destino, con igual suma de bytes;
+- dos pasadas `rsync -aH --numeric-ids --one-file-system --partial`;
+- segunda pasada con cero archivos transferidos;
+- dry-run final con `PENDING_CHANGES=0`;
+- prioridad reducida mediante `nice` e `ionice`;
+- estado root-only en
+  `/sisoc/backups/media/20260713_172352/status.txt`;
+- ningun servicio fue detenido o reiniciado.
+
+La copia es util para rollback local y como fuente de migracion, pero no es
+disaster recovery: comparte servidor, disco logico y filesystem con el origen.
+Fue tomada en vivo, por lo que no constituye un snapshot atomico. No se hizo un
+checksum completo ni una copia fuera del host.
+
 ## Base de datos
 
 La identidad canonica fue confirmada desde Django con una consulta de solo
@@ -139,6 +162,10 @@ metadatos:
 - UUID remoto `029056ed-ca22-11ea-a02b-005056a21400`;
 - schema `sisoc_local`;
 - conectividad TCP confirmada.
+
+El responsable informo que existen backups de la DB. No se inspeccionaron su
+ubicacion, retencion, integridad ni evidencia de restore, por lo que esos puntos
+siguen pendientes.
 
 MySQL local:
 
@@ -264,10 +291,17 @@ Solo lectura:
 - conteos sanitizados de cron y logs, sin imprimir su contenido;
 - consulta read-only del `main` actual mediante GitHub.
 
+Escritura aprobada:
+
+- creacion de `/sisoc/backups/media/20260713_172352/media` y `status.txt`;
+- copia local de media en dos pasadas con `rsync`, sin `--delete`;
+- validacion por conteo, bytes y dry-run final sin diferencias pendientes.
+
 ## No verificado
 
-1. Backup, retencion y ultimo restore probado de DB `10.80.5.46`.
-2. Backup, checksum y crecimiento historico de los 65 GiB de media.
+1. Ubicacion, retencion, integridad y ultimo restore probado de los backups DB
+   informados para `10.80.5.46`.
+2. Checksum completo, copia fuera del host y crecimiento historico de media.
 3. Linea exacta del cron root de poda Docker y resultado de sus ejecuciones.
 4. Flujo efectivo de deploy/rollback de SISOC-Mobile.
 5. Owner/proceso exacto del listener local 556.
@@ -275,3 +309,5 @@ Solo lectura:
 7. Firewall/ACL efectivos para 3306, 8001, 10000 y 10050.
 8. Politica de retencion legal/operativa de logs y auditoria.
 9. Backups seguros de configuracion fuera del host.
+10. Uso de disco posterior al backup local: el reintento read-only de `df`
+    encontro un timeout SSH y no se repitio en esta fase.

--- a/docs/infra/PROD_MIGRATION_CHECKLIST.md
+++ b/docs/infra/PROD_MIGRATION_CHECKLIST.md
@@ -3,7 +3,8 @@
 Fuente canonica actual: `prd-old` (`10.80.5.45`). Los hosts AWS son referencias
 de una posible migracion y no forman parte del runtime vigente.
 
-Este checklist no autoriza cutover, deploy, backup, restore ni cambios.
+Este checklist no autoriza nuevos cutovers, deploys, backups, restores ni
+cambios. El backup local de media ya ejecutado tuvo aprobacion separada.
 
 ## Gobierno previo
 
@@ -22,14 +23,18 @@ Este checklist no autoriza cutover, deploy, backup, restore ni cambios.
       `ec7c163fede8b3877fff0fd7863f0a7812043c2c`.
 - [x] DB real: `10.80.5.46:3306`, servidor `ldmzsql-sisoc`, schema
       `sisoc_local`.
-- [x] Media: 65 GiB, 68,455 archivos.
+- [x] Media: 65 GiB, 68,548 archivos al tomar el backup local.
 - [x] Servicios activos: siete contenedores, NGINX, runner, Zabbix y Webmin.
 - [ ] Repetir HEAD/conteos inmediatamente antes del cutover.
 
 ## Respaldar y copiar
 
-- [ ] Crear backup consistente de DB `10.80.5.46` y probar restore aislado.
-- [ ] Copiar `/sisoc/SISOC/media` preservando metadata y verificar checksums.
+- [ ] Verificar ubicacion, retencion e integridad de los backups DB informados y
+      probar restore aislado de `10.80.5.46`.
+- [x] Crear copia local de `/sisoc/SISOC/media` preservando metadata en
+      `/sisoc/backups/media/20260713_172352/media`; dos pasadas y cero
+      diferencias pendientes.
+- [ ] Copiar media fuera de `prd-old` y verificar checksums antes del cutover.
 - [ ] Transferir `.env` backend/mobile por canal seguro, sin imprimir valores.
 - [ ] Exportar configuracion NGINX, metadata TLS, systemd/runner y cron efectivo.
 - [ ] Guardar commits, Compose, Dockerfiles y scripts operativos versionados.

--- a/docs/infra/PROD_RISKS.md
+++ b/docs/infra/PROD_RISKS.md
@@ -1,14 +1,17 @@
 # Produccion - Riesgos de infraestructura
 
-Estado: auditoria read-only del 2026-07-13. Ninguna recomendacion de este
-documento autoriza cambios en produccion.
+Estado: auditoria inicial read-only del 2026-07-13, seguida unicamente por un
+backup local de media aprobado. Ninguna recomendacion restante de este documento
+autoriza cambios en produccion.
 
 ## Riesgos criticos
 
-### 1. Backups y restores de DB/media no demostrados
+### 1. Backups externos y restores no demostrados
 
-La DB canonica vive en `10.80.5.46` y media ocupa 65 GiB/68,455 archivos. No se
-obtuvo evidencia de backup vigente ni restore probado para ninguno.
+El responsable informo que existen backups de la DB canonica `10.80.5.46`, pero
+no se verificaron ubicacion, retencion, integridad ni restore. Media tiene una
+copia local completa de 65 GiB/68,548 archivos, pero vive en el mismo servidor y
+filesystem; tampoco tiene checksum completo ni restore probado.
 
 Impacto: perdida de datos, migracion incompleta o imposibilidad de rollback.
 
@@ -92,7 +95,8 @@ reversible futuro.
 
 ## Migrabilidad
 
-- Media 65 GiB sin copia verificada.
+- Media 65 GiB con copia local reconciliada, pero sin copia externa, checksum
+  completo ni restore probado.
 - DB externa sin restore probado.
 - Secretos backend/mobile deben transferirse por canal seguro.
 - NGINX, runner, cron, monitoreo y DNS/TLS deben recrearse.
@@ -104,8 +108,10 @@ reversible futuro.
 1. Mantener y revisar estos documentos.
 2. Monitorear disco, health, listeners y tamanios en modo read-only.
 3. Obtener evidencia externa de backups/restores sin tocar la DB.
-4. Confirmar linea exacta de cron root mediante un conteo sanitizado.
-5. Clasificar owners de puertos y responsables operativos.
+4. Replicar el snapshot de media fuera del host y verificarlo antes de borrar
+   cualquier copia.
+5. Confirmar linea exacta de cron root mediante un conteo sanitizado.
+6. Clasificar owners de puertos y responsables operativos.
 
 ## Requiere aprobacion explicita
 
@@ -121,7 +127,8 @@ reversible futuro.
 
 ## No conviene tocar todavia
 
-1. DB, media y logs hasta tener backup/retencion/restore acordados.
+1. DB, media original, snapshot local y logs hasta tener
+   backup/retencion/restore acordados.
 2. MySQL local hasta una ventana, backup root-only y observacion aprobados.
 3. Cron root hasta leer la linea exacta y validar ownership funcional.
 4. Deploy mobile hasta probar rollback y compatibilidad con `main`.


### PR DESCRIPTION
## Que cambio

- Registra el backup local aprobado de `/sisoc/SISOC/media` en `/sisoc/backups/media/20260713_172352/media`.
- Documenta dos pasadas de rsync, 68.548 archivos coincidentes y cero cambios pendientes.
- Actualiza inventario, riesgos, checklist de migracion y propuestas de produccion.
- Distingue el snapshot local de un backup externo/disaster recovery.
- Registra que los backups DB fueron informados pero su retencion, integridad y restore siguen sin verificar.

## Por que

El PR de auditoria de produccion ya fue mergeado antes de ejecutar el backup de media. Este follow-up mantiene la documentacion operativa alineada con el estado real sin aplicar nuevos cambios en el servidor.

## Validacion

- `git diff --check`
- Segunda pasada rsync: cero archivos transferidos.
- Fuente/destino: 68.548 archivos.
- Dry-run final: `PENDING_CHANGES=0`.

## Riesgos pendientes

- La copia comparte servidor y filesystem con el origen; no cubre perdida del host.
- Falta copia externa, checksum completo y prueba de restore.
- El `df` posterior no se confirmo por timeout SSH y queda explicitamente documentado.