### PR TITLE
fix(users): credenciales PWA y descarga CSV por lote

### DIFF
--- a/AGENT_REPO_MAP.md
+++ b/AGENT_REPO_MAP.md
@@ -340,6 +340,17 @@ La siguiente tabla mezcla hechos observados con inferencias explicitas cuando no
 - `users/management/commands/create_groups.py`
 - templates en `users/templates/`
 
+### Si necesitas cambiar la importacion masiva de usuarios
+
+- `users/services_user_import.py`: parsing, alta/actualizacion, mail de
+  credenciales y exportacion CSV.
+- `users/services_user_import_jobs.py`: procesamiento y reanudacion del lote.
+- `users/views_user_import.py`, `users/urls.py` y
+  `users/templates/user/user_import_job_detail.html`: detalle y descargas.
+- Las credenciales se agrupan al finalizar el lote; los lotes PWA deben usar
+  `/mobile/login` y las descargas sensibles se limitan al solicitante o a un
+  superusuario.
+
 ### Si necesitas cambiar permisos o IAM
 
 - `users/bootstrap/groups_seed.py`

--- a/docs/registro/cambios/2026-07-17-importacion-usuarios-pwa-csv-credenciales.md
+++ b/docs/registro/cambios/2026-07-17-importacion-usuarios-pwa-csv-credenciales.md
@@ -1,0 +1,16 @@
+# 2026-07-17 - Importación de usuarios: acceso PWA y CSV de credenciales
+
+## Cambio
+
+- Los correos de credenciales enviados por lotes de usuarios PWA ahora indican
+  la ruta `/mobile/login`; los lotes de SISOC Web mantienen el enlace habitual.
+- El detalle del lote permite descargar un CSV con los usuarios efectivamente
+  creados, sus datos básicos y la contraseña temporal vigente.
+
+## Seguridad
+
+- El CSV solo está disponible para quien creó el lote o para un superusuario.
+- No persiste una nueva copia de contraseñas: si la contraseña temporal ya fue
+  cambiada o reseteada, la celda se exporta vacía.
+- Los valores textuales se neutralizan para evitar inyección de fórmulas al
+  abrir el archivo en una planilla.

