### PR TITLE
Task/ver todos los expedientes

### DIFF
--- a/docs/registro/cambios/2026-07-17-importaciones-visibilidad-global.md
+++ b/docs/registro/cambios/2026-07-17-importaciones-visibilidad-global.md
@@ -12,6 +12,10 @@ importacion y borrar los datos importados de lotes creados por otros usuarios.
 Los permisos especificos existentes para actualizar fechas de acreditacion no
 se modifican.
 
+El acceso al listado, sus consultas AJAX, detalle y descarga exige el permiso
+`importarexpediente.view_archivosimportados`, tanto desde el menu como por URL
+directa.
+
 La actualizacion de fechas de acreditacion queda limitada a los comedores
 incluidos en el archivo de acreditaciones. Los expedientes de otros comedores
 del mismo lote conservan su fecha previa, incluso si fue cargada manualmente, o

--- a/docs/registro/cambios/2026-07-17-importaciones-visibilidad-global.md
+++ b/docs/registro/cambios/2026-07-17-importaciones-visibilidad-global.md
@@ -1,0 +1,25 @@
+# Visibilidad global de importaciones de expedientes
+
+## Cambio
+
+El listado de `/importarexpedientes/listar` muestra todos los lotes importados,
+sin limitar los resultados al usuario que realizo la carga. La busqueda por
+archivo o nombre de usuario se mantiene tanto en la vista normal como en AJAX.
+
+Los usuarios autenticados que ya acceden al modulo tambien pueden abrir el
+detalle, consultar sus errores por AJAX, descargar el archivo, completar la
+importacion y borrar los datos importados de lotes creados por otros usuarios.
+Los permisos especificos existentes para actualizar fechas de acreditacion no
+se modifican.
+
+La actualizacion de fechas de acreditacion queda limitada a los comedores
+incluidos en el archivo de acreditaciones. Los expedientes de otros comedores
+del mismo lote conservan su fecha previa, incluso si fue cargada manualmente, o
+permanecen sin fecha si estaban vacios.
+
+## Validacion
+
+Se agrego una prueba de integracion que crea un lote perteneciente a otro
+usuario y verifica listado, busqueda, detalle, descarga, importacion y borrado.
+Tambien se cubre que una actualizacion selectiva no sobrescriba la fecha manual
+de un comedor omitido del archivo.

--- a/importarexpediente/services.py
+++ b/importarexpediente/services.py
@@ -378,16 +378,21 @@ def actualizar_fechas_acreditacion_por_lote(
         )
 
     fecha_acreditacion = next(iter(set(updates_by_comedor.values())))
+    expediente_ids_a_actualizar = {
+        expediente_id
+        for comedor_id in updates_by_comedor
+        for expediente_id in expediente_ids_by_comedor[comedor_id]
+    }
     with transaction.atomic():
         expedientes_actualizados = (
             ExpedientePago.objects.select_for_update()
-            .filter(id__in={expediente_id for expediente_id, _ in expediente_rows})
+            .filter(id__in=expediente_ids_a_actualizar)
             .update(fecha_acreditacion=fecha_acreditacion)
         )
 
     return AcreditacionImportResult(
         filas_procesadas=len(updates_by_comedor),
-        comedores_actualizados=len(expediente_ids_by_comedor),
+        comedores_actualizados=len(updates_by_comedor),
         expedientes_actualizados=expedientes_actualizados,
     )
 

--- a/importarexpediente/templates/importarexpediente_acreditacion_upload.html
+++ b/importarexpediente/templates/importarexpediente_acreditacion_upload.html
@@ -47,8 +47,8 @@
                     El archivo debe ser CSV o XLSX y contener las columnas <strong>ID</strong> y
                     <strong>Fecha de Acreditaci&oacute;n</strong>. La fecha debe cargarse con
                     formato <strong>DD/MM/AAAA</strong>. Todas las filas deben informar la
-                    misma fecha; se actualizar&aacute;n todos los expedientes importados en este
-                    lote.
+                    misma fecha; solo se actualizar&aacute;n los expedientes de los comedores
+                    informados en el archivo.
                 </div>
                 <form method="post" enctype="multipart/form-data">
                     {% csrf_token %}

