### PR TITLE
fix(deploy): evitar falso dirty check en HML

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -58,6 +58,7 @@ jobs:
                   fi
 
                   cd "$APP_ROOT"
+                  git -C /sisoc/SISOC-Mobile update-index --refresh
                   echo "Commit previo al deploy para rollback: $(git rev-parse HEAD)"
                   ./scripts/operacion/deploy_refresh.sh --yes --with-mobile --mobile-dir /sisoc/SISOC-Mobile
 

--- a/scripts/operacion/deploy_refresh.sh
+++ b/scripts/operacion/deploy_refresh.sh
@@ -160,8 +160,10 @@ ensure_clean_branch() {
   fi
 
   if [[ "$ALLOW_DIRTY" -eq 0 ]]; then
-    git -C "$repo_dir" diff-index --quiet HEAD -- \
-      || fail "$label tiene cambios tracked locales. Commit/stash o usa --allow-dirty."
+    if ! git -C "$repo_dir" diff --quiet -- \
+      || ! git -C "$repo_dir" diff --cached --quiet --; then
+      fail "$label tiene cambios tracked locales. Commit/stash o usa --allow-dirty."
+    fi
   fi
 
   printf -v "$branch_var_name" '%s' "$branch"


### PR DESCRIPTION
## Qué cambia

Reemplaza el guard basado en `git diff-index` por las comprobaciones de árbol de trabajo e índice de Git.

## Causa raíz

Después de corregir ownership del checkout Mobile, `diff-index` conservaba metadatos de archivos obsoletos y devolvía cambios inexistentes. `git diff` y `git diff --cached` verifican que no haya modificaciones reales.

## Validación

- Sintaxis Bash.
- `git diff --check`.
- En HML, ambas comprobaciones nuevas devuelven limpio para SISOC-Mobile.