--- a/tests/test_users_import_export.py
+++ b/tests/test_users_import_export.py
@@ -1,0 +1,169 @@
+import csv
+from io import StringIO
+
+import pytest
+from django.contrib.auth import get_user_model
+from django.contrib.auth.models import Permission
+from django.core import mail
+from django.test import override_settings
+from django.urls import reverse
+
+from users.models import UserImportJob, UserImportJobRow
+from users.services_user_import import send_user_import_job_credentials
+
+User = get_user_model()
+
+
+@pytest.mark.django_db
+@override_settings(
+    EMAIL_BACKEND="django.core.mail.backends.locmem.EmailBackend",
+    ENVIRONMENT="prd",
+    DOMINIO="sisoc.secretarianaf.gob.ar",
+)
+def test_user_import_pwa_credentials_email_uses_mobile_login_url():
+    operator = User.objects.create_user(username="import_operator")
+    imported_user = User.objects.create_user(
+        username="pwa_user",
+        email="pwa@example.com",
+        first_name="PWA",
+        last_name="User",
+    )
+    imported_user.profile.must_change_password = True
+    imported_user.profile.temporary_password_plaintext = "Temporal123"
+    imported_user.profile.save(
+        update_fields=["must_change_password", "temporary_password_plaintext"]
+    )
+    job = UserImportJob.objects.create(
+        requested_by=operator,
+        original_filename="usuarios.xlsx",
+        is_pwa_import=True,
+        send_credentials=True,
+    )
+    UserImportJobRow.objects.create(
+        job=job,
+        created_user=imported_user,
+        fila=2,
+        email=imported_user.email,
+        status=UserImportJobRow.Status.CREATED,
+    )
+
+    send_user_import_job_credentials(job)
+
+    assert len(mail.outbox) == 1
+    assert "https://sisoc.secretarianaf.gob.ar/mobile/login" in mail.outbox[0].body
+
+
+@pytest.mark.django_db
+@override_settings(
+    EMAIL_BACKEND="django.core.mail.backends.locmem.EmailBackend",
+    ENVIRONMENT="prd",
+    DOMINIO="sisoc.secretarianaf.gob.ar",
+)
+def test_user_import_web_credentials_email_keeps_web_login_url():
+    operator = User.objects.create_user(username="import_operator_web")
+    imported_user = User.objects.create_user(
+        username="web_user",
+        email="web@example.com",
+    )
+    imported_user.profile.must_change_password = True
+    imported_user.profile.temporary_password_plaintext = "Temporal123"
+    imported_user.profile.save(
+        update_fields=["must_change_password", "temporary_password_plaintext"]
+    )
+    job = UserImportJob.objects.create(
+        requested_by=operator,
+        original_filename="usuarios.xlsx",
+        send_credentials=True,
+    )
+    UserImportJobRow.objects.create(
+        job=job,
+        created_user=imported_user,
+        fila=2,
+        email=imported_user.email,
+        status=UserImportJobRow.Status.CREATED,
+    )
+
+    send_user_import_job_credentials(job)
+
+    assert len(mail.outbox) == 1
+    assert "https://sisoc.secretarianaf.gob.ar/" in mail.outbox[0].body
+    assert "/mobile/login" not in mail.outbox[0].body
+
+
+@pytest.mark.django_db
+def test_user_import_job_download_exports_only_created_users_with_temp_password(client):
+    operator = User.objects.create_user(username="import_operator")
+    operator.user_permissions.add(
+        Permission.objects.get(content_type__app_label="auth", codename="add_user")
+    )
+    created_user = User.objects.create_user(
+        username="ana.garcia",
+        email="ana@example.com",
+        first_name="Ana",
+        last_name="García",
+    )
+    created_user.profile.must_change_password = True
+    created_user.profile.temporary_password_plaintext = "Temporal123"
+    created_user.profile.save(
+        update_fields=["must_change_password", "temporary_password_plaintext"]
+    )
+    job = UserImportJob.objects.create(
+        requested_by=operator,
+        original_filename="usuarios.xlsx",
+    )
+    UserImportJobRow.objects.create(
+        job=job,
+        created_user=created_user,
+        fila=2,
+        nombre="Ana",
+        apellido="García",
+        email="ana@example.com",
+        rol="Operadora",
+        status=UserImportJobRow.Status.CREATED,
+    )
+    UserImportJobRow.objects.create(
+        job=job,
+        fila=3,
+        nombre="Omitido",
+        status=UserImportJobRow.Status.SKIPPED,
+    )
+    client.force_login(operator)
+
+    response = client.get(
+        reverse("usuarios_importar_descargar_csv", kwargs={"pk": job.pk})
+    )
+
+    assert response.status_code == 200
+    assert response["Content-Type"] == "text/csv; charset=utf-8"
+    assert f"lote-usuarios-{job.pk}.csv" in response["Content-Disposition"]
+    assert list(csv.reader(StringIO(response.content.decode("utf-8-sig")))) == [
+        ["Usuario", "Nombre", "Apellido", "Correo", "Rol", "Contraseña temporal"],
+        ["ana.garcia", "Ana", "García", "ana@example.com", "Operadora", "Temporal123"],
+    ]
+    detail_response = client.get(
+        reverse("usuarios_importar_detalle", kwargs={"pk": job.pk})
+    )
+    assert detail_response.status_code == 200
+    assert reverse(
+        "usuarios_importar_descargar_csv", kwargs={"pk": job.pk}
+    ) in detail_response.content.decode()
+
+
+@pytest.mark.django_db
+def test_user_import_job_download_is_not_available_to_another_operator(client):
+    owner = User.objects.create_user(username="import_owner")
+    other_operator = User.objects.create_user(username="other_operator")
+    other_operator.user_permissions.add(
+        Permission.objects.get(content_type__app_label="auth", codename="add_user")
+    )
+    job = UserImportJob.objects.create(
+        requested_by=owner,
+        original_filename="usuarios.xlsx",
+    )
+    client.force_login(other_operator)
+
+    response = client.get(
+        reverse("usuarios_importar_descargar_csv", kwargs={"pk": job.pk})
+    )
+
+    assert response.status_code == 404

--- a/tests/test_users_import_export.py
+++ b/tests/test_users_import_export.py
@@ -144,9 +144,10 @@ def test_user_import_job_download_exports_only_created_users_with_temp_password(
         reverse("usuarios_importar_detalle", kwargs={"pk": job.pk})
     )
     assert detail_response.status_code == 200
-    assert reverse(
-        "usuarios_importar_descargar_csv", kwargs={"pk": job.pk}
-    ) in detail_response.content.decode()
+    assert (
+        reverse("usuarios_importar_descargar_csv", kwargs={"pk": job.pk})
+        in detail_response.content.decode()
+    )
 
 
 @pytest.mark.django_db

