### PR TITLE
fix(infra): harden mobile checkout preparation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@
 - [sin-area] fix(cdi): asegurar carga atomica de asistencia. (PR #2059)
 - [sin-area] feat(infra): preparar mantenimiento nocturno de produccion. (PR #2060)
 - [sin-area] fix(ci): autoaprobar sincronizacion descendente. (PR #2070)
-- [sin-area] fix(infra): harden mobile checkout preparation. (PR #2073)
+- [Infraestructura y deploy de SISOC-Mobile.] Evita falsos cambios tracked y garantiza rollback verificable al preparar SISOC-Mobile en produccion. (PR #2073)
 <!-- AUTO-GENERATED RELEASE END: 2026-07-15 -->
 
 <!-- AUTO-GENERATED RELEASE START: 2026-07-14 -->

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 - [sin-area] fix(cdi): asegurar carga atomica de asistencia. (PR #2059)
 - [sin-area] feat(infra): preparar mantenimiento nocturno de produccion. (PR #2060)
 - [sin-area] fix(ci): autoaprobar sincronizacion descendente. (PR #2070)
+- [sin-area] fix(infra): harden mobile checkout preparation. (PR #2073)
 <!-- AUTO-GENERATED RELEASE END: 2026-07-15 -->
 
 <!-- AUTO-GENERATED RELEASE START: 2026-07-14 -->

--- a/docs/contexto/features/pr-2073-fix-infra-harden-mobile-checkout-preparation.md
+++ b/docs/contexto/features/pr-2073-fix-infra-harden-mobile-checkout-preparation.md
@@ -1,0 +1,47 @@
+# Contexto de feature PR #2073 - fix(infra): harden mobile checkout preparation
+
+## Resumen
+
+- PR: https://github.com/dsocial118/SISOC/pull/2073
+- Base: `main`
+- Rama origen: `codex/prod-mobile-prep-stat-cache-fix`
+- Autor: `juanikitro`
+
+## Contexto funcional
+
+- No informado explícitamente; inferir desde el título del PR y el diff.
+
+## Arquitectura tocada
+
+- No se detectó un patrón arquitectónico dominante más allá del diff observado.
+
+## Decisiones y supuestos detectados
+
+- Tipo de cambio declarado: No informado
+- Área principal declarada: No informada
+- Impacto usuario declarado: No informado
+- Riesgos / rollback: No informado
+
+## Design system y UI
+
+- Sin cambios visibles de UI o design system detectados en el diff.
+
+## Memoria operativa para agentes
+
+- Empezar por `docs/registro/prs/PR-2073.md` para contexto resumido del PR.
+- Revisar primero estos archivos del diff:
+- `docs/registro/cambios/2026-07-14-paquete-mantenimiento-produccion.md`
+- `scripts/infra/prepare_prod_mobile_checkout.sh`
+- `scripts/infra/rollback_prod_mobile_checkout.sh`
+- `tests/test_prod_infra_scripts.py`
+- Documentación sugerida para ampliar contexto:
+- `docs/indice.md`
+- `docs/ia/CONTEXT_HYGIENE.md`
+- `docs/ia/ARCHITECTURE.md`
+- `docs/ia/TESTING.md`
+- `docs/registro/cambios/2026-07-14-paquete-mantenimiento-produccion.md`
+
+## Trazabilidad
+
+- Documento generado automáticamente desde el evento de `pull_request`.
+- Si este PR cambia de título, el archivo se renombrará para mantener el slug alineado.

--- a/docs/contexto/features/pr-2073-fix-infra-harden-mobile-checkout-preparation.md
+++ b/docs/contexto/features/pr-2073-fix-infra-harden-mobile-checkout-preparation.md
@@ -9,7 +9,7 @@
 
 ## Contexto funcional
 
-- No informado explícitamente; inferir desde el título del PR y el diff.
+- Gate 1 de produccion fallo por un falso positivo de Git despues de cambiar ownership del checkout mobile.
 
 ## Arquitectura tocada
 
@@ -17,10 +17,10 @@
 
 ## Decisiones y supuestos detectados
 
-- Tipo de cambio declarado: No informado
-- Área principal declarada: No informada
-- Impacto usuario declarado: No informado
-- Riesgos / rollback: No informado
+- Tipo de cambio declarado: Bugfix operativo de infraestructura.
+- Área principal declarada: Infraestructura y deploy de SISOC-Mobile.
+- Impacto usuario declarado: Reduce el riesgo de abortar o dejar metadata inconsistente durante el deploy productivo.
+- Riesgos / rollback: No cambia runtime ni datos; el rollback restaura origin y ACL desde backup sellado. Requiere repetir todos los gates con un nuevo SHA.
 
 ## Design system y UI
 
@@ -30,7 +30,11 @@
 
 - Empezar por `docs/registro/prs/PR-2073.md` para contexto resumido del PR.
 - Revisar primero estos archivos del diff:
+- `CHANGELOG.md`
+- `docs/contexto/features/pr-2073-fix-infra-harden-mobile-checkout-preparation.md`
 - `docs/registro/cambios/2026-07-14-paquete-mantenimiento-produccion.md`
+- `docs/registro/prs/PR-2073.md`
+- `docs/registro/releases/pending/2026-07-15-pr-2073.md`
 - `scripts/infra/prepare_prod_mobile_checkout.sh`
 - `scripts/infra/rollback_prod_mobile_checkout.sh`
 - `tests/test_prod_infra_scripts.py`
@@ -39,7 +43,10 @@
 - `docs/ia/CONTEXT_HYGIENE.md`
 - `docs/ia/ARCHITECTURE.md`
 - `docs/ia/TESTING.md`
+- `docs/contexto/features/pr-2073-fix-infra-harden-mobile-checkout-preparation.md`
 - `docs/registro/cambios/2026-07-14-paquete-mantenimiento-produccion.md`
+- `docs/registro/prs/PR-2073.md`
+- `docs/registro/releases/pending/2026-07-15-pr-2073.md`
 
 ## Trazabilidad
 

--- a/docs/registro/cambios/2026-07-14-paquete-mantenimiento-produccion.md
+++ b/docs/registro/cambios/2026-07-14-paquete-mantenimiento-produccion.md
@@ -2,7 +2,9 @@
 
 ## Estado
 
-Preparado y validado en el repositorio. No ejecutado en `prd-old`.
+Preparado y validado en el repositorio. La primera ventana en `prd-old` aprobo
+Gate 0 y se detuvo en Gate 1, con rollback automatico, porque el cambio de
+ownership invalido el stat-cache de Git antes de validar el working tree.
 
 ## Alcance
 
@@ -33,3 +35,13 @@ fuera del alcance.
 - `git diff --check`.
 
 La validacion real de host requiere el preflight nocturno y un GO explicito.
+
+## Ajuste posterior a Gate 1
+
+- se refresca el indice de Git despues de alinear ownership y antes de ejecutar
+  `diff-index`, para no interpretar cambios de metadata como cambios tracked;
+- el backup mobile queda sellado con `SHA256SUMS` antes de la primera mutacion,
+  de modo que el rollback independiente sea utilizable tambien ante un fallo
+  durante el apply;
+- una nueva ventana debe reconstruir el paquete desde el nuevo SHA y repetir
+  todos los gates; el run productivo anterior no debe aprobarse.

--- a/docs/registro/prs/PR-2073.md
+++ b/docs/registro/prs/PR-2073.md
@@ -6,7 +6,7 @@
 - Base: `main`
 - Rama origen: `codex/prod-mobile-prep-stat-cache-fix`
 - Autor: `juanikitro`
-- Última actualización: `2026-07-15T01:39:51Z`
+- Última actualización: `2026-07-15T01:41:49Z`
 
 ## Resumen operativo
 

--- a/docs/registro/prs/PR-2073.md
+++ b/docs/registro/prs/PR-2073.md
@@ -6,25 +6,31 @@
 - Base: `main`
 - Rama origen: `codex/prod-mobile-prep-stat-cache-fix`
 - Autor: `juanikitro`
-- Última actualización: `2026-07-15T01:38:33Z`
+- Última actualización: `2026-07-15T01:39:51Z`
 
 ## Resumen operativo
 
-- Tipo de cambio: No informado
-- Área principal: No informada
-- Contexto funcional: No informado explícitamente; revisar título, diff y documentación relacionada.
-- Resumen para changelog: No informado
-- Impacto usuario: No informado
+- Tipo de cambio: Bugfix operativo de infraestructura.
+- Área principal: Infraestructura y deploy de SISOC-Mobile.
+- Contexto funcional: Gate 1 de produccion fallo por un falso positivo de Git despues de cambiar ownership del checkout mobile.
+- Resumen para changelog: Evita falsos cambios tracked y garantiza rollback verificable al preparar SISOC-Mobile en produccion.
+- Impacto usuario: Reduce el riesgo de abortar o dejar metadata inconsistente durante el deploy productivo.
 
 ## Áreas afectadas
 
+- `CHANGELOG.md`
+- `docs/contexto`
 - `docs/registro`
 - `scripts`
 - `tests`
 
 ## Archivos relevantes del diff
 
+- `CHANGELOG.md`
+- `docs/contexto/features/pr-2073-fix-infra-harden-mobile-checkout-preparation.md`
 - `docs/registro/cambios/2026-07-14-paquete-mantenimiento-produccion.md`
+- `docs/registro/prs/PR-2073.md`
+- `docs/registro/releases/pending/2026-07-15-pr-2073.md`
 - `scripts/infra/prepare_prod_mobile_checkout.sh`
 - `scripts/infra/rollback_prod_mobile_checkout.sh`
 - `tests/test_prod_infra_scripts.py`
@@ -36,7 +42,7 @@
 
 ## Riesgos y rollback
 
-- No informado explícitamente en el PR.
+- No cambia runtime ni datos; el rollback restaura origin y ACL desde backup sellado. Requiere repetir todos los gates con un nuevo SHA.
 
 ## Documentación sugerida para lectura
 
@@ -44,7 +50,10 @@
 - `docs/ia/CONTEXT_HYGIENE.md`
 - `docs/ia/ARCHITECTURE.md`
 - `docs/ia/TESTING.md`
+- `docs/contexto/features/pr-2073-fix-infra-harden-mobile-checkout-preparation.md`
 - `docs/registro/cambios/2026-07-14-paquete-mantenimiento-produccion.md`
+- `docs/registro/prs/PR-2073.md`
+- `docs/registro/releases/pending/2026-07-15-pr-2073.md`
 
 ## Notas para continuidad
 

--- a/docs/registro/prs/PR-2073.md
+++ b/docs/registro/prs/PR-2073.md
@@ -6,7 +6,7 @@
 - Base: `main`
 - Rama origen: `codex/prod-mobile-prep-stat-cache-fix`
 - Autor: `juanikitro`
-- Última actualización: `2026-07-15T01:42:44Z`
+- Última actualización: `2026-07-15T01:43:00Z`
 
 ## Resumen operativo
 

--- a/docs/registro/prs/PR-2073.md
+++ b/docs/registro/prs/PR-2073.md
@@ -6,7 +6,7 @@
 - Base: `main`
 - Rama origen: `codex/prod-mobile-prep-stat-cache-fix`
 - Autor: `juanikitro`
-- Última actualización: `2026-07-15T01:41:49Z`
+- Última actualización: `2026-07-15T01:42:44Z`
 
 ## Resumen operativo
 

--- a/docs/registro/prs/PR-2073.md
+++ b/docs/registro/prs/PR-2073.md
@@ -1,0 +1,52 @@
+# PR #2073 - fix(infra): harden mobile checkout preparation
+
+## Metadata
+
+- PR: https://github.com/dsocial118/SISOC/pull/2073
+- Base: `main`
+- Rama origen: `codex/prod-mobile-prep-stat-cache-fix`
+- Autor: `juanikitro`
+- Última actualización: `2026-07-15T01:38:33Z`
+
+## Resumen operativo
+
+- Tipo de cambio: No informado
+- Área principal: No informada
+- Contexto funcional: No informado explícitamente; revisar título, diff y documentación relacionada.
+- Resumen para changelog: No informado
+- Impacto usuario: No informado
+
+## Áreas afectadas
+
+- `docs/registro`
+- `scripts`
+- `tests`
+
+## Archivos relevantes del diff
+
+- `docs/registro/cambios/2026-07-14-paquete-mantenimiento-produccion.md`
+- `scripts/infra/prepare_prod_mobile_checkout.sh`
+- `scripts/infra/rollback_prod_mobile_checkout.sh`
+- `tests/test_prod_infra_scripts.py`
+
+## Validación declarada
+
+- Pruebas automáticas: No informado en el PR.
+- Pruebas manuales: No informado en el PR.
+
+## Riesgos y rollback
+
+- No informado explícitamente en el PR.
+
+## Documentación sugerida para lectura
+
+- `docs/indice.md`
+- `docs/ia/CONTEXT_HYGIENE.md`
+- `docs/ia/ARCHITECTURE.md`
+- `docs/ia/TESTING.md`
+- `docs/registro/cambios/2026-07-14-paquete-mantenimiento-produccion.md`
+
+## Notas para continuidad
+
+- Este documento es generado automáticamente desde el contexto del PR y sirve como índice rápido para revisión y futuras sesiones de agentes.
+- Si la metadata del body del PR está incompleta, varias secciones usarán fallbacks derivados del título o del diff.

--- a/docs/registro/releases/pending/2026-07-15-pr-2073.md
+++ b/docs/registro/releases/pending/2026-07-15-pr-2073.md
@@ -1,0 +1,19 @@
+---
+pr: 2073
+release_date: 2026-07-15
+category: Actualizaciones
+area: sin-area
+title: fix(infra): harden mobile checkout preparation
+summary: fix(infra): harden mobile checkout preparation
+impact: No informado
+source_url: https://github.com/dsocial118/SISOC/pull/2073
+---
+# Release note preliminar PR #2073
+
+- Fecha objetivo de release: 2026-07-15
+- Categoría: Actualizaciones
+- Área: sin-area
+- Título del PR: fix(infra): harden mobile checkout preparation
+- Resumen: fix(infra): harden mobile checkout preparation
+- Impacto usuario: No informado
+- Fuente: https://github.com/dsocial118/SISOC/pull/2073

--- a/docs/registro/releases/pending/2026-07-15-pr-2073.md
+++ b/docs/registro/releases/pending/2026-07-15-pr-2073.md
@@ -2,18 +2,18 @@
 pr: 2073
 release_date: 2026-07-15
 category: Actualizaciones
-area: sin-area
+area: Infraestructura y deploy de SISOC-Mobile.
 title: fix(infra): harden mobile checkout preparation
-summary: fix(infra): harden mobile checkout preparation
-impact: No informado
+summary: Evita falsos cambios tracked y garantiza rollback verificable al preparar SISOC-Mobile en produccion
+impact: Reduce el riesgo de abortar o dejar metadata inconsistente durante el deploy productivo.
 source_url: https://github.com/dsocial118/SISOC/pull/2073
 ---
 # Release note preliminar PR #2073
 
 - Fecha objetivo de release: 2026-07-15
 - Categoría: Actualizaciones
-- Área: sin-area
+- Área: Infraestructura y deploy de SISOC-Mobile.
 - Título del PR: fix(infra): harden mobile checkout preparation
-- Resumen: fix(infra): harden mobile checkout preparation
-- Impacto usuario: No informado
+- Resumen: Evita falsos cambios tracked y garantiza rollback verificable al preparar SISOC-Mobile en produccion
+- Impacto usuario: Reduce el riesgo de abortar o dejar metadata inconsistente durante el deploy productivo.
 - Fuente: https://github.com/dsocial118/SISOC/pull/2073

--- a/scripts/infra/prepare_prod_mobile_checkout.sh
+++ b/scripts/infra/prepare_prod_mobile_checkout.sh
@@ -106,15 +106,20 @@ preflight() {
 }
 
 rollback_on_error() {
-  local rc=$?
+  local rc=$? mobile_owner
   trap - EXIT
   if [[ "$ROLLBACK_NEEDED" -eq 1 && -n "$BACKUP_DIR" ]]; then
     log "Fallo durante preparacion mobile; restaurando ACL/owners y remote."
-    setfacl --restore="$BACKUP_DIR/mobile.acl-ownership.before" || true
     if [[ -r "$BACKUP_DIR/mobile-origin.before" ]]; then
       git -c safe.directory="$MOBILE_ROOT" -C "$MOBILE_ROOT" remote set-url origin \
         "$(cat "$BACKUP_DIR/mobile-origin.before")" || true
     fi
+    setfacl --restore="$BACKUP_DIR/mobile.acl-ownership.before" || true
+    mobile_owner="$(stat -c '%U' "$MOBILE_ROOT")"
+    runuser -u "$mobile_owner" -- git -C "$MOBILE_ROOT" update-index --refresh -q \
+      >/dev/null 2>&1 || true
+    runuser -u "$mobile_owner" -- git -C "$MOBILE_ROOT" diff-index --quiet HEAD -- \
+      || log "ERROR: El rollback mobile dejo cambios tracked."
     bash "$SCRIPT_DIR/healthcheck_prod.sh" || true
   fi
   exit "$rc"
@@ -134,6 +139,11 @@ apply_changes() {
   before_head="$(git -c safe.directory="$MOBILE_ROOT" -C "$MOBILE_ROOT" rev-parse HEAD)"
   printf '%s\n' "$before_head" > "$BACKUP_DIR/mobile-head.before"
   find "$BACKUP_DIR" -type f -exec chmod 600 {} +
+  (
+    cd "$BACKUP_DIR"
+    find . -type f ! -name SHA256SUMS -print0 | sort -z | xargs -0 sha256sum
+  ) > "$BACKUP_DIR/SHA256SUMS"
+  chmod 600 "$BACKUP_DIR/SHA256SUMS"
 
   trap rollback_on_error EXIT
   ROLLBACK_NEEDED=1
@@ -145,6 +155,8 @@ apply_changes() {
   [[ "$after_head" == "$before_head" ]] || fail "El fetch cambio el HEAD local."
   [[ "$(runuser -u "$TARGET_USER" -- git -C "$MOBILE_ROOT" branch --show-current)" == main ]] \
     || fail "Mobile dejo de estar en main."
+  runuser -u "$TARGET_USER" -- git -C "$MOBILE_ROOT" update-index --refresh -q \
+    >/dev/null 2>&1 || true
   runuser -u "$TARGET_USER" -- git -C "$MOBILE_ROOT" diff-index --quiet HEAD -- \
     || fail "Aparecieron cambios tracked en mobile."
   [[ "$(remote_state)" == https ]] || fail "Origin mobile no quedo en HTTPS."

--- a/scripts/infra/rollback_prod_mobile_checkout.sh
+++ b/scripts/infra/rollback_prod_mobile_checkout.sh
@@ -35,6 +35,8 @@ parse_args() {
 }
 
 main() {
+  local mobile_owner
+
   parse_args "$@"
   [[ "$EUID" -eq 0 ]] || fail "Ejecutar como root mediante sudo."
   [[ "$(hostname -s)" == "$EXPECTED_HOSTNAME" ]] || fail "Host inesperado."
@@ -58,10 +60,14 @@ main() {
     esac
   fi
 
-  setfacl --restore="$BACKUP_DIR/mobile.acl-ownership.before"
   git -c safe.directory="$MOBILE_ROOT" -C "$MOBILE_ROOT" remote set-url origin \
     "$(cat "$BACKUP_DIR/mobile-origin.before")"
-  git -c safe.directory="$MOBILE_ROOT" -C "$MOBILE_ROOT" diff-index --quiet HEAD -- \
+  setfacl --restore="$BACKUP_DIR/mobile.acl-ownership.before"
+  mobile_owner="$(stat -c '%U' "$MOBILE_ROOT")"
+  id "$mobile_owner" >/dev/null 2>&1 || fail "Owner mobile restaurado inexistente."
+  runuser -u "$mobile_owner" -- git -C "$MOBILE_ROOT" update-index --refresh -q \
+    >/dev/null 2>&1 || true
+  runuser -u "$mobile_owner" -- git -C "$MOBILE_ROOT" diff-index --quiet HEAD -- \
     || fail "El checkout mobile tiene cambios tracked despues del rollback."
   bash "$SCRIPT_DIR/healthcheck_prod.sh"
   printf '[%s] Rollback mobile aplicado; health OK.\n' "$SCRIPT_NAME"

--- a/tests/test_prod_infra_scripts.py
+++ b/tests/test_prod_infra_scripts.py
@@ -124,7 +124,9 @@ def test_rollback_mobile_restaura_acl_despues_de_modificar_origin():
         encoding="utf-8"
     )
 
-    restore_origin = 'git -c safe.directory="$MOBILE_ROOT" -C "$MOBILE_ROOT" remote set-url origin'
+    restore_origin = (
+        'git -c safe.directory="$MOBILE_ROOT" -C "$MOBILE_ROOT" remote set-url origin'
+    )
     restore_acl = 'setfacl --restore="$BACKUP_DIR/mobile.acl-ownership.before"'
 
     assert rollback.index(restore_origin) < rollback.index(restore_acl)

--- a/tests/test_prod_infra_scripts.py
+++ b/tests/test_prod_infra_scripts.py
@@ -76,3 +76,55 @@ def test_preparacion_mobile_acota_chown_y_guarda_rollback_completo():
     assert 'getfacl -R -p "$MOBILE_ROOT"' in prepare
     assert 'setfacl --restore="$BACKUP_DIR/mobile.acl-ownership.before"' in rollback
     assert '"$(cat "$BACKUP_DIR/mobile-origin.before")"' in rollback
+
+
+def test_preparacion_mobile_refresca_indice_antes_de_validar_tracked_changes():
+    prepare = (INFRA_DIR / "prepare_prod_mobile_checkout.sh").read_text(
+        encoding="utf-8"
+    )
+    apply_changes = prepare.split("apply_changes() {", maxsplit=1)[1].split(
+        "\nmain()", maxsplit=1
+    )[0]
+
+    refresh_index = 'git -C "$MOBILE_ROOT" update-index --refresh -q'
+    validate_tracked = 'git -C "$MOBILE_ROOT" diff-index --quiet HEAD --'
+
+    assert refresh_index in apply_changes
+    assert apply_changes.index(refresh_index) < apply_changes.index(validate_tracked)
+
+
+def test_preparacion_mobile_sella_backup_antes_del_primer_cambio():
+    prepare = (INFRA_DIR / "prepare_prod_mobile_checkout.sh").read_text(
+        encoding="utf-8"
+    )
+    apply_changes = prepare.split("apply_changes() {", maxsplit=1)[1].split(
+        "\nmain()", maxsplit=1
+    )[0]
+
+    checksum = ') > "$BACKUP_DIR/SHA256SUMS"'
+    first_mutation = 'chown -R "$TARGET_USER:$TARGET_GROUP" "$MOBILE_ROOT"'
+
+    assert apply_changes.index(checksum) < apply_changes.index(first_mutation)
+
+
+def test_rollback_mobile_refresca_indice_antes_de_validar_tracked_changes():
+    rollback = (INFRA_DIR / "rollback_prod_mobile_checkout.sh").read_text(
+        encoding="utf-8"
+    )
+
+    refresh_index = 'git -C "$MOBILE_ROOT" update-index --refresh -q'
+    validate_tracked = 'git -C "$MOBILE_ROOT" diff-index --quiet HEAD --'
+
+    assert refresh_index in rollback
+    assert rollback.index(refresh_index) < rollback.index(validate_tracked)
+
+
+def test_rollback_mobile_restaura_acl_despues_de_modificar_origin():
+    rollback = (INFRA_DIR / "rollback_prod_mobile_checkout.sh").read_text(
+        encoding="utf-8"
+    )
+
+    restore_origin = 'git -c safe.directory="$MOBILE_ROOT" -C "$MOBILE_ROOT" remote set-url origin'
+    restore_acl = 'setfacl --restore="$BACKUP_DIR/mobile.acl-ownership.before"'
+
+    assert rollback.index(restore_origin) < rollback.index(restore_acl)


### PR DESCRIPTION
# Información de la Tarea

Sin issue. Correccion derivada del Gate 1 de la ventana productiva del 2026-07-14.

### **Resumen de la Solución:**
- Refrescar el stat-cache de Git como el owner efectivo antes de validar cambios tracked.
- Sellar el backup mobile antes de la primera mutacion.
- Restaurar origin antes de ACL/owners para preservar ownership durante rollback.

### **Información Adicional:**
- No aprobar el run productivo anterior `29380132545`.
- Despues del merge se debe esperar Plan A y QA/HML verdes, registrar el nuevo SHA/run y repetir Gates 0-5.

# Descripción de los Cambios

### **Cambios:**
- `prepare_prod_mobile_checkout.sh`: backup pre-mutation, refresh de indice y rollback automatico verificable.
- `rollback_prod_mobile_checkout.sh`: restauracion de origin antes de ACL y validacion Git como owner restaurado.
- regresiones focalizadas y registro operativo de la ventana detenida.

# Cómo Testear los Cambios

### **Pruebas Automáticas:**
- `8 passed, 1 deselected` en `tests/test_prod_infra_scripts.py` sin cargar Django.
- `bash -n` sobre los dos scripts modificados, normalizando CRLF solo en stdin desde Windows.
- `python -m py_compile tests/test_prod_infra_scripts.py`.
- `git diff --check`.

### **Prubeas Manuales:**
- La evidencia de PRD confirmo cero diferencias reales tras refrescar el indice y health OK despues del rollback.
- No se repitio el apply productivo desde este PR.

# Metadata para documentación automática

- Contexto funcional: Gate 1 de produccion fallo por un falso positivo de Git despues de cambiar ownership del checkout mobile.
- Tipo de cambio: Bugfix operativo de infraestructura.
- Área principal: Infraestructura y deploy de SISOC-Mobile.
- Resumen para changelog: Evita falsos cambios tracked y garantiza rollback verificable al preparar SISOC-Mobile en produccion.
- Impacto usuario: Reduce el riesgo de abortar o dejar metadata inconsistente durante el deploy productivo.
- Riesgos / rollback: No cambia runtime ni datos; el rollback restaura origin y ACL desde backup sellado. Requiere repetir todos los gates con un nuevo SHA.

# Capturas de Pantalla

No aplica.