### PR TITLE
fix(layout): evitar solapamiento del sidebar con el footer

### DIFF
--- a/static/custom/css/main.css
+++ b/static/custom/css/main.css
@@ -114,6 +114,7 @@ header.main-header {
     .sidebar-expand-lg.layout-fixed .app-sidebar {
         position: sticky;
         top: 76px !important;
+        bottom: auto;
         align-self: start;
         max-height: calc(100vh - 76px);
     }


### PR DESCRIPTION
## Qué cambia

Restablece `bottom: auto` para el sidebar desktop con `position: sticky`.

## Causa raíz

El sidebar heredaba `bottom: 0` de AdminLTE. Junto con `top: 76px` y `position: sticky`, esa restricción lo extendía sobre la fila del footer. En development se verificó una superposición de aproximadamente 6px.

## Validación

- Verificación en development de estilos computados y geometría de sidebar/footer.
- Comprobación estructural de la regla CSS modificada.
- `git diff --check`.

No se ejecutaron tests automatizados: es un ajuste CSS aislado sin suite de layout de navegador.