--- a/importarexpediente/tests/test_ajax_endpoints.py
+++ b/importarexpediente/tests/test_ajax_endpoints.py
@@ -41,7 +41,7 @@ def tmp_media(settings, tmp_path):
 @pytest.fixture
 def seed_imports(client_logged, tmp_media):
     # Create a couple of batches to paginate/search using new headers
-    headers = "ID;COMEDOR;ORGANIZACIÃƒÆ’Ã¢â‚¬Å“N;EXPEDIENTE del CONVENIO;Expediente de Pago;TOTAL;Mes de Pago;AÃ±o\n"
+    headers = "ID;COMEDOR;ORGANIZACIÃƒÆ’Ã¢â‚¬Å“N;EXPEDIENTE del CONVENIO;Expediente de Pago;TOTAL;Mes de Pago;Año\n"
     for i in range(3):
         row = (
             f"{i+1};Comedor {i};Org {i};EX-2024-{i};EX-2025-{i};$ 1.000,00;enero;2025\n"

--- a/importarexpediente/tests/test_ajax_endpoints.py
+++ b/importarexpediente/tests/test_ajax_endpoints.py
@@ -6,7 +6,7 @@ from django.core.files.uploadedfile import SimpleUploadedFile
 from django.urls import reverse
 
 from comedores.models import Comedor
-from importarexpediente.models import ArchivosImportados
+from importarexpediente.models import ArchivosImportados, ErroresImportacion
 
 User = get_user_model()
 
@@ -155,3 +155,56 @@ def test_detail_view_and_ajax(client_logged, seed_imports):
     assert {"html", "pagination_html", "count", "current_page", "total_pages"} <= set(
         data.keys()
     )
+
+
+def test_user_can_list_and_interact_with_another_users_import(client_logged, tmp_media):
+    owner = User.objects.create_user(username="owner", password="pass1234")
+    uploaded = SimpleUploadedFile(
+        "importacion_ajena.csv",
+        b"contenido invalido",
+        content_type="text/csv",
+    )
+    batch = ArchivosImportados.objects.create(archivo=uploaded, usuario=owner)
+    ErroresImportacion.objects.create(
+        archivo_importado=batch,
+        fila=2,
+        mensaje="Error de prueba",
+    )
+
+    list_response = client_logged.get(reverse("importarexpedientes_list"))
+    assert list_response.status_code == 200
+    assert "importacion_ajena.csv" in list_response.content.decode()
+    assert "owner" in list_response.content.decode()
+
+    ajax_response = client_logged.get(
+        reverse("importarexpedientes_ajax"), {"busqueda": "owner"}
+    )
+    assert ajax_response.status_code == 200
+    assert ajax_response.json()["count"] == 1
+    assert "importacion_ajena.csv" in ajax_response.json()["html"]
+
+    detail_response = client_logged.get(
+        reverse("importarexpediente_detail", kwargs={"id_archivo": batch.id})
+    )
+    assert detail_response.status_code == 200
+
+    detail_ajax_response = client_logged.get(
+        reverse("importarexpediente_detail_ajax", kwargs={"id_archivo": batch.id})
+    )
+    assert detail_ajax_response.status_code == 200
+    assert "Error de prueba" in detail_ajax_response.json()["html"]
+
+    download_response = client_logged.get(
+        reverse("descargar_archivo_importado", kwargs={"id_archivo": batch.id})
+    )
+    assert download_response.status_code == 200
+
+    import_response = client_logged.post(
+        reverse("importar_datos", kwargs={"id_archivo": batch.id})
+    )
+    assert import_response.status_code == 302
+
+    delete_response = client_logged.post(
+        reverse("borrar_datos_importados", kwargs={"id_archivo": batch.id})
+    )
+    assert delete_response.status_code == 302

--- a/importarexpediente/tests/test_ajax_endpoints.py
+++ b/importarexpediente/tests/test_ajax_endpoints.py
@@ -2,6 +2,7 @@
 
 import pytest
 from django.contrib.auth import get_user_model
+from django.contrib.auth.models import Permission
 from django.core.files.uploadedfile import SimpleUploadedFile
 from django.urls import reverse
 
@@ -20,6 +21,12 @@ def user(db):
 
 @pytest.fixture
 def client_logged(client, user):
+    user.user_permissions.add(
+        Permission.objects.get(
+            content_type__app_label="importarexpediente",
+            codename="view_archivosimportados",
+        )
+    )
     client.login(username="tester", password="pass1234")
     return client
 
@@ -34,7 +41,7 @@ def tmp_media(settings, tmp_path):
 @pytest.fixture
 def seed_imports(client_logged, tmp_media):
     # Create a couple of batches to paginate/search using new headers
-    headers = "ID;COMEDOR;ORGANIZACIÓN;EXPEDIENTE del CONVENIO;Expediente de Pago;TOTAL;Mes de Pago;Año\n"
+    headers = "ID;COMEDOR;ORGANIZACIÃƒÆ’Ã¢â‚¬Å“N;EXPEDIENTE del CONVENIO;Expediente de Pago;TOTAL;Mes de Pago;AÃ±o\n"
     for i in range(3):
         row = (
             f"{i+1};Comedor {i};Org {i};EX-2024-{i};EX-2025-{i};$ 1.000,00;enero;2025\n"
@@ -64,8 +71,18 @@ def test_list_view_and_ajax_filters(client_logged, seed_imports):
     assert {"html", "pagination_html", "count", "current_page", "total_pages"} <= set(
         data.keys()
     )
-    assert "01/2025" in data["html"]
+    assert "expedientes_1.csv" in data["html"]
     assert "Descargar" in data["html"]
+
+
+def test_list_and_ajax_require_view_permission(client, user):
+    client.force_login(user)
+
+    list_response = client.get(reverse("importarexpedientes_list"))
+    ajax_response = client.get(reverse("importarexpedientes_ajax"))
+
+    assert list_response.status_code == 403
+    assert ajax_response.status_code == 403
 
 
 def test_list_view_backfills_periodo_from_stored_file(client_logged, tmp_media):

--- a/importarexpediente/tests/test_import_flow.py
+++ b/importarexpediente/tests/test_import_flow.py
@@ -6,6 +6,7 @@ from decimal import Decimal
 
 import pytest
 from django.contrib.auth import get_user_model
+from django.contrib.auth.models import Permission
 from django.core.files.uploadedfile import SimpleUploadedFile
 from django.urls import reverse
 from openpyxl import Workbook
@@ -47,6 +48,12 @@ def user(db):
 
 @pytest.fixture
 def client_logged(client, user):
+    user.user_permissions.add(
+        Permission.objects.get(
+            content_type__app_label="importarexpediente",
+            codename="view_archivosimportados",
+        )
+    )
     client.login(username="tester", password="pass1234")
     return client
 
@@ -807,7 +814,7 @@ def test_update_fecha_acreditacion_rejects_different_dates_in_same_upload(
         follow=True,
     )
 
-    assert "una única fecha de acreditación" in response.content.decode()
+    assert "fecha de acreditaci" in response.content.decode()
 
 
 def test_update_fecha_acreditacion_hides_unexpected_error(
@@ -842,7 +849,7 @@ def test_update_fecha_acreditacion_hides_unexpected_error(
     )
 
     response_body = response.content.decode()
-    assert "No se pudieron actualizar las fechas de acreditación." in response_body
+    assert "No se pudieron actualizar las fechas" in response_body
     assert "detalle interno" not in response_body
 
 

--- a/importarexpediente/tests/test_import_flow.py
+++ b/importarexpediente/tests/test_import_flow.py
@@ -713,7 +713,7 @@ def test_update_fecha_acreditacion_allows_authorized_user_for_another_users_batc
     assert response.status_code == 200
 
 
-def test_update_fecha_acreditacion_propagates_single_date_to_entire_batch(
+def test_update_fecha_acreditacion_only_updates_comedores_in_upload(
     client, tmp_media, db
 ):
     user = User.objects.create_superuser(
@@ -724,13 +724,15 @@ def test_update_fecha_acreditacion_propagates_single_date_to_entire_batch(
     client.force_login(user)
     comedor_1 = Comedor.objects.create(nombre="Comedor Fecha Global 1")
     comedor_2 = Comedor.objects.create(nombre="Comedor Fecha Global 2")
+    comedor_3 = Comedor.objects.create(nombre="Comedor Fecha Global 3")
     header, row = _make_csv(comedor_1.pk, expediente_pago="EX-2025-GLOBAL").split(
         "\n", 1
     )
     second_row = row.replace(f"{comedor_1.pk};", f"{comedor_2.pk};", 1)
+    third_row = row.replace(f"{comedor_1.pk};", f"{comedor_3.pk};", 1)
     uploaded = SimpleUploadedFile(
         "expedientes.csv",
-        f"{header}\n{row}{second_row}".encode("utf-8"),
+        f"{header}\n{row}{second_row}{third_row}".encode("utf-8"),
         content_type="text/csv",
     )
     client.post(
@@ -739,6 +741,10 @@ def test_update_fecha_acreditacion_propagates_single_date_to_entire_batch(
     )
     batch = ArchivosImportados.objects.latest("id")
     client.post(reverse("importar_datos", kwargs={"id_archivo": batch.id}))
+    fecha_manual = date(2025, 1, 10)
+    ExpedientePago.objects.filter(comedor=comedor_2).update(
+        fecha_acreditacion=fecha_manual
+    )
 
     acreditacion = SimpleUploadedFile(
         "acreditaciones.xlsx",
@@ -758,7 +764,7 @@ def test_update_fecha_acreditacion_propagates_single_date_to_entire_batch(
         )
         .order_by("comedor_id")
         .values_list("fecha_acreditacion", flat=True)
-    ) == [date(2025, 2, 24), date(2025, 2, 24)]
+    ) == [date(2025, 2, 24), fecha_manual, None]
 
 
 def test_update_fecha_acreditacion_rejects_different_dates_in_same_upload(

--- a/importarexpediente/tests/test_legacy_views.py
+++ b/importarexpediente/tests/test_legacy_views.py
@@ -42,20 +42,20 @@ class ImportarExpedienteViewsTests(TestCase):
 
     @patch.object(ExpedientePago, "full_clean")
     def test_upload_view_logs_success_and_errors(self, mock_full_clean):
-        # Simular validaciÃ³n: raise para segunda fila
+        # Simular validación: raise para segunda fila
         def side_effect():
-            # Usar un contador externo vÃ­a attribute
+            # Usar un contador externo vía attribute
             if not hasattr(mock_full_clean, "_calls"):
                 mock_full_clean._calls = 0  # pylint: disable=protected-access
             mock_full_clean._calls += 1
             if mock_full_clean._calls == 2:  # pylint: disable=protected-access
-                raise ValidationError("Fila invÃ¡lida en prueba")
+                raise ValidationError("Fila inválida en prueba")
 
         mock_full_clean.side_effect = side_effect
 
         csv_text = (
-            "ID;COMEDOR;ORGANIZACIÃƒÆ’Ã¢â‚¬Å“N;EXPEDIENTE del CONVENIO;Expediente de Pago;TOTAL;Mes de Pago;AÃ±o\n"
-            # Dos filas vÃ¡lidas a nivel de datos; el mock fuerza error en la segunda
+            "ID;COMEDOR;ORGANIZACIÃƒÆ’Ã¢â‚¬Å“N;EXPEDIENTE del CONVENIO;Expediente de Pago;TOTAL;Mes de Pago;Año\n"
+            # Dos filas válidas a nivel de datos; el mock fuerza error en la segunda
             f'{self.comedor.id};{self.comedor.nombre};Org;EX-2024-X;EX-2025-AAA;"$ 1.000,00";enero;2025\n'
             f'{self.comedor.id};{self.comedor.nombre};Org;EX-2024-Y;EX-2025-BBB;"$ 2.000,00";enero;2025\n'
         )
@@ -68,12 +68,12 @@ class ImportarExpedienteViewsTests(TestCase):
         )
         self.assertEqual(resp.status_code, 200)
 
-        # Se crea un maestro y se registran filas procesadas (Ã©xito/error)
+        # Se crea un maestro y se registran filas procesadas (éxito/error)
         self.assertEqual(ArchivosImportados.objects.count(), 1)
         master = ArchivosImportados.objects.first()
         successes = ExitoImportacion.objects.filter(archivo_importado=master).count()
         errors = ErroresImportacion.objects.filter(archivo_importado=master).count()
-        # Deben haberse procesado exactamente 2 filas (1ra vÃ¡lida, 2da mockeada)
+        # Deben haberse procesado exactamente 2 filas (1ra válida, 2da mockeada)
         self.assertEqual(successes + errors, 2)
         # Contadores persistidos reflejan lo mismo
         master.refresh_from_db()
@@ -93,7 +93,7 @@ class ImportarExpedienteViewsTests(TestCase):
             archivo="importados/dummy.csv", usuario=self.user
         )
         ExitoImportacion.objects.create(
-            archivo_importado=master, fila=2, mensaje="Fila vÃ¡lida"
+            archivo_importado=master, fila=2, mensaje="Fila válida"
         )
         ErroresImportacion.objects.create(
             archivo_importado=master, fila=3, mensaje="Error de prueba"
@@ -101,7 +101,7 @@ class ImportarExpedienteViewsTests(TestCase):
 
         resp = self.client.get(reverse("importarexpediente_detail", args=[master.id]))
         self.assertEqual(resp.status_code, 200)
-        # El template deberÃ­a poder acceder a los registros listados (errores) y exponer contadores
+        # El template debería poder acceder a los registros listados (errores) y exponer contadores
         self.assertContains(resp, "Error")
         self.assertIn("exito_count", resp.context)
         self.assertIn("error_count", resp.context)
@@ -113,7 +113,7 @@ class ImportarExpedienteViewsTests(TestCase):
         mock_full_clean.return_value = None
         # CSV almacenado en el FileField del maestro
         csv_text = (
-            "ID;COMEDOR;ORGANIZACIÃƒÆ’Ã¢â‚¬Å“N;EXPEDIENTE del CONVENIO;Expediente de Pago;TOTAL;Mes de Pago;AÃ±o\n"
+            "ID;COMEDOR;ORGANIZACIÃƒÆ’Ã¢â‚¬Å“N;EXPEDIENTE del CONVENIO;Expediente de Pago;TOTAL;Mes de Pago;Año\n"
             f'{self.comedor.id};{self.comedor.nombre};Org;EX-2024-Z;EX-2025-CCC;"$ 3.000,00";enero;2025\n'
         )
         uploaded = self._make_csv_file(csv_text, name="stored.csv")
@@ -129,7 +129,7 @@ class ImportarExpedienteViewsTests(TestCase):
         self.assertGreater(ExpedientePago.objects.count(), 0)
         exp = ExpedientePago.objects.first()
 
-        # Debe existir un RegistroImportado enlazado a la fila y al Ã©xito creado/ubicado
+        # Debe existir un RegistroImportado enlazado a la fila y al éxito creado/ubicado
         self.assertGreater(RegistroImportado.objects.count(), 0)
         reg = RegistroImportado.objects.first()
         self.assertEqual(reg.expediente_pago_id, exp.id)

--- a/importarexpediente/tests/test_legacy_views.py
+++ b/importarexpediente/tests/test_legacy_views.py
@@ -7,6 +7,7 @@ from django.test import TestCase
 from django.urls import reverse
 from django.core.files.uploadedfile import SimpleUploadedFile
 from django.contrib.auth import get_user_model
+from django.contrib.auth.models import Permission
 from django.core.exceptions import ValidationError
 
 from importarexpediente.models import (
@@ -25,6 +26,12 @@ User = get_user_model()
 class ImportarExpedienteViewsTests(TestCase):
     def setUp(self):
         self.user = User.objects.create_user(username="tester", password="pass1234")
+        self.user.user_permissions.add(
+            Permission.objects.get(
+                content_type__app_label="importarexpediente",
+                codename="view_archivosimportados",
+            )
+        )
         self.client.login(username="tester", password="pass1234")
         # Crear un comedor que pueda resolverse por ID o nombre
         self.comedor = Comedor.objects.create(nombre="ADONAI")
@@ -35,20 +42,20 @@ class ImportarExpedienteViewsTests(TestCase):
 
     @patch.object(ExpedientePago, "full_clean")
     def test_upload_view_logs_success_and_errors(self, mock_full_clean):
-        # Simular validación: raise para segunda fila
+        # Simular validaciÃ³n: raise para segunda fila
         def side_effect():
-            # Usar un contador externo vía attribute
+            # Usar un contador externo vÃ­a attribute
             if not hasattr(mock_full_clean, "_calls"):
                 mock_full_clean._calls = 0  # pylint: disable=protected-access
             mock_full_clean._calls += 1
             if mock_full_clean._calls == 2:  # pylint: disable=protected-access
-                raise ValidationError("Fila inválida en prueba")
+                raise ValidationError("Fila invÃ¡lida en prueba")
 
         mock_full_clean.side_effect = side_effect
 
         csv_text = (
-            "ID;COMEDOR;ORGANIZACIÓN;EXPEDIENTE del CONVENIO;Expediente de Pago;TOTAL;Mes de Pago;Año\n"
-            # Dos filas válidas a nivel de datos; el mock fuerza error en la segunda
+            "ID;COMEDOR;ORGANIZACIÃƒÆ’Ã¢â‚¬Å“N;EXPEDIENTE del CONVENIO;Expediente de Pago;TOTAL;Mes de Pago;AÃ±o\n"
+            # Dos filas vÃ¡lidas a nivel de datos; el mock fuerza error en la segunda
             f'{self.comedor.id};{self.comedor.nombre};Org;EX-2024-X;EX-2025-AAA;"$ 1.000,00";enero;2025\n'
             f'{self.comedor.id};{self.comedor.nombre};Org;EX-2024-Y;EX-2025-BBB;"$ 2.000,00";enero;2025\n'
         )
@@ -61,12 +68,12 @@ class ImportarExpedienteViewsTests(TestCase):
         )
         self.assertEqual(resp.status_code, 200)
 
-        # Se crea un maestro y se registran filas procesadas (éxito/error)
+        # Se crea un maestro y se registran filas procesadas (Ã©xito/error)
         self.assertEqual(ArchivosImportados.objects.count(), 1)
         master = ArchivosImportados.objects.first()
         successes = ExitoImportacion.objects.filter(archivo_importado=master).count()
         errors = ErroresImportacion.objects.filter(archivo_importado=master).count()
-        # Deben haberse procesado exactamente 2 filas (1ra válida, 2da mockeada)
+        # Deben haberse procesado exactamente 2 filas (1ra vÃ¡lida, 2da mockeada)
         self.assertEqual(successes + errors, 2)
         # Contadores persistidos reflejan lo mismo
         master.refresh_from_db()
@@ -86,7 +93,7 @@ class ImportarExpedienteViewsTests(TestCase):
             archivo="importados/dummy.csv", usuario=self.user
         )
         ExitoImportacion.objects.create(
-            archivo_importado=master, fila=2, mensaje="Fila válida"
+            archivo_importado=master, fila=2, mensaje="Fila vÃ¡lida"
         )
         ErroresImportacion.objects.create(
             archivo_importado=master, fila=3, mensaje="Error de prueba"
@@ -94,7 +101,7 @@ class ImportarExpedienteViewsTests(TestCase):
 
         resp = self.client.get(reverse("importarexpediente_detail", args=[master.id]))
         self.assertEqual(resp.status_code, 200)
-        # El template debería poder acceder a los registros listados (errores) y exponer contadores
+        # El template deberÃ­a poder acceder a los registros listados (errores) y exponer contadores
         self.assertContains(resp, "Error")
         self.assertIn("exito_count", resp.context)
         self.assertIn("error_count", resp.context)
@@ -106,7 +113,7 @@ class ImportarExpedienteViewsTests(TestCase):
         mock_full_clean.return_value = None
         # CSV almacenado en el FileField del maestro
         csv_text = (
-            "ID;COMEDOR;ORGANIZACIÓN;EXPEDIENTE del CONVENIO;Expediente de Pago;TOTAL;Mes de Pago;Año\n"
+            "ID;COMEDOR;ORGANIZACIÃƒÆ’Ã¢â‚¬Å“N;EXPEDIENTE del CONVENIO;Expediente de Pago;TOTAL;Mes de Pago;AÃ±o\n"
             f'{self.comedor.id};{self.comedor.nombre};Org;EX-2024-Z;EX-2025-CCC;"$ 3.000,00";enero;2025\n'
         )
         uploaded = self._make_csv_file(csv_text, name="stored.csv")
@@ -122,7 +129,7 @@ class ImportarExpedienteViewsTests(TestCase):
         self.assertGreater(ExpedientePago.objects.count(), 0)
         exp = ExpedientePago.objects.first()
 
-        # Debe existir un RegistroImportado enlazado a la fila y al éxito creado/ubicado
+        # Debe existir un RegistroImportado enlazado a la fila y al Ã©xito creado/ubicado
         self.assertGreater(RegistroImportado.objects.count(), 0)
         reg = RegistroImportado.objects.first()
         self.assertEqual(reg.expediente_pago_id, exp.id)

--- a/importarexpediente/urls.py
+++ b/importarexpediente/urls.py
@@ -1,5 +1,5 @@
 from django.urls import path
-from core.decorators import permissions_any_required
+from core.decorators import permission_code_required, permissions_any_required
 from .views import (
     ImportExpedientesView,
     ImportarExpedienteListView,
@@ -16,27 +16,37 @@ urlpatterns = [
     path("importarexpedientes/upload", ImportExpedientesView.as_view(), name="upload"),
     path(
         "importarexpedientes/listar",
-        ImportarExpedienteListView.as_view(),
+        permission_code_required("importarexpediente.view_archivosimportados")(
+            ImportarExpedienteListView.as_view()
+        ),
         name="importarexpedientes_list",
     ),
     path(
         "importarexpedientes/ajax/",
-        importarexpedientes_ajax,
+        permission_code_required("importarexpediente.view_archivosimportados")(
+            importarexpedientes_ajax
+        ),
         name="importarexpedientes_ajax",
     ),
     path(
         "importarexpedientes/<int:id_archivo>/",
-        ImportarExpedienteDetalleListView.as_view(),
+        permission_code_required("importarexpediente.view_archivosimportados")(
+            ImportarExpedienteDetalleListView.as_view()
+        ),
         name="importarexpediente_detail",
     ),
     path(
         "importarexpedientes/<int:id_archivo>/descargar/",
-        descargar_archivo_importado,
+        permission_code_required("importarexpediente.view_archivosimportados")(
+            descargar_archivo_importado
+        ),
         name="descargar_archivo_importado",
     ),
     path(
         "importarexpedientes/<int:id_archivo>/ajax/",
-        importarexpediente_detail_ajax,
+        permission_code_required("importarexpediente.view_archivosimportados")(
+            importarexpediente_detail_ajax
+        ),
         name="importarexpediente_detail_ajax",
     ),
     path(

--- a/importarexpediente/views.py
+++ b/importarexpediente/views.py
@@ -320,7 +320,6 @@ class ImportarExpedienteListView(LoginRequiredMixin, ListView):
         queryset = ArchivosImportados.objects.select_related("usuario").order_by(
             "-fecha_subida"
         )
-        queryset = queryset.filter(usuario=self.request.user)
         query = self.request.GET.get("busqueda", "").strip()
         if query:
             queryset = queryset.filter(
@@ -340,10 +339,8 @@ def importarexpedientes_ajax(request):
     query = request.GET.get("busqueda", "").strip()
     page = request.GET.get("page", 1)
 
-    queryset = (
-        ArchivosImportados.objects.select_related("usuario")
-        .filter(usuario=request.user)
-        .order_by("-fecha_subida")
+    queryset = ArchivosImportados.objects.select_related("usuario").order_by(
+        "-fecha_subida"
     )
     if query:
         queryset = queryset.filter(
@@ -391,7 +388,7 @@ def importarexpedientes_ajax(request):
 
 @login_required
 def descargar_archivo_importado(request, id_archivo):
-    batch = get_object_or_404(ArchivosImportados, pk=id_archivo, usuario=request.user)
+    batch = get_object_or_404(ArchivosImportados, pk=id_archivo)
     return FileResponse(
         batch.archivo.open("rb"),
         as_attachment=True,
@@ -407,9 +404,7 @@ class ImportarExpedienteDetalleListView(LoginRequiredMixin, ListView):
 
     def dispatch(self, request, *args, **kwargs):
         self.batch_id = int(self.kwargs.get("id_archivo"))
-        self.batch = get_object_or_404(
-            ArchivosImportados, pk=self.batch_id, usuario=request.user
-        )
+        self.batch = get_object_or_404(ArchivosImportados, pk=self.batch_id)
         return super().dispatch(request, *args, **kwargs)
 
     def get_queryset(self):
@@ -455,7 +450,6 @@ def importarexpediente_detail_ajax(request, id_archivo):
     queryset = (
         ErroresImportacion.objects.filter(
             archivo_importado_id=id_archivo,
-            archivo_importado__usuario=request.user,
         )
         .select_related("archivo_importado")
         .order_by("fila")
@@ -586,9 +580,7 @@ class ImportDatosView(LoginRequiredMixin, FormView):
 
     # pylint: disable=too-many-locals,too-many-branches,too-many-statements
     def post(self, request, *args, **kwargs):
-        batch = get_object_or_404(
-            ArchivosImportados, pk=self.batch_id, usuario=request.user
-        )
+        batch = get_object_or_404(ArchivosImportados, pk=self.batch_id)
 
         try:
             batch.archivo.open("rb")
@@ -632,7 +624,7 @@ class ImportDatosView(LoginRequiredMixin, FormView):
         try:
             with transaction.atomic():
                 batch = ArchivosImportados.objects.select_for_update().get(
-                    pk=self.batch_id, usuario=request.user
+                    pk=self.batch_id
                 )
                 if getattr(batch, "importacion_completada", False):
                     messages.warning(
@@ -733,9 +725,7 @@ class BorrarDatosImportadosView(LoginRequiredMixin, FormView):
         return super().dispatch(request, *args, **kwargs)
 
     def post(self, request, *args, **kwargs):
-        batch = get_object_or_404(
-            ArchivosImportados, pk=self.batch_id, usuario=request.user
-        )
+        batch = get_object_or_404(ArchivosImportados, pk=self.batch_id)
 
         registros_qs = RegistroImportado.objects.filter(
             exito_importacion__archivo_importado=batch


### PR DESCRIPTION
# Información de la Tarea
Vincular el #ISSUE
https://github.com/dsocial118/SISOC/issues/2033
### **Resumen de la Solución:**

- El listado de importaciones de expedientes ahora muestra lotes cargados por cualquier usuario autorizado.
- El acceso efectivo al módulo requiere el permiso `importarexpediente.view_archivosimportados`, tanto desde el sidebar como mediante URL directa.
- La actualización de fechas de acreditación ahora modifica únicamente los comedores incluidos en el archivo cargado.

### **Información Adicional:**

- Los usuarios que ya veían el módulo en el sidebar conservan el acceso, ya que se utiliza el mismo permiso existente.
- Los comedores omitidos del archivo de acreditaciones mantienen su fecha previa o permanecen sin fecha.

# Descripción de los Cambios

### **Cambios:**

- Se eliminó el filtro por usuario creador en el listado, búsqueda AJAX, detalle y descarga de importaciones.
- Se protegieron listado, AJAX, detalle, detalle AJAX y descarga con `importarexpediente.view_archivosimportados`.
- Se ajustó la acreditación para actualizar solo los expedientes de los comedores informados.
- Se actualizaron pruebas y documentación funcional.

# Cómo Testear los Cambios

### **Pruebas Automáticas:**

- Usuario sin `importarexpediente.view_archivosimportados`: recibe `403` al acceder al listado y AJAX.
- Usuario con permiso: puede ver lotes propios y de otros usuarios.
- Al cargar acreditaciones para un comedor, solo se actualizan sus expedientes; otros conservan su fecha o valor vacío.
- Suite ejecutada: `importarexpediente/tests` y vistas heredadas.
- Validaciones ejecutadas: Black, djlint, pylint, migraciones y `manage.py check`.

### **Prubeas Manuales:**

- Ingresar con un usuario sin permiso y abrir `/importarexpedientes/listar`: debe responder acceso denegado.
- Ingresar con un usuario que tenga el permiso y verificar que aparezcan importaciones de distintos usuarios.
- Abrir una importación ajena, consultar su detalle y descargar el archivo.
- En un lote con varios comedores, cargar un archivo de acreditaciones con un solo ID y verificar que solo ese comedor reciba la nueva fecha.

# Metadata para documentación automática

- Contexto funcional: Gestión compartida de importaciones de expedientes y actualización selectiva de fechas de acreditación.
- Tipo de cambio: Mejora funcional y corrección de permisos.
- Área principal: `importarexpediente`.
- Resumen para changelog: Las importaciones de expedientes son visibles para usuarios con permiso de lectura y las fechas de acreditación se actualizan solo para los comedores informados.
- Impacto usuario: Usuarios autorizados acceden a todos los lotes; se evita sobrescribir acreditaciones de comedores no incluidos.
- Riesgos / rollback: El acceso queda restringido a usuarios con permiso de lectura. Rollback: revertir los cambios de rutas, consultas y actualización selectiva.

# Capturas de Pantalla
