### PR TITLE
(comedores):cambios-mes-ejecucion

### DIFF
--- a/comedores/admin.py
+++ b/comedores/admin.py
@@ -32,7 +32,7 @@ class ComedorAdmin(admin.ModelAdmin):
         "ultimo_estado__estado_general__estado_actividad",
     ]
     search_fields = ["nombre", "codigo_de_proyecto"]
-    readonly_fields = ["fecha_validado"]
+    readonly_fields = ["fecha_validado", "mes_ejecucion"]
 
 
 @admin.register(HistorialValidacion)

--- a/comedores/forms/comedor_form.py
+++ b/comedores/forms/comedor_form.py
@@ -541,6 +541,7 @@ class ComedorForm(forms.ModelForm):
         exclude = [
             "ultimo_estado",
             "fecha_validado",
+            "mes_ejecucion",
         ]  # IMPORTANTE: Excluir para que no se sobrescriba
         labels = {
             "tipocomedor": "Tipo comedor",

--- a/comedores/migrations/0048_comedor_mes_ejecucion.py
+++ b/comedores/migrations/0048_comedor_mes_ejecucion.py
@@ -1,0 +1,22 @@
+from django.core.validators import MaxValueValidator, MinValueValidator
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ("comedores", "0047_remove_conformidad_periodo_unique"),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name="comedor",
+            name="mes_ejecucion",
+            field=models.IntegerField(
+                blank=True,
+                null=True,
+                validators=[MinValueValidator(-2), MaxValueValidator(6)],
+                verbose_name="Mes de ejecución",
+            ),
+        ),
+    ]

--- a/comedores/models.py
+++ b/comedores/models.py
@@ -246,6 +246,12 @@ class Comedor(SoftDeleteModelMixin, models.Model):
     programa = models.ForeignKey(
         to=Programas, blank=True, null=True, on_delete=models.PROTECT
     )
