### PR TITLE
fix(layout): priorizar footer sobre sidebar

### DIFF
--- a/static/custom/css/main.css
+++ b/static/custom/css/main.css
@@ -14,7 +14,7 @@ footer.app-footer {
     border-top: 15px solid #e7ba61 !important;
     color: #ffffff !important;
     margin-top: auto;
-    z-index: 20;
+    z-index: 1041; /* Por encima del sidebar si ambas áreas llegan a tocarse. */
     display: flex;
 }
 


### PR DESCRIPTION
## Qué cambia

Eleva el `z-index` del footer a `1041`, un nivel por encima del sidebar (`1040`).

## Causa raíz

En ciertos tamaños de viewport, el sidebar y la franja superior del footer se llegan a tocar. Como el sidebar se pintaba por encima, ocultaba los primeros píxeles de la franja amarilla y daba la impresión de que el menú invadía el footer.

## Validación

- Análisis de la captura: la franja amarilla comienza 5px más abajo bajo el sidebar que en el resto de la pantalla.
- Verificación del orden de capas CSS: footer `1041`, sidebar `1040`, header `1050`, modales `3050+`.
- `git diff --check`.

No se ejecutaron tests automatizados: es un ajuste CSS aislado sin suite de layout de navegador.