### PR TITLE
fix(deploy): alinear workers y Mobile en HML

### DIFF
--- a/docs/operacion/deploy_entornos_docker_nginx_mysql.md
+++ b/docs/operacion/deploy_entornos_docker_nginx_mysql.md
@@ -30,7 +30,7 @@ Convenciones recomendadas:
 | Entorno      | Branch         | `ENVIRONMENT`  | Compose app                                                   |
 | ------------ | -------------- | -------------- | ------------------------------------------------------------- |
 | QA           | `development`  | `qa`           | `docker-compose.deploy.yml`                                   |
-| Homologacion | `homologacion` | `homologacion` | `docker-compose.deploy.yml`                                   |
+| Homologacion | `homologacion` | `homologacion` | `docker-compose.deploy.yml` + `docker-compose.produccion.yml` |
 | Produccion   | `main`         | `prd`          | `docker-compose.deploy.yml` + `docker-compose.produccion.yml` |
 
 No usar para deploy:
@@ -743,7 +743,7 @@ MYSQL_PWD='<DB_APP_PASSWORD>' mysql --ssl=0 \
 
 ## 8. Levantar aplicacion
 
-QA y homologacion:
+QA:
 
 ```bash
 cd "$APP_ROOT"
@@ -758,6 +758,13 @@ sudo -H -u "$APP_USER" docker compose \
   -f docker-compose.deploy.yml \
   -f docker-compose.produccion.yml \
   up -d --build
+```
+
+Homologacion usa el mismo compose de workers que produccion y
+`deploy_refresh.sh` refresca SISOC-Mobile automaticamente:
+
+```bash
+bash scripts/operacion/deploy_refresh.sh
 ```
 
 Revisar logs hasta Gunicorn:

--- a/docs/operacion/infraestructura.md
+++ b/docs/operacion/infraestructura.md
@@ -34,7 +34,7 @@
 | Entorno      | URL(s)                                 | Hosting                     | Notas                                                                                                 | Owner     |
 | ------------ | -------------------------------------- | --------------------------- | ----------------------------------------------------------------------------------------------------- | --------- |
 | qa           | http://10.1.131.121/                   | Self-hosted + NGINX interno | Deploy desde branch `development`; usa `docker-compose.deploy.yml` + `.env` del servidor; DB dedicada en `10.1.130.88` | Tech Lead |
-| homologacion | https://homologacion.sisoc.example.gov.ar/ | Self-hosted + NGINX interno | Deploy desde branch `homologacion`; entorno similar a produccion, definido por `.env` del servidor | Tech Lead |
+| homologacion | https://homologacion.sisoc.example.gov.ar/ | Self-hosted + NGINX interno | Deploy desde branch `homologacion`; usa `docker-compose.deploy.yml` + `docker-compose.produccion.yml` y despliega SISOC-Mobile | Tech Lead |
 | prd          | https://sisoc.secretarianaf.gob.ar/    | Self-hosted + NGINX interno | Deploy desde branch `main`; usa `docker-compose.deploy.yml` + `docker-compose.produccion.yml`       | Tech Lead |
 
 ## 3. Architecture (High-level)
@@ -82,8 +82,8 @@
 - Process model:
   - Proceso web Django.
   - `docker-compose.yml` local define `mysql` + `django`.
-  - Los deploys versionados usan `docker-compose.deploy.yml`; hoy solo produccion agrega `docker-compose.produccion.yml`.
-  - QA y homologacion se resuelven con el mismo compose base y el `.env` del servidor.
+  - Los deploys versionados usan `docker-compose.deploy.yml`; homologacion y produccion agregan `docker-compose.produccion.yml` para levantar los workers de background.
+  - QA usa solo el compose base; homologacion tambien refresca SISOC-Mobile.
   - Jobs programados por cron del host (limpieza logs, prune Docker, hetrixtools, purge_auditlog).
 
 - Autoscaling rules (if any):

--- a/scripts/operacion/deploy_refresh.sh
+++ b/scripts/operacion/deploy_refresh.sh
@@ -41,7 +41,10 @@ Opciones:
 
 Mapeo por entorno:
   ENVIRONMENT=dev|local|development -> docker-compose.yml
-  ENVIRONMENT=qa|homologacion       -> docker-compose.deploy.yml
+  ENVIRONMENT=qa                    -> docker-compose.deploy.yml
+  ENVIRONMENT=homologacion|hml|staging
+                                  -> docker-compose.deploy.yml + docker-compose.produccion.yml
+                                     + SISOC-Mobile
   ENVIRONMENT=prd|prod|production   -> docker-compose.deploy.yml + docker-compose.produccion.yml
 USAGE
 }
@@ -180,8 +183,9 @@ compose_for_environment() {
       EXPECTED_BRANCH="${QA_BRANCH:-development}"
       ;;
     homologacion|hml|staging)
-      COMPOSE_FILES=("docker-compose.deploy.yml")
+      COMPOSE_FILES=("docker-compose.deploy.yml" "docker-compose.produccion.yml")
       EXPECTED_BRANCH="${HOMOLOGACION_BRANCH:-homologacion}"
+      WITH_MOBILE=1
       ;;
     prd|prod|production|produccion)
       COMPOSE_FILES=("docker-compose.deploy.yml" "docker-compose.produccion.yml")


### PR DESCRIPTION
## Qué cambia

- HML carga `docker-compose.produccion.yml` junto al compose base, levantando los workers de background equivalentes a producción.
- El refresco de HML despliega SISOC-Mobile automáticamente.
- Se actualizan los runbooks de infraestructura y deploy.

## Motivo

HML estaba levantando solo el compose base, por lo que no iniciaba los workers adicionales ni refrescaba Mobile.

## Validación

- Sintaxis Bash del script verificada.
- `docker compose -f docker-compose.deploy.yml -f docker-compose.produccion.yml config --services` confirma los workers esperados.
- `git diff --check`.