### PR TITLE
feat(infra): preparar mantenimiento nocturno de produccion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - [sin-area] hotfix. (PR #2046)
 - [sin-area] hotfix: asistencia de trabajadores CDI (backport a main de PR #2046). (PR #2048)
 - [sin-area] Main (resuelve conflicto PR #2052). (PR #2054)
+- [sin-area] feat(infra): preparar mantenimiento nocturno de produccion. (PR #2060)
 <!-- AUTO-GENERATED RELEASE END: 2026-07-15 -->
 
 <!-- AUTO-GENERATED RELEASE START: 2026-07-08 -->

--- a/docs/contexto/features/pr-2060-feat-infra-preparar-mantenimiento-nocturno-de-produccion.md
+++ b/docs/contexto/features/pr-2060-feat-infra-preparar-mantenimiento-nocturno-de-produccion.md
@@ -1,0 +1,65 @@
+# Contexto de feature PR #2060 - feat(infra): preparar mantenimiento nocturno de produccion
+
+## Resumen
+
+- PR: https://github.com/dsocial118/SISOC/pull/2060
+- Base: `main`
+- Rama origen: `codex/prod-night-package`
+- Autor: `juanikitro`
+
+## Contexto funcional
+
+- No informado explícitamente; inferir desde el título del PR y el diff.
+
+## Arquitectura tocada
+
+- No se detectó un patrón arquitectónico dominante más allá del diff observado.
+
+## Decisiones y supuestos detectados
+
+- Tipo de cambio declarado: No informado
+- Área principal declarada: No informada
+- Impacto usuario declarado: No informado
+- Riesgos / rollback: No informado
+
+## Design system y UI
+
+- Sin cambios visibles de UI o design system detectados en el diff.
+
+## Memoria operativa para agentes
+
+- Empezar por `docs/registro/prs/PR-2060.md` para contexto resumido del PR.
+- Revisar primero estos archivos del diff:
+- `docs/infra/PROD_CHANGE_PROPOSALS.md`
+- `docs/infra/PROD_INVENTORY.md`
+- `docs/infra/PROD_MIGRATION_CHECKLIST.md`
+- `docs/infra/PROD_RISKS.md`
+- `docs/plans/2026-07-14-produccion-ventana-nocturna-design.md`
+- `docs/registro/cambios/2026-07-14-paquete-mantenimiento-produccion.md`
+- `scripts/infra/backup_prod_configs.sh`
+- `scripts/infra/cleanup_prod_disk.sh`
+- `scripts/infra/healthcheck_prod.sh`
+- `scripts/infra/install_prod_maintenance.sh`
+- `scripts/infra/prepare_prod_mobile_checkout.sh`
+- `scripts/infra/prod_night_preflight.sh`
+- `scripts/infra/retire_prod_local_mysql_stage1.sh`
+- `scripts/infra/rollback_prod_maintenance.sh`
+- `scripts/infra/rollback_prod_mobile_checkout.sh`
+- `scripts/infra/verify_prod_release.sh`
+- `tests/test_prod_infra_scripts.py`
+- Documentación sugerida para ampliar contexto:
+- `docs/indice.md`
+- `docs/ia/CONTEXT_HYGIENE.md`
+- `docs/ia/ARCHITECTURE.md`
+- `docs/ia/TESTING.md`
+- `docs/infra/PROD_CHANGE_PROPOSALS.md`
+- `docs/infra/PROD_INVENTORY.md`
+- `docs/infra/PROD_MIGRATION_CHECKLIST.md`
+- `docs/infra/PROD_RISKS.md`
+- `docs/plans/2026-07-14-produccion-ventana-nocturna-design.md`
+- `docs/registro/cambios/2026-07-14-paquete-mantenimiento-produccion.md`
+
+## Trazabilidad
+
+- Documento generado automáticamente desde el evento de `pull_request`.
+- Si este PR cambia de título, el archivo se renombrará para mantener el slug alineado.

--- a/docs/infra/PROD_CHANGE_PROPOSALS.md
+++ b/docs/infra/PROD_CHANGE_PROPOSALS.md
@@ -5,6 +5,17 @@ ejecutado en produccion. El unico cambio aplicado fue el backup local de media
 aprobado y registrado en `PROD_INVENTORY.md`. Cada propuesta restante requiere
 aprobacion separada, ventana y responsable.
 
+El paquete versionado de ejecucion y rollback se prepara en:
+
+- `scripts/infra/prod_night_preflight.sh`;
+- `scripts/infra/install_prod_maintenance.sh`;
+- `scripts/infra/retire_prod_local_mysql_stage1.sh`;
+- `scripts/infra/verify_prod_release.sh`;
+- `docs/plans/2026-07-14-produccion-ventana-nocturna-design.md`.
+
+Preparar estos archivos no cambia PRD. Los flags `--apply` siguen requiriendo
+el GO de la ventana.
+
 No ejecutar bloques completos por copia/pega sin revisar nuevamente el estado.
 
 ## Prioridad sugerida
@@ -385,6 +396,9 @@ quedan disabled/inactive y app sigue 200. Fallo: desaparece otra entrada o se
 afecta health/monitoreo; restaurar crontab y enablement.
 
 ## Propuesta 6 - Promover deploy de SISOC-Mobile a produccion
+
+Estado actualizado: el cambio ya esta versionado en GitHub `main`; queda
+pendiente ejecutar y validar el primer deploy coordinado en la ventana.
 
 ### Que cambiaria
 

--- a/docs/infra/PROD_INVENTORY.md
+++ b/docs/infra/PROD_INVENTORY.md
@@ -35,7 +35,7 @@ alcance y se conservan solo como referencia de una posible migracion.
 | Media | 2.8 GiB | 48 GiB | 65 GiB | Principal dato a migrar |
 | Disco raiz | 77% post-limpieza | 88% post-limpieza | 12% | PRD no tiene presion de disco |
 | MySQL local | Stage 1 inactivo | Stage 1 inactivo | Activo/habilitado, 200 MB | No tocar en esta fase |
-| Deploy mobile | no aplica | incluido en workflow | no incluido en `main` actual | Diferencia real de ramas |
+| Deploy mobile | no aplica | incluido en workflow | incluido en GitHub `main`, pendiente de primer deploy coordinado | Runtime PRD aun no validado |
 
 ## Servicios y agentes
 
@@ -257,10 +257,11 @@ artefacto frontend servido por NGINX.
 5. El script baja el stack, hace pull `--ff-only`, reconstruye y levanta.
 6. El entrypoint puede ejecutar migraciones y otras escrituras DB.
 
-El workflow presente en `main` productivo no incluye `--with-mobile`, mientras
-la rama usada en HML si lo incluye. El checkout productivo coincide con GitHub;
-no es drift local. El deploy/rollback de SISOC-Mobile en produccion queda como
-flujo separado no confirmado.
+El checkout productivo auditado conserva el commit `980c2b053...` y todavia no
+ejecuto el cambio posterior que agrega `--with-mobile`. GitHub `main` ya incluye
+el deploy coordinado backend/mobile; su primer uso queda preparado por el
+runbook `docs/plans/2026-07-14-produccion-ventana-nocturna-design.md` y requiere
+Environment `production`, backup y ventana. No es un cambio local aplicado.
 
 ## Dependencias externas criticas
 

--- a/docs/infra/PROD_MIGRATION_CHECKLIST.md
+++ b/docs/infra/PROD_MIGRATION_CHECKLIST.md
@@ -38,6 +38,8 @@ cambios. El backup local de media ya ejecutado tuvo aprobacion separada.
 - [ ] Transferir `.env` backend/mobile por canal seguro, sin imprimir valores.
 - [ ] Exportar configuracion NGINX, metadata TLS, systemd/runner y cron efectivo.
 - [ ] Guardar commits, Compose, Dockerfiles y scripts operativos versionados.
+- [x] Preparar scripts versionados de preflight, backup, mantenimiento,
+      verificacion y rollback para la ventana productiva.
 - [ ] Definir si logs deben copiarse por requisito legal/forense; no moverlos por
       defecto.
 - [ ] Guardar inventario de owners/permisos sin replicar modos inseguros a ciegas.

--- a/docs/infra/PROD_RISKS.md
+++ b/docs/infra/PROD_RISKS.md
@@ -47,8 +47,11 @@ reversible futuro.
   logrotate detectadas; los logs Django agregan 1.3 GB.
 - No hay politica demostrada de backup/retencion para configuracion, cron y
   runner.
-- El workflow de produccion no despliega SISOC-Mobile, a diferencia de HML; un
-  deploy backend puede dejar versiones no coordinadas.
+- GitHub `main` ya coordina backend/mobile, pero el primer deploy sigue
+  pendiente de validacion en PRD.
+- El checkout mobile tiene 866 entradas bajo ownership historico y origin SSH;
+  `sisoc-deploy` no puede operar Git sobre ese arbol. Sin el gate de preparacion
+  versionado, el primer deploy automatico fallaria al actualizar mobile.
 - Gunicorn queda publicado en todas las interfaces por 8001, permitiendo bypass
   de NGINX/TLS si la red lo alcanza.
 - `.env` mobile es `root:root` modo 664: es world-readable y el owner/grupo no
@@ -91,7 +94,8 @@ reversible futuro.
 - Servicios legacy habilitados/fallidos alrededor del runtime real.
 - Logs voluminosos fuera de una politica de rotacion confirmada.
 - Deploy/restart backend puede escribir DB por el entrypoint.
-- No hay runbook productivo versionado que cierre backup, mobile y restore.
+- El runbook y scripts productivos estan preparados, pero todavia no ejecutados
+  ni validados sobre el host con privilegios root.
 
 ## Migrabilidad
 

--- a/docs/plans/2026-07-14-produccion-ventana-nocturna-design.md
+++ b/docs/plans/2026-07-14-produccion-ventana-nocturna-design.md
@@ -24,6 +24,8 @@ La estrategia aprobada divide el trabajo en dos subventanas:
 - deshabilitar el arranque futuro de `apache2` y `sisoc.service`, hoy fallidos;
 - preparar, revisar, mergear y desplegar el cambio que incorpora
   SISOC-Mobile al deploy de produccion;
+- desplegar el release pendiente de `main`, incluido PR #2048 y la migracion
+  aditiva `centrodeinfancia.0036_asistenciatrabajador`;
 - documentar evidencia, resultado y rollback disponible.
 
 ## Exclusiones
@@ -31,7 +33,8 @@ La estrategia aprobada divide el trabajo en dos subventanas:
 - TLS, por decision explicita del responsable;
 - purge de MySQL, paquetes o `/var/lib/mysql`;
 - borrado de media, logs, imagenes, volumenes, checkouts o backups;
-- migraciones manuales o comandos SQL que modifiquen datos;
+- migraciones manuales o comandos SQL ad hoc que modifiquen datos; la migracion
+  automatica `0036_asistenciatrabajador` esta aprobada como parte del release;
 - cambios de versiones, dependencias, Docker, NGINX, MySQL o sistema operativo;
 - limpieza manual Docker durante la ventana;
 - copia externa de media mientras no exista un destino aprobado.
@@ -56,6 +59,13 @@ Preflight read-only del 2026-07-14 10:52 ART:
 - snapshot local de media existente:
   `/sisoc/backups/media/20260713_172352/media`.
 
+Despues de este baseline, `main` avanzo a
+`cabcabdaf96ec0ec6723be6695ecc02e460e8615` por el merge de PR #2048. Ese
+release todavia no esta desplegado en PRD y forma parte explicita de la ventana.
+Existe un workflow productivo anterior en espera de aprobacion, run
+`29338795554`, que desplegaria PR #2048 sin mobile. No se debe aprobar: se cancela
+en el Gate 5 antes de mergear el PR mobile, evitando dos deploys consecutivos.
+
 Este baseline se debe repetir antes de cada subventana. No se usa como evidencia
 si tiene mas de 30 minutos.
 
@@ -77,6 +87,37 @@ original. Esto evita dos escrituras y rollbacks ambiguos.
   impacto con cambios todavia no validados.
 - Ejecutar purges o limpiezas para ganar espacio: el disco esta al 21% y no lo
   justifica.
+
+### Release de aplicacion aprobado
+
+El delta productivo `980c2b053...cabcabdaf` incluye PR #2048:
+
+- funcionalidad de asistencia de trabajadores CDI;
+- migracion nueva `0036_asistenciatrabajador`;
+- cambios de modelos, views, URLs, templates y CSS;
+- tests especificos de asistencia y regresiones CDI;
+- checks de `main` completados correctamente antes de la ventana.
+
+La migracion solo crea una tabla, su indice y constraints; no altera tablas
+existentes. Django puede revertirla eliminando la tabla, pero ese rollback
+borraria cualquier asistencia creada despues del deploy. Por eso el rollback
+operativo revierte codigo sin desmigrar automaticamente. Una desmigracion exige
+aprobacion de datos separada y confirmacion de que la tabla sigue vacia.
+
+La revision previa del release dejo dos riesgos funcionales abiertos:
+
+- la carga POST de asistencias ejecuta multiples `update_or_create` sin una
+  transaccion unica; un error intermedio podria dejar una carga parcial. Ademas,
+  una fecha invalida cae en la fecha actual y cualquier marca distinta de `1`
+  se interpreta como ausencia;
+- `observaciones` existe en modelo y POST, pero la UI la envia oculta y no permite
+  verla ni editarla, aunque el registro funcional la describe como editable.
+
+Los checks verdes no cubren fecha invalida, rollback de una carga interrumpida ni
+edicion real de observaciones desde la UI. Son riesgos conocidos del release, no
+de la migracion. Antes del Gate 5 se requiere una decision explicita entre
+corregirlos mediante un PR separado y revalidar, o aceptar el riesgo para esta
+ventana. No se mezclan correcciones improvisadas con el deploy nocturno.
 
 ## Roles minimos
 
@@ -299,12 +340,19 @@ Antes del merge:
 
 - PR mobile con diff exacto y checks verdes;
 - aprobacion de reviewer;
-- no existen otros commits inesperados en `main`;
+- `main` contiene el release aprobado de PR #2048 y ningun commit adicional no
+  clasificado;
 - CI no reporta migraciones pendientes;
 - no hay trabajos masivos o mailings en curso;
 - recapturar commits, imagenes y restart counts;
 - repetir health y DB identity;
 - confirmar que el rollback de imagenes puede ejecutarse.
+- registrar la decision sobre los dos riesgos funcionales abiertos de PR #2048:
+  PR correctivo validado o aceptacion explicita del riesgo para esta ventana.
+
+Cancelar el workflow stale `29338795554` y verificar estado `cancelled` antes
+del merge. Como `cancel-in-progress` esta deshabilitado para deploys, dejarlo en
+espera bloquearia o podria ejecutar un deploy backend-only fuera de secuencia.
 
 Mergear el PR a `main`. El job `deploy-produccion` debe quedar bajo el Environment
 `production`. No aprobar el Environment hasta repetir el baseline una ultima vez.
@@ -333,6 +381,10 @@ Validar:
 - restart counts estables;
 - `/`, `/health/` y `/mobile/` en 200;
 - DB remota correcta;
+- `showmigrations centrodeinfancia` marca `0036_asistenciatrabajador` aplicada;
+- tabla nueva accesible mediante una consulta ORM read-only;
+- pagina CDI y acceso a asistencia verificados por un usuario autorizado, sin
+  crear datos ficticios;
 - static y un media existente accesibles;
 - NGINX escribiendo logs;
 - workers presentes sin reprocesamientos inesperados;
@@ -351,6 +403,10 @@ Observar durante al menos 40 minutos antes de cerrar.
 | `.env` mobile | Restaurar `root:root` modo 664 desde metadata/copia root-only |
 | MySQL Stage 1 | `systemctl enable --now mysql`, validar listeners y health |
 | Deploy backend/mobile | Recuperar servicio primero con commits/imagenes registrados; luego revertir el PR mediante otro PR |
+
+El rollback del release de aplicacion no revierte la migracion `0036` durante la
+ventana. La tabla puede quedar aplicada y sin uso mientras se revierte el codigo;
+esto preserva cualquier registro creado y evita perdida de datos.
 
 Para rollback de runtime Docker, recapturar antes del deploy el nombre e ID de
 cada imagen. Si un build falla despues de `compose down`, priorizar levantar los

--- a/docs/plans/2026-07-14-produccion-ventana-nocturna-design.md
+++ b/docs/plans/2026-07-14-produccion-ventana-nocturna-design.md
@@ -1,480 +1,302 @@
-# Produccion: preparacion y mantenimiento nocturno completo
+# Produccion: ejecucion nocturna preparada
 
-## Objetivo
+Estado: paquete preparado; no ejecutado en `prd-old`.
 
-Preparar y ejecutar una ventana controlada sobre el productivo canonico
-`prd-old` (`10.80.5.45`) durante la noche del 2026-07-14, dejando cada cambio
-respaldado, verificable y reversible.
+Host canonico: `10.80.5.45` / `mdsldmz-ssies`. Los hosts AWS quedan fuera. TLS
+queda excluido por decision explicita.
 
-La estrategia aprobada divide el trabajo en dos subventanas:
+## Resultado buscado
 
-1. mantenimiento host-side y observacion;
-2. promocion del deploy automatico de SISOC-Mobile y deploy productivo.
+Al cerrar la ventana:
 
-## Alcance aprobado
+- `main` esta desplegado en backend y SISOC-Mobile;
+- QA y HML contienen todo `main` por el Plan A y sus deploys estan verdes;
+- los siete contenedores productivos, NGINX y runner estan sanos;
+- Django usa exclusivamente MySQL remoto `10.80.5.46`;
+- el MySQL local queda inactivo/deshabilitado, con datadir/paquetes intactos;
+- la poda root con `--volumes` y dos cron legacy rotos ya no existen;
+- `sisoc-deploy` tiene una limpieza diaria por umbral, retencion 14 dias y sin
+  volumenes;
+- los logs NGINX bajo `/sisoc` tienen rotacion;
+- `.env` mobile queda `root:sisoc-deploy` modo 640;
+- `apache2` y `sisoc.service` quedan disabled, sin borrar unidades/paquetes;
+- existe backup root-only y rollback exacto de cada cambio host-side.
 
-- verificar conectividad, health, DB remota, disco, Git, Docker y workers;
-- verificar evidencia de backup de DB y el snapshot local de media;
-- respaldar configuracion critica en una ubicacion root-only;
-- reemplazar la poda Docker agresiva por retencion de 14 dias sin volumenes;
-- retirar dos entradas cron que apuntan a paths inexistentes;
-- agregar rotacion para los logs NGINX bajo `/sisoc/logs/nginx`;
-- restringir `/sisoc/SISOC-Mobile/.env` a `root:sisoc-deploy` modo 640;
-- aplicar Stage 1 reversible al MySQL local del app host;
-- deshabilitar el arranque futuro de `apache2` y `sisoc.service`, hoy fallidos;
-- preparar, revisar, mergear y desplegar el cambio que incorpora
-  SISOC-Mobile al deploy de produccion;
-- desplegar el release pendiente de `main`, incluido PR #2048 y la migracion
-  aditiva `centrodeinfancia.0036_asistenciatrabajador`;
-- documentar evidencia, resultado y rollback disponible.
+## Cambios que deben llegar a `main` antes de la ventana
 
-## Exclusiones
+Integrar en este orden y esperar checks verdes:
 
-- TLS, por decision explicita del responsable;
-- purge de MySQL, paquetes o `/var/lib/mysql`;
-- borrado de media, logs, imagenes, volumenes, checkouts o backups;
-- migraciones manuales o comandos SQL ad hoc que modifiquen datos; la migracion
-  automatica `0036_asistenciatrabajador` esta aprobada como parte del release;
-- cambios de versiones, dependencias, Docker, NGINX, MySQL o sistema operativo;
-- limpieza manual Docker durante la ventana;
-- copia externa de media mientras no exista un destino aprobado.
+1. PR #2058: Plan A y remote HTTPS de SISOC-Mobile.
+2. PR #2059: hardening atomico de asistencia CDI.
+3. PR del paquete nocturno de produccion que contiene este documento.
 
-## Baseline confirmado
+Cada merge a `main` crea un deploy productivo en espera. No aprobar ninguno
+durante la preparacion. El Plan A debe integrar `main` en `development` y
+`homologacion`, y los deploys QA/HML deben terminar verdes antes del GO de PRD.
 
-Preflight read-only del 2026-07-14 10:52 ART:
-
-- host `mdsldmz-ssies`;
-- filesystem raiz: 785 GB, 155 GB usados, 598 GB libres, 21%;
-- inodos: 2%;
-- Docker, containerd, NGINX, cron y runner de produccion activos/habilitados;
-- MySQL local activo/habilitado;
-- `apache2` y `sisoc.service` fallidos/habilitados;
-- siete contenedores activos; SISOC-Mobile healthy;
-- `/`, `/health/` y `/mobile/` respondieron 200;
-- backend en `main`, commit `980c2b05397b3a18bdcd5853763c6942632232ed`,
-  solo `tmp/` no trackeado;
-- mobile en `main`, commit `ec7c163fede8b3877fff0fd7863f0a7812043c2c`,
-  solo `.env` no trackeado;
-- todos los contenedores observados tenian `RestartCount=0`;
-- snapshot local de media existente:
-  `/sisoc/backups/media/20260713_172352/media`.
-
-Despues de este baseline, `main` avanzo a
-`cabcabdaf96ec0ec6723be6695ecc02e460e8615` por el merge de PR #2048. Ese
-release todavia no esta desplegado en PRD y forma parte explicita de la ventana.
-Existe un workflow productivo anterior en espera de aprobacion, run
-`29338795554`, que desplegaria PR #2048 sin mobile. No se debe aprobar: se cancela
-en el Gate 5 antes de mergear el PR mobile, evitando dos deploys consecutivos.
-
-Este baseline se debe repetir antes de cada subventana. No se usa como evidencia
-si tiene mas de 30 minutos.
-
-## Decisiones de ejecucion
-
-### Secuencia elegida
-
-Se ejecutan cambios pequenos y reversibles primero. El deploy queda ultimo para
-no mezclar una falla de configuracion del host con una falla de build/runtime.
-
-El root crontab se transforma una sola vez: se reemplaza la poda Docker y se
-retiran las dos lineas legacy en la misma instalacion, con un unico backup
-original. Esto evita dos escrituras y rollbacks ambiguos.
-
-### Alternativas descartadas
-
-- Una unica pasada sin checkpoints: dificulta identificar la causa de un fallo.
-- Desplegar mobile antes del mantenimiento host-side: mezcla el mayor radio de
-  impacto con cambios todavia no validados.
-- Ejecutar purges o limpiezas para ganar espacio: el disco esta al 21% y no lo
-  justifica.
-
-### Release de aplicacion aprobado
-
-El delta productivo `980c2b053...cabcabdaf` incluye PR #2048:
-
-- funcionalidad de asistencia de trabajadores CDI;
-- migracion nueva `0036_asistenciatrabajador`;
-- cambios de modelos, views, URLs, templates y CSS;
-- tests especificos de asistencia y regresiones CDI;
-- checks de `main` completados correctamente antes de la ventana.
-
-La migracion solo crea una tabla, su indice y constraints; no altera tablas
-existentes. Django puede revertirla eliminando la tabla, pero ese rollback
-borraria cualquier asistencia creada despues del deploy. Por eso el rollback
-operativo revierte codigo sin desmigrar automaticamente. Una desmigracion exige
-aprobacion de datos separada y confirmacion de que la tabla sigue vacia.
-
-La revision previa del release dejo dos riesgos funcionales abiertos:
-
-- la carga POST de asistencias ejecuta multiples `update_or_create` sin una
-  transaccion unica; un error intermedio podria dejar una carga parcial. Ademas,
-  una fecha invalida cae en la fecha actual y cualquier marca distinta de `1`
-  se interpreta como ausencia;
-- `observaciones` existe en modelo y POST, pero la UI la envia oculta y no permite
-  verla ni editarla, aunque el registro funcional la describe como editable.
-
-Los checks verdes no cubren fecha invalida, rollback de una carga interrumpida ni
-edicion real de observaciones desde la UI. Son riesgos conocidos del release, no
-de la migracion. Antes del Gate 5 se requiere una decision explicita entre
-corregirlos mediante un PR separado y revalidar, o aceptar el riesgo para esta
-ventana. No se mezclan correcciones improvisadas con el deploy nocturno.
-
-## Roles minimos
-
-- Operador: ejecuta comandos en `prd-old` y no avanza sin resultado esperado.
-- Validador: controla health, contenedores, DB identity y evidencia de rollback.
-- Aprobador GitHub: reviewer y aprobador del Environment `production`.
-- Responsable DB: confirma backup vigente y restore probado o su evidencia.
-
-Una misma persona puede cumplir mas de un rol, pero no debe ejecutar dos bloques
-en paralelo.
-
-## Ventana recomendada
-
-Horario ART propuesto: 22:00 a 02:00.
-
-| Horario | Bloque |
-| --- | --- |
-| Antes de 21:30 | PR mobile preparado, checks verdes, sin mergear |
-| 21:30-22:00 | Gate 0, evidencia DB y backup de configuracion |
-| 22:00-22:25 | Root cron y servicios legacy |
-| 22:25-22:50 | Logrotate NGINX y permisos `.env` mobile |
-| 22:50-23:15 | Stage 1 del MySQL local |
-| 23:15-23:45 | Observacion de subventana A |
-| 23:45-00:10 | Rebaseline, merge del PR y espera del gate GitHub |
-| 00:10-00:40 | Aprobacion y deploy backend/mobile |
-| 00:40-01:20 | Observacion de subventana B |
-| 01:20-02:00 | Cierre, evidencia y reserva para rollback |
-
-Si el trabajo empieza en otro horario, conservar duraciones y orden.
-
-## Preparacion diurna
-
-### PR mobile
-
-Crear una branch nueva desde el `origin/main` vigente. No reutilizar directamente
-la branch historica `codex/mobile-auto-deploy`.
-
-Aplicar el commit ya revisado `f68aca084f911542e53e9f42435b17bb098b533f`.
-El diff esperado es solamente:
-
-- `.github/workflows/deploy.yml`;
-- `scripts/operacion/deploy_refresh.sh`;
-- cuatro inserciones y tres eliminaciones.
-
-Validaciones minimas:
+Invariantes Git finales:
 
 ```bash
-git diff --check origin/main...HEAD
-bash -n scripts/operacion/deploy_refresh.sh
-git diff --name-only origin/main...HEAD
+git fetch origin --prune
+git merge-base --is-ancestor origin/main origin/development
+git merge-base --is-ancestor origin/main origin/homologacion
 ```
 
-El PR debe apuntar a `main`, no ser draft, tener checks verdes y quedar sin
-mergear hasta aprobar el Gate 5 nocturno.
+## Alcance de los scripts
 
-El script presente hoy en produccion ya reconoce `--with-mobile` y
-`--mobile-dir`; por eso el primer workflow puede invocarlos antes de hacer pull.
-El commit agrega ademas la exigencia de branch `main` para SISOC-Mobile.
+| Script | Comportamiento por defecto | Mutacion autorizable |
+| --- | --- | --- |
+| `prod_night_preflight.sh` | read-only | ninguna |
+| `backup_prod_configs.sh` | crea backup root-only | solo backup |
+| `prepare_prod_mobile_checkout.sh` | audita checkout/remote | `--apply` alinea owner y HTTPS |
+| `install_prod_maintenance.sh` | preflight read-only | `--apply` cambia cron/logrotate/permisos/enablement |
+| `cleanup_prod_disk.sh` | informa | `--apply` poda solo si `/ >= 80%` |
+| `retire_prod_local_mysql_stage1.sh` | preflight read-only | `--apply` stop+disable local |
+| `healthcheck_prod.sh` | read-only | ninguna |
+| `verify_prod_release.sh` | read-only | ninguna |
+| `rollback_prod_maintenance.sh` | informa | `--apply` restaura backup host-side |
+| `rollback_prod_mobile_checkout.sh` | informa | `--apply` restaura owners/ACL y remote |
 
-### Material operativo
+Ningun script ejecuta `docker volume prune`, `docker system prune`,
+`down --volumes`, DROP, purge de paquetes, borrado de media/checkouts/backups o
+cambios TLS.
 
-Antes de la ventana deben estar disponibles:
+## Preparar el paquete en el servidor sin tocar el checkout activo
 
-- `docs/infra/PROD_CHANGE_PROPOSALS.md`;
-- este runbook;
-- acceso SSH y sudo interactivo;
-- acceso GitHub autenticado;
-- reviewer y aprobador del Environment disponibles;
-- ubicacion/timestamp del ultimo backup DB y evidencia de restore;
-- canal de comunicacion durante la ventana.
+Despues de los tres merges, registrar los SHA objetivo:
 
-## Gate 0 - No-go inicial
-
-No iniciar cambios si ocurre cualquiera de estos casos:
-
-- SSH inestable o identidad distinta de `mdsldmz-ssies`;
-- menos de 100 GB libres o mas de 80% de disco;
-- alguno de los siete contenedores ausente/restarting/unhealthy;
-- `/`, `/health/` o `/mobile/` distinto de 200;
-- DB Django distinta de `10.80.5.46`, `ldmzsql-sisoc`, `sisoc_local`;
-- cambios Git tracked en backend o mobile;
-- branch distinta de `main` en cualquiera de los dos checkouts;
-- importacion masiva, mailing u otro worker con tarea no interrumpible;
-- deploy GitHub en progreso;
-- backup DB no confirmado;
-- snapshot local de media sin `status=complete`;
-- operador, validador o aprobador GitHub no disponibles.
-
-Los no trackeados `tmp/` backend y `.env` mobile son baseline conocido. Cualquier
-otro no trackeado se clasifica antes de avanzar.
-
-## Gate 1 - Backup root-only y evidencia
-
-Crear una carpeta unica:
-
-```text
-/var/backups/sisoc/night-maintenance/prod/YYYYMMDD_HHMMSS/
+```bash
+sudo -u sisoc-deploy git -C /sisoc/SISOC fetch origin main --prune
+TARGET_BACKEND_SHA="$(sudo -u sisoc-deploy git -C /sisoc/SISOC rev-parse origin/main)"
+TARGET_MOBILE_SHA="$(git ls-remote https://github.com/dsocial118/SISOC-Mobile.git refs/heads/main | awk '{print $1}')"
+printf 'backend=%s\nmobile=%s\n' "$TARGET_BACKEND_SHA" "$TARGET_MOBILE_SHA"
 ```
 
-Debe quedar `root:root`, directorios 700 y archivos 600. Guardar:
+Extraer solo scripts versionados desde el commit objetivo, sin switch/pull:
 
-- root crontab original y conteos sanitizados;
-- `/etc/nginx` y regla logrotate previa, si existe;
-- `/etc/mysql`, `auto.cnf` y metadata de `mysql.service`;
-- metadata de `apache2`, `sisoc.service`, NGINX, Docker y runner;
-- copia root-only del `.env` mobile solo para rollback de permisos;
-- commits backend/mobile;
-- nombres e IDs de imagenes Docker y restart counts;
-- estado de disco, servicios, listeners y health;
-- resultado `docker compose config -q` y lista de servicios.
+```bash
+PACKAGE_ROOT=/root/sisoc-prod-night-package
+sudo install -d -o root -g root -m 700 "$PACKAGE_ROOT"
+sudo -u sisoc-deploy git -C /sisoc/SISOC archive \
+  "$TARGET_BACKEND_SHA" scripts/infra \
+  | sudo tar -x -C "$PACKAGE_ROOT"
+sudo find "$PACKAGE_ROOT" -type d -exec chmod 700 {} +
+sudo find "$PACKAGE_ROOT/scripts/infra" -type f -name '*.sh' -exec chmod 700 {} +
+sudo bash -n "$PACKAGE_ROOT"/scripts/infra/*prod*.sh
+```
 
-No guardar en salidas o reportes:
+No copiar `.env` al paquete ni imprimirlo.
 
-- contenido de `.env`;
-- variables de `docker inspect`;
-- queries, URLs o payloads de logs;
-- claves TLS o privadas;
-- credenciales DB.
+## Gate 0 - No-go y preflight read-only
 
-No continuar si el backup no puede releerse con sudo o si el crontab original no
-quedo preservado.
+Antes de las 22:00 ART confirmar externamente:
 
-## Subventana A - Mantenimiento host-side
+- backup DB vigente y restore probado o evidencia aceptada;
+- snapshot media `/sisoc/backups/media/20260713_172352` completo;
+- sin importaciones, credenciales masivas ni mailings activos;
+- operador, validador y aprobador del Environment disponibles;
+- ningun deploy en ejecucion;
+- HML verde con el mismo `main`.
 
-### Gate 2 - Root cron y servicios legacy
+En PRD:
 
-Preflight obligatorio:
+```bash
+sudo bash "$PACKAGE_ROOT/scripts/infra/prod_night_preflight.sh"
+```
 
-- exactamente una linea Docker con retencion 24h y `--volumes`;
-- exactamente una referencia al path legacy bajo `/home/admin-ssies`;
-- exactamente una referencia al path legacy bajo `/opt/ssies`;
-- entrada HetrixTools preservada;
-- los dos paths legacy siguen inexistentes.
+Abortar si no termina exactamente con `PROD NIGHT PREFLIGHT: OK`. El script
+exige host correcto, 100 GiB libres, uso menor a 80%, Git tracked limpio,
+branches `main`, Compose valido, siete contenedores, health/DB remota, cero
+restart counts y preflights exactos de cron/MySQL.
 
-Transformacion unica:
+## Gate 1 - Preparar checkout de SISOC-Mobile
 
-- reemplazar Docker por retencion `until=336h`, sin `--volumes`;
-- retirar solo las dos lineas de paths inexistentes;
-- preservar todo el resto del crontab;
-- deshabilitar `apache2` y `sisoc.service`, sin iniciar ni borrar unidades.
+El read-only del 2026-07-14 confirmo que el checkout mobile pertenece al usuario
+historico `admin-ssies`, usa el origin SSH esperado y `sisoc-deploy` no puede
+operarlo. HML ya usa ownership del runner. Sin corregir esto, el primer deploy
+productivo automatico fallaria antes de actualizar mobile.
 
-No ejecutar `docker prune` esta noche.
+Preflight sin cambios:
 
-Validar conteos exactos, `crontab -l`, NGINX/Docker activos y los tres health 200.
-Ante una diferencia, restaurar el crontab original y el enablement previo.
+```bash
+sudo bash "$PACKAGE_ROOT/scripts/infra/prepare_prod_mobile_checkout.sh"
+```
 
-### Gate 3 - Logrotate y permisos mobile
+Con GO explicito para el cambio recursivo de owner **solo en
+`/sisoc/SISOC-Mobile`**:
 
-Instalar la regla NGINX ya definida en
-`docs/infra/PROD_CHANGE_PROPOSALS.md`, con:
+```bash
+sudo bash "$PACKAGE_ROOT/scripts/infra/prepare_prod_mobile_checkout.sh" \
+  --apply --yes
+```
 
-- rotacion diaria o al superar 100 MB;
-- 30 rotaciones;
-- compresion diferida;
-- archivos nuevos `www-data:root` modo 640;
-- `USR1` a NGINX, sin restart completo.
+El script guarda ACL, owners, grupos y modos de las 866 entradas observadas,
+preserva la metadata previa de `.env`, cambia el checkout a
+`sisoc-deploy:sisoc-deploy`, normaliza origin a HTTPS publica y valida un fetch
+sin mover HEAD. Registrar `MOBILE_BACKUP_DIR` con el `BACKUP_DIR` informado.
 
-Ejecutar primero dry-run. La aplicacion real debe apuntar solamente a la regla
-SISOC, no forzar toda la configuracion global. No borrar logs rotados.
+Rollback exacto:
 
-Luego respaldar y cambiar `/sisoc/SISOC-Mobile/.env` de `root:root` 664 a
-`root:sisoc-deploy` 640. Validar lectura como `sisoc-deploy` y
-`docker compose config --services` sin imprimir variables.
+```bash
+sudo bash "$PACKAGE_ROOT/scripts/infra/rollback_prod_mobile_checkout.sh" \
+  --backup-dir "$MOBILE_BACKUP_DIR"
+sudo bash "$PACKAGE_ROOT/scripts/infra/rollback_prod_mobile_checkout.sh" \
+  --backup-dir "$MOBILE_BACKUP_DIR" --apply --yes
+```
 
-Health obligatorio despues de cada cambio. Si falla logging o lectura del
-`.env`, restaurar la configuracion/metadata previa antes de avanzar.
+## Gate 2 - Mantenimiento host-side
 
-### Gate 4 - Stage 1 del MySQL local
+Aplicar con backup y rollback automatico ante un error:
 
-Repetir todos los preflights de `PROD_CHANGE_PROPOSALS.md`:
+```bash
+sudo bash "$PACKAGE_ROOT/scripts/infra/install_prod_maintenance.sh" \
+  --apply --yes --rotate-logs-now
+```
 
-- Django sigue usando DB remota `10.80.5.46`;
-- cero schemas de aplicacion locales;
-- cero conexiones inesperadas;
-- cero eventos habilitados;
-- cero replica channels;
-- cero miembros Group Replication.
+Registrar el `BACKUP_DIR` informado. El bloque:
 
-Solo si todos dan cero:
+1. guarda configuracion, cron, Git/Docker metadata y copia sensible root-only;
+2. retira exactamente tres lineas root conocidas: poda con `--volumes` y dos
+   paths inexistentes;
+3. instala limpieza diaria 03:40 como `sisoc-deploy`, umbral 80% y retencion
+   336h; en el baseline actual no poda porque el disco esta muy por debajo;
+4. instala y aplica solo `/etc/logrotate.d/sisoc-nginx`;
+5. cambia solo owner/grupo/modo de `.env` mobile;
+6. deshabilita servicios legacy solo si no estaban activos;
+7. valida health como root y como `sisoc-deploy`.
 
-1. completar backup root-only de `/etc/mysql`, `auto.cnf`, unidad y metadata;
-2. detener y deshabilitar `mysql.service` local;
-3. verificar que desaparecieron listeners 3306/33060 locales;
-4. confirmar nuevamente identidad DB remota desde Django;
-5. validar siete contenedores y health.
+Verificar de nuevo:
 
-Conservar datadir de 200 MB y paquetes por al menos 14 dias. No ejecutar purge.
+```bash
+sudo bash "$PACKAGE_ROOT/scripts/infra/healthcheck_prod.sh"
+sudo -u sisoc-deploy /home/sisoc-deploy/bin/cleanup_prod_disk.sh
+sudo crontab -l | grep -Fc -- '--volumes'
+sudo crontab -u sisoc-deploy -l
+sudo logrotate -d /etc/logrotate.d/sisoc-nginx
+```
 
-Rollback inmediato:
+Resultado esperado: health OK, cleanup informativo, conteo `--volumes=0` y una
+sola entrada de cleanup productivo. Observar 15 minutos.
+
+Rollback host-side:
+
+```bash
+sudo bash "$PACKAGE_ROOT/scripts/infra/rollback_prod_maintenance.sh" \
+  --backup-dir "$BACKUP_DIR"
+sudo bash "$PACKAGE_ROOT/scripts/infra/rollback_prod_maintenance.sh" \
+  --backup-dir "$BACKUP_DIR" --apply --yes
+```
+
+La primera linea solo muestra el plan. La segunda restaura crons, `.env`,
+logrotate, scripts y enablement; no deshace archivos de log ya rotados.
+
+## Gate 3 - Stage 1 del MySQL local
+
+Repetir preflight inmediatamente antes de detener:
+
+```bash
+sudo bash "$PACKAGE_ROOT/scripts/infra/retire_prod_local_mysql_stage1.sh"
+```
+
+Debe confirmar DB remota correcta y cinco conteos locales en cero. Aplicar:
+
+```bash
+sudo bash "$PACKAGE_ROOT/scripts/infra/retire_prod_local_mysql_stage1.sh" \
+  --apply --yes
+```
+
+Conserva `/var/lib/mysql`, `/etc/mysql` y paquetes por 14 dias. Rollback
+inmediato si falla health, DB identity o aparece un consumidor:
 
 ```bash
 sudo systemctl enable --now mysql
+sudo systemctl show mysql -p ActiveState -p UnitFileState --no-pager
+sudo ss -Hlnpt 'sport = :3306'
 ```
 
-Luego validar servicio, listeners y health. Cualquier consumidor local inesperado
-obliga a rollback y cierre del Gate 4.
+Observar 30 minutos y ejecutar:
 
-## Observacion entre subventanas
+```bash
+sudo bash "$PACKAGE_ROOT/scripts/infra/prod_night_preflight.sh" --skip-mysql
+```
 
-Duracion minima: 30 minutos.
+## Gate 4 - Elegir un unico deploy de produccion
 
-Cada cinco minutos registrar sin contenido sensible:
+Listar los runs de `main`:
 
-- HTTP de `/`, `/health/` y `/mobile/`;
-- estado y restart count de siete contenedores;
-- identidad DB remota;
-- NGINX activo y logs con crecimiento;
-- MySQL local inactive/disabled y sin listener;
-- disco e inodos;
-- journal por conteos de errores, sin copiar mensajes con PII.
+```bash
+gh run list --repo dsocial118/SISOC --workflow deploy.yml --branch main \
+  --limit 20 --json databaseId,headSha,status,conclusion,createdAt,url
+```
 
-No abrir la subventana B ante un solo health fallido, restart count nuevo, error
-NGINX, DB identity distinta o rollback pendiente.
+Cancelar todos los runs productivos anteriores al que tenga
+`headSha=$TARGET_BACKEND_SHA`:
 
-## Subventana B - Deploy backend y SISOC-Mobile
+```bash
+gh run cancel RUN_ID_ANTERIOR --repo dsocial118/SISOC
+```
 
-### Gate 5 - Merge y aprobacion
+No cancelar el run objetivo. Repetir Gate 0/health, confirmar que no aparecieron
+nuevos commits y aprobar **solo ese run** en el Environment `production`.
 
-Antes del merge:
+```bash
+gh run watch RUN_ID_OBJETIVO --repo dsocial118/SISOC --exit-status
+```
 
-- PR mobile con diff exacto y checks verdes;
-- aprobacion de reviewer;
-- `main` contiene el release aprobado de PR #2048 y ningun commit adicional no
-  clasificado;
-- CI no reporta migraciones pendientes;
-- no hay trabajos masivos o mailings en curso;
-- recapturar commits, imagenes y restart counts;
-- repetir health y DB identity;
-- confirmar que el rollback de imagenes puede ejecutarse.
-- registrar la decision sobre los dos riesgos funcionales abiertos de PR #2048:
-  PR correctivo validado o aceptacion explicita del riesgo para esta ventana.
+El deploy baja/levanta backend y mobile sin volumenes, hace pulls `--ff-only` y
+puede ejecutar migraciones del entrypoint. La DB y media ya deben estar
+respaldadas antes de aprobar.
 
-Cancelar el workflow stale `29338795554` y verificar estado `cancelled` antes
-del merge. Como `cancel-in-progress` esta deshabilitado para deploys, dejarlo en
-espera bloquearia o podria ejecutar un deploy backend-only fuera de secuencia.
+## Gate 5 - Verificacion final
 
-Mergear el PR a `main`. El job `deploy-produccion` debe quedar bajo el Environment
-`production`. No aprobar el Environment hasta repetir el baseline una ultima vez.
+```bash
+sudo bash "$PACKAGE_ROOT/scripts/infra/verify_prod_release.sh" \
+  --backend-sha "$TARGET_BACKEND_SHA" \
+  --mobile-sha "$TARGET_MOBILE_SHA"
+```
 
-El deploy esperado:
+Ademas, con un usuario autorizado y sin crear datos ficticios:
 
-1. baja el stack backend sin volumenes;
-2. hace pull `--ff-only` de `main`;
-3. reconstruye y levanta Django y cinco workers;
-4. baja el stack mobile sin volumenes;
-5. hace pull `--ff-only` de mobile `main`;
-6. reconstruye y levanta SISOC-Mobile.
+- login;
+- detalle CDI, nomina y asistencia;
+- confirmar que observaciones es editable;
+- static y un media existente;
+- workers presentes, sin reprocesamiento inesperado;
+- logs NGINX creciendo con owner/modo esperados.
 
-Hay indisponibilidad esperada mientras los stacks estan abajo. El entrypoint
-backend puede ejecutar migraciones; por eso el backup DB y los checks de
-migraciones son gates obligatorios.
+Observar 40 minutos. Cerrar solo con `PROD RELEASE VERIFICATION: OK` y smoke
+funcional aceptado.
 
-### Gate 6 - Verificacion post-deploy
+## Rollback del deploy
 
-Validar:
+Antes de aprobar, registrar commits e imagenes previos desde el backup. Si el
+build falla despues del `down`, recuperar primero servicio con las imagenes
+anteriores; no podar durante la ventana. El rollback definitivo de codigo se
+hace mediante revert PR, nunca con force-push o `git reset --hard`.
 
-- workflow productivo verde;
-- backend en el commit mergeado y mobile en el commit esperado;
-- working trees sin cambios tracked;
-- siete contenedores activos y mobile healthy;
-- restart counts estables;
-- `/`, `/health/` y `/mobile/` en 200;
-- DB remota correcta;
-- `showmigrations centrodeinfancia` marca `0036_asistenciatrabajador` aplicada;
-- tabla nueva accesible mediante una consulta ORM read-only;
-- pagina CDI y acceso a asistencia verificados por un usuario autorizado, sin
-  crear datos ficticios;
-- smoke read-only de detalle CDI, nomina y formularios de destinatario/trabajador,
-  porque PR #2048 tambien modifica ampliamente esas pantallas;
-- static y un media existente accesibles;
-- NGINX escribiendo logs;
-- workers presentes sin reprocesamientos inesperados;
-- runner, cron y monitoreo activos;
-- MySQL local sigue inactive/disabled.
-
-Observar durante al menos 40 minutos antes de cerrar.
-
-## Rollback por bloque
-
-| Bloque | Rollback |
-| --- | --- |
-| Root cron | Restaurar el crontab original root-only y verificar conteos |
-| Servicios legacy | Restaurar enablement previo; no iniciar servicios fallidos |
-| Logrotate | Restaurar regla anterior o mover la nueva al backup; conservar logs rotados; enviar `USR1` |
-| `.env` mobile | Restaurar `root:root` modo 664 desde metadata/copia root-only |
-| MySQL Stage 1 | `systemctl enable --now mysql`, validar listeners y health |
-| Deploy backend/mobile | Recuperar servicio primero con commits/imagenes registrados; luego revertir el PR mediante otro PR |
-
-El rollback del release de aplicacion no revierte la migracion `0036` durante la
-ventana. La tabla puede quedar aplicada y sin uso mientras se revierte el codigo;
-esto preserva cualquier registro creado y evita perdida de datos.
-
-Para rollback de runtime Docker, recapturar antes del deploy el nombre e ID de
-cada imagen. Si un build falla despues de `compose down`, priorizar levantar los
-tags/IDs anteriores con `docker compose up -d --no-build`. No podar imagenes
-durante la ventana.
-
-No usar `git reset --hard`, force-push, `docker system prune`, `down --volumes` ni
-restauraciones parciales sobre la DB productiva.
-
-Si el checkout debe volver temporalmente a un commit anterior para restaurar
-servicio, requiere un GO de emergencia explicito y luego debe normalizarse con
-un revert PR; no dejar produccion detached como cierre.
-
-## Criterios de abortar
-
-Abortar el bloque actual, ejecutar su rollback y no avanzar si:
-
-- un conteo preflight no coincide exactamente;
-- un backup no puede validarse;
-- health deja de responder 200;
-- aparece un restart inesperado;
-- cambia la identidad DB;
-- NGINX deja de escribir;
-- un worker reprocesa o pierde una tarea;
-- el PR contiene archivos extra, checks fallidos o commits inesperados;
-- el deploy excede 20 minutos con un stack abajo;
-- falta el operador, validador o aprobador requerido.
-
-Un bloque abortado no autoriza a improvisar una alternativa durante la misma
-ventana.
+No desmigrar automaticamente `0036_asistenciatrabajador`: eliminar la tabla
+podria perder asistencias ya creadas. Revertir codigo manteniendo la tabla es el
+rollback seguro inicial; cualquier desmigracion requiere aprobacion de datos.
 
 ## Evidencia de cierre
 
-Guardar root-only y luego resumir sin secretos:
+Guardar root-only y resumir sin secretos:
 
-- timestamp de inicio/fin por gate;
-- backup path;
-- cambios aplicados y rollback path;
-- commits antes/despues;
-- imagenes antes/despues;
-- estado de servicios, puertos, contenedores, disco e inodos;
-- health y DB identity;
-- URL del PR y workflow;
-- cambios omitidos y causa;
-- periodo de observacion y riesgos abiertos.
+- SHA backend/mobile y run objetivo;
+- `BACKUP_DIR` de mantenimiento y MySQL;
+- hora/resultado de cada gate;
+- cron y servicios antes/despues;
+- disco, contenedores/restart counts y health;
+- DB identity y migracion aplicada;
+- cambios omitidos, rollback usado y periodo de observacion.
 
-Actualizar al dia siguiente `PROD_INVENTORY.md`, `PROD_RISKS.md`,
-`PROD_CHANGE_PROPOSALS.md` y `PROD_MIGRATION_CHECKLIST.md` mediante PR a
-`development`.
+## Exclusiones y seguimiento
 
-## Seguimiento
-
-- observar 24 horas sin borrar backups ni datadir MySQL;
-- revisar primera ejecucion del nuevo cron Docker;
-- verificar rotacion y permisos de logs NGINX;
-- confirmar proximo deploy backend/mobile coordinado;
-- definir destino externo para media y prueba de restore;
-- mantener TLS fuera hasta una autorizacion separada.
-
-## Datos pendientes antes de ejecutar
-
-1. hora final de inicio si difiere de 22:00 ART;
-2. responsable y evidencia del backup DB/restauracion;
-3. confirmacion de que no habra importaciones/mailings durante la ventana;
-4. reviewer y aprobador GitHub disponibles;
-5. destino externo de media, si se quiere incluir esa copia en otro trabajo.
-
-La aprobacion de este diseño permite preparar scripts/PRs y la ventana. La
-ejecucion productiva comienza solamente con un GO explicito al Gate 0.
+- TLS sigue fuera.
+- No se borra datadir/paquetes MySQL antes de 14 dias y nueva aprobacion.
+- No se borra media, backups, checkouts historicos, `tmp/`, logs de aplicacion
+  ni volumenes Docker.
+- El snapshot media sigue siendo local al mismo host: falta copia externa y
+  prueba de restore para disaster recovery.
+- La retencion de audit trail DB no se automatiza hasta definir politica
+  funcional/legal; se elimina solo el cron roto, no datos.

--- a/docs/plans/2026-07-14-produccion-ventana-nocturna-design.md
+++ b/docs/plans/2026-07-14-produccion-ventana-nocturna-design.md
@@ -385,6 +385,8 @@ Validar:
 - tabla nueva accesible mediante una consulta ORM read-only;
 - pagina CDI y acceso a asistencia verificados por un usuario autorizado, sin
   crear datos ficticios;
+- smoke read-only de detalle CDI, nomina y formularios de destinatario/trabajador,
+  porque PR #2048 tambien modifica ampliamente esas pantallas;
 - static y un media existente accesibles;
 - NGINX escribiendo logs;
 - workers presentes sin reprocesamientos inesperados;

--- a/docs/plans/2026-07-14-produccion-ventana-nocturna-design.md
+++ b/docs/plans/2026-07-14-produccion-ventana-nocturna-design.md
@@ -1,0 +1,422 @@
+# Produccion: preparacion y mantenimiento nocturno completo
+
+## Objetivo
+
+Preparar y ejecutar una ventana controlada sobre el productivo canonico
+`prd-old` (`10.80.5.45`) durante la noche del 2026-07-14, dejando cada cambio
+respaldado, verificable y reversible.
+
+La estrategia aprobada divide el trabajo en dos subventanas:
+
+1. mantenimiento host-side y observacion;
+2. promocion del deploy automatico de SISOC-Mobile y deploy productivo.
+
+## Alcance aprobado
+
+- verificar conectividad, health, DB remota, disco, Git, Docker y workers;
+- verificar evidencia de backup de DB y el snapshot local de media;
+- respaldar configuracion critica en una ubicacion root-only;
+- reemplazar la poda Docker agresiva por retencion de 14 dias sin volumenes;
+- retirar dos entradas cron que apuntan a paths inexistentes;
+- agregar rotacion para los logs NGINX bajo `/sisoc/logs/nginx`;
+- restringir `/sisoc/SISOC-Mobile/.env` a `root:sisoc-deploy` modo 640;
+- aplicar Stage 1 reversible al MySQL local del app host;
+- deshabilitar el arranque futuro de `apache2` y `sisoc.service`, hoy fallidos;
+- preparar, revisar, mergear y desplegar el cambio que incorpora
+  SISOC-Mobile al deploy de produccion;
+- documentar evidencia, resultado y rollback disponible.
+
+## Exclusiones
+
+- TLS, por decision explicita del responsable;
+- purge de MySQL, paquetes o `/var/lib/mysql`;
+- borrado de media, logs, imagenes, volumenes, checkouts o backups;
+- migraciones manuales o comandos SQL que modifiquen datos;
+- cambios de versiones, dependencias, Docker, NGINX, MySQL o sistema operativo;
+- limpieza manual Docker durante la ventana;
+- copia externa de media mientras no exista un destino aprobado.
+
+## Baseline confirmado
+
+Preflight read-only del 2026-07-14 10:52 ART:
+
+- host `mdsldmz-ssies`;
+- filesystem raiz: 785 GB, 155 GB usados, 598 GB libres, 21%;
+- inodos: 2%;
+- Docker, containerd, NGINX, cron y runner de produccion activos/habilitados;
+- MySQL local activo/habilitado;
+- `apache2` y `sisoc.service` fallidos/habilitados;
+- siete contenedores activos; SISOC-Mobile healthy;
+- `/`, `/health/` y `/mobile/` respondieron 200;
+- backend en `main`, commit `980c2b05397b3a18bdcd5853763c6942632232ed`,
+  solo `tmp/` no trackeado;
+- mobile en `main`, commit `ec7c163fede8b3877fff0fd7863f0a7812043c2c`,
+  solo `.env` no trackeado;
+- todos los contenedores observados tenian `RestartCount=0`;
+- snapshot local de media existente:
+  `/sisoc/backups/media/20260713_172352/media`.
+
+Este baseline se debe repetir antes de cada subventana. No se usa como evidencia
+si tiene mas de 30 minutos.
+
+## Decisiones de ejecucion
+
+### Secuencia elegida
+
+Se ejecutan cambios pequenos y reversibles primero. El deploy queda ultimo para
+no mezclar una falla de configuracion del host con una falla de build/runtime.
+
+El root crontab se transforma una sola vez: se reemplaza la poda Docker y se
+retiran las dos lineas legacy en la misma instalacion, con un unico backup
+original. Esto evita dos escrituras y rollbacks ambiguos.
+
+### Alternativas descartadas
+
+- Una unica pasada sin checkpoints: dificulta identificar la causa de un fallo.
+- Desplegar mobile antes del mantenimiento host-side: mezcla el mayor radio de
+  impacto con cambios todavia no validados.
+- Ejecutar purges o limpiezas para ganar espacio: el disco esta al 21% y no lo
+  justifica.
+
+## Roles minimos
+
+- Operador: ejecuta comandos en `prd-old` y no avanza sin resultado esperado.
+- Validador: controla health, contenedores, DB identity y evidencia de rollback.
+- Aprobador GitHub: reviewer y aprobador del Environment `production`.
+- Responsable DB: confirma backup vigente y restore probado o su evidencia.
+
+Una misma persona puede cumplir mas de un rol, pero no debe ejecutar dos bloques
+en paralelo.
+
+## Ventana recomendada
+
+Horario ART propuesto: 22:00 a 02:00.
+
+| Horario | Bloque |
+| --- | --- |
+| Antes de 21:30 | PR mobile preparado, checks verdes, sin mergear |
+| 21:30-22:00 | Gate 0, evidencia DB y backup de configuracion |
+| 22:00-22:25 | Root cron y servicios legacy |
+| 22:25-22:50 | Logrotate NGINX y permisos `.env` mobile |
+| 22:50-23:15 | Stage 1 del MySQL local |
+| 23:15-23:45 | Observacion de subventana A |
+| 23:45-00:10 | Rebaseline, merge del PR y espera del gate GitHub |
+| 00:10-00:40 | Aprobacion y deploy backend/mobile |
+| 00:40-01:20 | Observacion de subventana B |
+| 01:20-02:00 | Cierre, evidencia y reserva para rollback |
+
+Si el trabajo empieza en otro horario, conservar duraciones y orden.
+
+## Preparacion diurna
+
+### PR mobile
+
+Crear una branch nueva desde el `origin/main` vigente. No reutilizar directamente
+la branch historica `codex/mobile-auto-deploy`.
+
+Aplicar el commit ya revisado `f68aca084f911542e53e9f42435b17bb098b533f`.
+El diff esperado es solamente:
+
+- `.github/workflows/deploy.yml`;
+- `scripts/operacion/deploy_refresh.sh`;
+- cuatro inserciones y tres eliminaciones.
+
+Validaciones minimas:
+
+```bash
+git diff --check origin/main...HEAD
+bash -n scripts/operacion/deploy_refresh.sh
+git diff --name-only origin/main...HEAD
+```
+
+El PR debe apuntar a `main`, no ser draft, tener checks verdes y quedar sin
+mergear hasta aprobar el Gate 5 nocturno.
+
+El script presente hoy en produccion ya reconoce `--with-mobile` y
+`--mobile-dir`; por eso el primer workflow puede invocarlos antes de hacer pull.
+El commit agrega ademas la exigencia de branch `main` para SISOC-Mobile.
+
+### Material operativo
+
+Antes de la ventana deben estar disponibles:
+
+- `docs/infra/PROD_CHANGE_PROPOSALS.md`;
+- este runbook;
+- acceso SSH y sudo interactivo;
+- acceso GitHub autenticado;
+- reviewer y aprobador del Environment disponibles;
+- ubicacion/timestamp del ultimo backup DB y evidencia de restore;
+- canal de comunicacion durante la ventana.
+
+## Gate 0 - No-go inicial
+
+No iniciar cambios si ocurre cualquiera de estos casos:
+
+- SSH inestable o identidad distinta de `mdsldmz-ssies`;
+- menos de 100 GB libres o mas de 80% de disco;
+- alguno de los siete contenedores ausente/restarting/unhealthy;
+- `/`, `/health/` o `/mobile/` distinto de 200;
+- DB Django distinta de `10.80.5.46`, `ldmzsql-sisoc`, `sisoc_local`;
+- cambios Git tracked en backend o mobile;
+- branch distinta de `main` en cualquiera de los dos checkouts;
+- importacion masiva, mailing u otro worker con tarea no interrumpible;
+- deploy GitHub en progreso;
+- backup DB no confirmado;
+- snapshot local de media sin `status=complete`;
+- operador, validador o aprobador GitHub no disponibles.
+
+Los no trackeados `tmp/` backend y `.env` mobile son baseline conocido. Cualquier
+otro no trackeado se clasifica antes de avanzar.
+
+## Gate 1 - Backup root-only y evidencia
+
+Crear una carpeta unica:
+
+```text
+/var/backups/sisoc/night-maintenance/prod/YYYYMMDD_HHMMSS/
+```
+
+Debe quedar `root:root`, directorios 700 y archivos 600. Guardar:
+
+- root crontab original y conteos sanitizados;
+- `/etc/nginx` y regla logrotate previa, si existe;
+- `/etc/mysql`, `auto.cnf` y metadata de `mysql.service`;
+- metadata de `apache2`, `sisoc.service`, NGINX, Docker y runner;
+- copia root-only del `.env` mobile solo para rollback de permisos;
+- commits backend/mobile;
+- nombres e IDs de imagenes Docker y restart counts;
+- estado de disco, servicios, listeners y health;
+- resultado `docker compose config -q` y lista de servicios.
+
+No guardar en salidas o reportes:
+
+- contenido de `.env`;
+- variables de `docker inspect`;
+- queries, URLs o payloads de logs;
+- claves TLS o privadas;
+- credenciales DB.
+
+No continuar si el backup no puede releerse con sudo o si el crontab original no
+quedo preservado.
+
+## Subventana A - Mantenimiento host-side
+
+### Gate 2 - Root cron y servicios legacy
+
+Preflight obligatorio:
+
+- exactamente una linea Docker con retencion 24h y `--volumes`;
+- exactamente una referencia al path legacy bajo `/home/admin-ssies`;
+- exactamente una referencia al path legacy bajo `/opt/ssies`;
+- entrada HetrixTools preservada;
+- los dos paths legacy siguen inexistentes.
+
+Transformacion unica:
+
+- reemplazar Docker por retencion `until=336h`, sin `--volumes`;
+- retirar solo las dos lineas de paths inexistentes;
+- preservar todo el resto del crontab;
+- deshabilitar `apache2` y `sisoc.service`, sin iniciar ni borrar unidades.
+
+No ejecutar `docker prune` esta noche.
+
+Validar conteos exactos, `crontab -l`, NGINX/Docker activos y los tres health 200.
+Ante una diferencia, restaurar el crontab original y el enablement previo.
+
+### Gate 3 - Logrotate y permisos mobile
+
+Instalar la regla NGINX ya definida en
+`docs/infra/PROD_CHANGE_PROPOSALS.md`, con:
+
+- rotacion diaria o al superar 100 MB;
+- 30 rotaciones;
+- compresion diferida;
+- archivos nuevos `www-data:root` modo 640;
+- `USR1` a NGINX, sin restart completo.
+
+Ejecutar primero dry-run. La aplicacion real debe apuntar solamente a la regla
+SISOC, no forzar toda la configuracion global. No borrar logs rotados.
+
+Luego respaldar y cambiar `/sisoc/SISOC-Mobile/.env` de `root:root` 664 a
+`root:sisoc-deploy` 640. Validar lectura como `sisoc-deploy` y
+`docker compose config --services` sin imprimir variables.
+
+Health obligatorio despues de cada cambio. Si falla logging o lectura del
+`.env`, restaurar la configuracion/metadata previa antes de avanzar.
+
+### Gate 4 - Stage 1 del MySQL local
+
+Repetir todos los preflights de `PROD_CHANGE_PROPOSALS.md`:
+
+- Django sigue usando DB remota `10.80.5.46`;
+- cero schemas de aplicacion locales;
+- cero conexiones inesperadas;
+- cero eventos habilitados;
+- cero replica channels;
+- cero miembros Group Replication.
+
+Solo si todos dan cero:
+
+1. completar backup root-only de `/etc/mysql`, `auto.cnf`, unidad y metadata;
+2. detener y deshabilitar `mysql.service` local;
+3. verificar que desaparecieron listeners 3306/33060 locales;
+4. confirmar nuevamente identidad DB remota desde Django;
+5. validar siete contenedores y health.
+
+Conservar datadir de 200 MB y paquetes por al menos 14 dias. No ejecutar purge.
+
+Rollback inmediato:
+
+```bash
+sudo systemctl enable --now mysql
+```
+
+Luego validar servicio, listeners y health. Cualquier consumidor local inesperado
+obliga a rollback y cierre del Gate 4.
+
+## Observacion entre subventanas
+
+Duracion minima: 30 minutos.
+
+Cada cinco minutos registrar sin contenido sensible:
+
+- HTTP de `/`, `/health/` y `/mobile/`;
+- estado y restart count de siete contenedores;
+- identidad DB remota;
+- NGINX activo y logs con crecimiento;
+- MySQL local inactive/disabled y sin listener;
+- disco e inodos;
+- journal por conteos de errores, sin copiar mensajes con PII.
+
+No abrir la subventana B ante un solo health fallido, restart count nuevo, error
+NGINX, DB identity distinta o rollback pendiente.
+
+## Subventana B - Deploy backend y SISOC-Mobile
+
+### Gate 5 - Merge y aprobacion
+
+Antes del merge:
+
+- PR mobile con diff exacto y checks verdes;
+- aprobacion de reviewer;
+- no existen otros commits inesperados en `main`;
+- CI no reporta migraciones pendientes;
+- no hay trabajos masivos o mailings en curso;
+- recapturar commits, imagenes y restart counts;
+- repetir health y DB identity;
+- confirmar que el rollback de imagenes puede ejecutarse.
+
+Mergear el PR a `main`. El job `deploy-produccion` debe quedar bajo el Environment
+`production`. No aprobar el Environment hasta repetir el baseline una ultima vez.
+
+El deploy esperado:
+
+1. baja el stack backend sin volumenes;
+2. hace pull `--ff-only` de `main`;
+3. reconstruye y levanta Django y cinco workers;
+4. baja el stack mobile sin volumenes;
+5. hace pull `--ff-only` de mobile `main`;
+6. reconstruye y levanta SISOC-Mobile.
+
+Hay indisponibilidad esperada mientras los stacks estan abajo. El entrypoint
+backend puede ejecutar migraciones; por eso el backup DB y los checks de
+migraciones son gates obligatorios.
+
+### Gate 6 - Verificacion post-deploy
+
+Validar:
+
+- workflow productivo verde;
+- backend en el commit mergeado y mobile en el commit esperado;
+- working trees sin cambios tracked;
+- siete contenedores activos y mobile healthy;
+- restart counts estables;
+- `/`, `/health/` y `/mobile/` en 200;
+- DB remota correcta;
+- static y un media existente accesibles;
+- NGINX escribiendo logs;
+- workers presentes sin reprocesamientos inesperados;
+- runner, cron y monitoreo activos;
+- MySQL local sigue inactive/disabled.
+
+Observar durante al menos 40 minutos antes de cerrar.
+
+## Rollback por bloque
+
+| Bloque | Rollback |
+| --- | --- |
+| Root cron | Restaurar el crontab original root-only y verificar conteos |
+| Servicios legacy | Restaurar enablement previo; no iniciar servicios fallidos |
+| Logrotate | Restaurar regla anterior o mover la nueva al backup; conservar logs rotados; enviar `USR1` |
+| `.env` mobile | Restaurar `root:root` modo 664 desde metadata/copia root-only |
+| MySQL Stage 1 | `systemctl enable --now mysql`, validar listeners y health |
+| Deploy backend/mobile | Recuperar servicio primero con commits/imagenes registrados; luego revertir el PR mediante otro PR |
+
+Para rollback de runtime Docker, recapturar antes del deploy el nombre e ID de
+cada imagen. Si un build falla despues de `compose down`, priorizar levantar los
+tags/IDs anteriores con `docker compose up -d --no-build`. No podar imagenes
+durante la ventana.
+
+No usar `git reset --hard`, force-push, `docker system prune`, `down --volumes` ni
+restauraciones parciales sobre la DB productiva.
+
+Si el checkout debe volver temporalmente a un commit anterior para restaurar
+servicio, requiere un GO de emergencia explicito y luego debe normalizarse con
+un revert PR; no dejar produccion detached como cierre.
+
+## Criterios de abortar
+
+Abortar el bloque actual, ejecutar su rollback y no avanzar si:
+
+- un conteo preflight no coincide exactamente;
+- un backup no puede validarse;
+- health deja de responder 200;
+- aparece un restart inesperado;
+- cambia la identidad DB;
+- NGINX deja de escribir;
+- un worker reprocesa o pierde una tarea;
+- el PR contiene archivos extra, checks fallidos o commits inesperados;
+- el deploy excede 20 minutos con un stack abajo;
+- falta el operador, validador o aprobador requerido.
+
+Un bloque abortado no autoriza a improvisar una alternativa durante la misma
+ventana.
+
+## Evidencia de cierre
+
+Guardar root-only y luego resumir sin secretos:
+
+- timestamp de inicio/fin por gate;
+- backup path;
+- cambios aplicados y rollback path;
+- commits antes/despues;
+- imagenes antes/despues;
+- estado de servicios, puertos, contenedores, disco e inodos;
+- health y DB identity;
+- URL del PR y workflow;
+- cambios omitidos y causa;
+- periodo de observacion y riesgos abiertos.
+
+Actualizar al dia siguiente `PROD_INVENTORY.md`, `PROD_RISKS.md`,
+`PROD_CHANGE_PROPOSALS.md` y `PROD_MIGRATION_CHECKLIST.md` mediante PR a
+`development`.
+
+## Seguimiento
+
+- observar 24 horas sin borrar backups ni datadir MySQL;
+- revisar primera ejecucion del nuevo cron Docker;
+- verificar rotacion y permisos de logs NGINX;
+- confirmar proximo deploy backend/mobile coordinado;
+- definir destino externo para media y prueba de restore;
+- mantener TLS fuera hasta una autorizacion separada.
+
+## Datos pendientes antes de ejecutar
+
+1. hora final de inicio si difiere de 22:00 ART;
+2. responsable y evidencia del backup DB/restauracion;
+3. confirmacion de que no habra importaciones/mailings durante la ventana;
+4. reviewer y aprobador GitHub disponibles;
+5. destino externo de media, si se quiere incluir esa copia en otro trabajo.
+
+La aprobacion de este diseño permite preparar scripts/PRs y la ventana. La
+ejecucion productiva comienza solamente con un GO explicito al Gate 0.

--- a/docs/registro/cambios/2026-07-14-paquete-mantenimiento-produccion.md
+++ b/docs/registro/cambios/2026-07-14-paquete-mantenimiento-produccion.md
@@ -1,0 +1,35 @@
+# Paquete de mantenimiento nocturno de producción
+
+## Estado
+
+Preparado y validado en el repositorio. No ejecutado en `prd-old`.
+
+## Alcance
+
+- preflight read-only con barreras de host, disco, Git, Docker, DB y health;
+- backup root-only de configuracion y metadata sin publicar secretos;
+- alineacion reversible del checkout mobile con el usuario del runner, con
+  backup completo de owners/ACL y normalizacion del origin publico a HTTPS;
+- reemplazo controlado de la poda root con `--volumes` por mantenimiento diario
+  como `sisoc-deploy`, umbral 80% y retencion de 14 dias;
+- logrotate dedicado para NGINX bajo `/sisoc`;
+- hardening de permisos del `.env` mobile;
+- disable reversible de dos servicios legacy inactivos;
+- Stage 1 del MySQL local con backup y rollback automatico;
+- verificacion por SHA de backend/mobile y del runtime final;
+- rollback host-side desde el backup creado por la instalacion.
+
+## Seguridad
+
+Los scripts no borran media, backups, checkouts, datadir MySQL, paquetes ni
+volumenes Docker. No imprimen `.env` ni variables de contenedores. TLS queda
+fuera del alcance.
+
+## Validacion
+
+- `bash -n` sobre los diez scripts productivos;
+- pruebas focalizadas de invariantes destructivos: cleanup sin system/volume
+  prune, Stage 1 sin purge/`rm -rf`/DROP y cron de cleanup sin privilegios root;
+- `git diff --check`.
+
+La validacion real de host requiere el preflight nocturno y un GO explicito.

--- a/docs/registro/prs/PR-2060.md
+++ b/docs/registro/prs/PR-2060.md
@@ -1,0 +1,72 @@
+# PR #2060 - feat(infra): preparar mantenimiento nocturno de produccion
+
+## Metadata
+
+- PR: https://github.com/dsocial118/SISOC/pull/2060
+- Base: `main`
+- Rama origen: `codex/prod-night-package`
+- Autor: `juanikitro`
+- Última actualización: `2026-07-14T16:18:04Z`
+
+## Resumen operativo
+
+- Tipo de cambio: No informado
+- Área principal: No informada
+- Contexto funcional: No informado explícitamente; revisar título, diff y documentación relacionada.
+- Resumen para changelog: No informado
+- Impacto usuario: No informado
+
+## Áreas afectadas
+
+- `docs/infra`
+- `docs/plans`
+- `docs/registro`
+- `scripts`
+- `tests`
+
+## Archivos relevantes del diff
+
+- `docs/infra/PROD_CHANGE_PROPOSALS.md`
+- `docs/infra/PROD_INVENTORY.md`
+- `docs/infra/PROD_MIGRATION_CHECKLIST.md`
+- `docs/infra/PROD_RISKS.md`
+- `docs/plans/2026-07-14-produccion-ventana-nocturna-design.md`
+- `docs/registro/cambios/2026-07-14-paquete-mantenimiento-produccion.md`
+- `scripts/infra/backup_prod_configs.sh`
+- `scripts/infra/cleanup_prod_disk.sh`
+- `scripts/infra/healthcheck_prod.sh`
+- `scripts/infra/install_prod_maintenance.sh`
+- `scripts/infra/prepare_prod_mobile_checkout.sh`
+- `scripts/infra/prod_night_preflight.sh`
+- `scripts/infra/retire_prod_local_mysql_stage1.sh`
+- `scripts/infra/rollback_prod_maintenance.sh`
+- `scripts/infra/rollback_prod_mobile_checkout.sh`
+- `scripts/infra/verify_prod_release.sh`
+- `tests/test_prod_infra_scripts.py`
+
+## Validación declarada
+
+- Pruebas automáticas: No informado en el PR.
+- Pruebas manuales: No informado en el PR.
+
+## Riesgos y rollback
+
+- No informado explícitamente en el PR.
+
+## Documentación sugerida para lectura
+
+- `docs/indice.md`
+- `docs/ia/CONTEXT_HYGIENE.md`
+- `docs/ia/ARCHITECTURE.md`
+- `docs/ia/TESTING.md`
+- `docs/infra/PROD_CHANGE_PROPOSALS.md`
+- `docs/infra/PROD_INVENTORY.md`
+- `docs/infra/PROD_MIGRATION_CHECKLIST.md`
+- `docs/infra/PROD_RISKS.md`
+- `docs/plans/2026-07-14-produccion-ventana-nocturna-design.md`
+- `docs/registro/cambios/2026-07-14-paquete-mantenimiento-produccion.md`
+
+## Notas para continuidad
+
+- Este documento es generado automáticamente desde el contexto del PR y sirve como índice rápido para revisión y futuras sesiones de agentes.
+- Si la metadata del body del PR está incompleta, varias secciones usarán fallbacks derivados del título o del diff.

--- a/docs/registro/releases/pending/2026-07-15-pr-2060.md
+++ b/docs/registro/releases/pending/2026-07-15-pr-2060.md
@@ -1,0 +1,19 @@
+---
+pr: 2060
+release_date: 2026-07-15
+category: Actualizaciones
+area: sin-area
+title: feat(infra): preparar mantenimiento nocturno de produccion
+summary: feat(infra): preparar mantenimiento nocturno de produccion
+impact: No informado
+source_url: https://github.com/dsocial118/SISOC/pull/2060
+---
+# Release note preliminar PR #2060
+
+- Fecha objetivo de release: 2026-07-15
+- Categoría: Actualizaciones
+- Área: sin-area
+- Título del PR: feat(infra): preparar mantenimiento nocturno de produccion
+- Resumen: feat(infra): preparar mantenimiento nocturno de produccion
+- Impacto usuario: No informado
+- Fuente: https://github.com/dsocial118/SISOC/pull/2060

--- a/scripts/infra/backup_prod_configs.sh
+++ b/scripts/infra/backup_prod_configs.sh
@@ -1,0 +1,135 @@
+#!/usr/bin/env bash
+set -Eeuo pipefail
+
+SCRIPT_NAME="$(basename "$0")"
+EXPECTED_HOSTNAME="${PROD_EXPECTED_HOSTNAME:-mdsldmz-ssies}"
+APP_ROOT="${APP_ROOT:-/sisoc/SISOC}"
+MOBILE_ROOT="${MOBILE_ROOT:-/sisoc/SISOC-Mobile}"
+TARGET_USER="${PROD_MAINTENANCE_USER:-sisoc-deploy}"
+TIMESTAMP="$(date +%Y%m%d_%H%M%S)"
+BACKUP_DIR="${BACKUP_DIR:-/var/backups/sisoc/night-maintenance/prod/$TIMESTAMP}"
+RUNNER_UNIT="${PROD_RUNNER_UNIT:-actions.runner.dsocial118-SISOC.sisoc-produccion.service}"
+
+umask 077
+
+log() {
+  printf '[%s] %s\n' "$SCRIPT_NAME" "$*"
+}
+
+fail() {
+  log "ERROR: $*" >&2
+  exit 1
+}
+
+copy_if_present() {
+  local source="$1" destination="$2"
+  if [[ -e "$source" || -L "$source" ]]; then
+    mkdir -p "$(dirname "$destination")"
+    cp -a -- "$source" "$destination"
+  else
+    printf '%s\n' "$source" >> "$BACKUP_DIR/MISSING.txt"
+  fi
+}
+
+export_env_keys() {
+  local source="$1" destination="$2"
+  if [[ -r "$source" ]]; then
+    sed -nE 's/^[[:space:]]*(export[[:space:]]+)?([A-Za-z_][A-Za-z0-9_]*)[[:space:]]*=.*$/\2=/p' \
+      "$source" > "$destination"
+  else
+    printf '%s\n' "$source" >> "$BACKUP_DIR/MISSING.txt"
+  fi
+}
+
+main() {
+  local relative
+
+  [[ "$EUID" -eq 0 ]] || fail "Ejecutar como root mediante sudo."
+  [[ "$(hostname -s)" == "$EXPECTED_HOSTNAME" ]] || fail "Host inesperado."
+  id "$TARGET_USER" >/dev/null 2>&1 || fail "No existe $TARGET_USER."
+  git -c safe.directory="$APP_ROOT" -C "$APP_ROOT" rev-parse --is-inside-work-tree >/dev/null 2>&1 \
+    || fail "No se encontro el checkout backend."
+  git -c safe.directory="$MOBILE_ROOT" -C "$MOBILE_ROOT" rev-parse --is-inside-work-tree >/dev/null 2>&1 \
+    || fail "No se encontro el checkout mobile."
+  [[ ! -e "$BACKUP_DIR" ]] || fail "El backup ya existe: $BACKUP_DIR"
+
+  install -d -o root -g root -m 700 \
+    "$BACKUP_DIR" \
+    "$BACKUP_DIR/config" \
+    "$BACKUP_DIR/docker" \
+    "$BACKUP_DIR/git" \
+    "$BACKUP_DIR/sensitive" \
+    "$BACKUP_DIR/status"
+
+  copy_if_present /etc/nginx "$BACKUP_DIR/config/nginx"
+  copy_if_present /etc/logrotate.d/sisoc-nginx \
+    "$BACKUP_DIR/config/sisoc-nginx.before"
+  copy_if_present /etc/mysql "$BACKUP_DIR/config/mysql"
+  copy_if_present /etc/systemd/system/sisoc.service \
+    "$BACKUP_DIR/config/sisoc.service"
+  copy_if_present "/etc/systemd/system/$RUNNER_UNIT" \
+    "$BACKUP_DIR/config/$RUNNER_UNIT"
+
+  for relative in \
+    .github/workflows/deploy.yml \
+    docker-compose.deploy.yml \
+    docker-compose.produccion.yml \
+    docker/django/Dockerfile \
+    docker/django/entrypoint.py \
+    scripts/operacion/deploy_refresh.sh \
+    scripts/crontab; do
+    copy_if_present "$APP_ROOT/$relative" "$BACKUP_DIR/config/repo/$relative"
+  done
+  copy_if_present "$MOBILE_ROOT/compose.prod.yaml" \
+    "$BACKUP_DIR/config/mobile/compose.prod.yaml"
+
+  export_env_keys "$APP_ROOT/.env" "$BACKUP_DIR/config/backend.env.keys"
+  export_env_keys "$MOBILE_ROOT/.env" "$BACKUP_DIR/config/mobile.env.keys"
+  copy_if_present "$MOBILE_ROOT/.env" "$BACKUP_DIR/sensitive/mobile.env.before"
+  git -c safe.directory="$MOBILE_ROOT" -C "$MOBILE_ROOT" remote get-url origin \
+    > "$BACKUP_DIR/sensitive/mobile-origin.before"
+  chmod 600 "$BACKUP_DIR/sensitive/mobile.env.before" 2>/dev/null || true
+  stat -c 'path=%n owner=%U:%G mode=%a' "$APP_ROOT/.env" "$MOBILE_ROOT/.env" \
+    > "$BACKUP_DIR/status/env.metadata.before.txt"
+
+  crontab -l > "$BACKUP_DIR/status/root.crontab.before" 2>/dev/null || :
+  crontab -u "$TARGET_USER" -l \
+    > "$BACKUP_DIR/status/deploy-user.crontab.before" 2>/dev/null || :
+  systemctl show apache2 sisoc.service nginx docker mysql "$RUNNER_UNIT" \
+    -p Id -p ActiveState -p UnitFileState -p FragmentPath --no-pager \
+    > "$BACKUP_DIR/status/systemd.before.txt"
+  printf 'apache2=%s\n' "$(systemctl is-enabled apache2 2>/dev/null || true)" \
+    > "$BACKUP_DIR/status/legacy.enabled.before.txt"
+  printf 'sisoc.service=%s\n' "$(systemctl is-enabled sisoc.service 2>/dev/null || true)" \
+    >> "$BACKUP_DIR/status/legacy.enabled.before.txt"
+  ss -Hlnpt > "$BACKUP_DIR/status/listeners.before.txt"
+  df -hT > "$BACKUP_DIR/status/df-hT.before.txt"
+  df -ih > "$BACKUP_DIR/status/df-ih.before.txt"
+
+  git -c safe.directory="$APP_ROOT" -C "$APP_ROOT" status --short --branch \
+    > "$BACKUP_DIR/git/backend.status.before.txt"
+  git -c safe.directory="$APP_ROOT" -C "$APP_ROOT" rev-parse HEAD \
+    > "$BACKUP_DIR/git/backend.head.before.txt"
+  git -c safe.directory="$MOBILE_ROOT" -C "$MOBILE_ROOT" status --short --branch \
+    > "$BACKUP_DIR/git/mobile.status.before.txt"
+  git -c safe.directory="$MOBILE_ROOT" -C "$MOBILE_ROOT" rev-parse HEAD \
+    > "$BACKUP_DIR/git/mobile.head.before.txt"
+
+  docker ps --no-trunc > "$BACKUP_DIR/docker/containers.before.txt"
+  docker image ls --digests --no-trunc > "$BACKUP_DIR/docker/images.before.txt"
+  docker system df -v > "$BACKUP_DIR/docker/system-df.before.txt"
+  docker inspect --format '{{.Name}}|{{.Image}}|{{.RestartCount}}' \
+    $(docker ps -q) > "$BACKUP_DIR/docker/runtime.before.txt"
+
+  (
+    cd "$BACKUP_DIR"
+    find . -type f ! -name SHA256SUMS -print0 | sort -z | xargs -0 sha256sum
+  ) > "$BACKUP_DIR/SHA256SUMS"
+  find "$BACKUP_DIR" -type d -exec chmod 700 {} +
+  find "$BACKUP_DIR" -type f -exec chmod 600 {} +
+
+  log "Backup root-only validado."
+  printf 'BACKUP_DIR=%s\n' "$BACKUP_DIR"
+}
+
+main "$@"

--- a/scripts/infra/cleanup_prod_disk.sh
+++ b/scripts/infra/cleanup_prod_disk.sh
@@ -1,0 +1,139 @@
+#!/usr/bin/env bash
+set -Eeuo pipefail
+
+SCRIPT_NAME="$(basename "$0")"
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+EXPECTED_HOSTNAME="${PROD_EXPECTED_HOSTNAME:-mdsldmz-ssies}"
+APP_ROOT="${APP_ROOT:-/sisoc/SISOC}"
+ENV_FILE="${ENV_FILE:-$APP_ROOT/.env}"
+THRESHOLD_PERCENT="${PROD_DISK_THRESHOLD_PERCENT:-80}"
+RETENTION="${PROD_DOCKER_IMAGE_RETENTION:-336h}"
+APPLY=0
+ASSUME_YES=0
+
+usage() {
+  cat <<'USAGE'
+Uso:
+  cleanup_prod_disk.sh [--apply] [--yes]
+
+Sin --apply muestra estado y plan. Con --apply, y solo cuando / alcanza el
+umbral, poda imagenes y build cache Docker no usados mas antiguos que 14 dias.
+Nunca toca volumenes, media, logs, contenedores, MySQL ni checkouts.
+USAGE
+}
+
+log() {
+  local message="$*"
+  printf '[%s] %s\n' "$SCRIPT_NAME" "$message"
+  if [[ "$APPLY" -eq 1 ]]; then
+    /usr/bin/logger -t sisoc-prod-disk-cleanup -- "$message" 2>/dev/null || true
+  fi
+}
+
+fail() {
+  log "ERROR: $*" >&2
+  exit 1
+}
+
+read_env_value() {
+  local key="$1" line value
+  line="$(grep -E "^[[:space:]]*(export[[:space:]]+)?${key}[[:space:]]*=" "$ENV_FILE" | tail -n 1 || true)"
+  [[ -n "$line" ]] || return 1
+  value="${line#*=}"
+  value="${value%%#*}"
+  value="${value//$'\r'/}"
+  value="${value#"${value%%[![:space:]]*}"}"
+  value="${value%"${value##*[![:space:]]}"}"
+  value="${value%\"}"
+  value="${value#\"}"
+  value="${value%\'}"
+  value="${value#\'}"
+  printf '%s' "$value"
+}
+
+used_percent() {
+  df -P / | awk 'NR == 2 {gsub(/%/, "", $5); print $5}'
+}
+
+active_container_images() {
+  local container_id
+  while IFS= read -r container_id; do
+    [[ -n "$container_id" ]] || continue
+    docker inspect --format '{{.Name}}|{{.Image}}' "$container_id"
+  done < <(docker ps -q | sort)
+}
+
+parse_args() {
+  while [[ $# -gt 0 ]]; do
+    case "$1" in
+      --apply) APPLY=1 ;;
+      --yes) ASSUME_YES=1 ;;
+      -h|--help) usage; exit 0 ;;
+      *) fail "Opcion no reconocida: $1" ;;
+    esac
+    shift
+  done
+}
+
+main() {
+  local environment before_usage after_usage before_runtime after_runtime
+
+  parse_args "$@"
+  [[ "$THRESHOLD_PERCENT" =~ ^[0-9]+$ ]] || fail "El umbral debe ser entero."
+  (( THRESHOLD_PERCENT >= 1 && THRESHOLD_PERCENT <= 100 )) \
+    || fail "El umbral debe estar entre 1 y 100."
+  [[ "$RETENTION" =~ ^[1-9][0-9]*h$ ]] \
+    || fail "La retencion debe expresarse en horas positivas."
+  [[ "$(hostname -s)" == "$EXPECTED_HOSTNAME" ]] || fail "Host inesperado."
+  [[ -r "$ENV_FILE" ]] || fail "No se puede leer $ENV_FILE"
+  [[ -x "$SCRIPT_DIR/healthcheck_prod.sh" ]] || fail "Falta healthcheck_prod.sh."
+
+  environment="$(read_env_value ENVIRONMENT || true)"
+  environment="$(printf '%s' "$environment" | tr '[:upper:]' '[:lower:]')"
+  case "$environment" in
+    prd|prod|production|produccion) ;;
+    *) fail "ENVIRONMENT no corresponde a produccion." ;;
+  esac
+
+  docker info >/dev/null || fail "El usuario no puede consultar Docker."
+  bash "$SCRIPT_DIR/healthcheck_prod.sh"
+  before_usage="$(used_percent)"
+  log "host=$(hostname -s) root_usage=${before_usage}% threshold=${THRESHOLD_PERCENT}% retention=$RETENTION"
+  docker system df
+
+  if [[ "$APPLY" -eq 0 ]]; then
+    log "Modo informativo. Plan: image prune y builder prune; sin volumenes."
+    exit 0
+  fi
+
+  exec 9>/tmp/sisoc-prod-disk-cleanup.lock
+  flock -n 9 || fail "Ya hay otra limpieza en ejecucion."
+
+  if (( before_usage < THRESHOLD_PERCENT )); then
+    log "No se limpia: el uso esta por debajo del umbral."
+    exit 0
+  fi
+
+  if [[ "$ASSUME_YES" -eq 0 ]]; then
+    read -r -p "Podar recursos Docker no usados con mas de $RETENTION? [y/N] " answer
+    case "$answer" in
+      y|Y|yes|YES|si|SI) ;;
+      *) fail "Operacion cancelada." ;;
+    esac
+  fi
+
+  before_runtime="$(active_container_images | sort)"
+  docker image prune -af --filter "until=$RETENTION"
+  docker builder prune -af --filter "until=$RETENTION"
+  after_runtime="$(active_container_images | sort)"
+  [[ "$after_runtime" == "$before_runtime" ]] \
+    || fail "Cambio inesperado en contenedores o imagenes activas."
+  bash "$SCRIPT_DIR/healthcheck_prod.sh"
+
+  after_usage="$(used_percent)"
+  log "Poda finalizada: before=${before_usage}% after=${after_usage}% health=ok"
+  df -h /
+  docker system df
+}
+
+main "$@"

--- a/scripts/infra/healthcheck_prod.sh
+++ b/scripts/infra/healthcheck_prod.sh
@@ -1,0 +1,70 @@
+#!/usr/bin/env bash
+set -Eeuo pipefail
+
+SCRIPT_NAME="$(basename "$0")"
+EXPECTED_HOSTNAME="${PROD_EXPECTED_HOSTNAME:-mdsldmz-ssies}"
+EXPECTED_DB_HOST="${PROD_EXPECTED_DB_HOST:-10.80.5.46}"
+EXPECTED_DB_SERVER="${PROD_EXPECTED_DB_SERVER:-ldmzsql-sisoc}"
+EXPECTED_DB_NAME="${PROD_EXPECTED_DB_NAME:-sisoc_local}"
+DOMAIN="${PROD_DOMAIN:-sisoc.secretarianaf.gob.ar}"
+RUNNER_UNIT="${PROD_RUNNER_UNIT:-actions.runner.dsocial118-SISOC.sisoc-produccion.service}"
+CONTAINERS=(
+  sisoc-django-1
+  sisoc-ocr_worker-1
+  sisoc-bulk_credentials_worker-1
+  sisoc-ciudadanos_import_worker-1
+  sisoc-mailing_worker-1
+  sisoc-user_import_worker-1
+  sisoc-mobile-frontend-1
+)
+
+fail() {
+  printf '[%s] ERROR: %s\n' "$SCRIPT_NAME" "$*" >&2
+  exit 1
+}
+
+container_up() {
+  docker ps --format '{{.Names}}|{{.Status}}' | grep -q "^$1|Up "
+}
+
+main() {
+  local container identity configured_host actual_server actual_db
+
+  [[ "$(hostname -s)" == "$EXPECTED_HOSTNAME" ]] || fail "Host inesperado."
+  command -v docker >/dev/null || fail "Docker no esta disponible."
+  command -v curl >/dev/null || fail "curl no esta disponible."
+
+  systemctl is-active --quiet docker || fail "docker no esta activo."
+  systemctl is-active --quiet nginx || fail "nginx no esta activo."
+  systemctl is-active --quiet "$RUNNER_UNIT" || fail "El runner de produccion no esta activo."
+
+  for container in "${CONTAINERS[@]}"; do
+    container_up "$container" || fail "Contenedor ausente o no activo: $container"
+  done
+
+  [[ "$(docker inspect --format '{{if .State.Health}}{{.State.Health.Status}}{{else}}missing{{end}}' sisoc-mobile-frontend-1)" == "healthy" ]] \
+    || fail "SISOC-Mobile no esta healthy."
+
+  curl --max-time 8 -kfsS -o /dev/null --resolve "$DOMAIN:443:127.0.0.1" \
+    "https://$DOMAIN/"
+  curl --max-time 8 -kfsS -o /dev/null --resolve "$DOMAIN:443:127.0.0.1" \
+    "https://$DOMAIN/health/"
+  curl --max-time 8 -kfsS -o /dev/null --resolve "$DOMAIN:443:127.0.0.1" \
+    "https://$DOMAIN/mobile/"
+
+  identity="$(
+    docker exec sisoc-django-1 python manage.py shell -c \
+      "from django.db import connection; connection.ensure_connection(); c=connection.cursor(); c.execute('SELECT @@hostname, DATABASE()'); row=c.fetchone(); c.close(); print(str(connection.settings_dict.get('HOST'))+'|'+str(row[0])+'|'+str(row[1]))" \
+      | tail -n 1
+  )"
+  IFS='|' read -r configured_host actual_server actual_db <<< "$identity"
+  [[ "$configured_host" == "$EXPECTED_DB_HOST" ]] || fail "Django configura una DB inesperada."
+  [[ "$actual_server" == "$EXPECTED_DB_SERVER" ]] || fail "Servidor DB inesperado."
+  [[ "$actual_db" == "$EXPECTED_DB_NAME" ]] || fail "Schema DB inesperado."
+
+  printf 'PROD functional health check: OK\n'
+  printf 'db_host=%s db_server=%s db_name=%s containers=%s\n' \
+    "$configured_host" "$actual_server" "$actual_db" "${#CONTAINERS[@]}"
+}
+
+main "$@"

--- a/scripts/infra/install_prod_maintenance.sh
+++ b/scripts/infra/install_prod_maintenance.sh
@@ -1,0 +1,310 @@
+#!/usr/bin/env bash
+set -Eeuo pipefail
+
+SCRIPT_NAME="$(basename "$0")"
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+EXPECTED_HOSTNAME="${PROD_EXPECTED_HOSTNAME:-mdsldmz-ssies}"
+TARGET_USER="${PROD_MAINTENANCE_USER:-sisoc-deploy}"
+TARGET_GROUP="${PROD_MAINTENANCE_GROUP:-sisoc-deploy}"
+TARGET_HOME="${PROD_MAINTENANCE_HOME:-/home/sisoc-deploy}"
+TARGET_BIN="$TARGET_HOME/bin"
+MOBILE_ENV="${MOBILE_ENV:-/sisoc/SISOC-Mobile/.env}"
+LOGROTATE_FILE="/etc/logrotate.d/sisoc-nginx"
+OLD_ROOT_DOCKER='0 3 * * 0 /usr/bin/docker system prune -af --filter "until=24h" --volumes'
+DEPLOY_CRON_MARKER="# SISOC PROD conservative Docker cleanup"
+DEPLOY_CRON_LINE="40 3 * * * $TARGET_BIN/cleanup_prod_disk.sh --apply --yes >/dev/null 2>&1"
+SCRIPTS=(healthcheck_prod.sh cleanup_prod_disk.sh)
+APPLY=0
+ASSUME_YES=0
+ROTATE_LOGS_NOW=0
+BACKUP_DIR=""
+MUTATION_STARTED=0
+LOGROTATE_EXISTED=0
+APACHE_WAS_ENABLED=0
+SISOC_WAS_ENABLED=0
+
+usage() {
+  cat <<'USAGE'
+Uso:
+  install_prod_maintenance.sh [--apply] [--yes] [--rotate-logs-now]
+
+Sin --apply ejecuta preflight read-only. Con --apply:
+  - crea backup root-only;
+  - retira solo la poda Docker root con --volumes y dos cron legacy rotos;
+  - instala limpieza diaria conservadora como sisoc-deploy;
+  - instala logrotate para /sisoc/logs/nginx;
+  - restringe .env mobile a root:sisoc-deploy 640;
+  - deshabilita apache2 y sisoc.service solo si no estan activos.
+
+--rotate-logs-now aplica solo la nueva regla NGINX durante esta ejecucion.
+No toca TLS, media, DB, paquetes, volumenes ni checkouts historicos.
+USAGE
+}
+
+log() {
+  printf '[%s] %s\n' "$SCRIPT_NAME" "$*"
+}
+
+fail() {
+  log "ERROR: $*" >&2
+  exit 1
+}
+
+generate_logrotate() {
+  cat <<'LOGROTATE'
+/sisoc/logs/nginx/*.log {
+    daily
+    maxsize 100M
+    rotate 30
+    missingok
+    notifempty
+    compress
+    delaycompress
+    create 0640 www-data root
+    sharedscripts
+    postrotate
+        if [ -s /run/nginx.pid ]; then
+            kill -USR1 "$(cat /run/nginx.pid)"
+        fi
+    endscript
+}
+LOGROTATE
+}
+
+parse_args() {
+  while [[ $# -gt 0 ]]; do
+    case "$1" in
+      --apply) APPLY=1 ;;
+      --yes) ASSUME_YES=1 ;;
+      --rotate-logs-now) ROTATE_LOGS_NOW=1 ;;
+      -h|--help) usage; exit 0 ;;
+      *) fail "Opcion no reconocida: $1" ;;
+    esac
+    shift
+  done
+}
+
+service_inactive_or_failed() {
+  local state
+  state="$(systemctl is-active "$1" 2>/dev/null || true)"
+  [[ "$state" == "inactive" || "$state" == "failed" ]]
+}
+
+preflight() {
+  local script mobile_metadata root_cron deploy_cron
+  local old_count home_legacy_count opt_legacy_count deploy_refs deploy_exact
+
+  [[ "$EUID" -eq 0 ]] || fail "Ejecutar como root mediante sudo."
+  [[ "$(hostname -s)" == "$EXPECTED_HOSTNAME" ]] || fail "Host inesperado."
+  id "$TARGET_USER" >/dev/null 2>&1 || fail "No existe $TARGET_USER."
+  id -nG "$TARGET_USER" | tr ' ' '\n' | grep -qx docker \
+    || fail "$TARGET_USER no pertenece al grupo docker."
+  [[ -f "$MOBILE_ENV" ]] || fail "No existe $MOBILE_ENV"
+  [[ -d /sisoc/logs/nginx ]] || fail "No existe /sisoc/logs/nginx"
+  command -v logrotate >/dev/null || fail "logrotate no esta disponible."
+  command -v nginx >/dev/null || fail "nginx no esta disponible."
+
+  for script in "${SCRIPTS[@]}" backup_prod_configs.sh; do
+    [[ -r "$SCRIPT_DIR/$script" ]] || fail "Falta $SCRIPT_DIR/$script"
+    bash -n "$SCRIPT_DIR/$script" || fail "Sintaxis invalida: $script"
+  done
+
+  bash "$SCRIPT_DIR/healthcheck_prod.sh"
+  runuser -u "$TARGET_USER" -- docker info >/dev/null \
+    || fail "$TARGET_USER no puede consultar Docker."
+  nginx -t
+
+  root_cron="$(mktemp)"
+  deploy_cron="$(mktemp)"
+  crontab -l > "$root_cron" 2>/dev/null || :
+  crontab -u "$TARGET_USER" -l > "$deploy_cron" 2>/dev/null || :
+
+  old_count="$(grep -Fxc -- "$OLD_ROOT_DOCKER" "$root_cron" || true)"
+  home_legacy_count="$(grep -Fc '/home/admin-ssies/SISOC-Backoffice' "$root_cron" || true)"
+  opt_legacy_count="$(grep -Fc '/opt/ssies/SISOC-Backoffice' "$root_cron" || true)"
+  deploy_refs="$(grep -Fc "$TARGET_BIN/cleanup_prod_disk.sh" "$deploy_cron" || true)"
+  deploy_exact="$(grep -Fxc "$DEPLOY_CRON_LINE" "$deploy_cron" || true)"
+
+  if [[ "$old_count" -eq 1 && "$home_legacy_count" -eq 1 && "$opt_legacy_count" -eq 1 && "$deploy_refs" -eq 0 ]]; then
+    log "Cron en estado inicial esperado."
+  elif [[ "$old_count" -eq 0 && "$home_legacy_count" -eq 0 && "$opt_legacy_count" -eq 0 && "$deploy_refs" -eq 1 && "$deploy_exact" -eq 1 ]]; then
+    log "Cron ya esta en estado instalado esperado."
+  else
+    fail "Conteos de cron inesperados; no se modificara ningun crontab."
+  fi
+
+  [[ ! -e /home/admin-ssies/SISOC-Backoffice ]] \
+    || fail "El path legacy de /home volvio a existir."
+  [[ ! -e /opt/ssies/SISOC-Backoffice ]] \
+    || fail "El path legacy de /opt volvio a existir."
+  service_inactive_or_failed apache2 || fail "apache2 esta activo; no se deshabilitara."
+  service_inactive_or_failed sisoc.service || fail "sisoc.service esta activo."
+
+  mobile_metadata="$(stat -c '%U:%G:%a' "$MOBILE_ENV")"
+  case "$mobile_metadata" in
+    root:root:664|root:sisoc-deploy:640) ;;
+    *) fail "Metadata inesperada en .env mobile: $mobile_metadata" ;;
+  esac
+
+  if [[ -e "$LOGROTATE_FILE" ]]; then
+    LOGROTATE_EXISTED=1
+    generate_logrotate | cmp -s - "$LOGROTATE_FILE" \
+      || fail "$LOGROTATE_FILE ya existe con contenido distinto."
+  fi
+  systemctl is-enabled --quiet apache2 && APACHE_WAS_ENABLED=1 || true
+  systemctl is-enabled --quiet sisoc.service && SISOC_WAS_ENABLED=1 || true
+  rm -f -- "$root_cron" "$deploy_cron"
+
+  log "Preflight OK: cron, servicios, permisos, NGINX, Docker y health."
+}
+
+rollback_on_error() {
+  local rc=$?
+  trap - EXIT
+  if [[ "$MUTATION_STARTED" -eq 1 && -n "$BACKUP_DIR" ]]; then
+    log "Fallo durante instalacion; restaurando cambios reversibles."
+    crontab "$BACKUP_DIR/status/root.crontab.before" || true
+    crontab -u "$TARGET_USER" "$BACKUP_DIR/status/deploy-user.crontab.before" || true
+    cp -a -- "$BACKUP_DIR/sensitive/mobile.env.before" "$MOBILE_ENV" || true
+    if [[ "$LOGROTATE_EXISTED" -eq 1 ]]; then
+      cp -a -- "$BACKUP_DIR/config/sisoc-nginx.before" "$LOGROTATE_FILE" || true
+    elif [[ -e "$LOGROTATE_FILE" ]]; then
+      install -d -m 700 "$BACKUP_DIR/rollback"
+      mv -- "$LOGROTATE_FILE" "$BACKUP_DIR/rollback/sisoc-nginx.disabled" || true
+    fi
+    [[ "$APACHE_WAS_ENABLED" -eq 1 ]] && systemctl enable apache2 >/dev/null 2>&1 || true
+    [[ "$SISOC_WAS_ENABLED" -eq 1 ]] && systemctl enable sisoc.service >/dev/null 2>&1 || true
+    for script in "${SCRIPTS[@]}"; do
+      if [[ -e "$BACKUP_DIR/config/installed-before/$script" ]]; then
+        cp -a -- "$BACKUP_DIR/config/installed-before/$script" "$TARGET_BIN/$script" || true
+      elif [[ -e "$TARGET_BIN/$script" ]]; then
+        install -d -m 700 "$BACKUP_DIR/rollback"
+        mv -- "$TARGET_BIN/$script" "$BACKUP_DIR/rollback/$script.disabled" || true
+      fi
+    done
+    bash "$SCRIPT_DIR/healthcheck_prod.sh" || true
+  fi
+  exit "$rc"
+}
+
+install_cron_and_scripts() {
+  local script root_after deploy_after old_count
+
+  install -d -o "$TARGET_USER" -g "$TARGET_GROUP" -m 750 "$TARGET_BIN"
+  for script in "${SCRIPTS[@]}"; do
+    if [[ -e "$TARGET_BIN/$script" ]]; then
+      install -d -m 700 "$BACKUP_DIR/config/installed-before"
+      cp -a -- "$TARGET_BIN/$script" "$BACKUP_DIR/config/installed-before/$script"
+    fi
+    install -o "$TARGET_USER" -g "$TARGET_GROUP" -m 750 \
+      "$SCRIPT_DIR/$script" "$TARGET_BIN/$script"
+  done
+
+  root_after="$BACKUP_DIR/status/root.crontab.after"
+  deploy_after="$BACKUP_DIR/status/deploy-user.crontab.after"
+  old_count="$(grep -Fxc -- "$OLD_ROOT_DOCKER" "$BACKUP_DIR/status/root.crontab.before" || true)"
+
+  if [[ "$old_count" -eq 1 ]]; then
+    awk -v old="$OLD_ROOT_DOCKER" '
+      $0 == old { next }
+      /\/home\/admin-ssies\/SISOC-Backoffice\/cron_logs\/borrar_logs.py/ { next }
+      /cd \/opt\/ssies\/SISOC-Backoffice .*purge_auditlog/ { next }
+      { print }
+    ' "$BACKUP_DIR/status/root.crontab.before" > "$root_after"
+  else
+    cp -- "$BACKUP_DIR/status/root.crontab.before" "$root_after"
+  fi
+
+  cp -- "$BACKUP_DIR/status/deploy-user.crontab.before" "$deploy_after"
+  if ! grep -Fqx "$DEPLOY_CRON_LINE" "$deploy_after"; then
+    printf '\n%s\n%s\n' "$DEPLOY_CRON_MARKER" "$DEPLOY_CRON_LINE" >> "$deploy_after"
+  fi
+
+  [[ "$(grep -Fc -- '--volumes' "$root_after" || true)" -eq 0 ]] \
+    || fail "El root cron propuesto conserva --volumes."
+  [[ "$(grep -Fc '/home/admin-ssies/SISOC-Backoffice' "$root_after" || true)" -eq 0 ]] \
+    || fail "El root cron propuesto conserva el path legacy de /home."
+  [[ "$(grep -Fc '/opt/ssies/SISOC-Backoffice' "$root_after" || true)" -eq 0 ]] \
+    || fail "El root cron propuesto conserva el path legacy de /opt."
+  [[ "$(grep -Fxc "$DEPLOY_CRON_LINE" "$deploy_after" || true)" -eq 1 ]] \
+    || fail "El cron de mantenimiento no quedaria exactamente una vez."
+
+  chmod 600 "$root_after" "$deploy_after"
+  crontab "$root_after"
+  crontab -u "$TARGET_USER" "$deploy_after"
+}
+
+apply_changes() {
+  local timestamp logrotate_tmp
+
+  timestamp="$(date +%Y%m%d_%H%M%S)"
+  BACKUP_DIR="/var/backups/sisoc/night-maintenance/prod/$timestamp"
+  BACKUP_DIR="$BACKUP_DIR" bash "$SCRIPT_DIR/backup_prod_configs.sh"
+
+  MUTATION_STARTED=1
+  trap rollback_on_error EXIT
+  install_cron_and_scripts
+
+  logrotate_tmp="$(mktemp)"
+  generate_logrotate > "$logrotate_tmp"
+  install -o root -g root -m 644 "$logrotate_tmp" "$LOGROTATE_FILE"
+  rm -f -- "$logrotate_tmp"
+  logrotate -d "$LOGROTATE_FILE" >/dev/null
+
+  chown root:"$TARGET_GROUP" "$MOBILE_ENV"
+  chmod 640 "$MOBILE_ENV"
+  runuser -u "$TARGET_USER" -- test -r "$MOBILE_ENV"
+  runuser -u "$TARGET_USER" -- docker compose \
+    -f /sisoc/SISOC-Mobile/compose.prod.yaml \
+    --project-directory /sisoc/SISOC-Mobile config --services >/dev/null
+
+  systemctl disable apache2 sisoc.service >/dev/null
+  if [[ "$ROTATE_LOGS_NOW" -eq 1 ]]; then
+    logrotate -f -v "$LOGROTATE_FILE"
+  fi
+
+  runuser -u "$TARGET_USER" -- "$TARGET_BIN/healthcheck_prod.sh"
+  runuser -u "$TARGET_USER" -- "$TARGET_BIN/cleanup_prod_disk.sh"
+  [[ "$(crontab -u "$TARGET_USER" -l | grep -Fxc "$DEPLOY_CRON_LINE" || true)" -eq 1 ]] \
+    || fail "No quedo instalado el cron de mantenimiento."
+  [[ "$(crontab -l | grep -Fc -- '--volumes' || true)" -eq 0 ]] \
+    || fail "Root cron todavia contiene --volumes."
+  systemctl is-enabled --quiet apache2 && fail "apache2 sigue habilitado."
+  systemctl is-enabled --quiet sisoc.service && fail "sisoc.service sigue habilitado."
+  [[ "$(stat -c '%U:%G:%a' "$MOBILE_ENV")" == "root:$TARGET_GROUP:640" ]] \
+    || fail "Metadata final inesperada en .env mobile."
+
+  printf 'applied_at=%s\nbackup_dir=%s\nlogs_rotated_now=%s\n' \
+    "$(date --iso-8601=seconds)" "$BACKUP_DIR" "$ROTATE_LOGS_NOW" \
+    > "$BACKUP_DIR/MAINTENANCE_APPLIED"
+  chmod 600 "$BACKUP_DIR/MAINTENANCE_APPLIED"
+  (
+    cd "$BACKUP_DIR"
+    find . -type f ! -name SHA256SUMS -print0 | sort -z | xargs -0 sha256sum
+  ) > "$BACKUP_DIR/SHA256SUMS"
+
+  MUTATION_STARTED=0
+  trap - EXIT
+  log "Mantenimiento instalado y validado."
+  printf 'BACKUP_DIR=%s\n' "$BACKUP_DIR"
+}
+
+main() {
+  parse_args "$@"
+  preflight
+
+  if [[ "$APPLY" -eq 0 ]]; then
+    log "Modo read-only. Use --apply solo dentro de la ventana aprobada."
+    exit 0
+  fi
+  if [[ "$ASSUME_YES" -eq 0 ]]; then
+    read -r -p "Aplicar mantenimiento host-side reversible en produccion? [y/N] " answer
+    case "$answer" in
+      y|Y|yes|YES|si|SI) ;;
+      *) fail "Operacion cancelada." ;;
+    esac
+  fi
+  apply_changes
+}
+
+main "$@"

--- a/scripts/infra/prepare_prod_mobile_checkout.sh
+++ b/scripts/infra/prepare_prod_mobile_checkout.sh
@@ -1,0 +1,185 @@
+#!/usr/bin/env bash
+set -Eeuo pipefail
+
+SCRIPT_NAME="$(basename "$0")"
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+EXPECTED_HOSTNAME="${PROD_EXPECTED_HOSTNAME:-mdsldmz-ssies}"
+TARGET_USER="${PROD_MAINTENANCE_USER:-sisoc-deploy}"
+TARGET_GROUP="${PROD_MAINTENANCE_GROUP:-sisoc-deploy}"
+MOBILE_ROOT="${MOBILE_ROOT:-/sisoc/SISOC-Mobile}"
+MOBILE_ENV="$MOBILE_ROOT/.env"
+HTTPS_REMOTE="https://github.com/dsocial118/SISOC-Mobile.git"
+BACKUP_BASE="${BACKUP_BASE:-/var/backups/sisoc/mobile-checkout-preparation}"
+BACKUP_DIR=""
+APPLY=0
+ASSUME_YES=0
+ROLLBACK_NEEDED=0
+
+usage() {
+  cat <<'USAGE'
+Uso:
+  prepare_prod_mobile_checkout.sh [--apply] [--yes]
+
+Sin --apply audita checkout, ownership y remote sin cambiar nada. Con --apply:
+  - guarda ACL/owners/modes completos y remote en backup root-only;
+  - cambia recursivamente owner/grupo SOLO de /sisoc/SISOC-Mobile al usuario
+    del runner;
+  - restaura la metadata previa de .env;
+  - cambia el origin SSH conocido a HTTPS publica;
+  - valida fetch, branch, commit, working tree y health.
+
+No mueve ni borra archivos. El cambio recursivo de owner requiere el GO
+explicito de este gate.
+USAGE
+}
+
+log() {
+  printf '[%s] %s\n' "$SCRIPT_NAME" "$*"
+}
+
+fail() {
+  log "ERROR: $*" >&2
+  exit 1
+}
+
+parse_args() {
+  while [[ $# -gt 0 ]]; do
+    case "$1" in
+      --apply) APPLY=1 ;;
+      --yes) ASSUME_YES=1 ;;
+      -h|--help) usage; exit 0 ;;
+      *) fail "Opcion no reconocida: $1" ;;
+    esac
+    shift
+  done
+}
+
+remote_state() {
+  local remote
+  remote="$(git -c safe.directory="$MOBILE_ROOT" -C "$MOBILE_ROOT" remote get-url origin 2>/dev/null)" \
+    || fail "SISOC-Mobile no tiene origin."
+  case "$remote" in
+    "$HTTPS_REMOTE"|https://github.com/dsocial118/SISOC-Mobile)
+      printf 'https'
+      ;;
+    git@github.com:dsocial118/SISOC-Mobile.git|ssh://git@github.com/dsocial118/SISOC-Mobile.git)
+      printf 'ssh'
+      ;;
+    *)
+      fail "Origin mobile inesperado; no se imprime para evitar exponer credenciales."
+      ;;
+  esac
+}
+
+preflight() {
+  local branch tracked_changes non_target_entries state
+
+  [[ "$EUID" -eq 0 ]] || fail "Ejecutar como root mediante sudo."
+  [[ "$(hostname -s)" == "$EXPECTED_HOSTNAME" ]] || fail "Host inesperado."
+  id "$TARGET_USER" >/dev/null 2>&1 || fail "No existe $TARGET_USER."
+  command -v getfacl >/dev/null || fail "getfacl no esta disponible."
+  command -v setfacl >/dev/null || fail "setfacl no esta disponible."
+  git -c safe.directory="$MOBILE_ROOT" -C "$MOBILE_ROOT" rev-parse --is-inside-work-tree >/dev/null 2>&1 \
+    || fail "No se encontro el checkout mobile."
+  [[ -f "$MOBILE_ENV" ]] || fail "No existe .env mobile."
+  branch="$(git -c safe.directory="$MOBILE_ROOT" -C "$MOBILE_ROOT" branch --show-current)"
+  [[ "$branch" == main ]] || fail "SISOC-Mobile no esta en main."
+  if ! git -c safe.directory="$MOBILE_ROOT" -C "$MOBILE_ROOT" diff-index --quiet HEAD --; then
+    tracked_changes="$(git -c safe.directory="$MOBILE_ROOT" -C "$MOBILE_ROOT" diff-index --name-only HEAD -- | wc -l)"
+    fail "SISOC-Mobile tiene $tracked_changes archivos tracked modificados."
+  fi
+
+  state="$(remote_state)"
+  non_target_entries="$(
+    find "$MOBILE_ROOT" -xdev ! -path "$MOBILE_ENV" \
+      \( ! -user "$TARGET_USER" -o ! -group "$TARGET_GROUP" \) -printf . | wc -c
+  )"
+  log "branch=main remote=$state entries_outside_target_owner=$non_target_entries"
+  if [[ "$non_target_entries" -eq 0 && "$state" == https ]]; then
+    runuser -u "$TARGET_USER" -- git -C "$MOBILE_ROOT" status --porcelain >/dev/null \
+      || fail "El checkout parece preparado pero el runner no puede usarlo."
+    log "Checkout mobile ya esta preparado."
+  else
+    [[ "$state" == ssh ]] || fail "Estado parcial inesperado del checkout mobile."
+    log "Checkout mobile requiere alineacion de owner y remote antes del primer deploy."
+  fi
+}
+
+rollback_on_error() {
+  local rc=$?
+  trap - EXIT
+  if [[ "$ROLLBACK_NEEDED" -eq 1 && -n "$BACKUP_DIR" ]]; then
+    log "Fallo durante preparacion mobile; restaurando ACL/owners y remote."
+    setfacl --restore="$BACKUP_DIR/mobile.acl-ownership.before" || true
+    if [[ -r "$BACKUP_DIR/mobile-origin.before" ]]; then
+      git -c safe.directory="$MOBILE_ROOT" -C "$MOBILE_ROOT" remote set-url origin \
+        "$(cat "$BACKUP_DIR/mobile-origin.before")" || true
+    fi
+    bash "$SCRIPT_DIR/healthcheck_prod.sh" || true
+  fi
+  exit "$rc"
+}
+
+apply_changes() {
+  local timestamp before_head after_head
+
+  timestamp="$(date +%Y%m%d_%H%M%S)"
+  BACKUP_DIR="$BACKUP_BASE/$timestamp"
+  umask 077
+  install -d -o root -g root -m 700 "$BACKUP_DIR"
+  getfacl -R -p "$MOBILE_ROOT" > "$BACKUP_DIR/mobile.acl-ownership.before"
+  getfacl -p "$MOBILE_ENV" > "$BACKUP_DIR/mobile-env.acl-ownership.before"
+  git -c safe.directory="$MOBILE_ROOT" -C "$MOBILE_ROOT" remote get-url origin \
+    > "$BACKUP_DIR/mobile-origin.before"
+  before_head="$(git -c safe.directory="$MOBILE_ROOT" -C "$MOBILE_ROOT" rev-parse HEAD)"
+  printf '%s\n' "$before_head" > "$BACKUP_DIR/mobile-head.before"
+  find "$BACKUP_DIR" -type f -exec chmod 600 {} +
+
+  trap rollback_on_error EXIT
+  ROLLBACK_NEEDED=1
+  chown -R "$TARGET_USER:$TARGET_GROUP" "$MOBILE_ROOT"
+  setfacl --restore="$BACKUP_DIR/mobile-env.acl-ownership.before"
+  runuser -u "$TARGET_USER" -- git -C "$MOBILE_ROOT" remote set-url origin "$HTTPS_REMOTE"
+  runuser -u "$TARGET_USER" -- git -C "$MOBILE_ROOT" fetch origin --prune
+  after_head="$(runuser -u "$TARGET_USER" -- git -C "$MOBILE_ROOT" rev-parse HEAD)"
+  [[ "$after_head" == "$before_head" ]] || fail "El fetch cambio el HEAD local."
+  [[ "$(runuser -u "$TARGET_USER" -- git -C "$MOBILE_ROOT" branch --show-current)" == main ]] \
+    || fail "Mobile dejo de estar en main."
+  runuser -u "$TARGET_USER" -- git -C "$MOBILE_ROOT" diff-index --quiet HEAD -- \
+    || fail "Aparecieron cambios tracked en mobile."
+  [[ "$(remote_state)" == https ]] || fail "Origin mobile no quedo en HTTPS."
+  bash "$SCRIPT_DIR/healthcheck_prod.sh"
+
+  printf 'applied_at=%s\nhead=%s\n' "$(date --iso-8601=seconds)" "$after_head" \
+    > "$BACKUP_DIR/PREPARATION_APPLIED"
+  chmod 600 "$BACKUP_DIR/PREPARATION_APPLIED"
+  (
+    cd "$BACKUP_DIR"
+    find . -type f ! -name SHA256SUMS -print0 | sort -z | xargs -0 sha256sum
+  ) > "$BACKUP_DIR/SHA256SUMS"
+  chmod 600 "$BACKUP_DIR/SHA256SUMS"
+
+  ROLLBACK_NEEDED=0
+  trap - EXIT
+  log "Checkout mobile preparado para deploy no interactivo."
+  printf 'BACKUP_DIR=%s\n' "$BACKUP_DIR"
+}
+
+main() {
+  parse_args "$@"
+  preflight
+  if [[ "$APPLY" -eq 0 ]]; then
+    log "Modo read-only. Use --apply solo con aprobacion del owner recursivo."
+    exit 0
+  fi
+  if [[ "$ASSUME_YES" -eq 0 ]]; then
+    read -r -p "Alinear owner del checkout mobile y cambiar origin a HTTPS? [y/N] " answer
+    case "$answer" in
+      y|Y|yes|YES|si|SI) ;;
+      *) fail "Operacion cancelada." ;;
+    esac
+  fi
+  apply_changes
+}
+
+main "$@"

--- a/scripts/infra/prod_night_preflight.sh
+++ b/scripts/infra/prod_night_preflight.sh
@@ -1,0 +1,102 @@
+#!/usr/bin/env bash
+set -Eeuo pipefail
+
+SCRIPT_NAME="$(basename "$0")"
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+EXPECTED_HOSTNAME="${PROD_EXPECTED_HOSTNAME:-mdsldmz-ssies}"
+APP_ROOT="${APP_ROOT:-/sisoc/SISOC}"
+MOBILE_ROOT="${MOBILE_ROOT:-/sisoc/SISOC-Mobile}"
+TARGET_USER="${PROD_MAINTENANCE_USER:-sisoc-deploy}"
+MEDIA_STATUS="${PROD_MEDIA_BACKUP_STATUS:-/sisoc/backups/media/20260713_172352/status.txt}"
+MIN_FREE_BYTES="${PROD_MIN_FREE_BYTES:-107374182400}"
+SKIP_MYSQL=0
+
+usage() {
+  cat <<'USAGE'
+Uso:
+  prod_night_preflight.sh [--skip-mysql]
+
+Preflight read-only de la ventana productiva. --skip-mysql se usa solamente
+despues de completar Stage 1, cuando el MySQL local ya debe estar inactivo.
+No imprime .env, secretos ni contenido de logs.
+USAGE
+}
+
+fail() {
+  printf '[%s] ERROR: %s\n' "$SCRIPT_NAME" "$*" >&2
+  exit 1
+}
+
+parse_args() {
+  while [[ $# -gt 0 ]]; do
+    case "$1" in
+      --skip-mysql) SKIP_MYSQL=1 ;;
+      -h|--help) usage; exit 0 ;;
+      *) fail "Opcion no reconocida: $1" ;;
+    esac
+    shift
+  done
+}
+
+assert_git_checkout() {
+  local path="$1" expected_branch="$2" label="$3" branch tracked_changes
+  git -c safe.directory="$path" -C "$path" rev-parse --is-inside-work-tree >/dev/null 2>&1 \
+    || fail "$label no es un checkout Git."
+  branch="$(git -c safe.directory="$path" -C "$path" branch --show-current)"
+  [[ "$branch" == "$expected_branch" ]] || fail "$label no esta en $expected_branch."
+  if ! git -c safe.directory="$path" -C "$path" diff-index --quiet HEAD --; then
+    tracked_changes="$(git -c safe.directory="$path" -C "$path" diff-index --name-only HEAD -- | wc -l)"
+    fail "$label tiene $tracked_changes archivos tracked modificados."
+  fi
+}
+
+main() {
+  local available_bytes used_percent backend_head mobile_head restart_sum
+
+  parse_args "$@"
+  [[ "$EUID" -eq 0 ]] || fail "Ejecutar como root mediante sudo."
+  [[ "$(hostname -s)" == "$EXPECTED_HOSTNAME" ]] || fail "Host inesperado."
+  [[ -r "$MEDIA_STATUS" ]] || fail "No se puede leer el estado del backup de media."
+  grep -q '^BACKUP_STATUS=complete$' "$MEDIA_STATUS" \
+    || fail "El backup de media no figura completo."
+
+  available_bytes="$(df -B1 --output=avail / | tail -n 1 | tr -d ' ')"
+  used_percent="$(df -P / | awk 'NR == 2 {gsub(/%/, "", $5); print $5}')"
+  (( available_bytes >= MIN_FREE_BYTES )) || fail "Hay menos de 100 GiB libres."
+  (( used_percent < 80 )) || fail "El filesystem raiz alcanzo 80% o mas."
+
+  assert_git_checkout "$APP_ROOT" main "SISOC"
+  assert_git_checkout "$MOBILE_ROOT" main "SISOC-Mobile"
+  backend_head="$(git -c safe.directory="$APP_ROOT" -C "$APP_ROOT" rev-parse HEAD)"
+  mobile_head="$(git -c safe.directory="$MOBILE_ROOT" -C "$MOBILE_ROOT" rev-parse HEAD)"
+
+  runuser -u "$TARGET_USER" -- docker compose \
+    -f "$APP_ROOT/docker-compose.deploy.yml" \
+    -f "$APP_ROOT/docker-compose.produccion.yml" \
+    --project-directory "$APP_ROOT" config -q
+  runuser -u "$TARGET_USER" -- docker compose \
+    -f "$MOBILE_ROOT/compose.prod.yaml" \
+    --project-directory "$MOBILE_ROOT" config -q
+
+  bash "$SCRIPT_DIR/healthcheck_prod.sh"
+  restart_sum="$(docker inspect --format '{{.RestartCount}}' $(docker ps -q) | awk '{sum += $1} END {print sum + 0}')"
+  (( restart_sum == 0 )) || fail "Hay restart counts acumulados; clasificar antes de avanzar."
+
+  bash "$SCRIPT_DIR/prepare_prod_mobile_checkout.sh"
+  bash "$SCRIPT_DIR/install_prod_maintenance.sh"
+  if [[ "$SKIP_MYSQL" -eq 0 ]]; then
+    bash "$SCRIPT_DIR/retire_prod_local_mysql_stage1.sh"
+  else
+    systemctl is-active --quiet mysql && fail "MySQL local sigue activo."
+    systemctl is-enabled --quiet mysql && fail "MySQL local sigue habilitado."
+    ss -Hlnpt 'sport = :3306' | grep -q . && fail "3306 local sigue escuchando."
+    ss -Hlnpt 'sport = :33060' | grep -q . && fail "33060 local sigue escuchando."
+  fi
+
+  printf 'PROD NIGHT PREFLIGHT: OK\n'
+  printf 'backend_head=%s\nmobile_head=%s\nroot_usage=%s%%\n' \
+    "$backend_head" "$mobile_head" "$used_percent"
+  printf 'operator_confirmation_required=DB backup, no active imports/mailings, latest GitHub run\n'
+}
+
+main "$@"

--- a/scripts/infra/retire_prod_local_mysql_stage1.sh
+++ b/scripts/infra/retire_prod_local_mysql_stage1.sh
@@ -1,0 +1,220 @@
+#!/usr/bin/env bash
+set -Eeuo pipefail
+
+SCRIPT_NAME="$(basename "$0")"
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+EXPECTED_HOSTNAME="${PROD_EXPECTED_HOSTNAME:-mdsldmz-ssies}"
+EXPECTED_DB_HOST="${PROD_EXPECTED_DB_HOST:-10.80.5.46}"
+EXPECTED_DB_SERVER="${PROD_EXPECTED_DB_SERVER:-ldmzsql-sisoc}"
+EXPECTED_DB_NAME="${PROD_EXPECTED_DB_NAME:-sisoc_local}"
+EXPECTED_LOCAL_UUID="${PROD_EXPECTED_LOCAL_MYSQL_UUID:-39c3f26e-78f1-11f0-8e8b-005056a21960}"
+CONTAINER_NAME="${PROD_DJANGO_CONTAINER:-sisoc-django-1}"
+BACKUP_BASE="${BACKUP_BASE:-/var/backups/sisoc/mysql-local-retirement/prod}"
+APPLY=0
+ASSUME_YES=0
+ROLLBACK_NEEDED=0
+BACKUP_DIR=""
+MYSQL=(mysql --protocol=socket --batch --skip-column-names --raw)
+
+usage() {
+  cat <<'USAGE'
+Uso:
+  retire_prod_local_mysql_stage1.sh [--apply] [--yes]
+
+Sin --apply ejecuta solo el preflight. Stage 1 crea backup root-only y
+detiene/deshabilita el MySQL local. Conserva paquetes, configuracion y datadir
+por al menos 14 dias; nunca ejecuta DROP, purge ni borrado.
+USAGE
+}
+
+log() {
+  printf '[%s] %s\n' "$SCRIPT_NAME" "$*"
+}
+
+fail() {
+  log "ERROR: $*" >&2
+  exit 1
+}
+
+rollback_on_error() {
+  local rc=$?
+  if [[ "$ROLLBACK_NEEDED" -eq 1 ]]; then
+    log "Fallo posterior al stop; restaurando mysql.service."
+    systemctl enable mysql >/dev/null 2>&1 || true
+    systemctl start mysql || true
+  fi
+  exit "$rc"
+}
+
+parse_args() {
+  while [[ $# -gt 0 ]]; do
+    case "$1" in
+      --apply) APPLY=1 ;;
+      --yes) ASSUME_YES=1 ;;
+      -h|--help) usage; exit 0 ;;
+      *) fail "Opcion no reconocida: $1" ;;
+    esac
+    shift
+  done
+}
+
+django_db_identity() {
+  docker exec "$CONTAINER_NAME" python manage.py shell -c \
+    "from django.db import connection; connection.ensure_connection(); c=connection.cursor(); c.execute('SELECT @@hostname, @@server_uuid, DATABASE()'); row=c.fetchone(); c.close(); print(str(connection.settings_dict.get('HOST'))+'|'+str(connection.connection.get_host_info())+'|'+str(row[0])+'|'+str(row[1])+'|'+str(row[2]))" \
+    | tail -n 1
+}
+
+validate_django_remote_db() {
+  local identity configured_host connection_info actual_server actual_uuid actual_db
+  identity="$(django_db_identity)"
+  IFS='|' read -r configured_host connection_info actual_server actual_uuid actual_db <<< "$identity"
+  [[ "$configured_host" == "$EXPECTED_DB_HOST" ]] \
+    || fail "Django configura un host inesperado."
+  [[ "$connection_info" == *"$EXPECTED_DB_HOST"* ]] \
+    || fail "Django no conecta por TCP al host esperado."
+  [[ "$actual_server" == "$EXPECTED_DB_SERVER" ]] \
+    || fail "Servidor DB inesperado."
+  [[ "$actual_db" == "$EXPECTED_DB_NAME" ]] \
+    || fail "Schema DB inesperado."
+  log "Django DB: configured=$configured_host actual=$actual_server uuid=$actual_uuid database=$actual_db"
+}
+
+preflight_local_mysql() {
+  local local_identity local_uuid application_schemas unexpected_connections
+  local enabled_events replica_channels group_members
+
+  systemctl is-active --quiet mysql || fail "mysql.service no esta activo."
+  systemctl is-enabled --quiet mysql || fail "mysql.service no esta habilitado."
+  [[ -d /var/lib/mysql ]] || fail "No existe /var/lib/mysql"
+
+  local_identity="$("${MYSQL[@]}" -e "SELECT CONCAT(@@hostname, '|', @@server_uuid, '|', @@server_id, '|', @@event_scheduler);")"
+  local_uuid="$("${MYSQL[@]}" -e "SELECT @@server_uuid;")"
+  [[ "$local_uuid" == "$EXPECTED_LOCAL_UUID" ]] \
+    || fail "UUID del MySQL local inesperado."
+  log "MySQL local: $local_identity"
+
+  application_schemas="$("${MYSQL[@]}" -e "
+    SELECT COUNT(*) FROM information_schema.schemata
+    WHERE schema_name NOT IN ('information_schema', 'performance_schema', 'mysql', 'sys');
+  ")"
+  unexpected_connections="$("${MYSQL[@]}" -e "
+    SELECT COUNT(*) FROM information_schema.processlist
+    WHERE ID <> CONNECTION_ID()
+      AND NOT (USER = 'event_scheduler' AND COMMAND = 'Daemon');
+  ")"
+  enabled_events="$("${MYSQL[@]}" -e "SELECT COUNT(*) FROM information_schema.EVENTS WHERE STATUS = 'ENABLED';")"
+  replica_channels="$("${MYSQL[@]}" -e "SELECT COUNT(*) FROM performance_schema.replication_connection_status WHERE SERVICE_STATE = 'ON';")"
+  group_members="$("${MYSQL[@]}" -e "SELECT COUNT(*) FROM performance_schema.replication_group_members WHERE MEMBER_STATE = 'ONLINE';")"
+
+  log "preflight application_schemas=$application_schemas unexpected_connections=$unexpected_connections enabled_events=$enabled_events replica_channels=$replica_channels group_members=$group_members"
+  (( application_schemas == 0 )) || fail "Hay schemas locales no clasificados."
+  (( unexpected_connections == 0 )) || fail "Hay conexiones locales no clasificadas."
+  (( enabled_events == 0 )) || fail "Hay eventos MySQL habilitados."
+  (( replica_channels == 0 )) || fail "Hay canales de replicacion activos."
+  (( group_members == 0 )) || fail "Hay miembros Group Replication online."
+}
+
+create_backup() {
+  local timestamp
+  timestamp="$(date +%Y%m%d_%H%M%S)"
+  BACKUP_DIR="$BACKUP_BASE/$timestamp"
+  umask 077
+  install -d -o root -g root -m 700 "$BACKUP_DIR" "$BACKUP_DIR/metadata"
+
+  cp -a /etc/mysql "$BACKUP_DIR/etc-mysql"
+  cp -a /var/lib/mysql/auto.cnf "$BACKUP_DIR/metadata/auto.cnf"
+  systemctl cat mysql > "$BACKUP_DIR/metadata/mysql.service.txt"
+  systemctl status mysql --no-pager > "$BACKUP_DIR/metadata/mysql.status.before.txt"
+  systemctl is-enabled mysql > "$BACKUP_DIR/metadata/mysql.enabled.before.txt"
+  du -sh /var/lib/mysql > "$BACKUP_DIR/metadata/datadir-size.txt"
+  ss -Hlnpt 'sport = :3306' > "$BACKUP_DIR/metadata/listener-3306.before.txt" || true
+  ss -Hlnpt 'sport = :33060' > "$BACKUP_DIR/metadata/listener-33060.before.txt" || true
+  dpkg-query -W -f='${binary:Package}\t${Version}\t${db:Status-Status}\n' 'mysql-server*' \
+    > "$BACKUP_DIR/metadata/packages.txt" 2>/dev/null || true
+  "${MYSQL[@]}" -e "SELECT @@hostname, @@port, @@server_uuid, @@server_id, @@datadir, @@event_scheduler, @@read_only, @@super_read_only;" \
+    > "$BACKUP_DIR/metadata/server-identity.tsv"
+  "${MYSQL[@]}" -e "SELECT schema_name FROM information_schema.schemata ORDER BY schema_name;" \
+    > "$BACKUP_DIR/metadata/schemas.tsv"
+  "${MYSQL[@]}" -e "
+    SELECT ID, USER, HOST, COALESCE(DB, '-'), COMMAND, TIME, COALESCE(STATE, '-')
+    FROM information_schema.processlist WHERE ID <> CONNECTION_ID();
+  " > "$BACKUP_DIR/metadata/processlist.tsv"
+  "${MYSQL[@]}" -e "
+    SELECT CHANNEL_NAME, HOST, PORT FROM performance_schema.replication_connection_configuration;
+  " > "$BACKUP_DIR/metadata/replication.tsv"
+  "${MYSQL[@]}" -e "
+    SELECT EVENT_SCHEMA, EVENT_NAME, STATUS, INTERVAL_VALUE, INTERVAL_FIELD, LAST_EXECUTED
+    FROM information_schema.EVENTS ORDER BY EVENT_SCHEMA, EVENT_NAME;
+  " > "$BACKUP_DIR/metadata/events.tsv"
+  django_db_identity > "$BACKUP_DIR/metadata/django-db-identity.txt"
+
+  (
+    cd "$BACKUP_DIR"
+    find . -type f ! -name SHA256SUMS -print0 | sort -z | xargs -0 sha256sum
+  ) > "$BACKUP_DIR/SHA256SUMS"
+  find "$BACKUP_DIR" -type d -exec chmod 700 {} +
+  find "$BACKUP_DIR" -type f -exec chmod 600 {} +
+  log "Backup root-only creado en $BACKUP_DIR"
+}
+
+verify_after_stop() {
+  systemctl is-active --quiet mysql && fail "mysql.service sigue activo."
+  systemctl is-enabled --quiet mysql && fail "mysql.service sigue habilitado."
+  if ss -Hlnpt 'sport = :3306' | grep -q .; then
+    fail "El puerto local 3306 sigue escuchando."
+  fi
+  if ss -Hlnpt 'sport = :33060' | grep -q .; then
+    fail "El puerto local 33060 sigue escuchando."
+  fi
+  validate_django_remote_db
+  bash "$SCRIPT_DIR/healthcheck_prod.sh"
+}
+
+main() {
+  parse_args "$@"
+  [[ "$EUID" -eq 0 ]] || fail "Ejecutar como root mediante sudo."
+  [[ "$(hostname -s)" == "$EXPECTED_HOSTNAME" ]] || fail "Host inesperado."
+  command -v mysql >/dev/null || fail "mysql client no esta disponible."
+  command -v docker >/dev/null || fail "Docker no esta disponible."
+  [[ -r "$SCRIPT_DIR/healthcheck_prod.sh" ]] || fail "Falta healthcheck_prod.sh."
+
+  bash "$SCRIPT_DIR/healthcheck_prod.sh"
+  validate_django_remote_db
+  preflight_local_mysql
+
+  if [[ "$APPLY" -eq 0 ]]; then
+    log "Preflight OK. Plan: backup, stop+disable y verificacion; sin purge."
+    exit 0
+  fi
+  if [[ "$ASSUME_YES" -eq 0 ]]; then
+    read -r -p "Detener y deshabilitar solo el MySQL local de PRD? [y/N] " answer
+    case "$answer" in
+      y|Y|yes|YES|si|SI) ;;
+      *) fail "Operacion cancelada." ;;
+    esac
+  fi
+
+  create_backup
+  trap rollback_on_error EXIT
+  ROLLBACK_NEEDED=1
+  timeout 60 systemctl stop mysql
+  systemctl disable mysql
+  verify_after_stop
+
+  printf 'applied_at=%s\nobserve_until=%s\n' \
+    "$(date --iso-8601=seconds)" "$(date -d '+14 days' --iso-8601=seconds)" \
+    > "$BACKUP_DIR/STAGE1_APPLIED"
+  chmod 600 "$BACKUP_DIR/STAGE1_APPLIED"
+  (
+    cd "$BACKUP_DIR"
+    find . -type f ! -name SHA256SUMS -print0 | sort -z | xargs -0 sha256sum
+  ) > "$BACKUP_DIR/SHA256SUMS"
+
+  ROLLBACK_NEEDED=0
+  trap - EXIT
+  log "Stage 1 finalizado. MySQL local inactivo/deshabilitado; datadir y paquetes intactos."
+  log "Observar 14 dias antes de cualquier purge. Backup: $BACKUP_DIR"
+  df -h /
+}
+
+main "$@"

--- a/scripts/infra/rollback_prod_maintenance.sh
+++ b/scripts/infra/rollback_prod_maintenance.sh
@@ -1,0 +1,118 @@
+#!/usr/bin/env bash
+set -Eeuo pipefail
+
+SCRIPT_NAME="$(basename "$0")"
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+EXPECTED_HOSTNAME="${PROD_EXPECTED_HOSTNAME:-mdsldmz-ssies}"
+TARGET_USER="${PROD_MAINTENANCE_USER:-sisoc-deploy}"
+TARGET_HOME="${PROD_MAINTENANCE_HOME:-/home/sisoc-deploy}"
+TARGET_BIN="$TARGET_HOME/bin"
+MOBILE_ENV="${MOBILE_ENV:-/sisoc/SISOC-Mobile/.env}"
+LOGROTATE_FILE="/etc/logrotate.d/sisoc-nginx"
+BACKUP_DIR=""
+APPLY=0
+ASSUME_YES=0
+SCRIPTS=(healthcheck_prod.sh cleanup_prod_disk.sh)
+
+usage() {
+  cat <<'USAGE'
+Uso:
+  rollback_prod_maintenance.sh --backup-dir PATH [--apply] [--yes]
+
+Restaura crontabs, metadata/contenido del .env mobile, logrotate, scripts
+instalados y enablement previo de apache2/sisoc.service desde un backup creado
+por install_prod_maintenance.sh. No revierte rotaciones ya hechas ni MySQL.
+USAGE
+}
+
+log() {
+  printf '[%s] %s\n' "$SCRIPT_NAME" "$*"
+}
+
+fail() {
+  log "ERROR: $*" >&2
+  exit 1
+}
+
+parse_args() {
+  while [[ $# -gt 0 ]]; do
+    case "$1" in
+      --backup-dir)
+        shift
+        [[ $# -gt 0 ]] || fail "--backup-dir requiere valor."
+        BACKUP_DIR="$1"
+        ;;
+      --apply) APPLY=1 ;;
+      --yes) ASSUME_YES=1 ;;
+      -h|--help) usage; exit 0 ;;
+      *) fail "Opcion no reconocida: $1" ;;
+    esac
+    shift
+  done
+}
+
+main() {
+  local script apache_before sisoc_before rollback_dir
+
+  parse_args "$@"
+  [[ "$EUID" -eq 0 ]] || fail "Ejecutar como root mediante sudo."
+  [[ "$(hostname -s)" == "$EXPECTED_HOSTNAME" ]] || fail "Host inesperado."
+  [[ "$BACKUP_DIR" == /var/backups/sisoc/night-maintenance/prod/* ]] \
+    || fail "Backup fuera de la raiz productiva esperada."
+  [[ -d "$BACKUP_DIR" ]] || fail "No existe $BACKUP_DIR"
+  [[ -r "$BACKUP_DIR/status/root.crontab.before" ]] || fail "Falta root crontab."
+  [[ -r "$BACKUP_DIR/status/deploy-user.crontab.before" ]] || fail "Falta crontab de deploy."
+  [[ -r "$BACKUP_DIR/sensitive/mobile.env.before" ]] || fail "Falta backup de .env mobile."
+  [[ -r "$BACKUP_DIR/status/legacy.enabled.before.txt" ]] || fail "Falta metadata systemd."
+  (cd "$BACKUP_DIR" && sha256sum -c SHA256SUMS >/dev/null) \
+    || fail "Checksum del backup invalido."
+
+  apache_before="$(sed -n 's/^apache2=//p' "$BACKUP_DIR/status/legacy.enabled.before.txt")"
+  sisoc_before="$(sed -n 's/^sisoc.service=//p' "$BACKUP_DIR/status/legacy.enabled.before.txt")"
+  log "Plan: restaurar configuracion desde $BACKUP_DIR"
+  log "apache2_before=$apache_before sisoc_before=$sisoc_before"
+
+  if [[ "$APPLY" -eq 0 ]]; then
+    log "Modo informativo; no se modifico el host."
+    exit 0
+  fi
+  if [[ "$ASSUME_YES" -eq 0 ]]; then
+    read -r -p "Restaurar mantenimiento host-side desde este backup? [y/N] " answer
+    case "$answer" in
+      y|Y|yes|YES|si|SI) ;;
+      *) fail "Operacion cancelada." ;;
+    esac
+  fi
+
+  crontab "$BACKUP_DIR/status/root.crontab.before"
+  crontab -u "$TARGET_USER" "$BACKUP_DIR/status/deploy-user.crontab.before"
+  cp -a -- "$BACKUP_DIR/sensitive/mobile.env.before" "$MOBILE_ENV"
+
+  rollback_dir="$BACKUP_DIR/rollback-$(date +%Y%m%d_%H%M%S)"
+  install -d -o root -g root -m 700 "$rollback_dir"
+  if [[ -e "$BACKUP_DIR/config/sisoc-nginx.before" ]]; then
+    cp -a -- "$BACKUP_DIR/config/sisoc-nginx.before" "$LOGROTATE_FILE"
+  elif [[ -e "$LOGROTATE_FILE" ]]; then
+    mv -- "$LOGROTATE_FILE" "$rollback_dir/sisoc-nginx.disabled"
+  fi
+
+  for script in "${SCRIPTS[@]}"; do
+    if [[ -e "$BACKUP_DIR/config/installed-before/$script" ]]; then
+      cp -a -- "$BACKUP_DIR/config/installed-before/$script" "$TARGET_BIN/$script"
+    elif [[ -e "$TARGET_BIN/$script" ]]; then
+      mv -- "$TARGET_BIN/$script" "$rollback_dir/$script.disabled"
+    fi
+  done
+
+  [[ "$apache_before" == enabled ]] && systemctl enable apache2 >/dev/null || true
+  [[ "$sisoc_before" == enabled ]] && systemctl enable sisoc.service >/dev/null || true
+  nginx -t
+  bash "$SCRIPT_DIR/healthcheck_prod.sh"
+  printf 'rollback_applied_at=%s\nsource_backup=%s\n' \
+    "$(date --iso-8601=seconds)" "$BACKUP_DIR" \
+    > "$rollback_dir/ROLLBACK_APPLIED"
+  chmod 600 "$rollback_dir/ROLLBACK_APPLIED"
+  log "Rollback host-side aplicado. No se iniciaron servicios legacy."
+}
+
+main "$@"

--- a/scripts/infra/rollback_prod_mobile_checkout.sh
+++ b/scripts/infra/rollback_prod_mobile_checkout.sh
@@ -1,0 +1,70 @@
+#!/usr/bin/env bash
+set -Eeuo pipefail
+
+SCRIPT_NAME="$(basename "$0")"
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+EXPECTED_HOSTNAME="${PROD_EXPECTED_HOSTNAME:-mdsldmz-ssies}"
+MOBILE_ROOT="${MOBILE_ROOT:-/sisoc/SISOC-Mobile}"
+BACKUP_DIR=""
+APPLY=0
+ASSUME_YES=0
+
+fail() {
+  printf '[%s] ERROR: %s\n' "$SCRIPT_NAME" "$*" >&2
+  exit 1
+}
+
+parse_args() {
+  while [[ $# -gt 0 ]]; do
+    case "$1" in
+      --backup-dir)
+        shift
+        [[ $# -gt 0 ]] || fail "--backup-dir requiere valor."
+        BACKUP_DIR="$1"
+        ;;
+      --apply) APPLY=1 ;;
+      --yes) ASSUME_YES=1 ;;
+      -h|--help)
+        printf 'Uso: %s --backup-dir PATH [--apply] [--yes]\n' "$SCRIPT_NAME"
+        exit 0
+        ;;
+      *) fail "Opcion no reconocida: $1" ;;
+    esac
+    shift
+  done
+}
+
+main() {
+  parse_args "$@"
+  [[ "$EUID" -eq 0 ]] || fail "Ejecutar como root mediante sudo."
+  [[ "$(hostname -s)" == "$EXPECTED_HOSTNAME" ]] || fail "Host inesperado."
+  [[ "$BACKUP_DIR" == /var/backups/sisoc/mobile-checkout-preparation/* ]] \
+    || fail "Backup fuera de la raiz mobile esperada."
+  [[ -r "$BACKUP_DIR/mobile.acl-ownership.before" ]] || fail "Falta backup ACL/owners."
+  [[ -r "$BACKUP_DIR/mobile-origin.before" ]] || fail "Falta backup del origin."
+  (cd "$BACKUP_DIR" && sha256sum -c SHA256SUMS >/dev/null) \
+    || fail "Checksum del backup invalido."
+
+  printf '[%s] Plan: restaurar owners/ACL y origin desde %s\n' "$SCRIPT_NAME" "$BACKUP_DIR"
+  if [[ "$APPLY" -eq 0 ]]; then
+    printf '[%s] Modo informativo; no se modifico el checkout.\n' "$SCRIPT_NAME"
+    exit 0
+  fi
+  if [[ "$ASSUME_YES" -eq 0 ]]; then
+    read -r -p "Restaurar metadata y origin historicos del checkout mobile? [y/N] " answer
+    case "$answer" in
+      y|Y|yes|YES|si|SI) ;;
+      *) fail "Operacion cancelada." ;;
+    esac
+  fi
+
+  setfacl --restore="$BACKUP_DIR/mobile.acl-ownership.before"
+  git -c safe.directory="$MOBILE_ROOT" -C "$MOBILE_ROOT" remote set-url origin \
+    "$(cat "$BACKUP_DIR/mobile-origin.before")"
+  git -c safe.directory="$MOBILE_ROOT" -C "$MOBILE_ROOT" diff-index --quiet HEAD -- \
+    || fail "El checkout mobile tiene cambios tracked despues del rollback."
+  bash "$SCRIPT_DIR/healthcheck_prod.sh"
+  printf '[%s] Rollback mobile aplicado; health OK.\n' "$SCRIPT_NAME"
+}
+
+main "$@"

--- a/scripts/infra/verify_prod_release.sh
+++ b/scripts/infra/verify_prod_release.sh
@@ -1,0 +1,103 @@
+#!/usr/bin/env bash
+set -Eeuo pipefail
+
+SCRIPT_NAME="$(basename "$0")"
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+EXPECTED_HOSTNAME="${PROD_EXPECTED_HOSTNAME:-mdsldmz-ssies}"
+APP_ROOT="${APP_ROOT:-/sisoc/SISOC}"
+MOBILE_ROOT="${MOBILE_ROOT:-/sisoc/SISOC-Mobile}"
+TARGET_USER="${PROD_MAINTENANCE_USER:-sisoc-deploy}"
+TARGET_GROUP="${PROD_MAINTENANCE_GROUP:-sisoc-deploy}"
+TARGET_BIN="${PROD_MAINTENANCE_HOME:-/home/sisoc-deploy}/bin"
+DEPLOY_CRON_LINE="40 3 * * * $TARGET_BIN/cleanup_prod_disk.sh --apply --yes >/dev/null 2>&1"
+EXPECTED_BACKEND_SHA=""
+EXPECTED_MOBILE_SHA=""
+
+usage() {
+  cat <<'USAGE'
+Uso:
+  verify_prod_release.sh --backend-sha SHA --mobile-sha SHA
+
+Verificacion read-only final. Los SHA deben registrarse antes de aprobar el
+Environment production. No acepta prefijos ambiguos ni modifica servicios.
+USAGE
+}
+
+fail() {
+  printf '[%s] ERROR: %s\n' "$SCRIPT_NAME" "$*" >&2
+  exit 1
+}
+
+parse_args() {
+  while [[ $# -gt 0 ]]; do
+    case "$1" in
+      --backend-sha)
+        shift
+        [[ $# -gt 0 ]] || fail "--backend-sha requiere valor."
+        EXPECTED_BACKEND_SHA="$1"
+        ;;
+      --mobile-sha)
+        shift
+        [[ $# -gt 0 ]] || fail "--mobile-sha requiere valor."
+        EXPECTED_MOBILE_SHA="$1"
+        ;;
+      -h|--help) usage; exit 0 ;;
+      *) fail "Opcion no reconocida: $1" ;;
+    esac
+    shift
+  done
+}
+
+main() {
+  local backend_head mobile_head restart_sum
+
+  parse_args "$@"
+  [[ "$EUID" -eq 0 ]] || fail "Ejecutar como root mediante sudo."
+  [[ "$(hostname -s)" == "$EXPECTED_HOSTNAME" ]] || fail "Host inesperado."
+  [[ "$EXPECTED_BACKEND_SHA" =~ ^[0-9a-f]{40}$ ]] || fail "SHA backend invalido."
+  [[ "$EXPECTED_MOBILE_SHA" =~ ^[0-9a-f]{40}$ ]] || fail "SHA mobile invalido."
+
+  backend_head="$(git -c safe.directory="$APP_ROOT" -C "$APP_ROOT" rev-parse HEAD)"
+  mobile_head="$(git -c safe.directory="$MOBILE_ROOT" -C "$MOBILE_ROOT" rev-parse HEAD)"
+  [[ "$backend_head" == "$EXPECTED_BACKEND_SHA" ]] || fail "Backend en commit inesperado."
+  [[ "$mobile_head" == "$EXPECTED_MOBILE_SHA" ]] || fail "Mobile en commit inesperado."
+  [[ "$(git -c safe.directory="$APP_ROOT" -C "$APP_ROOT" branch --show-current)" == main ]] \
+    || fail "Backend no esta en main."
+  [[ "$(git -c safe.directory="$MOBILE_ROOT" -C "$MOBILE_ROOT" branch --show-current)" == main ]] \
+    || fail "Mobile no esta en main."
+  git -c safe.directory="$APP_ROOT" -C "$APP_ROOT" diff-index --quiet HEAD -- \
+    || fail "Backend tiene cambios tracked."
+  git -c safe.directory="$MOBILE_ROOT" -C "$MOBILE_ROOT" diff-index --quiet HEAD -- \
+    || fail "Mobile tiene cambios tracked."
+
+  bash "$SCRIPT_DIR/healthcheck_prod.sh"
+  restart_sum="$(docker inspect --format '{{.RestartCount}}' $(docker ps -q) | awk '{sum += $1} END {print sum + 0}')"
+  (( restart_sum == 0 )) || fail "Hay contenedores con RestartCount mayor a cero."
+
+  docker exec sisoc-django-1 python manage.py showmigrations centrodeinfancia \
+    | grep -Eq '^ \[X\] 0036_asistenciatrabajador$' \
+    || fail "La migracion 0036 no figura aplicada."
+  docker exec sisoc-django-1 python manage.py shell -c \
+    "from centrodeinfancia.models import AsistenciaTrabajador; AsistenciaTrabajador.objects.exists(); print('attendance_table=ok')" \
+    | grep -q '^attendance_table=ok$' \
+    || fail "No se pudo consultar la tabla de asistencia."
+
+  systemctl is-active --quiet mysql && fail "MySQL local sigue activo."
+  systemctl is-enabled --quiet mysql && fail "MySQL local sigue habilitado."
+  systemctl is-enabled --quiet apache2 && fail "apache2 sigue habilitado."
+  systemctl is-enabled --quiet sisoc.service && fail "sisoc.service sigue habilitado."
+  [[ "$(stat -c '%U:%G:%a' "$MOBILE_ROOT/.env")" == "root:$TARGET_GROUP:640" ]] \
+    || fail "Metadata de .env mobile inesperada."
+  [[ "$(crontab -u "$TARGET_USER" -l | grep -Fxc "$DEPLOY_CRON_LINE" || true)" -eq 1 ]] \
+    || fail "Cron de limpieza productiva ausente o duplicado."
+  [[ "$(crontab -l | grep -Fc -- '--volumes' || true)" -eq 0 ]] \
+    || fail "Root cron conserva una poda con --volumes."
+  [[ -f /etc/logrotate.d/sisoc-nginx ]] || fail "Falta logrotate SISOC NGINX."
+  logrotate -d /etc/logrotate.d/sisoc-nginx >/dev/null
+
+  printf 'PROD RELEASE VERIFICATION: OK\n'
+  printf 'backend_head=%s\nmobile_head=%s\ncontainers=7\n' \
+    "$backend_head" "$mobile_head"
+}
+
+main "$@"

--- a/tests/test_prod_infra_scripts.py
+++ b/tests/test_prod_infra_scripts.py
@@ -53,9 +53,7 @@ def test_stage1_mysql_prod_no_purga_ni_borra_datadir():
 
 
 def test_mantenimiento_prod_reemplaza_poda_root_por_cron_sin_privilegios():
-    content = (INFRA_DIR / "install_prod_maintenance.sh").read_text(
-        encoding="utf-8"
-    )
+    content = (INFRA_DIR / "install_prod_maintenance.sh").read_text(encoding="utf-8")
 
     assert "40 3 * * * $TARGET_BIN/cleanup_prod_disk.sh --apply --yes" in content
     assert 'crontab -u "$TARGET_USER" "$deploy_after"' in content

--- a/tests/test_prod_infra_scripts.py
+++ b/tests/test_prod_infra_scripts.py
@@ -1,0 +1,80 @@
+import subprocess
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+INFRA_DIR = REPO_ROOT / "scripts" / "infra"
+PROD_SCRIPTS = [
+    "backup_prod_configs.sh",
+    "cleanup_prod_disk.sh",
+    "healthcheck_prod.sh",
+    "install_prod_maintenance.sh",
+    "prepare_prod_mobile_checkout.sh",
+    "prod_night_preflight.sh",
+    "retire_prod_local_mysql_stage1.sh",
+    "rollback_prod_mobile_checkout.sh",
+    "rollback_prod_maintenance.sh",
+    "verify_prod_release.sh",
+]
+
+
+def test_prod_infra_scripts_tienen_sintaxis_bash_valida():
+    for script_name in PROD_SCRIPTS:
+        result = subprocess.run(
+            ["bash", "-n", f"scripts/infra/{script_name}"],
+            cwd=REPO_ROOT,
+            check=False,
+            text=True,
+            capture_output=True,
+        )
+
+        assert result.returncode == 0, f"{script_name}: {result.stderr}"
+
+
+def test_cleanup_prod_no_toca_volumenes_ni_contenedores():
+    content = (INFRA_DIR / "cleanup_prod_disk.sh").read_text(encoding="utf-8")
+
+    assert "docker image prune" in content
+    assert "docker builder prune" in content
+    assert "docker system prune" not in content
+    assert "docker volume prune" not in content
+    assert "down --volumes" not in content
+
+
+def test_stage1_mysql_prod_no_purga_ni_borra_datadir():
+    content = (INFRA_DIR / "retire_prod_local_mysql_stage1.sh").read_text(
+        encoding="utf-8"
+    )
+
+    assert "systemctl stop mysql" in content
+    assert "systemctl disable mysql" in content
+    assert "rm -rf" not in content
+    assert "DROP DATABASE" not in content.upper()
+    assert "apt purge" not in content
+
+
+def test_mantenimiento_prod_reemplaza_poda_root_por_cron_sin_privilegios():
+    content = (INFRA_DIR / "install_prod_maintenance.sh").read_text(
+        encoding="utf-8"
+    )
+
+    assert "40 3 * * * $TARGET_BIN/cleanup_prod_disk.sh --apply --yes" in content
+    assert 'crontab -u "$TARGET_USER" "$deploy_after"' in content
+    assert 'logrotate -f -v "$LOGROTATE_FILE"' in content
+    assert "PROD_DOCKER_IMAGE_RETENTION:-336h" in (
+        INFRA_DIR / "cleanup_prod_disk.sh"
+    ).read_text(encoding="utf-8")
+
+
+def test_preparacion_mobile_acota_chown_y_guarda_rollback_completo():
+    prepare = (INFRA_DIR / "prepare_prod_mobile_checkout.sh").read_text(
+        encoding="utf-8"
+    )
+    rollback = (INFRA_DIR / "rollback_prod_mobile_checkout.sh").read_text(
+        encoding="utf-8"
+    )
+
+    assert 'chown -R "$TARGET_USER:$TARGET_GROUP" "$MOBILE_ROOT"' in prepare
+    assert prepare.count("chown -R") == 1
+    assert 'getfacl -R -p "$MOBILE_ROOT"' in prepare
+    assert 'setfacl --restore="$BACKUP_DIR/mobile.acl-ownership.before"' in rollback
+    assert '"$(cat "$BACKUP_DIR/mobile-origin.before")"' in rollback


### PR DESCRIPTION
## Objetivo

Dejar versionado y listo el paquete que un agente con acceso a `prd-old` ejecutara durante la ventana nocturna, sin ejecutar cambios productivos desde este PR.

## Incluye

- runbook por gates, NO-GO, evidencia y rollback;
- healthcheck productivo exacto para 7 contenedores, NGINX, runner y MySQL remoto;
- backup root-only de configuracion y estado;
- preparacion reversible del checkout SISOC-Mobile para el runner;
- mantenimiento conservador de disco y logrotate sin volumenes;
- Stage 1 reversible para retirar el MySQL local conservando datadir y paquetes 14 dias;
- preflight y verificacion final por SHA exactos;
- inventario, riesgos, migracion y propuestas actualizados.

## Seguridad

- TLS queda explicitamente fuera;
- no hay `docker system prune`, `docker volume prune`, `down --volumes`, DROP, purge ni borrado de media/backups;
- el unico `chown -R` esta acotado a `/sisoc/SISOC-Mobile`, en un gate separado, con backup ACL/owners y rollback;
- ningun cambio fue aplicado en produccion.

## Validacion local

- `bash -n` sobre los 10 scripts;
- 5 tests estaticos/focalizados del paquete;
- `py_compile` del test;
- `git diff --check`;
- contraste read-only con host, runner, contenedores, DB y ownership reales de `prd-old`.

## Orden de integracion

Mergear despues de #2058 y #2059. No aprobar ningun Environment `production` hasta completar los gates 0-3 del runbook.