### PR TITLE
fix(inicio): corregir descentrado y footer ausente en pantalla de inicio (#2087)

### DIFF
--- a/static/custom/css/inicio.css
+++ b/static/custom/css/inicio.css
@@ -1,12 +1,5 @@
-body {
-    overflow-y:hidden;
-}
-
 body .app-main {
     background-color: white !important;
-    margin-top: 72px;
-    min-height: calc(100vh - 182px);
-    margin-left: 300px;
 }
 
 .inicio-presentacion {
@@ -47,10 +40,6 @@ body .app-main {
 }
 
 @media (max-width: 768px) {
-    body .app-main {
-        margin-left: 0;
-    }
-
     .inicio-presentacion__inet-card {
         min-height: 260px;
         padding: 1.5rem;


### PR DESCRIPTION
## Contexto

Cierra #2087. En `/inicio/` el contenido quedaba descentrado (empujado a la derecha) y el footer no se mostraba.

## Causa raíz

`static/custom/css/inicio.css` conservaba overrides obsoletos sobre `body .app-main` que peleaban con el layout de **CSS Grid** global definido en `static/custom/css/main.css` (que ya ubica `.app-main` en la columna derecha, con `padding-top: 76px` y footer full-width abajo):

- `body { overflow-y: hidden }` → recortaba el overflow y **ocultaba el footer**.
- `margin-left: 300px` → **doble offset** sobre el grid → contenido **descentrado** a la derecha.
- `margin-top: 72px` y `min-height: calc(100vh - 182px)` → conflictuaban con el `padding-top: 76px` y el `min-height` global.

## Cambio

Se eliminan esos overrides en `inicio.css` para que `/inicio/` herede el grid global como cualquier otra página. Se conserva el estilo propio de inicio: fondo blanco de `.app-main`, imagen de presentación (`.inicio-presentacion--default`) y la card/logo INET (`.inicio-presentacion--inet`, `__inet-card`, `__inet-logo`, incluido su media query).

Diff acotado a un solo archivo: **1 inserción, 12 borrados**.

## Validación

- No aplica build/tests (cambio de CSS estático).
- Verificación visual recomendada en `/inicio/` con usuario normal y con usuario de grupo CFP/INET.

🤖 Generated with [Claude Code](https://claude.com/claude-code)