--- a/users/services_user_import.py
+++ b/users/services_user_import.py
@@ -364,9 +364,7 @@ def generate_user_import_job_csv(job: UserImportJob) -> str:
         user = row.created_user
         profile = user.profile
         temporary_password = (
-            profile.temporary_password_plaintext
-            if profile.must_change_password
-            else ""
+            profile.temporary_password_plaintext if profile.must_change_password else ""
         )
         writer.writerow(
             [

--- a/users/services_user_import.py
+++ b/users/services_user_import.py
@@ -1,9 +1,10 @@
 from __future__ import annotations
 
+import csv
 import logging
 import unicodedata
 from dataclasses import dataclass
-from io import BytesIO
+from io import BytesIO, StringIO
 
 from django.conf import settings
 from django.contrib.auth import get_user_model
@@ -68,6 +69,14 @@ USER_IMPORT_TEMPLATE_HEADERS = (
     "Organizaciones",
     "Comedores",
 )
+USER_IMPORT_CSV_HEADERS = (
+    "Usuario",
+    "Nombre",
+    "Apellido",
+    "Correo",
+    "Rol",
+    "Contraseña temporal",
+)
 USERNAME_MAX_LENGTH = 150
 
 GROUP_ACTION_AGREGAR = "agregar"
@@ -76,11 +85,14 @@ GROUP_ACTION_REEMPLAZAR = "reemplazar"
 GROUP_ACTIONS = (GROUP_ACTION_AGREGAR, GROUP_ACTION_QUITAR, GROUP_ACTION_REEMPLAZAR)
 
 
-def _build_login_url() -> str:
-    try:
-        path = reverse("login")
-    except Exception:
-        path = "/"
+def _build_login_url(*, is_pwa_import: bool = False) -> str:
+    if is_pwa_import:
+        path = "/mobile/login"
+    else:
+        try:
+            path = reverse("login")
+        except Exception:
+            path = "/"
     domain = (
         str(settings.DOMINIO).replace("http://", "").replace("https://", "").rstrip("/")
     )
@@ -311,7 +323,7 @@ def send_user_import_job_credentials(job: UserImportJob) -> None:
             send_bulk_credentials_email(
                 recipient_email=recipient_email,
                 entries=entries,
-                login_url=_build_login_url(),
+                login_url=_build_login_url(is_pwa_import=job.is_pwa_import),
                 send_type="standard",
             )
         except Exception:
@@ -329,6 +341,44 @@ def send_user_import_job_credentials(job: UserImportJob) -> None:
         UserImportJobRow.objects.filter(pk__in=[row.pk for row in rows_to_send]).update(
             credentials_sent_at=timezone.now()
         )
+
+
+def _sanitize_csv_cell(value: object) -> str:
+    text = str(value or "")
+    return f"'{text}" if text.startswith(("=", "+", "-", "@")) else text
+
+
+def generate_user_import_job_csv(job: UserImportJob) -> str:
+    output = StringIO()
+    writer = csv.writer(output)
+    writer.writerow(USER_IMPORT_CSV_HEADERS)
+    rows = (
+        job.rows.filter(
+            status=UserImportJobRow.Status.CREATED,
+            created_user__isnull=False,
+        )
+        .select_related("created_user__profile")
+        .order_by("fila", "id")
+    )
+    for row in rows:
+        user = row.created_user
+        profile = user.profile
+        temporary_password = (
+            profile.temporary_password_plaintext
+            if profile.must_change_password
+            else ""
+        )
+        writer.writerow(
+            [
+                _sanitize_csv_cell(user.username),
+                _sanitize_csv_cell(row.nombre or user.first_name),
+                _sanitize_csv_cell(row.apellido or user.last_name),
+                _sanitize_csv_cell(user.email or row.email),
+                _sanitize_csv_cell(row.rol),
+                temporary_password or "",
+            ]
+        )
+    return output.getvalue()
 
 
 def _resolver_provincias(provincias_raw: str) -> list:

--- a/users/templates/user/user_import_job_detail.html
+++ b/users/templates/user/user_import_job_detail.html
@@ -25,6 +25,10 @@
                     <div class="d-flex flex-wrap gap-2">
                         <a href="{% url 'usuarios_importar_detalle' job.id %}"
                            class="btn btn-outline-primary">Actualizar estado</a>
+                        {% if has_csv_download %}
+                            <a href="{% url 'usuarios_importar_descargar_csv' job.id %}"
+                               class="btn btn-outline-success">Descargar CSV</a>
+                        {% endif %}
                         {% if is_resume_available %}
                             <form method="post" action="{% url 'usuarios_importar_reanudar' job.id %}">
                                 {% csrf_token %}

--- a/users/urls.py
+++ b/users/urls.py
@@ -24,6 +24,7 @@ from users.views_export import UserExportView, GroupExportView
 from users.views_user_import import (
     UserImportJobCreateView,
     UserImportJobDetailView,
+    UserImportJobDownloadCSVView,
     UserImportJobResumeView,
     UserImportTemplateView,
 )
@@ -128,6 +129,13 @@ urlpatterns = [
         "usuarios/importar/lotes/<int:pk>/reanudar/",
         permissions_any_required(["auth.add_user"])(UserImportJobResumeView.as_view()),
         name="usuarios_importar_reanudar",
+    ),
+    path(
+        "usuarios/importar/lotes/<int:pk>/descargar-csv/",
+        permissions_any_required(["auth.add_user"])(
+            UserImportJobDownloadCSVView.as_view()
+        ),
+        name="usuarios_importar_descargar_csv",
     ),
     path(
         "grupos/",

--- a/users/views_user_import.py
+++ b/users/views_user_import.py
@@ -1,16 +1,18 @@
 from django.contrib import messages
 from django.core.exceptions import ValidationError
 from django.core.paginator import Paginator
-from django.http import HttpResponse, HttpResponseRedirect
+from django.http import Http404, HttpResponse, HttpResponseRedirect
 from django.shortcuts import render
 from django.urls import reverse
 from django.views import View
 
 from users.forms import UserImportForm
+from users.models import UserImportJobRow
 from users.views import AdminRequiredMixin
 from users.services_user_import import (
     USER_IMPORT_TEMPLATE_FILENAME,
     create_user_import_job,
+    generate_user_import_job_csv,
     generate_user_import_template,
 )
 from users.services_user_import_jobs import (
@@ -92,6 +94,10 @@ class UserImportJobDetailView(AdminRequiredMixin, View):
                 "is_resume_available": can_resume_user_import_job(job),
                 "upload_url": reverse("usuarios_importar"),
                 "status_filter": status_filter,
+                "has_csv_download": job.rows.filter(
+                    status=UserImportJobRow.Status.CREATED,
+                    created_user__isnull=False,
+                ).exists(),
             },
         )
 
@@ -113,6 +119,24 @@ class UserImportJobResumeView(AdminRequiredMixin, View):
         return HttpResponseRedirect(
             reverse("usuarios_importar_detalle", kwargs={"pk": job.pk})
         )
+
+
+class UserImportJobDownloadCSVView(AdminRequiredMixin, View):
+    required_permissions = (USER_IMPORT_PERMISSION_CODE,)
+
+    def get(self, request, *args, **kwargs):
+        job = get_user_import_job_or_404(job_id=kwargs["pk"])
+        if not request.user.is_superuser and job.requested_by_id != request.user.id:
+            raise Http404("No existe el lote solicitado.")
+
+        response = HttpResponse(
+            "\ufeff" + generate_user_import_job_csv(job),
+            content_type="text/csv; charset=utf-8",
+        )
+        response["Content-Disposition"] = (
+            f'attachment; filename="lote-usuarios-{job.pk}.csv"'
+        )
+        return response
 
 
 class UserImportTemplateView(AdminRequiredMixin, View):


### PR DESCRIPTION
## Resumen

Corrige el enlace de acceso incluido en las credenciales de importación PWA y agrega la descarga CSV desde el detalle del lote.

- Los lotes PWA envían `https://<DOMINIO>/mobile/login`; SISOC Web conserva su URL actual.
- El CSV incluye únicamente usuarios efectivamente creados, con su contraseña temporal vigente.
- La descarga se limita al solicitante del lote o a un superusuario y neutraliza fórmulas de Excel.

## Validación

- `py -3 -m compileall -q users/services_user_import.py users/views_user_import.py users/urls.py tests/test_users_import_export.py`
- `git diff --check`
- Pendiente: `py -3 -m pytest tests/test_users_import_export.py -q` está bloqueado localmente porque falta `crispy_forms` antes de inicializar Django.

Closes #2086.