### PR TITLE
fix(cdi): asegurar carga atomica de asistencia

### DIFF
--- a/AGENT_REPO_MAP.md
+++ b/AGENT_REPO_MAP.md
@@ -281,7 +281,7 @@ La siguiente tabla mezcla hechos observados con inferencias explicitas cuando no
 | `ticketera/` | API server-to-server con kill-switch | `api_urls.py`, `api_views.py`, `api_serializers.py` | Medio |
 | `comunicados/` | mensajes/comunicados y API asociada | `models.py`, `views.py`, `api_views.py`, forms | Medio |
 | `organizaciones/` | entidades/organizaciones vinculadas | `models.py`, `views.py`, forms | Medio |
-| `centrodeinfancia/` | dominio de centros de infancia | `models.py`, `views.py`, urls | Medio |
+| `centrodeinfancia/` | dominio de centros de infancia, personal y asistencia | `models.py`, `services.py`, `views.py`, `tests/`, urls | Alto |
 | `acompanamientos/` | seguimiento/acompanamientos | `views.py`, service, templates | Medio |
 | `expedientespagos/` | expedientes de pagos | `models.py`, `views.py`, urls | Bajo |
 | `rendicioncuentasfinal/` | rendicion final | `models.py`, `views.py`, urls | Bajo |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - [sin-area] hotfix. (PR #2046)
 - [sin-area] hotfix: asistencia de trabajadores CDI (backport a main de PR #2046). (PR #2048)
 - [sin-area] Main (resuelve conflicto PR #2052). (PR #2054)
+- [sin-area] fix(cdi): asegurar carga atomica de asistencia. (PR #2059)
 <!-- AUTO-GENERATED RELEASE END: 2026-07-15 -->
 
 <!-- AUTO-GENERATED RELEASE START: 2026-07-08 -->

--- a/centrodeinfancia/services.py
+++ b/centrodeinfancia/services.py
@@ -92,9 +92,7 @@ class AsistenciaTrabajadorService:
             if marca is None:
                 continue
             if marca not in cls._MARCAS:
-                raise ValidationError(
-                    "El estado de asistencia recibido no es válido."
-                )
+                raise ValidationError("El estado de asistencia recibido no es válido.")
             observaciones = (datos.get(f"obs_{trabajador.pk}") or "").strip()
             cambios.append(
                 (

--- a/centrodeinfancia/services.py
+++ b/centrodeinfancia/services.py
@@ -1,9 +1,14 @@
+import datetime
 import logging
+import re
 
+from django.core.exceptions import ValidationError
 from django.db import transaction
+from django.utils import timezone
 
 from centrodeinfancia.access import aplicar_scope_centros_cdi
 from centrodeinfancia.models import (
+    AsistenciaTrabajador,
     CentroDeInfancia,
     NominaCentroInfancia,
     NominaCentroInfanciaDerivacion,
@@ -56,6 +61,62 @@ _CAMPOS_COPIABLES = [
     "adulto_responsable_parentesco",
     "observaciones",
 ]
+
+
+class AsistenciaTrabajadorService:
+    _MARCAS = {"0": False, "1": True}
+    _FORMATO_FECHA = re.compile(r"^\d{4}-\d{2}-\d{2}$")
+
+    @classmethod
+    def parsear_fecha(cls, fecha_raw):
+        if not fecha_raw:
+            return timezone.localdate()
+        if not cls._FORMATO_FECHA.fullmatch(fecha_raw):
+            raise ValidationError(
+                "La fecha debe tener formato AAAA-MM-DD y ser válida."
+            )
+        try:
+            return datetime.date.fromisoformat(fecha_raw)
+        except ValueError as exc:
+            raise ValidationError(
+                "La fecha debe tener formato AAAA-MM-DD y ser válida."
+            ) from exc
+
+    @classmethod
+    def guardar(cls, *, centro, fecha_raw, datos, usuario):
+        fecha = cls.parsear_fecha(fecha_raw)
+        cambios = []
+
+        for trabajador in centro.trabajadores.order_by("apellido", "nombre"):
+            marca = datos.get(f"presente_{trabajador.pk}")
+            if marca is None:
+                continue
+            if marca not in cls._MARCAS:
+                raise ValidationError(
+                    "El estado de asistencia recibido no es válido."
+                )
+            observaciones = (datos.get(f"obs_{trabajador.pk}") or "").strip()
+            cambios.append(
+                (
+                    trabajador,
+                    cls._MARCAS[marca],
+                    observaciones or None,
+                )
+            )
+
+        with transaction.atomic():
+            for trabajador, presente, observaciones in cambios:
+                AsistenciaTrabajador.objects.update_or_create(
+                    trabajador=trabajador,
+                    fecha=fecha,
+                    defaults={
+                        "presente": presente,
+                        "observaciones": observaciones,
+                        "registrado_por": usuario,
+                    },
+                )
+
+        return fecha
 
 
 class CentroDeInfanciaService:

--- a/centrodeinfancia/templates/centrodeinfancia/trabajador_asistencia.html
+++ b/centrodeinfancia/templates/centrodeinfancia/trabajador_asistencia.html
@@ -114,6 +114,7 @@
                                                 Marcar todos
                                             </label>
                                         </th>
+                                        <th>Observaciones</th>
                                     </tr>
                                 </thead>
                                 <tbody id="asisTablaBody">
@@ -130,9 +131,6 @@
                                                 {% endif %}
                                             </td>
                                             <td>
-                                                <input type="hidden"
-                                                       name="obs_{{ fila.trabajador.pk }}"
-                                                       value="{{ fila.observaciones|default:'' }}" />
                                                 <label class="cdf-mark">
                                                     <input type="radio"
                                                            class="cdf-check cdf-check--present asis-present"
@@ -151,6 +149,13 @@
                                                            {% if fila.presente == False %}checked{% endif %} />
                                                     Ausente
                                                 </label>
+                                            </td>
+                                            <td>
+                                                <input type="text"
+                                                       name="obs_{{ fila.trabajador.pk }}"
+                                                       value="{{ fila.observaciones|default:'' }}"
+                                                       class="cdf-input"
+                                                       aria-label="Observaciones para {{ fila.trabajador.apellido }}, {{ fila.trabajador.nombre }}" />
                                             </td>
                                         </tr>
                                     {% endfor %}

--- a/centrodeinfancia/tests/test_asistencia_trabajador.py
+++ b/centrodeinfancia/tests/test_asistencia_trabajador.py
@@ -68,6 +68,7 @@ def test_asistencia_get_carga_estado_guardado(client):
         trabajador=trabajador,
         fecha=fecha,
         presente=True,
+        observaciones="Llegó temprano",
         registrado_por=user,
     )
 
@@ -77,6 +78,10 @@ def test_asistencia_get_carga_estado_guardado(client):
     assert response.context["fecha"] == fecha
     assert response.context["total_presentes"] == 1
     assert response.context["filas"][0]["presente"] is True
+    content = response.content.decode("utf-8")
+    assert f'name="obs_{trabajador.pk}"' in content
+    assert 'type="text"' in content
+    assert 'value="Llegó temprano"' in content
 
 
 @pytest.mark.django_db
@@ -174,6 +179,98 @@ def test_asistencia_trabajador_sin_marcar_no_genera_registro(client):
     assert response.status_code == 302
     assert AsistenciaTrabajador.objects.filter(trabajador=marcado).exists()
     assert not AsistenciaTrabajador.objects.filter(trabajador=sin_marcar).exists()
+
+
+@pytest.mark.django_db
+def test_asistencia_post_rechaza_fecha_invalida_sin_guardar(client):
+    user = _crear_usuario("super-asis-invalid-date", superuser=True)
+    client.force_login(user)
+    centro = CentroDeInfancia.objects.create(nombre="CDI Fecha inválida")
+    trabajador = Trabajador.objects.create(
+        centro=centro,
+        nombre="Ana",
+        apellido="Lopez",
+    )
+
+    response = client.post(
+        _url(centro),
+        {
+            "fecha": "fecha-invalida",
+            f"presente_{trabajador.pk}": "1",
+        },
+    )
+
+    assert response.status_code == 302
+    assert not AsistenciaTrabajador.objects.exists()
+
+
+@pytest.mark.django_db
+def test_asistencia_post_valida_todas_las_marcas_antes_de_guardar(client):
+    user = _crear_usuario("super-asis-invalid-mark", superuser=True)
+    client.force_login(user)
+    centro = CentroDeInfancia.objects.create(nombre="CDI Marca inválida")
+    primero = Trabajador.objects.create(
+        centro=centro,
+        nombre="Ana",
+        apellido="Arias",
+    )
+    segundo = Trabajador.objects.create(
+        centro=centro,
+        nombre="Beto",
+        apellido="Benitez",
+    )
+
+    response = client.post(
+        _url(centro),
+        {
+            "fecha": "2026-06-21",
+            f"presente_{primero.pk}": "1",
+            f"presente_{segundo.pk}": "desconocido",
+        },
+    )
+
+    assert response.status_code == 302
+    assert not AsistenciaTrabajador.objects.exists()
+
+
+@pytest.mark.django_db
+def test_asistencia_post_revierte_el_lote_si_falla_una_escritura(
+    client,
+    monkeypatch,
+):
+    user = _crear_usuario("super-asis-atomic", superuser=True)
+    client.force_login(user)
+    centro = CentroDeInfancia.objects.create(nombre="CDI Lote atómico")
+    primero = Trabajador.objects.create(
+        centro=centro,
+        nombre="Ana",
+        apellido="Arias",
+    )
+    segundo = Trabajador.objects.create(
+        centro=centro,
+        nombre="Beto",
+        apellido="Benitez",
+    )
+    guardar_original = AsistenciaTrabajador.save
+
+    def guardar_con_falla(instancia, *args, **kwargs):
+        if instancia.trabajador_id == segundo.pk:
+            raise RuntimeError("falla simulada en segunda escritura")
+        return guardar_original(instancia, *args, **kwargs)
+
+    monkeypatch.setattr(AsistenciaTrabajador, "save", guardar_con_falla)
+
+    with pytest.raises(RuntimeError, match="falla simulada"):
+        client.post(
+            _url(centro),
+            {
+                "fecha": "2026-06-22",
+                f"presente_{primero.pk}": "1",
+                f"presente_{segundo.pk}": "0",
+            },
+        )
+
+    assert not AsistenciaTrabajador.objects.exists()
 
 
 @pytest.mark.django_db

--- a/centrodeinfancia/views.py
+++ b/centrodeinfancia/views.py
@@ -9,6 +9,7 @@ from django.contrib import messages
 from django.contrib.auth.decorators import login_required
 from django.contrib.auth.mixins import LoginRequiredMixin
 from django.contrib.contenttypes.models import ContentType
+from django.core.exceptions import ValidationError
 from django.core.paginator import Paginator
 from django.db import transaction
 from django.db.models import Exists, OuterRef, Q
@@ -63,7 +64,10 @@ from centrodeinfancia.models import (
     ObservacionCentroInfancia,
     Trabajador,
 )
-from centrodeinfancia.services import CentroDeInfanciaService
+from centrodeinfancia.services import (
+    AsistenciaTrabajadorService,
+    CentroDeInfanciaService,
+)
 from centrodeinfancia.views_formulario_cdi import construir_resumenes_formularios
 from intervenciones.constants import PROGRAMA_ALIASES_CENTRO_INFANCIA
 
@@ -1798,9 +1802,12 @@ class AsistenciaTrabajadorCentroView(LoginRequiredMixin, TemplateView):
             )
         return self._centro_cache
 
-    @staticmethod
-    def _parse_fecha(fecha_raw):
-        return _parse_fecha_renaper(fecha_raw) or timezone.localdate()
+    def _parse_fecha(self, fecha_raw):
+        try:
+            return AsistenciaTrabajadorService.parsear_fecha(fecha_raw)
+        except ValidationError as exc:
+            messages.error(self.request, exc.messages[0])
+            return timezone.localdate()
 
     @staticmethod
     def _trabajadores(centro):
@@ -1853,20 +1860,17 @@ class AsistenciaTrabajadorCentroView(LoginRequiredMixin, TemplateView):
 
     def post(self, request, *args, **kwargs):
         centro = self._get_centro()
-        fecha = self._parse_fecha(request.POST.get("fecha"))
-        for trabajador in self._trabajadores(centro):
-            marca = request.POST.get(f"presente_{trabajador.pk}")
-            if marca is None:
-                continue
-            observaciones = (request.POST.get(f"obs_{trabajador.pk}") or "").strip()
-            AsistenciaTrabajador.objects.update_or_create(
-                trabajador=trabajador,
-                fecha=fecha,
-                defaults={
-                    "presente": marca == "1",
-                    "observaciones": observaciones or None,
-                    "registrado_por": request.user,
-                },
+        try:
+            fecha = AsistenciaTrabajadorService.guardar(
+                centro=centro,
+                fecha_raw=request.POST.get("fecha"),
+                datos=request.POST,
+                usuario=request.user,
+            )
+        except ValidationError as exc:
+            messages.error(request, exc.messages[0])
+            return redirect(
+                "centrodeinfancia_trabajadores_asistencia", pk=centro.pk
             )
         messages.success(request, "Asistencia registrada correctamente.")
         url = reverse(

--- a/centrodeinfancia/views.py
+++ b/centrodeinfancia/views.py
@@ -1869,9 +1869,7 @@ class AsistenciaTrabajadorCentroView(LoginRequiredMixin, TemplateView):
             )
         except ValidationError as exc:
             messages.error(request, exc.messages[0])
-            return redirect(
-                "centrodeinfancia_trabajadores_asistencia", pk=centro.pk
-            )
+            return redirect("centrodeinfancia_trabajadores_asistencia", pk=centro.pk)
         messages.success(request, "Asistencia registrada correctamente.")
         url = reverse(
             "centrodeinfancia_trabajadores_asistencia", kwargs={"pk": centro.pk}

--- a/docs/contexto/features/pr-2059-fix-cdi-asegurar-carga-atomica-de-asistencia.md
+++ b/docs/contexto/features/pr-2059-fix-cdi-asegurar-carga-atomica-de-asistencia.md
@@ -33,19 +33,26 @@
 - Empezar por `docs/registro/prs/PR-2059.md` para contexto resumido del PR.
 - Revisar primero estos archivos del diff:
 - `AGENT_REPO_MAP.md`
+- `CHANGELOG.md`
 - `centrodeinfancia/services.py`
 - `centrodeinfancia/templates/centrodeinfancia/trabajador_asistencia.html`
 - `centrodeinfancia/tests/test_asistencia_trabajador.py`
 - `centrodeinfancia/views.py`
+- `docs/contexto/features/pr-2059-fix-cdi-asegurar-carga-atomica-de-asistencia.md`
 - `docs/plans/2026-07-14-cdi-asistencia-hardening-design.md`
 - `docs/registro/cambios/2026-07-13-cdi-asistencia-trabajadores.md`
+- `docs/registro/prs/PR-2059.md`
+- `docs/registro/releases/pending/2026-07-15-pr-2059.md`
 - Documentación sugerida para ampliar contexto:
 - `docs/indice.md`
 - `docs/ia/CONTEXT_HYGIENE.md`
 - `docs/ia/ARCHITECTURE.md`
 - `docs/ia/TESTING.md`
+- `docs/contexto/features/pr-2059-fix-cdi-asegurar-carga-atomica-de-asistencia.md`
 - `docs/plans/2026-07-14-cdi-asistencia-hardening-design.md`
 - `docs/registro/cambios/2026-07-13-cdi-asistencia-trabajadores.md`
+- `docs/registro/prs/PR-2059.md`
+- `docs/registro/releases/pending/2026-07-15-pr-2059.md`
 
 ## Trazabilidad
 

--- a/docs/contexto/features/pr-2059-fix-cdi-asegurar-carga-atomica-de-asistencia.md
+++ b/docs/contexto/features/pr-2059-fix-cdi-asegurar-carga-atomica-de-asistencia.md
@@ -1,0 +1,53 @@
+# Contexto de feature PR #2059 - fix(cdi): asegurar carga atomica de asistencia
+
+## Resumen
+
+- PR: https://github.com/dsocial118/SISOC/pull/2059
+- Base: `main`
+- Rama origen: `codex/cdi-attendance-safety`
+- Autor: `juanikitro`
+
+## Contexto funcional
+
+- No informado explícitamente; inferir desde el título del PR y el diff.
+
+## Arquitectura tocada
+
+- Hay cambios en vistas web y puede existir impacto en permisos o renderizado.
+- Se modifican templates, con posible impacto visual o de composición UI.
+
+## Decisiones y supuestos detectados
+
+- Tipo de cambio declarado: No informado
+- Área principal declarada: No informada
+- Impacto usuario declarado: No informado
+- Riesgos / rollback: No informado
+
+## Design system y UI
+
+- El PR toca piezas de UI y conviene revisar consistencia visual con el patrón existente.
+- Archivos visuales relevantes: centrodeinfancia/templates/centrodeinfancia/trabajador_asistencia.html
+
+## Memoria operativa para agentes
+
+- Empezar por `docs/registro/prs/PR-2059.md` para contexto resumido del PR.
+- Revisar primero estos archivos del diff:
+- `AGENT_REPO_MAP.md`
+- `centrodeinfancia/services.py`
+- `centrodeinfancia/templates/centrodeinfancia/trabajador_asistencia.html`
+- `centrodeinfancia/tests/test_asistencia_trabajador.py`
+- `centrodeinfancia/views.py`
+- `docs/plans/2026-07-14-cdi-asistencia-hardening-design.md`
+- `docs/registro/cambios/2026-07-13-cdi-asistencia-trabajadores.md`
+- Documentación sugerida para ampliar contexto:
+- `docs/indice.md`
+- `docs/ia/CONTEXT_HYGIENE.md`
+- `docs/ia/ARCHITECTURE.md`
+- `docs/ia/TESTING.md`
+- `docs/plans/2026-07-14-cdi-asistencia-hardening-design.md`
+- `docs/registro/cambios/2026-07-13-cdi-asistencia-trabajadores.md`
+
+## Trazabilidad
+
+- Documento generado automáticamente desde el evento de `pull_request`.
+- Si este PR cambia de título, el archivo se renombrará para mantener el slug alineado.

--- a/docs/plans/2026-07-14-cdi-asistencia-hardening-design.md
+++ b/docs/plans/2026-07-14-cdi-asistencia-hardening-design.md
@@ -1,0 +1,41 @@
+# Hardening de asistencia de trabajadores CDI
+
+Estado: aprobado para preparar antes del deploy productivo del 2026-07-14.
+
+## Riesgos a resolver
+
+- Una fecha POST invalida se convertia silenciosamente en la fecha actual.
+- Cualquier marca distinta de `1` se guardaba como ausencia.
+- El lote ejecutaba escrituras independientes sin una transaccion comun.
+- `observaciones` se reenviaba en un input oculto y no era editable en la UI.
+
+## Diseno
+
+La vista conserva scope, permisos y redirect existentes, pero delega la escritura
+en `AsistenciaTrabajadorService`:
+
+1. fecha ausente usa hoy para compatibilidad; fecha presente debe ser
+   `AAAA-MM-DD` valida;
+2. solo se aceptan las marcas `0` y `1`;
+3. se valida el lote completo antes de escribir;
+4. todos los `update_or_create` corren dentro de una unica
+   `transaction.atomic()`;
+5. un trabajador sin marcar sigue sin generar registro;
+6. observaciones se muestra como input editable por fila.
+
+Los errores de validacion muestran un mensaje y no escriben datos. Una excepcion
+de base de datos se propaga, pero la transaccion revierte el lote completo para
+que el error operativo sea visible y no deje una carga parcial.
+
+## Compatibilidad y rollback
+
+No cambia modelo, migracion, URL, permiso ni schema. El rollback es revertir el
+PR; los registros ya guardados siguen siendo compatibles con la version previa.
+
+## Validacion
+
+- regresiones existentes de asistencia;
+- fecha invalida sin escrituras;
+- marca invalida despues de una marca valida sin escrituras;
+- falla simulada en la segunda escritura con rollback de la primera;
+- observaciones existentes visibles y editables en el HTML.

--- a/docs/registro/cambios/2026-07-13-cdi-asistencia-trabajadores.md
+++ b/docs/registro/cambios/2026-07-13-cdi-asistencia-trabajadores.md
@@ -63,3 +63,17 @@ del CDI no tiene sesiones, así que la unidad de asistencia acá es **por fecha
 - Smoke con test client: botón presente en el detalle; GET default (fecha hoy,
   12 filas), POST crea registro y redirige con `?fecha=`, GET con fecha
   guardada refleja el presente.
+
+## Hardening previo a producción (2026-07-14)
+
+- El POST delega en `AsistenciaTrabajadorService`.
+- La fecha se valida estrictamente como `AAAA-MM-DD`; un valor inválido no cae
+  silenciosamente en la fecha actual ni genera registros.
+- Solo se aceptan las marcas `0` y `1`, y se valida el lote completo antes de
+  escribir.
+- Todos los `update_or_create` del lote corren en una única
+  `transaction.atomic()`, por lo que una falla intermedia revierte lo anterior.
+- `observaciones` ahora es un campo visible y editable en cada fila, en lugar
+  de un input oculto.
+- La cobertura agrega fecha/marca inválidas, rollback de una segunda escritura
+  fallida y render del campo de observaciones existente.

--- a/docs/registro/prs/PR-2059.md
+++ b/docs/registro/prs/PR-2059.md
@@ -6,7 +6,7 @@
 - Base: `main`
 - Rama origen: `codex/cdi-attendance-safety`
 - Autor: `juanikitro`
-- Última actualización: `2026-07-14T15:48:29Z`
+- Última actualización: `2026-07-14T15:48:43Z`
 
 ## Resumen operativo
 
@@ -19,19 +19,25 @@
 ## Áreas afectadas
 
 - `AGENT_REPO_MAP.md`
+- `CHANGELOG.md`
 - `centrodeinfancia`
+- `docs/contexto`
 - `docs/plans`
 - `docs/registro`
 
 ## Archivos relevantes del diff
 
 - `AGENT_REPO_MAP.md`
+- `CHANGELOG.md`
 - `centrodeinfancia/services.py`
 - `centrodeinfancia/templates/centrodeinfancia/trabajador_asistencia.html`
 - `centrodeinfancia/tests/test_asistencia_trabajador.py`
 - `centrodeinfancia/views.py`
+- `docs/contexto/features/pr-2059-fix-cdi-asegurar-carga-atomica-de-asistencia.md`
 - `docs/plans/2026-07-14-cdi-asistencia-hardening-design.md`
 - `docs/registro/cambios/2026-07-13-cdi-asistencia-trabajadores.md`
+- `docs/registro/prs/PR-2059.md`
+- `docs/registro/releases/pending/2026-07-15-pr-2059.md`
 
 ## Validación declarada
 
@@ -48,8 +54,11 @@
 - `docs/ia/CONTEXT_HYGIENE.md`
 - `docs/ia/ARCHITECTURE.md`
 - `docs/ia/TESTING.md`
+- `docs/contexto/features/pr-2059-fix-cdi-asegurar-carga-atomica-de-asistencia.md`
 - `docs/plans/2026-07-14-cdi-asistencia-hardening-design.md`
 - `docs/registro/cambios/2026-07-13-cdi-asistencia-trabajadores.md`
+- `docs/registro/prs/PR-2059.md`
+- `docs/registro/releases/pending/2026-07-15-pr-2059.md`
 
 ## Notas para continuidad
 

--- a/docs/registro/prs/PR-2059.md
+++ b/docs/registro/prs/PR-2059.md
@@ -6,7 +6,7 @@
 - Base: `main`
 - Rama origen: `codex/cdi-attendance-safety`
 - Autor: `juanikitro`
-- Última actualización: `2026-07-14T15:48:43Z`
+- Última actualización: `2026-07-14T16:09:34Z`
 
 ## Resumen operativo
 

--- a/docs/registro/prs/PR-2059.md
+++ b/docs/registro/prs/PR-2059.md
@@ -1,0 +1,57 @@
+# PR #2059 - fix(cdi): asegurar carga atomica de asistencia
+
+## Metadata
+
+- PR: https://github.com/dsocial118/SISOC/pull/2059
+- Base: `main`
+- Rama origen: `codex/cdi-attendance-safety`
+- Autor: `juanikitro`
+- Última actualización: `2026-07-14T15:48:29Z`
+
+## Resumen operativo
+
+- Tipo de cambio: No informado
+- Área principal: No informada
+- Contexto funcional: No informado explícitamente; revisar título, diff y documentación relacionada.
+- Resumen para changelog: No informado
+- Impacto usuario: No informado
+
+## Áreas afectadas
+
+- `AGENT_REPO_MAP.md`
+- `centrodeinfancia`
+- `docs/plans`
+- `docs/registro`
+
+## Archivos relevantes del diff
+
+- `AGENT_REPO_MAP.md`
+- `centrodeinfancia/services.py`
+- `centrodeinfancia/templates/centrodeinfancia/trabajador_asistencia.html`
+- `centrodeinfancia/tests/test_asistencia_trabajador.py`
+- `centrodeinfancia/views.py`
+- `docs/plans/2026-07-14-cdi-asistencia-hardening-design.md`
+- `docs/registro/cambios/2026-07-13-cdi-asistencia-trabajadores.md`
+
+## Validación declarada
+
+- Pruebas automáticas: No informado en el PR.
+- Pruebas manuales: No informado en el PR.
+
+## Riesgos y rollback
+
+- No informado explícitamente en el PR.
+
+## Documentación sugerida para lectura
+
+- `docs/indice.md`
+- `docs/ia/CONTEXT_HYGIENE.md`
+- `docs/ia/ARCHITECTURE.md`
+- `docs/ia/TESTING.md`
+- `docs/plans/2026-07-14-cdi-asistencia-hardening-design.md`
+- `docs/registro/cambios/2026-07-13-cdi-asistencia-trabajadores.md`
+
+## Notas para continuidad
+
+- Este documento es generado automáticamente desde el contexto del PR y sirve como índice rápido para revisión y futuras sesiones de agentes.
+- Si la metadata del body del PR está incompleta, varias secciones usarán fallbacks derivados del título o del diff.

--- a/docs/registro/releases/pending/2026-07-15-pr-2059.md
+++ b/docs/registro/releases/pending/2026-07-15-pr-2059.md
@@ -1,0 +1,19 @@
+---
+pr: 2059
+release_date: 2026-07-15
+category: Actualizaciones
+area: sin-area
+title: fix(cdi): asegurar carga atomica de asistencia
+summary: fix(cdi): asegurar carga atomica de asistencia
+impact: No informado
+source_url: https://github.com/dsocial118/SISOC/pull/2059
+---
+# Release note preliminar PR #2059
+
+- Fecha objetivo de release: 2026-07-15
+- Categoría: Actualizaciones
+- Área: sin-area
+- Título del PR: fix(cdi): asegurar carga atomica de asistencia
+- Resumen: fix(cdi): asegurar carga atomica de asistencia
+- Impacto usuario: No informado
+- Fuente: https://github.com/dsocial118/SISOC/pull/2059


### PR DESCRIPTION
## Riesgos corregidos

- fecha POST invalida ya no cae en hoy ni escribe;
- solo se aceptan marcas `0`/`1`;
- el lote completo se valida antes de guardar;
- los `update_or_create` comparten una unica transaccion;
- observaciones queda visible y editable por trabajador.

## Compatibilidad

No cambia modelo, migracion, URL ni permisos. Un trabajador sin marcar sigue sin generar registro.

## Cobertura agregada

- fecha invalida sin escrituras;
- marca invalida tardia sin escrituras parciales;
- rollback al fallar la segunda escritura;
- observacion guardada visible en un input editable.

## Validacion local

- `py_compile` de servicio, vista y tests;
- `git diff --check`.

Los tests Django y linters completos quedan a cargo de los checks del PR para no mutar el Docker/DB local compartido.