### PR TITLE
fix(deploy): confiar checkout Mobile en HML

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -45,6 +45,9 @@ jobs:
               shell: bash
               env:
                   GH_APP_ROOT: "${{ vars.APP_ROOT }}"
+                  GIT_CONFIG_COUNT: "1"
+                  GIT_CONFIG_KEY_0: safe.directory
+                  GIT_CONFIG_VALUE_0: /sisoc/SISOC-Mobile
               run: |
                   set -Eeuo pipefail
 


### PR DESCRIPTION
## Qué cambia

Configura `safe.directory=/sisoc/SISOC-Mobile` solamente para el job `deploy-homologacion`.

## Causa raíz

El runner corre como `sisoc-deploy`, mientras el checkout Mobile pertenece a `admin-ssies`. Git rechaza el repositorio por *dubious ownership* antes de iniciar el deploy.

## Impacto

La excepción vive sólo en el entorno del job: no modifica propietarios, permisos, `.env` ni configuración Git persistente del host.

## Validación

- YAML del workflow parseado y las variables del job verificadas.
- Configuración Git temporal verificada localmente.
- `git diff --check`.