+    mes_ejecucion = models.IntegerField(
+        verbose_name="Mes de ejecución",
+        blank=True,
+        null=True,
+        validators=[MinValueValidator(-2), MaxValueValidator(6)],
+    )
     id_externo = models.IntegerField(
         verbose_name="Id Externo",
         blank=True,

--- a/comedores/serializers/comedor_serializer.py
+++ b/comedores/serializers/comedor_serializer.py
@@ -48,3 +48,4 @@ class ComedorSerializer(serializers.ModelSerializer):
     class Meta:
         model = Comedor
         fields = "__all__"
+        read_only_fields = ("mes_ejecucion",)

--- a/comedores/services/comedor_service/impl.py
+++ b/comedores/services/comedor_service/impl.py
@@ -16,7 +16,6 @@ from django.db.models import (
     IntegerField,
     F,
     Func,
-    OuterRef,
     Subquery,
     BooleanField,
 )
@@ -61,8 +60,6 @@ from admisiones.models.admisiones import (
 )
 from rendicioncuentasmensual.models import RendicionCuentaMensual
 from intervenciones.models.intervenciones import Intervencion
-from expedientespagos.models import ExpedientePago
-from expedientespagos.services import ordenar_expedientes_por_periodo_desc
 from duplas.models import Dupla
 from organizaciones.models import Aval, Firmante
 
@@ -401,9 +398,6 @@ def _calcular_presupuesto_desde_prestaciones(count, valor_map):
 
 
 def _build_comedores_list_values_queryset(base_qs):
-    latest_mes_ejecucion = ordenar_expedientes_por_periodo_desc(
-        ExpedientePago.objects.filter(comedor_id=OuterRef("pk"))
-    ).values("mes_convenio")[:1]
     return (
         base_qs.select_related(
             "provincia",
@@ -419,11 +413,6 @@ def _build_comedores_list_values_queryset(base_qs):
             estado_general=Coalesce(
                 "ultimo_estado__estado_general__estado_actividad__estado",
                 Value(Comedor.ESTADO_GENERAL_DEFAULT),
-            ),
-            mes_ejecucion=Case(
-                When(programa_id=2, then=Subquery(latest_mes_ejecucion)),
-                default=Value(None),
-                output_field=IntegerField(),
             ),
         )
         .values(

--- a/comedores/services/filter_config/impl.py
+++ b/comedores/services/filter_config/impl.py
@@ -155,7 +155,9 @@ FILTER_FIELDS = [
         "name": "mes_ejecucion",
         "label": "Mes de ejecucion",
         "type": "choice",
-        "choices": [{"value": str(i), "label": str(i)} for i in range(1, 7)],
+        "choices": [
+            {"value": str(i), "label": str(i)} for i in (-2, -1, 1, 2, 3, 4, 5, 6)
+        ],
     },
     {"name": "numero", "label": "Numero", "type": "number"},
     {"name": "codigo_postal", "label": "Codigo Postal", "type": "number"},

--- a/comedores/templates/comedor/comedor_mes_ejecucion_card.html
+++ b/comedores/templates/comedor/comedor_mes_ejecucion_card.html
@@ -25,7 +25,7 @@
                     A&ntilde;o: <strong>{{ expediente.ano|default:"Sin informaci&oacute;n" }}</strong>
                 </p>
                 <p class="mb-0 fs-7">
-                    Mes de ejecuci&oacute;n: <strong>{{ expediente.mes_convenio|default:"Sin informaci&oacute;n" }}</strong>
+                    Mes de ejecuci&oacute;n: <strong>{{ mes_ejecucion_resumen.mes_ejecucion|default_if_none:"Sin informaci&oacute;n" }}</strong>
                 </p>
             {% endwith %}
         {% else %}

--- a/comedores/views/comedor.py
+++ b/comedores/views/comedor.py
@@ -919,7 +919,10 @@ def _build_mes_ejecucion_context(comedor_obj):
     expediente = ordenar_expedientes_por_periodo_desc(
         ExpedientePago.objects.filter(comedor_id=comedor_obj.id)
     ).first()
-    resumen = {"expediente": expediente}
+    resumen = {
+        "expediente": expediente,
+        "mes_ejecucion": comedor_obj.mes_ejecucion,
+    }
 
     if expediente:
         prestaciones = [

--- a/docs/registro/cambios/2026-07-16-mes-ejecucion-renovacion-comedores.md
+++ b/docs/registro/cambios/2026-07-16-mes-ejecucion-renovacion-comedores.md
@@ -1,0 +1,36 @@
+# Mes de ejecución durante la renovación de comedores
+
+## Contexto
+
+El mes de ejecución del listado y del legajo de comedores se obtenía del
+`mes_convenio` del último expediente de pago. Cuando un comedor de Alimentar
+Comunidad dejaba de aparecer en los lotes siguientes, el valor histórico seguía
+visible aunque su estado ya hubiera cambiado a renovación o baja.
+
+## Cambio funcional
+
+`Comedor.mes_ejecucion` conserva el valor operativo vigente sin modificar el
+`ExpedientePago.mes_convenio` histórico:
+
+- comedor presente en el lote: mes de convenio informado (`1` a `6`);
+- primera ausencia consecutiva: `-1`;
+- segunda ausencia consecutiva: `-2`;
+- tercera ausencia, o comedor que ya estaba inactivo: `null`.
+
+La regla se aplica solamente a comedores del programa Alimentar Comunidad y
+convive con la actualización de estados implementada en el flujo de importación.
+El listado, los filtros avanzados y el resumen del legajo consumen el nuevo
+campo operativo.
+
+## Migración y compatibilidad
+
+La migración inicializa `Comedor.mes_ejecucion` con el mes de convenio del
+último expediente de cada comedor de Alimentar Comunidad. Los expedientes y
+sus validadores de meses `1` a `6` no se modifican.
+
+## Validación
+
+- migraciones Django sin cambios pendientes;
+- `manage.py check` sin errores;
+- tests del flujo de importación, incluidas las transiciones a `-1`, `-2` y
+  `null`.

--- a/importarexpediente/migrations/0015_backfill_comedor_mes_ejecucion.py
+++ b/importarexpediente/migrations/0015_backfill_comedor_mes_ejecucion.py
@@ -1,0 +1,55 @@
+from django.db import migrations
+from django.db.models import Case, IntegerField, OuterRef, Subquery, Value, When
+
+
+MES_PAGO_ALIASES = (
+    (1, ("enero", "1", "01")),
+    (2, ("febrero", "2", "02")),
+    (3, ("marzo", "3", "03")),
+    (4, ("abril", "4", "04")),
+    (5, ("mayo", "5", "05")),
+    (6, ("junio", "6", "06")),
+    (7, ("julio", "7", "07")),
+    (8, ("agosto", "8", "08")),
+    (9, ("septiembre", "setiembre", "9", "09")),
+    (10, ("octubre", "10")),
+    (11, ("noviembre", "11")),
+    (12, ("diciembre", "12")),
+)
+
+
+def backfill_mes_ejecucion(apps, schema_editor):
+    Comedor = apps.get_model("comedores", "Comedor")
+    ExpedientePago = apps.get_model("expedientespagos", "ExpedientePago")
+
+    mes_order = Case(
+        *[
+            When(mes_pago__iexact=alias, then=Value(numero))
+            for numero, aliases in MES_PAGO_ALIASES
+            for alias in aliases
+        ],
+        default=Value(0),
+        output_field=IntegerField(),
+    )
+    ultimo_mes = (
+        ExpedientePago.objects.filter(comedor_id=OuterRef("pk"))
+        .annotate(_mes_pago_order=mes_order)
+        .order_by("-ano", "-_mes_pago_order", "-fecha_creacion", "-id")
+        .values("mes_convenio")[:1]
+    )
+    Comedor.objects.filter(programa_id=2).update(
+        mes_ejecucion=Subquery(ultimo_mes, output_field=IntegerField())
+    )
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ("comedores", "0048_comedor_mes_ejecucion"),
+        ("expedientespagos", "0002_expedientepago_total_prestaciones_and_more"),
+        ("importarexpediente", "0014_archivosimportados_periodo_pago"),
+    ]
+
+    operations = [
+        migrations.RunPython(backfill_mes_ejecucion, migrations.RunPython.noop),
+    ]

--- a/importarexpediente/services.py
+++ b/importarexpediente/services.py
@@ -611,6 +611,13 @@ def _registrar_estado(  # pylint: disable=too-many-arguments
     )
 
 
+def _actualizar_mes_ejecucion(comedor, mes_ejecucion):
+    if comedor.mes_ejecucion == mes_ejecucion:
+        return
+    Comedor.objects.filter(pk=comedor.pk).update(mes_ejecucion=mes_ejecucion)
+    comedor.mes_ejecucion = mes_ejecucion
+
+
 def aplicar_estados_por_lote(batch, usuario=None):  # pylint: disable=too-many-locals
     registros_actuales = list(
         RegistroImportado.objects.filter(
@@ -658,6 +665,7 @@ def aplicar_estados_por_lote(batch, usuario=None):  # pylint: disable=too-many-l
                 "en_plazo_renovacion",
                 usuario,
             )
+        _actualizar_mes_ejecucion(comedor, mes_convenio)
         updated_count += 1
 
     previous_batches = _new_imported_batches_before(batch)
@@ -699,6 +707,7 @@ def aplicar_estados_por_lote(batch, usuario=None):  # pylint: disable=too-many-l
                 "no_renovacion_comedor",
                 usuario,
             )
+            _actualizar_mes_ejecucion(comedor, None)
         else:
             _registrar_estado(
                 comedor,
@@ -708,6 +717,7 @@ def aplicar_estados_por_lote(batch, usuario=None):  # pylint: disable=too-many-l
                 None,
                 usuario,
             )
+            _actualizar_mes_ejecucion(comedor, -ausencias)
         updated_count += 1
 
     return updated_count

--- a/importarexpediente/tests/test_import_flow.py
+++ b/importarexpediente/tests/test_import_flow.py
@@ -894,6 +894,8 @@ def test_import_xlsx_persists_mes_convenio_and_updates_present_state(
         EN_EJECUCION,
         estados["en_plazo"].estado,
     )
+    comedor.refresh_from_db()
+    assert comedor.mes_ejecucion == 4
 
 
 def test_import_detail_displays_mes_convenio_and_totales(client_logged, tmp_media, db):
@@ -924,6 +926,8 @@ def test_import_updates_present_mes_1_to_active_execution(client_logged, tmp_med
     _upload_csv_and_import(client_logged, comedor, 1, "EX-2025-MES1")
 
     assert _estado_tuple(comedor) == (ACTIVO, EN_EJECUCION, None)
+    comedor.refresh_from_db()
+    assert comedor.mes_ejecucion == 1
     assert comedor.historial_estados.count() == 1
     assert estados["en_ejecucion"].estado == EN_EJECUCION
 
@@ -983,12 +987,18 @@ def test_import_updates_absent_active_program2_by_consecutive_batches(
 
     _upload_csv_and_import(client_logged, present, 1, "EX-2025-AUS-1")
     assert _estado_tuple(absent) == (ACTIVO, EN_PROCESO_RENOVACION, None)
+    absent.refresh_from_db()
+    assert absent.mes_ejecucion == -1
 
     _upload_csv_and_import(client_logged, present, 1, "EX-2025-AUS-2")
     assert _estado_tuple(absent) == (ACTIVO, EN_PROCESO_RENOVACION, None)
+    absent.refresh_from_db()
+    assert absent.mes_ejecucion == -2
 
     _upload_csv_and_import(client_logged, present, 1, "EX-2025-AUS-3")
     assert _estado_tuple(absent) == (INACTIVO, BAJA, NO_RENOVACION_COMEDOR)
+    absent.refresh_from_db()
+    assert absent.mes_ejecucion is None
 
 
 def test_import_absent_reactivated_active_starts_first_absence(


### PR DESCRIPTION
# Información de la Tarea
Vincular el #ISSUE
https://github.com/dsocial118/SISOC/issues/2034
### **Resumen de la Solución:**
- Se incorporó `mes_ejecucion` en `Comedor`, separado del `mes_convenio` histórico del expediente.

### **Información Adicional:**
- El valor pasa a `-1` en la primera ausencia, `-2` en la segunda y `null` desde la tercera.

# Descripción de los Cambios

### **Cambios:**
- Se actualizaron la importación, migración de datos, listado, filtros y legajo para utilizar el nuevo campo.

# Cómo Testear los Cambios

### **Pruebas Automáticas:**
- Ejecutar `pytest importarexpediente/tests/test_import_flow.py tests/test_comedor_views_unit.py -q`.

### **Pruebas Manuales:**
- Importar lotes consecutivos y verificar la transición: `1–6 → -1 → -2 → Sin información`.

# Metadata para documentación automática

- Contexto funcional: Actualización del mes de ejecución durante la renovación de comedores.
- Tipo de cambio: Corrección funcional.
- Área principal: Importación de expedientes de pago y comedores.
- Resumen para changelog: Se ajusta el mes de ejecución según ausencias consecutivas.
- Impacto usuario: El listado y legajo muestran el mes de ejecución vigente.
- Riesgos / rollback: Requiere migración; rollback mediante reversión del código y las migraciones asociadas.
# Capturas de Pantalla
