### PR TITLE
fix(logging): share daily logs with workers

### DIFF
--- a/core/tests/test_utils.py
+++ b/core/tests/test_utils.py
@@ -1,0 +1,22 @@
+import os
+import stat
+from datetime import datetime
+from unittest.mock import patch
+
+from core.utils import DailyFileHandler
+
+
+def test_daily_file_handler_creates_group_writable_log_path(tmp_path):
+    previous_umask = os.umask(0o022)
+    try:
+        with patch("core.utils.timezone.localtime", return_value=datetime(2026, 7, 14)):
+            handler = DailyFileHandler(tmp_path / "critical.log")
+    finally:
+        os.umask(previous_umask)
+
+    handler.close()
+    daily_folder = tmp_path / "2026-07-14"
+    log_file = daily_folder / "critical.log"
+
+    assert stat.S_IMODE(daily_folder.stat().st_mode) & stat.S_IWGRP
+    assert stat.S_IMODE(log_file.stat().st_mode) & stat.S_IWGRP

--- a/core/utils.py
+++ b/core/utils.py
@@ -2,6 +2,7 @@
 
 import logging
 import json
+import stat
 from datetime import datetime
 from pathlib import Path
 
@@ -28,8 +29,18 @@ class DailyFileHandler(logging.FileHandler):
         current_date = timezone.localtime().strftime("%Y-%m-%d")
         daily_folder = Path(filename).parent / current_date
         daily_folder.mkdir(parents=True, exist_ok=True)
+        self._ensure_group_writable(daily_folder)
         daily_filename = daily_folder / Path(filename).name
         super().__init__(daily_filename, mode, encoding, delay)
+        if daily_filename.exists():
+            self._ensure_group_writable(daily_filename)
+
+    @staticmethod
+    def _ensure_group_writable(path: Path) -> None:
+        """Permitir que los procesos del grupo compartan el mismo log."""
+        current_mode = stat.S_IMODE(path.stat().st_mode)
+        if not current_mode & stat.S_IWGRP:
+            path.chmod(current_mode | stat.S_IWGRP)
 
 
 class JSONDataFormatter(logging.Formatter):


### PR DESCRIPTION
## Cambio
- Hace que los directorios y archivos diarios de logging sean escribibles por el grupo.
- Permite que Django y los workers con UID no-root compartan los mismos logs.

## Causa
Django creaba los logs con permisos derivados de umask que bloqueaban a los workers de HML.

## Validacion
- py -3 -m pytest -q --noconftest -p no:django -o addopts='' core/tests/test_utils.py