### PR TITLE
fix(ci): autoaprobar sincronizacion descendente

### DIFF
--- a/.github/workflows/sync-main-downstream.yml
+++ b/.github/workflows/sync-main-downstream.yml
@@ -102,6 +102,16 @@ jobs:
                             );
                           }
 
+                          await github.rest.pulls.createReview({
+                            owner,
+                            repo,
+                            pull_number: pull.number,
+                            commit_id: pull.head.sha,
+                            event: "APPROVE",
+                            body: "Aprobacion automatica del Plan A para sincronizar main hacia una rama inferior.",
+                          });
+                          core.info(`PR #${pull.number} aprobado automaticamente.`);
+
                           const merged = await github.rest.pulls.merge({
                             owner,
                             repo,

--- a/AGENT_REPO_MAP.md
+++ b/AGENT_REPO_MAP.md
@@ -60,6 +60,7 @@ Mapa practico del repositorio `SISOC` para futuros agentes de IA y desarrollador
 | Docker Compose para local | Hecho observado | `docker-compose.yml` |
 | Compose separado para deploy | Hecho observado | `docker-compose.deploy.yml`, `docker-compose.produccion.yml` |
 | GitHub Actions para lint/tests/arquitectura/release sanity | Hecho observado | `.github/workflows/` |
+| Plan A descendente con autoaprobacion acotada | Hecho observado | `.github/workflows/sync-main-downstream.yml`, `docs/operacion/deploy_automatizado.md` |
 | Helpers de Codex/worktrees | Hecho observado | `scripts/ai/`, `.codex/environments/environment.toml` |
 
 ## Que tipo de proyecto es

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,11 +1,3 @@
-<!-- AUTO-GENERATED RELEASE START: 2026-07-14 -->
-# Versión SISOC 14.07.2026
-
-## Actualizaciones
-
-- [infraestructura] El deploy de HML y produccion ahora actualiza y levanta SISOC-Mobile junto con el backend. (PR #2051)
-<!-- AUTO-GENERATED RELEASE END: 2026-07-14 -->
-
 <!-- AUTO-GENERATED RELEASE START: 2026-07-15 -->
 # Versión SISOC 15.07.2026
 
@@ -15,10 +7,20 @@
 - [sin-area] hotfix. (PR #2046)
 - [sin-area] hotfix: asistencia de trabajadores CDI (backport a main de PR #2046). (PR #2048)
 - [sin-area] Main (resuelve conflicto PR #2052). (PR #2054)
-- [sin-area] feat(infra): preparar mantenimiento nocturno de produccion. (PR #2060)
-- [sin-area] fix(cdi): asegurar carga atomica de asistencia. (PR #2059)
 - [sin-area] feat(infra): automatizar sincronizacion descendente. (PR #2058)
+- [sin-area] fix(cdi): asegurar carga atomica de asistencia. (PR #2059)
+- [sin-area] feat(infra): preparar mantenimiento nocturno de produccion. (PR #2060)
+- [sin-area] fix(ci): autoaprobar sincronizacion descendente. (PR #2070)
 <!-- AUTO-GENERATED RELEASE END: 2026-07-15 -->
+
+<!-- AUTO-GENERATED RELEASE START: 2026-07-14 -->
+# Versión SISOC 14.07.2026
+
+## Actualizaciones
+
+- [infraestructura] El deploy de HML y produccion ahora actualiza y levanta SISOC-Mobile junto con el backend. (PR #2051)
+<!-- AUTO-GENERATED RELEASE END: 2026-07-14 -->
+
 
 <!-- AUTO-GENERATED RELEASE START: 2026-07-08 -->
 # Versión SISOC 08.07.2026

--- a/docs/contexto/features/pr-2070-fix-ci-autoaprobar-sincronizacion-descendente.md
+++ b/docs/contexto/features/pr-2070-fix-ci-autoaprobar-sincronizacion-descendente.md
@@ -32,15 +32,22 @@
 - Revisar primero estos archivos del diff:
 - `.github/workflows/sync-main-downstream.yml`
 - `AGENT_REPO_MAP.md`
+- `CHANGELOG.md`
+- `docs/contexto/features/pr-2070-fix-ci-autoaprobar-sincronizacion-descendente.md`
 - `docs/operacion/deploy_automatizado.md`
 - `docs/registro/cambios/2026-07-15-plan-a-autoaprobacion.md`
+- `docs/registro/prs/PR-2070.md`
+- `docs/registro/releases/pending/2026-07-15-pr-2070.md`
 - Documentación sugerida para ampliar contexto:
 - `docs/indice.md`
 - `docs/ia/CONTEXT_HYGIENE.md`
 - `docs/ia/ARCHITECTURE.md`
 - `docs/ia/TESTING.md`
+- `docs/contexto/features/pr-2070-fix-ci-autoaprobar-sincronizacion-descendente.md`
 - `docs/operacion/deploy_automatizado.md`
 - `docs/registro/cambios/2026-07-15-plan-a-autoaprobacion.md`
+- `docs/registro/prs/PR-2070.md`
+- `docs/registro/releases/pending/2026-07-15-pr-2070.md`
 
 ## Trazabilidad
 

--- a/docs/contexto/features/pr-2070-fix-ci-autoaprobar-sincronizacion-descendente.md
+++ b/docs/contexto/features/pr-2070-fix-ci-autoaprobar-sincronizacion-descendente.md
@@ -1,0 +1,48 @@
+# Contexto de feature PR #2070 - fix(ci): autoaprobar sincronizacion descendente
+
+## Resumen
+
+- PR: https://github.com/dsocial118/SISOC/pull/2070
+- Base: `main`
+- Rama origen: `codex/plan-a-autoapprove`
+- Autor: `juanikitro`
+
+## Contexto funcional
+
+- No informado explícitamente; inferir desde el título del PR y el diff.
+
+## Arquitectura tocada
+
+- El alcance incluye automatización o tooling de CI/CD.
+
+## Decisiones y supuestos detectados
+
+- Tipo de cambio declarado: No informado
+- Área principal declarada: No informada
+- Impacto usuario declarado: No informado
+- Riesgos / rollback: No informado
+
+## Design system y UI
+
+- Sin cambios visibles de UI o design system detectados en el diff.
+
+## Memoria operativa para agentes
+
+- Empezar por `docs/registro/prs/PR-2070.md` para contexto resumido del PR.
+- Revisar primero estos archivos del diff:
+- `.github/workflows/sync-main-downstream.yml`
+- `AGENT_REPO_MAP.md`
+- `docs/operacion/deploy_automatizado.md`
+- `docs/registro/cambios/2026-07-15-plan-a-autoaprobacion.md`
+- Documentación sugerida para ampliar contexto:
+- `docs/indice.md`
+- `docs/ia/CONTEXT_HYGIENE.md`
+- `docs/ia/ARCHITECTURE.md`
+- `docs/ia/TESTING.md`
+- `docs/operacion/deploy_automatizado.md`
+- `docs/registro/cambios/2026-07-15-plan-a-autoaprobacion.md`
+
+## Trazabilidad
+
+- Documento generado automáticamente desde el evento de `pull_request`.
+- Si este PR cambia de título, el archivo se renombrará para mantener el slug alineado.

--- a/docs/operacion/deploy_automatizado.md
+++ b/docs/operacion/deploy_automatizado.md
@@ -37,8 +37,10 @@ invariante:
 
 Ante cada push a `main`, y tambien como reconciliacion horaria, el workflow abre
 o reutiliza PRs `main -> development` y `main -> homologacion`. Solo los integra
-si GitHub confirma que no hay conflictos. Luego invoca `deploy.yml` de forma
-explicita sobre la rama actualizada.
+si GitHub confirma que no hay conflictos. En ramas que exigen revision, el
+`GITHUB_TOKEN` aprueba exclusivamente ese PR descendente antes de integrarlo;
+el repositorio debe permitir que Actions cree y apruebe pull requests. Luego
+invoca `deploy.yml` de forma explicita sobre la rama actualizada.
 
 Un conflicto deja el PR abierto, falla el job y no despliega ese entorno. No se
 usa force push, rebase automatico, PAT ni resolucion automatica de conflictos.

--- a/docs/registro/cambios/2026-07-15-plan-a-autoaprobacion.md
+++ b/docs/registro/cambios/2026-07-15-plan-a-autoaprobacion.md
@@ -1,0 +1,9 @@
+# Plan A: autoaprobacion de sincronizaciones descendentes
+
+El workflow `sync-main-downstream.yml` ahora aprueba con su `GITHUB_TOKEN` el
+PR exacto que abre o reutiliza desde `main` hacia `development` u
+`homologacion`, antes de intentar el merge.
+
+Esto satisface la regla de revision obligatoria de `development` sin ampliar el
+alcance a PRs con otra rama de origen. Requiere que el repositorio permita a
+GitHub Actions crear y aprobar pull requests.

--- a/docs/registro/prs/PR-2070.md
+++ b/docs/registro/prs/PR-2070.md
@@ -6,7 +6,7 @@
 - Base: `main`
 - Rama origen: `codex/plan-a-autoapprove`
 - Autor: `juanikitro`
-- Última actualización: `2026-07-15T00:43:23Z`
+- Última actualización: `2026-07-15T00:43:39Z`
 
 ## Resumen operativo
 
@@ -20,6 +20,8 @@
 
 - `.github/workflows`
 - `AGENT_REPO_MAP.md`
+- `CHANGELOG.md`
+- `docs/contexto`
 - `docs/operacion`
 - `docs/registro`
 
@@ -27,8 +29,12 @@
 
 - `.github/workflows/sync-main-downstream.yml`
 - `AGENT_REPO_MAP.md`
+- `CHANGELOG.md`
+- `docs/contexto/features/pr-2070-fix-ci-autoaprobar-sincronizacion-descendente.md`
 - `docs/operacion/deploy_automatizado.md`
 - `docs/registro/cambios/2026-07-15-plan-a-autoaprobacion.md`
+- `docs/registro/prs/PR-2070.md`
+- `docs/registro/releases/pending/2026-07-15-pr-2070.md`
 
 ## Validación declarada
 
@@ -45,8 +51,11 @@
 - `docs/ia/CONTEXT_HYGIENE.md`
 - `docs/ia/ARCHITECTURE.md`
 - `docs/ia/TESTING.md`
+- `docs/contexto/features/pr-2070-fix-ci-autoaprobar-sincronizacion-descendente.md`
 - `docs/operacion/deploy_automatizado.md`
 - `docs/registro/cambios/2026-07-15-plan-a-autoaprobacion.md`
+- `docs/registro/prs/PR-2070.md`
+- `docs/registro/releases/pending/2026-07-15-pr-2070.md`
 
 ## Notas para continuidad
 

--- a/docs/registro/prs/PR-2070.md
+++ b/docs/registro/prs/PR-2070.md
@@ -1,0 +1,54 @@
+# PR #2070 - fix(ci): autoaprobar sincronizacion descendente
+
+## Metadata
+
+- PR: https://github.com/dsocial118/SISOC/pull/2070
+- Base: `main`
+- Rama origen: `codex/plan-a-autoapprove`
+- Autor: `juanikitro`
+- Última actualización: `2026-07-15T00:43:23Z`
+
+## Resumen operativo
+
+- Tipo de cambio: No informado
+- Área principal: No informada
+- Contexto funcional: No informado explícitamente; revisar título, diff y documentación relacionada.
+- Resumen para changelog: No informado
+- Impacto usuario: No informado
+
+## Áreas afectadas
+
+- `.github/workflows`
+- `AGENT_REPO_MAP.md`
+- `docs/operacion`
+- `docs/registro`
+
+## Archivos relevantes del diff
+
+- `.github/workflows/sync-main-downstream.yml`
+- `AGENT_REPO_MAP.md`
+- `docs/operacion/deploy_automatizado.md`
+- `docs/registro/cambios/2026-07-15-plan-a-autoaprobacion.md`
+
+## Validación declarada
+
+- Pruebas automáticas: No informado en el PR.
+- Pruebas manuales: No informado en el PR.
+
+## Riesgos y rollback
+
+- No informado explícitamente en el PR.
+
+## Documentación sugerida para lectura
+
+- `docs/indice.md`
+- `docs/ia/CONTEXT_HYGIENE.md`
+- `docs/ia/ARCHITECTURE.md`
+- `docs/ia/TESTING.md`
+- `docs/operacion/deploy_automatizado.md`
+- `docs/registro/cambios/2026-07-15-plan-a-autoaprobacion.md`
+
+## Notas para continuidad
+
+- Este documento es generado automáticamente desde el contexto del PR y sirve como índice rápido para revisión y futuras sesiones de agentes.
+- Si la metadata del body del PR está incompleta, varias secciones usarán fallbacks derivados del título o del diff.

--- a/docs/registro/releases/pending/2026-07-15-pr-2070.md
+++ b/docs/registro/releases/pending/2026-07-15-pr-2070.md
@@ -1,0 +1,19 @@
+---
+pr: 2070
+release_date: 2026-07-15
+category: Actualizaciones
+area: sin-area
+title: fix(ci): autoaprobar sincronizacion descendente
+summary: fix(ci): autoaprobar sincronizacion descendente
+impact: No informado
+source_url: https://github.com/dsocial118/SISOC/pull/2070
+---
+# Release note preliminar PR #2070
+
+- Fecha objetivo de release: 2026-07-15
+- Categoría: Actualizaciones
+- Área: sin-area
+- Título del PR: fix(ci): autoaprobar sincronizacion descendente
+- Resumen: fix(ci): autoaprobar sincronizacion descendente
+- Impacto usuario: No informado
+- Fuente: https://github.com/dsocial118/SISOC/pull/2070


### PR DESCRIPTION
## Motivo\nPlan A ya podia crear PRs, pero development exige una revision aprobatoria y el workflow intentaba mergear sin crearla.\n\n## Cambio\nEl GITHUB_TOKEN aprueba solo el PR descendente exacto (main -> development|homologacion) anclado a su SHA antes del merge.\n\n## Validacion\n- git diff --check\n- Parseo YAML del workflow\n- Aserciones focalizadas de permisos, createReview y SHA exacto\n\n## Alcance\nNo cambia PRD ni aprueba deploys productivos.