### PR TITLE
feat(core): incorporar municipios y localidades faltantes desde BAHRA

### DIFF
--- a/core/fixtures/localidad_municipio_provincia.json
+++ b/core/fixtures/localidad_municipio_provincia.json
@@ -88782,5 +88782,52317 @@
       "nombre": "La Puerta",
       "municipio": 2273
     }
+  },
+  {
+    "model": "core.municipio",
+    "pk": 100000,
+    "fields": {
+      "nombre": "La Paz",
+      "provincia": 3
+    }
+  },
+  {
+    "model": "core.municipio",
+    "pk": 100001,
+    "fields": {
+      "nombre": "Avellaneda",
+      "provincia": 4
+    }
+  },
+  {
+    "model": "core.municipio",
+    "pk": 100002,
+    "fields": {
+      "nombre": "Colón",
+      "provincia": 4
+    }
+  },
+  {
+    "model": "core.municipio",
+    "pk": 100003,
+    "fields": {
+      "nombre": "El Rodeo",
+      "provincia": 4
+    }
+  },
+  {
+    "model": "core.municipio",
+    "pk": 100004,
+    "fields": {
+      "nombre": "General San Martín",
+      "provincia": 4
+    }
+  },
+  {
+    "model": "core.municipio",
+    "pk": 100005,
+    "fields": {
+      "nombre": "La Paz",
+      "provincia": 4
+    }
+  },
+  {
+    "model": "core.municipio",
+    "pk": 100006,
+    "fields": {
+      "nombre": "Malvinas Argentinas",
+      "provincia": 4
+    }
+  },
+  {
+    "model": "core.municipio",
+    "pk": 100007,
+    "fields": {
+      "nombre": "Pilar",
+      "provincia": 4
+    }
+  },
+  {
+    "model": "core.municipio",
+    "pk": 100008,
+    "fields": {
+      "nombre": "Saladillo",
+      "provincia": 4
+    }
+  },
+  {
+    "model": "core.municipio",
+    "pk": 100009,
+    "fields": {
+      "nombre": "San José",
+      "provincia": 4
+    }
+  },
+  {
+    "model": "core.municipio",
+    "pk": 100010,
+    "fields": {
+      "nombre": "San Vicente",
+      "provincia": 4
+    }
+  },
+  {
+    "model": "core.municipio",
+    "pk": 100011,
+    "fields": {
+      "nombre": "Santa María",
+      "provincia": 4
+    }
+  },
+  {
+    "model": "core.municipio",
+    "pk": 100012,
+    "fields": {
+      "nombre": "9 de Julio",
+      "provincia": 5
+    }
+  },
+  {
+    "model": "core.municipio",
+    "pk": 100013,
+    "fields": {
+      "nombre": "Lavalle",
+      "provincia": 5
+    }
+  },
+  {
+    "model": "core.municipio",
+    "pk": 100014,
+    "fields": {
+      "nombre": "San Isidro",
+      "provincia": 5
+    }
+  },
+  {
+    "model": "core.municipio",
+    "pk": 100015,
+    "fields": {
+      "nombre": "San Lorenzo",
+      "provincia": 5
+    }
+  },
+  {
+    "model": "core.municipio",
+    "pk": 100016,
+    "fields": {
+      "nombre": "San Roque",
+      "provincia": 5
+    }
+  },
+  {
+    "model": "core.municipio",
+    "pk": 100017,
+    "fields": {
+      "nombre": "Las Palmas",
+      "provincia": 6
+    }
+  },
+  {
+    "model": "core.municipio",
+    "pk": 100018,
+    "fields": {
+      "nombre": "San Fernando",
+      "provincia": 6
+    }
+  },
+  {
+    "model": "core.municipio",
+    "pk": 100019,
+    "fields": {
+      "nombre": "Florentino Ameghino",
+      "provincia": 7
+    }
+  },
+  {
+    "model": "core.municipio",
+    "pk": 100020,
+    "fields": {
+      "nombre": "Mártires",
+      "provincia": 7
+    }
+  },
+  {
+    "model": "core.municipio",
+    "pk": 100021,
+    "fields": {
+      "nombre": "Aldea Santa María",
+      "provincia": 8
+    }
+  },
+  {
+    "model": "core.municipio",
+    "pk": 100022,
+    "fields": {
+      "nombre": "General Alvear",
+      "provincia": 8
+    }
+  },
+  {
+    "model": "core.municipio",
+    "pk": 100023,
+    "fields": {
+      "nombre": "General Roca",
+      "provincia": 8
+    }
+  },
+  {
+    "model": "core.municipio",
+    "pk": 100024,
+    "fields": {
+      "nombre": "La Paz",
+      "provincia": 8
+    }
+  },
+  {
+    "model": "core.municipio",
+    "pk": 100025,
+    "fields": {
+      "nombre": "San José",
+      "provincia": 8
+    }
+  },
+  {
+    "model": "core.municipio",
+    "pk": 100026,
+    "fields": {
+      "nombre": "San Justo",
+      "provincia": 8
+    }
+  },
+  {
+    "model": "core.municipio",
+    "pk": 100027,
+    "fields": {
+      "nombre": "San Miguel",
+      "provincia": 8
+    }
+  },
+  {
+    "model": "core.municipio",
+    "pk": 100028,
+    "fields": {
+      "nombre": "San Pedro",
+      "provincia": 8
+    }
+  },
+  {
+    "model": "core.municipio",
+    "pk": 100029,
+    "fields": {
+      "nombre": "San Roque",
+      "provincia": 8
+    }
+  },
+  {
+    "model": "core.municipio",
+    "pk": 100030,
+    "fields": {
+      "nombre": "Santa Elena",
+      "provincia": 8
+    }
+  },
+  {
+    "model": "core.municipio",
+    "pk": 100031,
+    "fields": {
+      "nombre": "Santa Lucía",
+      "provincia": 8
+    }
+  },
+  {
+    "model": "core.municipio",
+    "pk": 100032,
+    "fields": {
+      "nombre": "Villa Fontana",
+      "provincia": 8
+    }
+  },
+  {
+    "model": "core.municipio",
+    "pk": 100033,
+    "fields": {
+      "nombre": "Bermejo",
+      "provincia": 9
+    }
+  },
+  {
+    "model": "core.municipio",
+    "pk": 100034,
+    "fields": {
+      "nombre": "General Manuel Belgrano",
+      "provincia": 9
+    }
+  },
+  {
+    "model": "core.municipio",
+    "pk": 100035,
+    "fields": {
+      "nombre": "San Francisco",
+      "provincia": 10
+    }
+  },
+  {
+    "model": "core.municipio",
+    "pk": 100036,
+    "fields": {
+      "nombre": "Santa Ana",
+      "provincia": 10
+    }
+  },
+  {
+    "model": "core.municipio",
+    "pk": 100037,
+    "fields": {
+      "nombre": "General Campos",
+      "provincia": 11
+    }
+  },
+  {
+    "model": "core.municipio",
+    "pk": 100038,
+    "fields": {
+      "nombre": "General San Martín",
+      "provincia": 11
+    }
+  },
+  {
+    "model": "core.municipio",
+    "pk": 100039,
+    "fields": {
+      "nombre": "General Belgrano",
+      "provincia": 12
+    }
+  },
+  {
+    "model": "core.municipio",
+    "pk": 100040,
+    "fields": {
+      "nombre": "Santa Rosa",
+      "provincia": 13
+    }
+  },
+  {
+    "model": "core.municipio",
+    "pk": 100041,
+    "fields": {
+      "nombre": "9 de Julio",
+      "provincia": 14
+    }
+  },
+  {
+    "model": "core.municipio",
+    "pk": 100042,
+    "fields": {
+      "nombre": "Almafuerte",
+      "provincia": 14
+    }
+  },
+  {
+    "model": "core.municipio",
+    "pk": 100043,
+    "fields": {
+      "nombre": "Arroyo del Medio",
+      "provincia": 14
+    }
+  },
+  {
+    "model": "core.municipio",
+    "pk": 100044,
+    "fields": {
+      "nombre": "Bonpland",
+      "provincia": 14
+    }
+  },
+  {
+    "model": "core.municipio",
+    "pk": 100045,
+    "fields": {
+      "nombre": "General Alvear",
+      "provincia": 14
+    }
+  },
+  {
+    "model": "core.municipio",
+    "pk": 100046,
+    "fields": {
+      "nombre": "Loreto",
+      "provincia": 14
+    }
+  },
+  {
+    "model": "core.municipio",
+    "pk": 100047,
+    "fields": {
+      "nombre": "San Martín",
+      "provincia": 14
+    }
+  },
+  {
+    "model": "core.municipio",
+    "pk": 100048,
+    "fields": {
+      "nombre": "Santa María",
+      "provincia": 14
+    }
+  },
+  {
+    "model": "core.municipio",
+    "pk": 100049,
+    "fields": {
+      "nombre": "Minas",
+      "provincia": 15
+    }
+  },
+  {
+    "model": "core.municipio",
+    "pk": 100050,
+    "fields": {
+      "nombre": "25 de Mayo",
+      "provincia": 16
+    }
+  },
+  {
+    "model": "core.municipio",
+    "pk": 100051,
+    "fields": {
+      "nombre": "9 de Julio",
+      "provincia": 16
+    }
+  },
+  {
+    "model": "core.municipio",
+    "pk": 100052,
+    "fields": {
+      "nombre": "Adolfo Alsina",
+      "provincia": 16
+    }
+  },
+  {
+    "model": "core.municipio",
+    "pk": 100053,
+    "fields": {
+      "nombre": "Avellaneda",
+      "provincia": 16
+    }
+  },
+  {
+    "model": "core.municipio",
+    "pk": 100054,
+    "fields": {
+      "nombre": "Campo Grande",
+      "provincia": 16
+    }
+  },
+  {
+    "model": "core.municipio",
+    "pk": 100055,
+    "fields": {
+      "nombre": "San Antonio",
+      "provincia": 16
+    }
+  },
+  {
+    "model": "core.municipio",
+    "pk": 100056,
+    "fields": {
+      "nombre": "Rivadavia",
+      "provincia": 18
+    }
+  },
+  {
+    "model": "core.municipio",
+    "pk": 100057,
+    "fields": {
+      "nombre": "San Martín",
+      "provincia": 18
+    }
+  },
+  {
+    "model": "core.municipio",
+    "pk": 100058,
+    "fields": {
+      "nombre": "Ayacucho",
+      "provincia": 19
+    }
+  },
+  {
+    "model": "core.municipio",
+    "pk": 100059,
+    "fields": {
+      "nombre": "Chacabuco",
+      "provincia": 19
+    }
+  },
+  {
+    "model": "core.municipio",
+    "pk": 100060,
+    "fields": {
+      "nombre": "Coronel Pringles",
+      "provincia": 19
+    }
+  },
+  {
+    "model": "core.municipio",
+    "pk": 100061,
+    "fields": {
+      "nombre": "Estancia Grande",
+      "provincia": 19
+    }
+  },
+  {
+    "model": "core.municipio",
+    "pk": 100062,
+    "fields": {
+      "nombre": "Junín",
+      "provincia": 19
+    }
+  },
+  {
+    "model": "core.municipio",
+    "pk": 100063,
+    "fields": {
+      "nombre": "La Calera",
+      "provincia": 19
+    }
+  },
+  {
+    "model": "core.municipio",
+    "pk": 100064,
+    "fields": {
+      "nombre": "Leandro N. Alem",
+      "provincia": 19
+    }
+  },
+  {
+    "model": "core.municipio",
+    "pk": 100065,
+    "fields": {
+      "nombre": "Libertador General San Martín",
+      "provincia": 19
+    }
+  },
+  {
+    "model": "core.municipio",
+    "pk": 100066,
+    "fields": {
+      "nombre": "Saladillo",
+      "provincia": 19
+    }
+  },
+  {
+    "model": "core.municipio",
+    "pk": 100067,
+    "fields": {
+      "nombre": "San Francisco",
+      "provincia": 19
+    }
+  },
+  {
+    "model": "core.municipio",
+    "pk": 100068,
+    "fields": {
+      "nombre": "Unión",
+      "provincia": 19
+    }
+  },
+  {
+    "model": "core.municipio",
+    "pk": 100069,
+    "fields": {
+      "nombre": "Avellaneda",
+      "provincia": 21
+    }
+  },
+  {
+    "model": "core.municipio",
+    "pk": 100070,
+    "fields": {
+      "nombre": "Colonia Iturraspe",
+      "provincia": 21
+    }
+  },
+  {
+    "model": "core.municipio",
+    "pk": 100071,
+    "fields": {
+      "nombre": "Ituzaingó",
+      "provincia": 21
+    }
+  },
+  {
+    "model": "core.municipio",
+    "pk": 100072,
+    "fields": {
+      "nombre": "La Criolla",
+      "provincia": 21
+    }
+  },
+  {
+    "model": "core.municipio",
+    "pk": 100073,
+    "fields": {
+      "nombre": "Las Garzas",
+      "provincia": 21
+    }
+  },
+  {
+    "model": "core.municipio",
+    "pk": 100074,
+    "fields": {
+      "nombre": "Las Toscas",
+      "provincia": 21
+    }
+  },
+  {
+    "model": "core.municipio",
+    "pk": 100075,
+    "fields": {
+      "nombre": "Los Molinos",
+      "provincia": 21
+    }
+  },
+  {
+    "model": "core.municipio",
+    "pk": 100076,
+    "fields": {
+      "nombre": "María Luisa",
+      "provincia": 21
+    }
+  },
+  {
+    "model": "core.municipio",
+    "pk": 100077,
+    "fields": {
+      "nombre": "Pilar",
+      "provincia": 21
+    }
+  },
+  {
+    "model": "core.municipio",
+    "pk": 100078,
+    "fields": {
+      "nombre": "Rivadavia",
+      "provincia": 21
+    }
+  },
+  {
+    "model": "core.municipio",
+    "pk": 100079,
+    "fields": {
+      "nombre": "San Agustín",
+      "provincia": 21
+    }
+  },
+  {
+    "model": "core.municipio",
+    "pk": 100080,
+    "fields": {
+      "nombre": "San Antonio",
+      "provincia": 21
+    }
+  },
+  {
+    "model": "core.municipio",
+    "pk": 100081,
+    "fields": {
+      "nombre": "San Bernardo",
+      "provincia": 21
+    }
+  },
+  {
+    "model": "core.municipio",
+    "pk": 100082,
+    "fields": {
+      "nombre": "San José",
+      "provincia": 21
+    }
+  },
+  {
+    "model": "core.municipio",
+    "pk": 100083,
+    "fields": {
+      "nombre": "San Vicente",
+      "provincia": 21
+    }
+  },
+  {
+    "model": "core.municipio",
+    "pk": 100084,
+    "fields": {
+      "nombre": "Sarmiento",
+      "provincia": 21
+    }
+  },
+  {
+    "model": "core.municipio",
+    "pk": 100085,
+    "fields": {
+      "nombre": "Tartagal",
+      "provincia": 21
+    }
+  },
+  {
+    "model": "core.municipio",
+    "pk": 100086,
+    "fields": {
+      "nombre": "Avellaneda",
+      "provincia": 22
+    }
+  },
+  {
+    "model": "core.municipio",
+    "pk": 100087,
+    "fields": {
+      "nombre": "Belgrano",
+      "provincia": 22
+    }
+  },
+  {
+    "model": "core.municipio",
+    "pk": 100088,
+    "fields": {
+      "nombre": "Pellegrini",
+      "provincia": 22
+    }
+  },
+  {
+    "model": "core.municipio",
+    "pk": 100089,
+    "fields": {
+      "nombre": "Rivadavia",
+      "provincia": 22
+    }
+  },
+  {
+    "model": "core.municipio",
+    "pk": 100090,
+    "fields": {
+      "nombre": "San Martín",
+      "provincia": 22
+    }
+  },
+  {
+    "model": "core.municipio",
+    "pk": 100091,
+    "fields": {
+      "nombre": "Sarmiento",
+      "provincia": 22
+    }
+  },
+  {
+    "model": "core.municipio",
+    "pk": 100092,
+    "fields": {
+      "nombre": "Bella Vista",
+      "provincia": 23
+    }
+  },
+  {
+    "model": "core.municipio",
+    "pk": 100093,
+    "fields": {
+      "nombre": "Buena Vista",
+      "provincia": 23
+    }
+  },
+  {
+    "model": "core.municipio",
+    "pk": 100094,
+    "fields": {
+      "nombre": "La Esperanza",
+      "provincia": 23
+    }
+  },
+  {
+    "model": "core.municipio",
+    "pk": 100095,
+    "fields": {
+      "nombre": "Río Chico",
+      "provincia": 23
+    }
+  },
+  {
+    "model": "core.municipio",
+    "pk": 100096,
+    "fields": {
+      "nombre": "Río Seco",
+      "provincia": 23
+    }
+  },
+  {
+    "model": "core.municipio",
+    "pk": 100097,
+    "fields": {
+      "nombre": "San Ignacio",
+      "provincia": 23
+    }
+  },
+  {
+    "model": "core.municipio",
+    "pk": 100098,
+    "fields": {
+      "nombre": "San Javier",
+      "provincia": 23
+    }
+  },
+  {
+    "model": "core.municipio",
+    "pk": 100099,
+    "fields": {
+      "nombre": "Santa Ana",
+      "provincia": 23
+    }
+  },
+  {
+    "model": "core.municipio",
+    "pk": 100100,
+    "fields": {
+      "nombre": "Santa Lucía",
+      "provincia": 23
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100000,
+    "fields": {
+      "nombre": "Ciudad de Buenos Aires",
+      "municipio": 25
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100001,
+    "fields": {
+      "nombre": "Puerto Madero",
+      "municipio": 25
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100002,
+    "fields": {
+      "nombre": "San Nicolás",
+      "municipio": 25
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100003,
+    "fields": {
+      "nombre": "San Telmo",
+      "municipio": 25
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100004,
+    "fields": {
+      "nombre": "Boedo",
+      "municipio": 29
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100005,
+    "fields": {
+      "nombre": "Caballito",
+      "municipio": 30
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100006,
+    "fields": {
+      "nombre": "Parque Chacabuco",
+      "municipio": 31
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100007,
+    "fields": {
+      "nombre": "Villa Riachuelo",
+      "municipio": 32
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100008,
+    "fields": {
+      "nombre": "Parque Avellaneda",
+      "municipio": 33
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100009,
+    "fields": {
+      "nombre": "Monte Castro",
+      "municipio": 34
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100010,
+    "fields": {
+      "nombre": "Vélez Sarsfield",
+      "municipio": 34
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100011,
+    "fields": {
+      "nombre": "Versalles",
+      "municipio": 34
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100012,
+    "fields": {
+      "nombre": "Villa Luro",
+      "municipio": 34
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100013,
+    "fields": {
+      "nombre": "Villa Real",
+      "municipio": 34
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100014,
+    "fields": {
+      "nombre": "Villa Devoto",
+      "municipio": 35
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100015,
+    "fields": {
+      "nombre": "Villa Santa Rita",
+      "municipio": 35
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100016,
+    "fields": {
+      "nombre": "Coghlan",
+      "municipio": 36
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100017,
+    "fields": {
+      "nombre": "Saavedra",
+      "municipio": 36
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100018,
+    "fields": {
+      "nombre": "Villa Urquiza",
+      "municipio": 36
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100019,
+    "fields": {
+      "nombre": "Belgrano",
+      "municipio": 37
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100020,
+    "fields": {
+      "nombre": "Nuñez",
+      "municipio": 37
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100021,
+    "fields": {
+      "nombre": "Agronomía",
+      "municipio": 39
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100022,
+    "fields": {
+      "nombre": "Chacarita",
+      "municipio": 39
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100023,
+    "fields": {
+      "nombre": "Parque Chas",
+      "municipio": 39
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100024,
+    "fields": {
+      "nombre": "Villa Crespo",
+      "municipio": 39
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100025,
+    "fields": {
+      "nombre": "Villa Ortúzar",
+      "municipio": 39
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100026,
+    "fields": {
+      "nombre": "Puerto Cuatreros",
+      "municipio": 47
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100027,
+    "fields": {
+      "nombre": "Isla Santiago",
+      "municipio": 74
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100028,
+    "fields": {
+      "nombre": "La Quinua",
+      "municipio": 85
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100029,
+    "fields": {
+      "nombre": "La Verónica",
+      "municipio": 85
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100030,
+    "fields": {
+      "nombre": "Magnasco",
+      "municipio": 88
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100031,
+    "fields": {
+      "nombre": "El Monasterio",
+      "municipio": 95
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100032,
+    "fields": {
+      "nombre": "Pradere",
+      "municipio": 96
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100033,
+    "fields": {
+      "nombre": "Las Chacras",
+      "municipio": 113
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100034,
+    "fields": {
+      "nombre": "Villa La Florida",
+      "municipio": 141
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100035,
+    "fields": {
+      "nombre": "Graciarena",
+      "municipio": 150
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100036,
+    "fields": {
+      "nombre": "Campos Salles",
+      "municipio": 157
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100037,
+    "fields": {
+      "nombre": "Villa Bajo La Alumbrera",
+      "municipio": 181
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100038,
+    "fields": {
+      "nombre": "Altamirano Norte",
+      "municipio": 192
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100039,
+    "fields": {
+      "nombre": "Arroyo Obispo",
+      "municipio": 192
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100040,
+    "fields": {
+      "nombre": "Pueblo Primero",
+      "municipio": 192
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100041,
+    "fields": {
+      "nombre": "Raices al Sud",
+      "municipio": 192
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100042,
+    "fields": {
+      "nombre": "Sauce Norte",
+      "municipio": 192
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100043,
+    "fields": {
+      "nombre": "El Bosquecillo",
+      "municipio": 199
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100044,
+    "fields": {
+      "nombre": "Arenal",
+      "municipio": 212
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100045,
+    "fields": {
+      "nombre": "Arenal Viejo",
+      "municipio": 212
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100046,
+    "fields": {
+      "nombre": "Balboa",
+      "municipio": 212
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100047,
+    "fields": {
+      "nombre": "Cámara",
+      "municipio": 212
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100048,
+    "fields": {
+      "nombre": "El Duraznito",
+      "municipio": 212
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100049,
+    "fields": {
+      "nombre": "El Porvenir",
+      "municipio": 212
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100050,
+    "fields": {
+      "nombre": "El Tandil",
+      "municipio": 212
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100051,
+    "fields": {
+      "nombre": "Horcones",
+      "municipio": 212
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100052,
+    "fields": {
+      "nombre": "Infiernillo",
+      "municipio": 212
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100053,
+    "fields": {
+      "nombre": "La Hoyada",
+      "municipio": 212
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100054,
+    "fields": {
+      "nombre": "Las Arcas",
+      "municipio": 212
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100055,
+    "fields": {
+      "nombre": "Las Mojarras",
+      "municipio": 212
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100056,
+    "fields": {
+      "nombre": "Los Mogotes",
+      "municipio": 212
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100057,
+    "fields": {
+      "nombre": "Ojo de Agua",
+      "municipio": 212
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100058,
+    "fields": {
+      "nombre": "Ovando",
+      "municipio": 212
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100059,
+    "fields": {
+      "nombre": "Arroyo de Álvarez Sur",
+      "municipio": 215
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100060,
+    "fields": {
+      "nombre": "Campo Baudin",
+      "municipio": 215
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100061,
+    "fields": {
+      "nombre": "Campo Carolini",
+      "municipio": 215
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100062,
+    "fields": {
+      "nombre": "Campo Daniele",
+      "municipio": 215
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100063,
+    "fields": {
+      "nombre": "Campo El Taco",
+      "municipio": 215
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100064,
+    "fields": {
+      "nombre": "Campo Falco",
+      "municipio": 215
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100065,
+    "fields": {
+      "nombre": "Campo Fichetti",
+      "municipio": 215
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100066,
+    "fields": {
+      "nombre": "Campo La Sirena",
+      "municipio": 215
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100067,
+    "fields": {
+      "nombre": "Campo Los Matorrales",
+      "municipio": 215
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100068,
+    "fields": {
+      "nombre": "Campo Marchand",
+      "municipio": 215
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100069,
+    "fields": {
+      "nombre": "Campo Minetti",
+      "municipio": 215
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100070,
+    "fields": {
+      "nombre": "Campo Scaramuzza",
+      "municipio": 215
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100071,
+    "fields": {
+      "nombre": "Campo Yañez",
+      "municipio": 215
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100072,
+    "fields": {
+      "nombre": "Cañada de Machado Sur",
+      "municipio": 215
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100073,
+    "fields": {
+      "nombre": "Colonia Adela",
+      "municipio": 215
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100074,
+    "fields": {
+      "nombre": "Colonia Dos Hermanas",
+      "municipio": 215
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100075,
+    "fields": {
+      "nombre": "Colonia Norte",
+      "municipio": 215
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100076,
+    "fields": {
+      "nombre": "Colonia San José de Aguas Coloradas",
+      "municipio": 215
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100077,
+    "fields": {
+      "nombre": "Corral de Arroyo",
+      "municipio": 215
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100078,
+    "fields": {
+      "nombre": "Costa Alegre",
+      "municipio": 215
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100079,
+    "fields": {
+      "nombre": "Costa del Carmen",
+      "municipio": 215
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100080,
+    "fields": {
+      "nombre": "El Polvorín",
+      "municipio": 215
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100081,
+    "fields": {
+      "nombre": "La Angelina",
+      "municipio": 215
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100082,
+    "fields": {
+      "nombre": "La Ramada",
+      "municipio": 215
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100083,
+    "fields": {
+      "nombre": "La Represa",
+      "municipio": 215
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100084,
+    "fields": {
+      "nombre": "La Ribera",
+      "municipio": 215
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100085,
+    "fields": {
+      "nombre": "Lagunilla",
+      "municipio": 215
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100086,
+    "fields": {
+      "nombre": "Las Heras",
+      "municipio": 215
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100087,
+    "fields": {
+      "nombre": "Los Tres Árboles",
+      "municipio": 215
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100088,
+    "fields": {
+      "nombre": "Oratorio de Peralta",
+      "municipio": 215
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100089,
+    "fields": {
+      "nombre": "Paso de Vélez",
+      "municipio": 215
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100090,
+    "fields": {
+      "nombre": "Pozo de las Yeguas",
+      "municipio": 215
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100091,
+    "fields": {
+      "nombre": "Rincón Viejo",
+      "municipio": 215
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100092,
+    "fields": {
+      "nombre": "Carrizal",
+      "municipio": 216
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100093,
+    "fields": {
+      "nombre": "Corrales",
+      "municipio": 216
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100094,
+    "fields": {
+      "nombre": "Isla El Espinillo",
+      "municipio": 216
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100095,
+    "fields": {
+      "nombre": "La Invernada",
+      "municipio": 216
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100096,
+    "fields": {
+      "nombre": "Los Cerros",
+      "municipio": 216
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100097,
+    "fields": {
+      "nombre": "Molino Doll",
+      "municipio": 216
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100098,
+    "fields": {
+      "nombre": "Pueblito Norte",
+      "municipio": 216
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100099,
+    "fields": {
+      "nombre": "Quebrachitos",
+      "municipio": 216
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100100,
+    "fields": {
+      "nombre": "Villa Libertad",
+      "municipio": 216
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100101,
+    "fields": {
+      "nombre": "25 de Mayo",
+      "municipio": 217
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100102,
+    "fields": {
+      "nombre": "9 de Julio",
+      "municipio": 217
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100103,
+    "fields": {
+      "nombre": "Ambargasta",
+      "municipio": 217
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100104,
+    "fields": {
+      "nombre": "Amimán",
+      "municipio": 217
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100105,
+    "fields": {
+      "nombre": "Amoladeras",
+      "municipio": 217
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100106,
+    "fields": {
+      "nombre": "Báez",
+      "municipio": 217
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100107,
+    "fields": {
+      "nombre": "Balbuena",
+      "municipio": 217
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100108,
+    "fields": {
+      "nombre": "Cachi",
+      "municipio": 217
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100109,
+    "fields": {
+      "nombre": "Campo Alegre",
+      "municipio": 217
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100110,
+    "fields": {
+      "nombre": "Campo de Leones",
+      "municipio": 217
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100111,
+    "fields": {
+      "nombre": "Chacras",
+      "municipio": 217
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100112,
+    "fields": {
+      "nombre": "Cruz del Norte",
+      "municipio": 217
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100113,
+    "fields": {
+      "nombre": "El 49",
+      "municipio": 217
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100114,
+    "fields": {
+      "nombre": "El Algarrobo",
+      "municipio": 217
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100115,
+    "fields": {
+      "nombre": "El Árbol",
+      "municipio": 217
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100116,
+    "fields": {
+      "nombre": "El Ayudante",
+      "municipio": 217
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100117,
+    "fields": {
+      "nombre": "El Barrial",
+      "municipio": 217
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100118,
+    "fields": {
+      "nombre": "El Cardonal",
+      "municipio": 217
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100119,
+    "fields": {
+      "nombre": "El Cerrito",
+      "municipio": 217
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100120,
+    "fields": {
+      "nombre": "El Jume",
+      "municipio": 217
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100121,
+    "fields": {
+      "nombre": "El Laurel",
+      "municipio": 217
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100122,
+    "fields": {
+      "nombre": "El Quebrachal",
+      "municipio": 217
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100123,
+    "fields": {
+      "nombre": "Inti Huasi",
+      "municipio": 217
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100124,
+    "fields": {
+      "nombre": "Jasimampa",
+      "municipio": 217
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100125,
+    "fields": {
+      "nombre": "Kilómetro 101",
+      "municipio": 217
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100126,
+    "fields": {
+      "nombre": "Kilómetro 88",
+      "municipio": 217
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100127,
+    "fields": {
+      "nombre": "Kilómetro 96",
+      "municipio": 217
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100128,
+    "fields": {
+      "nombre": "La Chirquita",
+      "municipio": 217
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100129,
+    "fields": {
+      "nombre": "La Cruz",
+      "municipio": 217
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100130,
+    "fields": {
+      "nombre": "La Esperanza",
+      "municipio": 217
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100131,
+    "fields": {
+      "nombre": "La Soledad",
+      "municipio": 217
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100132,
+    "fields": {
+      "nombre": "Las Mangas",
+      "municipio": 217
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100133,
+    "fields": {
+      "nombre": "Lomitas Blancas",
+      "municipio": 217
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100134,
+    "fields": {
+      "nombre": "Mercedes",
+      "municipio": 217
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100135,
+    "fields": {
+      "nombre": "Minguecho",
+      "municipio": 217
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100136,
+    "fields": {
+      "nombre": "Negra Muerta",
+      "municipio": 217
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100137,
+    "fields": {
+      "nombre": "Oncán",
+      "municipio": 217
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100138,
+    "fields": {
+      "nombre": "Pampa Grande",
+      "municipio": 217
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100139,
+    "fields": {
+      "nombre": "Piedra Blanca",
+      "municipio": 217
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100140,
+    "fields": {
+      "nombre": "Pozo del Garabato",
+      "municipio": 217
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100141,
+    "fields": {
+      "nombre": "Pozo Grande",
+      "municipio": 217
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100142,
+    "fields": {
+      "nombre": "Pozo Grande de Ambargasta",
+      "municipio": 217
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100143,
+    "fields": {
+      "nombre": "Puerta de los Cerros",
+      "municipio": 217
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100144,
+    "fields": {
+      "nombre": "Puerta de los Ríos",
+      "municipio": 217
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100145,
+    "fields": {
+      "nombre": "Río Saladillo",
+      "municipio": 217
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100146,
+    "fields": {
+      "nombre": "Rumi Pozo",
+      "municipio": 217
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100147,
+    "fields": {
+      "nombre": "San Francisco",
+      "municipio": 217
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100148,
+    "fields": {
+      "nombre": "San Juan",
+      "municipio": 217
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100149,
+    "fields": {
+      "nombre": "Santo Domingo",
+      "municipio": 217
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100150,
+    "fields": {
+      "nombre": "Sol de Julio",
+      "municipio": 217
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100151,
+    "fields": {
+      "nombre": "Suri Pozo",
+      "municipio": 217
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100152,
+    "fields": {
+      "nombre": "Tala Yacu",
+      "municipio": 217
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100153,
+    "fields": {
+      "nombre": "Totorillas",
+      "municipio": 217
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100154,
+    "fields": {
+      "nombre": "Villa Ojo de Agua",
+      "municipio": 217
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100155,
+    "fields": {
+      "nombre": "Colonia Médano de Oro",
+      "municipio": 218
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100156,
+    "fields": {
+      "nombre": "Colonia Pan de Azúcar",
+      "municipio": 218
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100157,
+    "fields": {
+      "nombre": "Colonia Rodas",
+      "municipio": 218
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100158,
+    "fields": {
+      "nombre": "El Ceibal",
+      "municipio": 219
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100159,
+    "fields": {
+      "nombre": "Rodeo de las Mulas",
+      "municipio": 219
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100160,
+    "fields": {
+      "nombre": "San Antonio",
+      "municipio": 219
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100161,
+    "fields": {
+      "nombre": "Carrán Curá",
+      "municipio": 220
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100162,
+    "fields": {
+      "nombre": "Cerrito Piñón",
+      "municipio": 220
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100163,
+    "fields": {
+      "nombre": "Collón Curá",
+      "municipio": 220
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100164,
+    "fields": {
+      "nombre": "Dique Pichi Picún Leufú",
+      "municipio": 220
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100165,
+    "fields": {
+      "nombre": "Dique Piedra del Águila",
+      "municipio": 220
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100166,
+    "fields": {
+      "nombre": "El Santuario",
+      "municipio": 220
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100167,
+    "fields": {
+      "nombre": "Huayquimil",
+      "municipio": 220
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100168,
+    "fields": {
+      "nombre": "Paso Yuncón",
+      "municipio": 220
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100169,
+    "fields": {
+      "nombre": "Piedra Pintada",
+      "municipio": 220
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100170,
+    "fields": {
+      "nombre": "San Ignacio",
+      "municipio": 220
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100171,
+    "fields": {
+      "nombre": "Sañico",
+      "municipio": 220
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100172,
+    "fields": {
+      "nombre": "Villa Rincón Chico",
+      "municipio": 220
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100173,
+    "fields": {
+      "nombre": "Aguas Coloradas",
+      "municipio": 221
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100174,
+    "fields": {
+      "nombre": "Averías",
+      "municipio": 221
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100175,
+    "fields": {
+      "nombre": "Bandera Bajada",
+      "municipio": 221
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100176,
+    "fields": {
+      "nombre": "Campo y Cielo",
+      "municipio": 221
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100177,
+    "fields": {
+      "nombre": "Cardón Esquina",
+      "municipio": 221
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100178,
+    "fields": {
+      "nombre": "Cartavio",
+      "municipio": 221
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100179,
+    "fields": {
+      "nombre": "Caspi Corral",
+      "municipio": 221
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100180,
+    "fields": {
+      "nombre": "Chañar Pozo",
+      "municipio": 221
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100181,
+    "fields": {
+      "nombre": "Colonia San Juan",
+      "municipio": 221
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100182,
+    "fields": {
+      "nombre": "Colonia Totorillas",
+      "municipio": 221
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100183,
+    "fields": {
+      "nombre": "Dique Los Figueroa",
+      "municipio": 221
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100184,
+    "fields": {
+      "nombre": "El Albardón",
+      "municipio": 221
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100185,
+    "fields": {
+      "nombre": "El Cero",
+      "municipio": 221
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100186,
+    "fields": {
+      "nombre": "El Crucero",
+      "municipio": 221
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100187,
+    "fields": {
+      "nombre": "El Negrito",
+      "municipio": 221
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100188,
+    "fields": {
+      "nombre": "El Negro",
+      "municipio": 221
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100189,
+    "fields": {
+      "nombre": "El Pirucho",
+      "municipio": 221
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100190,
+    "fields": {
+      "nombre": "El Quemado",
+      "municipio": 221
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100191,
+    "fields": {
+      "nombre": "El Tableado",
+      "municipio": 221
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100192,
+    "fields": {
+      "nombre": "Jume Esquina",
+      "municipio": 221
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100193,
+    "fields": {
+      "nombre": "Jume Viejo",
+      "municipio": 221
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100194,
+    "fields": {
+      "nombre": "Jumial Grande",
+      "municipio": 221
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100195,
+    "fields": {
+      "nombre": "Jumialito",
+      "municipio": 221
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100196,
+    "fields": {
+      "nombre": "Kilómetro 21",
+      "municipio": 221
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100197,
+    "fields": {
+      "nombre": "Kilómetro 30",
+      "municipio": 221
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100198,
+    "fields": {
+      "nombre": "Kilómetro 613",
+      "municipio": 221
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100199,
+    "fields": {
+      "nombre": "La Barrosa",
+      "municipio": 221
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100200,
+    "fields": {
+      "nombre": "La Cañada",
+      "municipio": 221
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100201,
+    "fields": {
+      "nombre": "La Candelaria",
+      "municipio": 221
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100202,
+    "fields": {
+      "nombre": "La Esperanza",
+      "municipio": 221
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100203,
+    "fields": {
+      "nombre": "La Guardia",
+      "municipio": 221
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100204,
+    "fields": {
+      "nombre": "La Invernada",
+      "municipio": 221
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100205,
+    "fields": {
+      "nombre": "La Invernada Sur",
+      "municipio": 221
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100206,
+    "fields": {
+      "nombre": "La Ramada",
+      "municipio": 221
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100207,
+    "fields": {
+      "nombre": "La Tapa",
+      "municipio": 221
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100208,
+    "fields": {
+      "nombre": "Lote La Cañada",
+      "municipio": 221
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100209,
+    "fields": {
+      "nombre": "Machaguay Huanchina",
+      "municipio": 221
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100210,
+    "fields": {
+      "nombre": "Maderas",
+      "municipio": 221
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100211,
+    "fields": {
+      "nombre": "Minerva",
+      "municipio": 221
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100212,
+    "fields": {
+      "nombre": "Mistolito",
+      "municipio": 221
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100213,
+    "fields": {
+      "nombre": "Nueva Esperanza",
+      "municipio": 221
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100214,
+    "fields": {
+      "nombre": "Pampa Muyoj",
+      "municipio": 221
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100215,
+    "fields": {
+      "nombre": "Pozo Cavado",
+      "municipio": 221
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100216,
+    "fields": {
+      "nombre": "Pozo del Castaño",
+      "municipio": 221
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100217,
+    "fields": {
+      "nombre": "Pueblo Nuevo",
+      "municipio": 221
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100218,
+    "fields": {
+      "nombre": "Puesto de Mena",
+      "municipio": 221
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100219,
+    "fields": {
+      "nombre": "Punitayoj",
+      "municipio": 221
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100220,
+    "fields": {
+      "nombre": "Quimilioj",
+      "municipio": 221
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100221,
+    "fields": {
+      "nombre": "Rumi",
+      "municipio": 221
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100222,
+    "fields": {
+      "nombre": "San Felipe",
+      "municipio": 221
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100223,
+    "fields": {
+      "nombre": "San Jorge",
+      "municipio": 221
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100224,
+    "fields": {
+      "nombre": "San José",
+      "municipio": 221
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100225,
+    "fields": {
+      "nombre": "San Pablo",
+      "municipio": 221
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100226,
+    "fields": {
+      "nombre": "San Roque",
+      "municipio": 221
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100227,
+    "fields": {
+      "nombre": "San Vicente",
+      "municipio": 221
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100228,
+    "fields": {
+      "nombre": "Santa Ana",
+      "municipio": 221
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100229,
+    "fields": {
+      "nombre": "Santa Catalina",
+      "municipio": 221
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100230,
+    "fields": {
+      "nombre": "Santa María",
+      "municipio": 221
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100231,
+    "fields": {
+      "nombre": "Santa María Este",
+      "municipio": 221
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100232,
+    "fields": {
+      "nombre": "Santo Domingo",
+      "municipio": 221
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100233,
+    "fields": {
+      "nombre": "Socco",
+      "municipio": 221
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100234,
+    "fields": {
+      "nombre": "Tablada del Boquerón",
+      "municipio": 221
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100235,
+    "fields": {
+      "nombre": "Toro Pozo",
+      "municipio": 221
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100236,
+    "fields": {
+      "nombre": "Tusca Pozo",
+      "municipio": 221
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100237,
+    "fields": {
+      "nombre": "Vaca Huañuna",
+      "municipio": 221
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100238,
+    "fields": {
+      "nombre": "Villa Figueroa",
+      "municipio": 221
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100239,
+    "fields": {
+      "nombre": "Vinal Isla",
+      "municipio": 221
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100240,
+    "fields": {
+      "nombre": "Yacu Hurmana",
+      "municipio": 221
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100241,
+    "fields": {
+      "nombre": "Capilla de Romero",
+      "municipio": 222
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100242,
+    "fields": {
+      "nombre": "Chañaritos",
+      "municipio": 222
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100243,
+    "fields": {
+      "nombre": "Conlara",
+      "municipio": 222
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100244,
+    "fields": {
+      "nombre": "El Salto",
+      "municipio": 222
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100245,
+    "fields": {
+      "nombre": "Pozo del Chañar",
+      "municipio": 222
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100246,
+    "fields": {
+      "nombre": "Valle del Lago",
+      "municipio": 222
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100247,
+    "fields": {
+      "nombre": "Arroyo Palmar",
+      "municipio": 223
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100248,
+    "fields": {
+      "nombre": "Cañada Grande",
+      "municipio": 223
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100249,
+    "fields": {
+      "nombre": "Colonia La Perla",
+      "municipio": 223
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100250,
+    "fields": {
+      "nombre": "Colonia Santa Margarita",
+      "municipio": 223
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100251,
+    "fields": {
+      "nombre": "Bajo Lindo",
+      "municipio": 250
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100252,
+    "fields": {
+      "nombre": "Canteras Quilpo",
+      "municipio": 250
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100253,
+    "fields": {
+      "nombre": "Cuchilla Nevada",
+      "municipio": 250
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100254,
+    "fields": {
+      "nombre": "El 16",
+      "municipio": 250
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100255,
+    "fields": {
+      "nombre": "El Barrialito",
+      "municipio": 250
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100256,
+    "fields": {
+      "nombre": "El Chaguaral",
+      "municipio": 250
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100257,
+    "fields": {
+      "nombre": "El Duraznal",
+      "municipio": 250
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100258,
+    "fields": {
+      "nombre": "Kilómetro 541",
+      "municipio": 250
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100259,
+    "fields": {
+      "nombre": "La Aguadita",
+      "municipio": 250
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100260,
+    "fields": {
+      "nombre": "La Brea",
+      "municipio": 250
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100261,
+    "fields": {
+      "nombre": "Las Ollas",
+      "municipio": 250
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100262,
+    "fields": {
+      "nombre": "Los Baños de Unquillo",
+      "municipio": 250
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100263,
+    "fields": {
+      "nombre": "Los Escalones",
+      "municipio": 250
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100264,
+    "fields": {
+      "nombre": "Los Gigantes",
+      "municipio": 250
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100265,
+    "fields": {
+      "nombre": "Los Leones",
+      "municipio": 250
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100266,
+    "fields": {
+      "nombre": "Los Patayes",
+      "municipio": 250
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100267,
+    "fields": {
+      "nombre": "Majada de Santiago",
+      "municipio": 250
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100268,
+    "fields": {
+      "nombre": "Oro Grueso",
+      "municipio": 250
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100269,
+    "fields": {
+      "nombre": "Paso de las Campanas",
+      "municipio": 250
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100270,
+    "fields": {
+      "nombre": "Pichanas",
+      "municipio": 250
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100271,
+    "fields": {
+      "nombre": "Represa de Morales",
+      "municipio": 250
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100272,
+    "fields": {
+      "nombre": "San Gregorio",
+      "municipio": 250
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100273,
+    "fields": {
+      "nombre": "Tabaquillo",
+      "municipio": 250
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100274,
+    "fields": {
+      "nombre": "Tres Árboles",
+      "municipio": 250
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100275,
+    "fields": {
+      "nombre": "Villa El Palmar",
+      "municipio": 250
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100276,
+    "fields": {
+      "nombre": "Burmeister",
+      "municipio": 303
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100277,
+    "fields": {
+      "nombre": "Campo La Adela",
+      "municipio": 303
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100278,
+    "fields": {
+      "nombre": "Colonia Astrada",
+      "municipio": 303
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100279,
+    "fields": {
+      "nombre": "Colonia La Juanita",
+      "municipio": 303
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100280,
+    "fields": {
+      "nombre": "Colonia Los Ceibos",
+      "municipio": 303
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100281,
+    "fields": {
+      "nombre": "Colonia Rocha",
+      "municipio": 303
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100282,
+    "fields": {
+      "nombre": "Colonia Santa Catalina",
+      "municipio": 303
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100283,
+    "fields": {
+      "nombre": "Colonia Stábile",
+      "municipio": 303
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100284,
+    "fields": {
+      "nombre": "Colonia White",
+      "municipio": 303
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100285,
+    "fields": {
+      "nombre": "El Campito",
+      "municipio": 303
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100286,
+    "fields": {
+      "nombre": "El Pampero",
+      "municipio": 303
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100287,
+    "fields": {
+      "nombre": "Estación Lecueder",
+      "municipio": 303
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100288,
+    "fields": {
+      "nombre": "Ingeniero Malmen",
+      "municipio": 303
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100289,
+    "fields": {
+      "nombre": "La Colorada",
+      "municipio": 303
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100290,
+    "fields": {
+      "nombre": "La Nacional",
+      "municipio": 303
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100291,
+    "fields": {
+      "nombre": "La Pacífica",
+      "municipio": 303
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100292,
+    "fields": {
+      "nombre": "La Penca",
+      "municipio": 303
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100293,
+    "fields": {
+      "nombre": "La Vanguardia",
+      "municipio": 303
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100294,
+    "fields": {
+      "nombre": "Laguna El 20",
+      "municipio": 303
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100295,
+    "fields": {
+      "nombre": "Larsen",
+      "municipio": 303
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100296,
+    "fields": {
+      "nombre": "Los Alfalfares",
+      "municipio": 303
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100297,
+    "fields": {
+      "nombre": "Modestino Pizarro",
+      "municipio": 303
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100298,
+    "fields": {
+      "nombre": "Nazca",
+      "municipio": 303
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100299,
+    "fields": {
+      "nombre": "Pegasano",
+      "municipio": 303
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100300,
+    "fields": {
+      "nombre": "Villa Moderna",
+      "municipio": 303
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100301,
+    "fields": {
+      "nombre": "Watt",
+      "municipio": 303
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100302,
+    "fields": {
+      "nombre": "Campo Carlitos",
+      "municipio": 309
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100303,
+    "fields": {
+      "nombre": "Campo El Zorro",
+      "municipio": 309
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100304,
+    "fields": {
+      "nombre": "Campo Evangelista",
+      "municipio": 309
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100305,
+    "fields": {
+      "nombre": "Campo Gaucho Nuevo",
+      "municipio": 309
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100306,
+    "fields": {
+      "nombre": "Campo Gerbaudo",
+      "municipio": 309
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100307,
+    "fields": {
+      "nombre": "Campo La Albina",
+      "municipio": 309
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100308,
+    "fields": {
+      "nombre": "Campo Laborde",
+      "municipio": 309
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100309,
+    "fields": {
+      "nombre": "Campo Las Lonjas",
+      "municipio": 309
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100310,
+    "fields": {
+      "nombre": "Campo Nata",
+      "municipio": 309
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100311,
+    "fields": {
+      "nombre": "Campo Novarino",
+      "municipio": 309
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100312,
+    "fields": {
+      "nombre": "Colonia Armando",
+      "municipio": 309
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100313,
+    "fields": {
+      "nombre": "Colonia Calchaquí",
+      "municipio": 309
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100314,
+    "fields": {
+      "nombre": "Colonia Carlos Casado",
+      "municipio": 309
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100315,
+    "fields": {
+      "nombre": "Colonia El Chajá",
+      "municipio": 309
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100316,
+    "fields": {
+      "nombre": "Colonia El Dorado",
+      "municipio": 309
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100317,
+    "fields": {
+      "nombre": "Colonia El Overo",
+      "municipio": 309
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100318,
+    "fields": {
+      "nombre": "Colonia Ermila",
+      "municipio": 309
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100319,
+    "fields": {
+      "nombre": "Colonia Garibaldi",
+      "municipio": 309
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100320,
+    "fields": {
+      "nombre": "Colonia Jerusalén",
+      "municipio": 309
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100321,
+    "fields": {
+      "nombre": "Colonia La Mariucha",
+      "municipio": 309
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100322,
+    "fields": {
+      "nombre": "Colonia Los Vascos",
+      "municipio": 309
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100323,
+    "fields": {
+      "nombre": "Colonia Luis Vélez",
+      "municipio": 309
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100324,
+    "fields": {
+      "nombre": "Colonia Mackey",
+      "municipio": 309
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100325,
+    "fields": {
+      "nombre": "Colonia Maizales",
+      "municipio": 309
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100326,
+    "fields": {
+      "nombre": "Colonia Marcos Sastre",
+      "municipio": 309
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100327,
+    "fields": {
+      "nombre": "Colonia Molles",
+      "municipio": 309
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100328,
+    "fields": {
+      "nombre": "Colonia Regernburguer",
+      "municipio": 309
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100329,
+    "fields": {
+      "nombre": "Flora",
+      "municipio": 309
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100330,
+    "fields": {
+      "nombre": "San José del Salteño",
+      "municipio": 309
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100331,
+    "fields": {
+      "nombre": "Santa Florinda",
+      "municipio": 309
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100332,
+    "fields": {
+      "nombre": "Codihue",
+      "municipio": 339
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100333,
+    "fields": {
+      "nombre": "Los Alazanes",
+      "municipio": 339
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100334,
+    "fields": {
+      "nombre": "Mallín de los Caballos",
+      "municipio": 339
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100335,
+    "fields": {
+      "nombre": "Mallín Quemado",
+      "municipio": 339
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100336,
+    "fields": {
+      "nombre": "Paso de Pino Hachado",
+      "municipio": 339
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100337,
+    "fields": {
+      "nombre": "Pino Hachado",
+      "municipio": 339
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100338,
+    "fields": {
+      "nombre": "Pozo del Gualicho",
+      "municipio": 339
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100339,
+    "fields": {
+      "nombre": "Primeros Pinos",
+      "municipio": 339
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100340,
+    "fields": {
+      "nombre": "12 de Octubre",
+      "municipio": 353
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100341,
+    "fields": {
+      "nombre": "Boca del Sauce",
+      "municipio": 353
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100342,
+    "fields": {
+      "nombre": "Campo de la Torre",
+      "municipio": 353
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100343,
+    "fields": {
+      "nombre": "Campo Esnaola",
+      "municipio": 353
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100344,
+    "fields": {
+      "nombre": "Campo La Calera",
+      "municipio": 353
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100345,
+    "fields": {
+      "nombre": "Campo Leofú",
+      "municipio": 353
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100346,
+    "fields": {
+      "nombre": "Campo Martinelli",
+      "municipio": 353
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100347,
+    "fields": {
+      "nombre": "Campo Santa María",
+      "municipio": 353
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100348,
+    "fields": {
+      "nombre": "Campo Zanón",
+      "municipio": 353
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100349,
+    "fields": {
+      "nombre": "Carolina",
+      "municipio": 353
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100350,
+    "fields": {
+      "nombre": "Chañaritos",
+      "municipio": 353
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100351,
+    "fields": {
+      "nombre": "Cinco Esquinas",
+      "municipio": 353
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100352,
+    "fields": {
+      "nombre": "Colonia 25 de Mayo",
+      "municipio": 353
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100353,
+    "fields": {
+      "nombre": "Colonia El Carmen",
+      "municipio": 353
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100354,
+    "fields": {
+      "nombre": "Colonia El Toro",
+      "municipio": 353
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100355,
+    "fields": {
+      "nombre": "Colonia La Argentina",
+      "municipio": 353
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100356,
+    "fields": {
+      "nombre": "Colonia La Carmencita",
+      "municipio": 353
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100357,
+    "fields": {
+      "nombre": "Colonia La Madera",
+      "municipio": 353
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100358,
+    "fields": {
+      "nombre": "Colonia La Mercantil",
+      "municipio": 353
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100359,
+    "fields": {
+      "nombre": "Colonia La Nueva",
+      "municipio": 353
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100360,
+    "fields": {
+      "nombre": "Colonia La Pinta",
+      "municipio": 353
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100361,
+    "fields": {
+      "nombre": "Colonia La Providencia",
+      "municipio": 353
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100362,
+    "fields": {
+      "nombre": "Colonia La Tercera",
+      "municipio": 353
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100363,
+    "fields": {
+      "nombre": "Colonia Nueva Sampacho",
+      "municipio": 353
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100364,
+    "fields": {
+      "nombre": "Colonia Orcavi",
+      "municipio": 353
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100365,
+    "fields": {
+      "nombre": "Colonia Santa Rosa",
+      "municipio": 353
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100366,
+    "fields": {
+      "nombre": "Costa del Tambo",
+      "municipio": 353
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100367,
+    "fields": {
+      "nombre": "Cuatro Vientos",
+      "municipio": 353
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100368,
+    "fields": {
+      "nombre": "El Cano",
+      "municipio": 353
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100369,
+    "fields": {
+      "nombre": "Espinillal",
+      "municipio": 353
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100370,
+    "fields": {
+      "nombre": "Espinillo",
+      "municipio": 353
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100371,
+    "fields": {
+      "nombre": "Estación San Ambrosio",
+      "municipio": 353
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100372,
+    "fields": {
+      "nombre": "Fragueyro",
+      "municipio": 353
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100373,
+    "fields": {
+      "nombre": "General Soler",
+      "municipio": 353
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100374,
+    "fields": {
+      "nombre": "La Barranquita",
+      "municipio": 353
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100375,
+    "fields": {
+      "nombre": "La Brianza",
+      "municipio": 353
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100376,
+    "fields": {
+      "nombre": "La Escondida",
+      "municipio": 353
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100377,
+    "fields": {
+      "nombre": "La Gilda",
+      "municipio": 353
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100378,
+    "fields": {
+      "nombre": "La Invernada",
+      "municipio": 353
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100379,
+    "fields": {
+      "nombre": "La Sara",
+      "municipio": 353
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100380,
+    "fields": {
+      "nombre": "Laguna Oscura",
+      "municipio": 353
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100381,
+    "fields": {
+      "nombre": "Laguna Seca",
+      "municipio": 353
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100382,
+    "fields": {
+      "nombre": "Las Cortaderas",
+      "municipio": 353
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100383,
+    "fields": {
+      "nombre": "Las Ensenadas",
+      "municipio": 353
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100384,
+    "fields": {
+      "nombre": "Las Gamas",
+      "municipio": 353
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100385,
+    "fields": {
+      "nombre": "Las Petacas",
+      "municipio": 353
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100386,
+    "fields": {
+      "nombre": "Los Jagüeles",
+      "municipio": 353
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100387,
+    "fields": {
+      "nombre": "Los Jagüeles Sud",
+      "municipio": 353
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100388,
+    "fields": {
+      "nombre": "Paraje Krisanich",
+      "municipio": 353
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100389,
+    "fields": {
+      "nombre": "Paunero",
+      "municipio": 353
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100390,
+    "fields": {
+      "nombre": "Piedra Blanca",
+      "municipio": 353
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100391,
+    "fields": {
+      "nombre": "Piedra Bola",
+      "municipio": 353
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100392,
+    "fields": {
+      "nombre": "Poste Fierro",
+      "municipio": 353
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100393,
+    "fields": {
+      "nombre": "Presa El Chañar",
+      "municipio": 353
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100394,
+    "fields": {
+      "nombre": "Pretot Freyre",
+      "municipio": 353
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100395,
+    "fields": {
+      "nombre": "Puente Los Molles",
+      "municipio": 353
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100396,
+    "fields": {
+      "nombre": "Puerta Colorada",
+      "municipio": 353
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100397,
+    "fields": {
+      "nombre": "San Ambrosio",
+      "municipio": 353
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100398,
+    "fields": {
+      "nombre": "San Bartolomé",
+      "municipio": 353
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100399,
+    "fields": {
+      "nombre": "San Bernardo",
+      "municipio": 353
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100400,
+    "fields": {
+      "nombre": "San Ernesto",
+      "municipio": 353
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100401,
+    "fields": {
+      "nombre": "Santa Flora",
+      "municipio": 353
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100402,
+    "fields": {
+      "nombre": "Tegua",
+      "municipio": 353
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100403,
+    "fields": {
+      "nombre": "Valle La Cocha",
+      "municipio": 353
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100404,
+    "fields": {
+      "nombre": "Villa Herminia",
+      "municipio": 353
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100405,
+    "fields": {
+      "nombre": "Villa Marcelina",
+      "municipio": 353
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100406,
+    "fields": {
+      "nombre": "Vuelta de la Cañada",
+      "municipio": 353
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100407,
+    "fields": {
+      "nombre": "Barranca Colorada",
+      "municipio": 363
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100408,
+    "fields": {
+      "nombre": "Buey Muerto",
+      "municipio": 363
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100409,
+    "fields": {
+      "nombre": "Cabinda",
+      "municipio": 363
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100410,
+    "fields": {
+      "nombre": "Campo Pucheta",
+      "municipio": 363
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100411,
+    "fields": {
+      "nombre": "Campo Ramallo",
+      "municipio": 363
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100412,
+    "fields": {
+      "nombre": "Capilla de Dolores",
+      "municipio": 363
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100413,
+    "fields": {
+      "nombre": "Capilla La Esperanza",
+      "municipio": 363
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100414,
+    "fields": {
+      "nombre": "Chacras Sur",
+      "municipio": 363
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100415,
+    "fields": {
+      "nombre": "Colonia El Fortín",
+      "municipio": 363
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100416,
+    "fields": {
+      "nombre": "Colonia La Argentina",
+      "municipio": 363
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100417,
+    "fields": {
+      "nombre": "Colonia San Rafael",
+      "municipio": 363
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100418,
+    "fields": {
+      "nombre": "El Alcalde",
+      "municipio": 363
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100419,
+    "fields": {
+      "nombre": "El Bagual",
+      "municipio": 363
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100420,
+    "fields": {
+      "nombre": "Isla Larga",
+      "municipio": 363
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100421,
+    "fields": {
+      "nombre": "La Colorada",
+      "municipio": 363
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100422,
+    "fields": {
+      "nombre": "La Vuelta",
+      "municipio": 363
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100423,
+    "fields": {
+      "nombre": "Las Acacias",
+      "municipio": 363
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100424,
+    "fields": {
+      "nombre": "Las Averías",
+      "municipio": 363
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100425,
+    "fields": {
+      "nombre": "Las Palmitas",
+      "municipio": 363
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100426,
+    "fields": {
+      "nombre": "Los Álvarez",
+      "municipio": 363
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100427,
+    "fields": {
+      "nombre": "Los Castaños",
+      "municipio": 363
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100428,
+    "fields": {
+      "nombre": "Los Guindos",
+      "municipio": 363
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100429,
+    "fields": {
+      "nombre": "Los Troncos",
+      "municipio": 363
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100430,
+    "fields": {
+      "nombre": "Monte del Rosario",
+      "municipio": 363
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100431,
+    "fields": {
+      "nombre": "Nueva Andalucía",
+      "municipio": 363
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100432,
+    "fields": {
+      "nombre": "Paso del Sauce",
+      "municipio": 363
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100433,
+    "fields": {
+      "nombre": "Pozo de la Esquina",
+      "municipio": 363
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100434,
+    "fields": {
+      "nombre": "Pozo de la Loma",
+      "municipio": 363
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100435,
+    "fields": {
+      "nombre": "Puesto de Afuera",
+      "municipio": 363
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100436,
+    "fields": {
+      "nombre": "Punta del Arroyo",
+      "municipio": 363
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100437,
+    "fields": {
+      "nombre": "Santa Isabel",
+      "municipio": 363
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100438,
+    "fields": {
+      "nombre": "Bajo del Carmen",
+      "municipio": 484
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100439,
+    "fields": {
+      "nombre": "El Mirador",
+      "municipio": 587
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100440,
+    "fields": {
+      "nombre": "Cañada del Coro",
+      "municipio": 606
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100441,
+    "fields": {
+      "nombre": "Ciénaga de Britos",
+      "municipio": 606
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100442,
+    "fields": {
+      "nombre": "Pinas",
+      "municipio": 606
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100443,
+    "fields": {
+      "nombre": "Represa del Árbol",
+      "municipio": 606
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100444,
+    "fields": {
+      "nombre": "Cachi Adentro",
+      "municipio": 641
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100445,
+    "fields": {
+      "nombre": "El Barrial",
+      "municipio": 641
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100446,
+    "fields": {
+      "nombre": "Escalchi",
+      "municipio": 641
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100447,
+    "fields": {
+      "nombre": "Escalchi Adentro",
+      "municipio": 641
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100448,
+    "fields": {
+      "nombre": "La Aguada",
+      "municipio": 641
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100449,
+    "fields": {
+      "nombre": "La Paya",
+      "municipio": 641
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100450,
+    "fields": {
+      "nombre": "Las Arcas",
+      "municipio": 641
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100451,
+    "fields": {
+      "nombre": "Las Pailas",
+      "municipio": 641
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100452,
+    "fields": {
+      "nombre": "Las Trancas",
+      "municipio": 641
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100453,
+    "fields": {
+      "nombre": "Los Cardones",
+      "municipio": 641
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100454,
+    "fields": {
+      "nombre": "Palermo",
+      "municipio": 641
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100455,
+    "fields": {
+      "nombre": "Puerta La Paya",
+      "municipio": 641
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100456,
+    "fields": {
+      "nombre": "Rancagua",
+      "municipio": 641
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100457,
+    "fields": {
+      "nombre": "Recta del Tin Tin",
+      "municipio": 641
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100458,
+    "fields": {
+      "nombre": "Aguadita",
+      "municipio": 642
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100459,
+    "fields": {
+      "nombre": "Amaicha",
+      "municipio": 642
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100460,
+    "fields": {
+      "nombre": "Banda Grande",
+      "municipio": 642
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100461,
+    "fields": {
+      "nombre": "Cochiyaco",
+      "municipio": 642
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100462,
+    "fields": {
+      "nombre": "Colomé",
+      "municipio": 642
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100463,
+    "fields": {
+      "nombre": "El Churcal",
+      "municipio": 642
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100464,
+    "fields": {
+      "nombre": "Hualfín",
+      "municipio": 642
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100465,
+    "fields": {
+      "nombre": "Pucarilla",
+      "municipio": 642
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100466,
+    "fields": {
+      "nombre": "Tacuil",
+      "municipio": 642
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100467,
+    "fields": {
+      "nombre": "Árraga",
+      "municipio": 646
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100468,
+    "fields": {
+      "nombre": "Campo Alegre",
+      "municipio": 646
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100469,
+    "fields": {
+      "nombre": "Coro Pampa",
+      "municipio": 646
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100470,
+    "fields": {
+      "nombre": "Huachana",
+      "municipio": 646
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100471,
+    "fields": {
+      "nombre": "La Abrita",
+      "municipio": 646
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100472,
+    "fields": {
+      "nombre": "La Higuera",
+      "municipio": 646
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100473,
+    "fields": {
+      "nombre": "La Ramadita",
+      "municipio": 646
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100474,
+    "fields": {
+      "nombre": "Manogasta",
+      "municipio": 646
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100475,
+    "fields": {
+      "nombre": "Nueva Francia",
+      "municipio": 646
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100476,
+    "fields": {
+      "nombre": "Puesto de Beltrán",
+      "municipio": 646
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100477,
+    "fields": {
+      "nombre": "San Andrés",
+      "municipio": 646
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100478,
+    "fields": {
+      "nombre": "San Vicente",
+      "municipio": 646
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100479,
+    "fields": {
+      "nombre": "Simbol",
+      "municipio": 646
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100480,
+    "fields": {
+      "nombre": "Sumamao",
+      "municipio": 646
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100481,
+    "fields": {
+      "nombre": "Tuama",
+      "municipio": 646
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100482,
+    "fields": {
+      "nombre": "Villa Silípica",
+      "municipio": 646
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100483,
+    "fields": {
+      "nombre": "Arrascaeta",
+      "municipio": 647
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100484,
+    "fields": {
+      "nombre": "Campo Pichuco",
+      "municipio": 647
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100485,
+    "fields": {
+      "nombre": "Colonia El Fortín",
+      "municipio": 647
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100486,
+    "fields": {
+      "nombre": "Estación Vera Mujica",
+      "municipio": 647
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100487,
+    "fields": {
+      "nombre": "La Pepita",
+      "municipio": 647
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100488,
+    "fields": {
+      "nombre": "Los Saladillos",
+      "municipio": 647
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100489,
+    "fields": {
+      "nombre": "ñandubay",
+      "municipio": 647
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100490,
+    "fields": {
+      "nombre": "Paikín",
+      "municipio": 647
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100491,
+    "fields": {
+      "nombre": "Vera Mujica",
+      "municipio": 647
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100492,
+    "fields": {
+      "nombre": "Campo de Batalla",
+      "municipio": 650
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100493,
+    "fields": {
+      "nombre": "Colonia Cantoni",
+      "municipio": 650
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100494,
+    "fields": {
+      "nombre": "Colonia Los Sauces",
+      "municipio": 651
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100495,
+    "fields": {
+      "nombre": "Alcaparrosa",
+      "municipio": 652
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100496,
+    "fields": {
+      "nombre": "Álvarez Condarco",
+      "municipio": 652
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100497,
+    "fields": {
+      "nombre": "Barrialito",
+      "municipio": 652
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100498,
+    "fields": {
+      "nombre": "Bella Vista",
+      "municipio": 652
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100499,
+    "fields": {
+      "nombre": "Castaño Nuevo",
+      "municipio": 652
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100500,
+    "fields": {
+      "nombre": "Castaño Viejo",
+      "municipio": 652
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100501,
+    "fields": {
+      "nombre": "Colón",
+      "municipio": 652
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100502,
+    "fields": {
+      "nombre": "El Leoncito",
+      "municipio": 652
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100503,
+    "fields": {
+      "nombre": "Guanaquitos",
+      "municipio": 652
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100504,
+    "fields": {
+      "nombre": "Hilario",
+      "municipio": 652
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100505,
+    "fields": {
+      "nombre": "La Alumbrera",
+      "municipio": 652
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100506,
+    "fields": {
+      "nombre": "La Capilla",
+      "municipio": 652
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100507,
+    "fields": {
+      "nombre": "La Junta",
+      "municipio": 652
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100508,
+    "fields": {
+      "nombre": "Laguna Blanca",
+      "municipio": 652
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100509,
+    "fields": {
+      "nombre": "Laguna Erizos",
+      "municipio": 652
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100510,
+    "fields": {
+      "nombre": "Las Amarillas",
+      "municipio": 652
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100511,
+    "fields": {
+      "nombre": "Las Hornillas",
+      "municipio": 652
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100512,
+    "fields": {
+      "nombre": "Llanos del Leoncito",
+      "municipio": 652
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100513,
+    "fields": {
+      "nombre": "Los Azules",
+      "municipio": 652
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100514,
+    "fields": {
+      "nombre": "Manantiales",
+      "municipio": 652
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100515,
+    "fields": {
+      "nombre": "Mina Buenaventura",
+      "municipio": 652
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100516,
+    "fields": {
+      "nombre": "Mina Casposo",
+      "municipio": 652
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100517,
+    "fields": {
+      "nombre": "Mina El Pachón",
+      "municipio": 652
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100518,
+    "fields": {
+      "nombre": "Pampa del Leoncito",
+      "municipio": 652
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100519,
+    "fields": {
+      "nombre": "Placeta",
+      "municipio": 652
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100520,
+    "fields": {
+      "nombre": "Portezuelo de la Totora",
+      "municipio": 652
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100521,
+    "fields": {
+      "nombre": "Puchuzún",
+      "municipio": 652
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100522,
+    "fields": {
+      "nombre": "Rincones de Araya",
+      "municipio": 652
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100523,
+    "fields": {
+      "nombre": "Sorocayense",
+      "municipio": 652
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100524,
+    "fields": {
+      "nombre": "Villa Corral",
+      "municipio": 652
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100525,
+    "fields": {
+      "nombre": "Villa Nueva",
+      "municipio": 652
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100526,
+    "fields": {
+      "nombre": "Colonia Paula",
+      "municipio": 653
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100527,
+    "fields": {
+      "nombre": "Domingo de Ramos",
+      "municipio": 653
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100528,
+    "fields": {
+      "nombre": "El Aibal",
+      "municipio": 653
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100529,
+    "fields": {
+      "nombre": "El Albardón",
+      "municipio": 653
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100530,
+    "fields": {
+      "nombre": "El Aromito",
+      "municipio": 653
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100531,
+    "fields": {
+      "nombre": "El Carmen",
+      "municipio": 653
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100532,
+    "fields": {
+      "nombre": "El Cuadro",
+      "municipio": 653
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100533,
+    "fields": {
+      "nombre": "El Huaico",
+      "municipio": 653
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100534,
+    "fields": {
+      "nombre": "La Providencia",
+      "municipio": 653
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100535,
+    "fields": {
+      "nombre": "Las Abras",
+      "municipio": 653
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100536,
+    "fields": {
+      "nombre": "Las Viboritas",
+      "municipio": 653
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100537,
+    "fields": {
+      "nombre": "Limache",
+      "municipio": 653
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100538,
+    "fields": {
+      "nombre": "Quebrachitos",
+      "municipio": 653
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100539,
+    "fields": {
+      "nombre": "San Nicolás",
+      "municipio": 653
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100540,
+    "fields": {
+      "nombre": "Villa Unión",
+      "municipio": 653
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100541,
+    "fields": {
+      "nombre": "Cerrillos",
+      "municipio": 655
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100542,
+    "fields": {
+      "nombre": "Doña Luisa",
+      "municipio": 655
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100543,
+    "fields": {
+      "nombre": "El Cadillo",
+      "municipio": 655
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100544,
+    "fields": {
+      "nombre": "El Mangrullo",
+      "municipio": 655
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100545,
+    "fields": {
+      "nombre": "El Simbolar",
+      "municipio": 655
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100546,
+    "fields": {
+      "nombre": "Guampacha",
+      "municipio": 655
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100547,
+    "fields": {
+      "nombre": "Illajes",
+      "municipio": 655
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100548,
+    "fields": {
+      "nombre": "Kilómetro 1121",
+      "municipio": 655
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100549,
+    "fields": {
+      "nombre": "La Calera",
+      "municipio": 655
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100550,
+    "fields": {
+      "nombre": "La Puerta Chiquita",
+      "municipio": 655
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100551,
+    "fields": {
+      "nombre": "Las Chacras",
+      "municipio": 655
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100552,
+    "fields": {
+      "nombre": "Las Juntas",
+      "municipio": 655
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100553,
+    "fields": {
+      "nombre": "Lavalle",
+      "municipio": 655
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100554,
+    "fields": {
+      "nombre": "Loma Yeso",
+      "municipio": 655
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100555,
+    "fields": {
+      "nombre": "Luján",
+      "municipio": 655
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100556,
+    "fields": {
+      "nombre": "Medio Mundo",
+      "municipio": 655
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100557,
+    "fields": {
+      "nombre": "Mistol Muyoj",
+      "municipio": 655
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100558,
+    "fields": {
+      "nombre": "Morón",
+      "municipio": 655
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100559,
+    "fields": {
+      "nombre": "Pampa Pozo",
+      "municipio": 655
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100560,
+    "fields": {
+      "nombre": "Paraná",
+      "municipio": 655
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100561,
+    "fields": {
+      "nombre": "Pozo Cavado",
+      "municipio": 655
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100562,
+    "fields": {
+      "nombre": "Puerta Grande",
+      "municipio": 655
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100563,
+    "fields": {
+      "nombre": "Puesto del Medio",
+      "municipio": 655
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100564,
+    "fields": {
+      "nombre": "San José",
+      "municipio": 655
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100565,
+    "fields": {
+      "nombre": "San Lorenzo",
+      "municipio": 655
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100566,
+    "fields": {
+      "nombre": "San Pedro",
+      "municipio": 655
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100567,
+    "fields": {
+      "nombre": "San Ramón",
+      "municipio": 655
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100568,
+    "fields": {
+      "nombre": "Santa Catalina",
+      "municipio": 655
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100569,
+    "fields": {
+      "nombre": "Tres Cerros",
+      "municipio": 655
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100570,
+    "fields": {
+      "nombre": "Tunas Punco",
+      "municipio": 655
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100571,
+    "fields": {
+      "nombre": "Villa Guasayán",
+      "municipio": 655
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100572,
+    "fields": {
+      "nombre": "Villa Rosa",
+      "municipio": 655
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100573,
+    "fields": {
+      "nombre": "Paso Frontera",
+      "municipio": 668
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100574,
+    "fields": {
+      "nombre": "Antonio Tomás Sur",
+      "municipio": 672
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100575,
+    "fields": {
+      "nombre": "Balneario Picún Leufú",
+      "municipio": 723
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100576,
+    "fields": {
+      "nombre": "Villa Chocón Medio",
+      "municipio": 723
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100577,
+    "fields": {
+      "nombre": "Yacimiento El Sauce",
+      "municipio": 723
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100578,
+    "fields": {
+      "nombre": "Arroyo San Antonio",
+      "municipio": 724
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100579,
+    "fields": {
+      "nombre": "Atos Pampa",
+      "municipio": 724
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100580,
+    "fields": {
+      "nombre": "Cañada El Durazno",
+      "municipio": 724
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100581,
+    "fields": {
+      "nombre": "Cerro Champaqui",
+      "municipio": 724
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100582,
+    "fields": {
+      "nombre": "Cerro Hermoso",
+      "municipio": 724
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100583,
+    "fields": {
+      "nombre": "Intiyaco",
+      "municipio": 724
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100584,
+    "fields": {
+      "nombre": "La Dormida",
+      "municipio": 724
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100585,
+    "fields": {
+      "nombre": "Las Lagunitas",
+      "municipio": 724
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100586,
+    "fields": {
+      "nombre": "Los Guindos",
+      "municipio": 724
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100587,
+    "fields": {
+      "nombre": "Sol de Mayo",
+      "municipio": 724
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100588,
+    "fields": {
+      "nombre": "Villa Alpina",
+      "municipio": 724
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100589,
+    "fields": {
+      "nombre": "Villa Berna",
+      "municipio": 724
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100590,
+    "fields": {
+      "nombre": "Villa Champaquí",
+      "municipio": 724
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100591,
+    "fields": {
+      "nombre": "Villa El Tala",
+      "municipio": 724
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100592,
+    "fields": {
+      "nombre": "Casimiro Gómez",
+      "municipio": 728
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100593,
+    "fields": {
+      "nombre": "Cochequingán",
+      "municipio": 728
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100594,
+    "fields": {
+      "nombre": "Colonia Calzada",
+      "municipio": 728
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100595,
+    "fields": {
+      "nombre": "Colonia El Porvenir",
+      "municipio": 728
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100596,
+    "fields": {
+      "nombre": "Colonia La Verde",
+      "municipio": 728
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100597,
+    "fields": {
+      "nombre": "Colonia Nueva Constitución",
+      "municipio": 728
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100598,
+    "fields": {
+      "nombre": "Colonia Urdaniz",
+      "municipio": 728
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100599,
+    "fields": {
+      "nombre": "Coronel Segovia",
+      "municipio": 728
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100600,
+    "fields": {
+      "nombre": "El Peje",
+      "municipio": 728
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100601,
+    "fields": {
+      "nombre": "Frisia",
+      "municipio": 728
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100602,
+    "fields": {
+      "nombre": "La Blanca",
+      "municipio": 728
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100603,
+    "fields": {
+      "nombre": "La Maroma",
+      "municipio": 728
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100604,
+    "fields": {
+      "nombre": "Los Overos",
+      "municipio": 728
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100605,
+    "fields": {
+      "nombre": "Martín de Loyola",
+      "municipio": 728
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100606,
+    "fields": {
+      "nombre": "Nahuel Mapá",
+      "municipio": 728
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100607,
+    "fields": {
+      "nombre": "Polledo",
+      "municipio": 728
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100608,
+    "fields": {
+      "nombre": "Usiyal",
+      "municipio": 728
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100609,
+    "fields": {
+      "nombre": "Alto Río Mayo",
+      "municipio": 730
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100610,
+    "fields": {
+      "nombre": "El Triana",
+      "municipio": 730
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100611,
+    "fields": {
+      "nombre": "La Confluencia",
+      "municipio": 730
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100612,
+    "fields": {
+      "nombre": "Los Tamariscos",
+      "municipio": 730
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100613,
+    "fields": {
+      "nombre": "Paso Guenguel",
+      "municipio": 730
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100614,
+    "fields": {
+      "nombre": "Paso Huemules",
+      "municipio": 730
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100615,
+    "fields": {
+      "nombre": "Paso Moreno",
+      "municipio": 730
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100616,
+    "fields": {
+      "nombre": "Pastos Blancos",
+      "municipio": 730
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100617,
+    "fields": {
+      "nombre": "Puerta de la Virgen",
+      "municipio": 730
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100618,
+    "fields": {
+      "nombre": "Sección Loma Redonda",
+      "municipio": 730
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100619,
+    "fields": {
+      "nombre": "El Bello",
+      "municipio": 731
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100620,
+    "fields": {
+      "nombre": "El Rincón",
+      "municipio": 731
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100621,
+    "fields": {
+      "nombre": "Hipólito Yrigoyen",
+      "municipio": 731
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100622,
+    "fields": {
+      "nombre": "Lago Belgrano",
+      "municipio": 731
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100623,
+    "fields": {
+      "nombre": "Lago Burmeister",
+      "municipio": 731
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100624,
+    "fields": {
+      "nombre": "Lago Cardiel",
+      "municipio": 731
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100625,
+    "fields": {
+      "nombre": "Lago Pueyrredón",
+      "municipio": 731
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100626,
+    "fields": {
+      "nombre": "Lagos del Furioso",
+      "municipio": 731
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100627,
+    "fields": {
+      "nombre": "Las Horquetas",
+      "municipio": 731
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100628,
+    "fields": {
+      "nombre": "Paso del Águila",
+      "municipio": 731
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100629,
+    "fields": {
+      "nombre": "Riera",
+      "municipio": 731
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100630,
+    "fields": {
+      "nombre": "Río Blanco",
+      "municipio": 731
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100631,
+    "fields": {
+      "nombre": "Río Olnie",
+      "municipio": 731
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100632,
+    "fields": {
+      "nombre": "Tamel Aike",
+      "municipio": 731
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100633,
+    "fields": {
+      "nombre": "Bajo Hondo",
+      "municipio": 732
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100634,
+    "fields": {
+      "nombre": "Callejón Bajada",
+      "municipio": 732
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100635,
+    "fields": {
+      "nombre": "Campo del Cielo",
+      "municipio": 732
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100636,
+    "fields": {
+      "nombre": "Canal Melero",
+      "municipio": 732
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100637,
+    "fields": {
+      "nombre": "Chichillal",
+      "municipio": 732
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100638,
+    "fields": {
+      "nombre": "Colonia Josefina",
+      "municipio": 732
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100639,
+    "fields": {
+      "nombre": "Colonia Seis de Septiembre",
+      "municipio": 732
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100640,
+    "fields": {
+      "nombre": "El 20",
+      "municipio": 732
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100641,
+    "fields": {
+      "nombre": "El Aibal",
+      "municipio": 732
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100642,
+    "fields": {
+      "nombre": "El Carretel",
+      "municipio": 732
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100643,
+    "fields": {
+      "nombre": "El Colorado",
+      "municipio": 732
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100644,
+    "fields": {
+      "nombre": "El Cuadrado",
+      "municipio": 732
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100645,
+    "fields": {
+      "nombre": "El Desvío",
+      "municipio": 732
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100646,
+    "fields": {
+      "nombre": "El Noque",
+      "municipio": 732
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100647,
+    "fields": {
+      "nombre": "El Saladillo",
+      "municipio": 732
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100648,
+    "fields": {
+      "nombre": "El Sauce",
+      "municipio": 732
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100649,
+    "fields": {
+      "nombre": "Kilómetro 477",
+      "municipio": 732
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100650,
+    "fields": {
+      "nombre": "Kilómetro 499",
+      "municipio": 732
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100651,
+    "fields": {
+      "nombre": "Kilómetro 546",
+      "municipio": 732
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100652,
+    "fields": {
+      "nombre": "La Estancia",
+      "municipio": 732
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100653,
+    "fields": {
+      "nombre": "La Pampa",
+      "municipio": 732
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100654,
+    "fields": {
+      "nombre": "La Soledad",
+      "municipio": 732
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100655,
+    "fields": {
+      "nombre": "Laguna Baya",
+      "municipio": 732
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100656,
+    "fields": {
+      "nombre": "Las Lomas",
+      "municipio": 732
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100657,
+    "fields": {
+      "nombre": "Las Palmeras",
+      "municipio": 732
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100658,
+    "fields": {
+      "nombre": "Llajta Mauca",
+      "municipio": 732
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100659,
+    "fields": {
+      "nombre": "Lojlo",
+      "municipio": 732
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100660,
+    "fields": {
+      "nombre": "Lote 29",
+      "municipio": 732
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100661,
+    "fields": {
+      "nombre": "Lote 32",
+      "municipio": 732
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100662,
+    "fields": {
+      "nombre": "Lote 53",
+      "municipio": 732
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100663,
+    "fields": {
+      "nombre": "Lote 59",
+      "municipio": 732
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100664,
+    "fields": {
+      "nombre": "Lote 63",
+      "municipio": 732
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100665,
+    "fields": {
+      "nombre": "Lote 69",
+      "municipio": 732
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100666,
+    "fields": {
+      "nombre": "Matará",
+      "municipio": 732
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100667,
+    "fields": {
+      "nombre": "Melero",
+      "municipio": 732
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100668,
+    "fields": {
+      "nombre": "Nasaló",
+      "municipio": 732
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100669,
+    "fields": {
+      "nombre": "Pozo del Tigre",
+      "municipio": 732
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100670,
+    "fields": {
+      "nombre": "Pozo del Toba",
+      "municipio": 732
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100671,
+    "fields": {
+      "nombre": "Puente Bajada",
+      "municipio": 732
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100672,
+    "fields": {
+      "nombre": "Punco",
+      "municipio": 732
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100673,
+    "fields": {
+      "nombre": "Rincón del Saladillo",
+      "municipio": 732
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100674,
+    "fields": {
+      "nombre": "Rodeo Bajada",
+      "municipio": 732
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100675,
+    "fields": {
+      "nombre": "Roldán",
+      "municipio": 732
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100676,
+    "fields": {
+      "nombre": "San Antonio",
+      "municipio": 732
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100677,
+    "fields": {
+      "nombre": "San Luis",
+      "municipio": 732
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100678,
+    "fields": {
+      "nombre": "San Luis Oeste",
+      "municipio": 732
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100679,
+    "fields": {
+      "nombre": "San Pedro",
+      "municipio": 732
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100680,
+    "fields": {
+      "nombre": "Santa Justina",
+      "municipio": 732
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100681,
+    "fields": {
+      "nombre": "Santa María",
+      "municipio": 732
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100682,
+    "fields": {
+      "nombre": "Suncho Corral",
+      "municipio": 732
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100683,
+    "fields": {
+      "nombre": "Taruy",
+      "municipio": 732
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100684,
+    "fields": {
+      "nombre": "Tiunpunco",
+      "municipio": 732
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100685,
+    "fields": {
+      "nombre": "Tobas",
+      "municipio": 732
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100686,
+    "fields": {
+      "nombre": "Vilelas",
+      "municipio": 732
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100687,
+    "fields": {
+      "nombre": "Yacu Hichacuna",
+      "municipio": 732
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100688,
+    "fields": {
+      "nombre": "Yuchán",
+      "municipio": 732
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100689,
+    "fields": {
+      "nombre": "El Salvaje",
+      "municipio": 771
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100690,
+    "fields": {
+      "nombre": "Aldea San Gregorio",
+      "municipio": 799
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100691,
+    "fields": {
+      "nombre": "Colonia La Gerónima",
+      "municipio": 799
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100692,
+    "fields": {
+      "nombre": "Colonia San Vicente",
+      "municipio": 799
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100693,
+    "fields": {
+      "nombre": "Rincón del Villaguay",
+      "municipio": 799
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100694,
+    "fields": {
+      "nombre": "Agua Bonita",
+      "municipio": 804
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100695,
+    "fields": {
+      "nombre": "El Alamito",
+      "municipio": 804
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100696,
+    "fields": {
+      "nombre": "El Bosque",
+      "municipio": 804
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100697,
+    "fields": {
+      "nombre": "Juan Jufré",
+      "municipio": 804
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100698,
+    "fields": {
+      "nombre": "Punta del Monte",
+      "municipio": 804
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100699,
+    "fields": {
+      "nombre": "Bahía Túnel",
+      "municipio": 805
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100700,
+    "fields": {
+      "nombre": "Canal Viedma",
+      "municipio": 805
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100701,
+    "fields": {
+      "nombre": "Charles Fuhr",
+      "municipio": 805
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100702,
+    "fields": {
+      "nombre": "Cóndor Cliff",
+      "municipio": 805
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100703,
+    "fields": {
+      "nombre": "El Cerrito",
+      "municipio": 805
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100704,
+    "fields": {
+      "nombre": "El Galpón del Glaciar",
+      "municipio": 805
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100705,
+    "fields": {
+      "nombre": "Gendarme Barreto",
+      "municipio": 805
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100706,
+    "fields": {
+      "nombre": "Hoya del Chenque",
+      "municipio": 805
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100707,
+    "fields": {
+      "nombre": "La Leona",
+      "municipio": 805
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100708,
+    "fields": {
+      "nombre": "La Porfiada",
+      "municipio": 805
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100709,
+    "fields": {
+      "nombre": "Lago del Desierto",
+      "municipio": 805
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100710,
+    "fields": {
+      "nombre": "Lago Roca",
+      "municipio": 805
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100711,
+    "fields": {
+      "nombre": "Lago San Martín",
+      "municipio": 805
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100712,
+    "fields": {
+      "nombre": "Laguna del Desierto",
+      "municipio": 805
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100713,
+    "fields": {
+      "nombre": "Mata Amarilla",
+      "municipio": 805
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100714,
+    "fields": {
+      "nombre": "Mirador del Glaciar",
+      "municipio": 805
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100715,
+    "fields": {
+      "nombre": "Paso Biggieri",
+      "municipio": 805
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100716,
+    "fields": {
+      "nombre": "Paso Portezuelo de la Divisoria",
+      "municipio": 805
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100717,
+    "fields": {
+      "nombre": "Piedra Clavada",
+      "municipio": 805
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100718,
+    "fields": {
+      "nombre": "Puerto Bahía Tranquila",
+      "municipio": 805
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100719,
+    "fields": {
+      "nombre": "Puerto Bajo Las Sombras",
+      "municipio": 805
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100720,
+    "fields": {
+      "nombre": "Puerto Irma",
+      "municipio": 805
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100721,
+    "fields": {
+      "nombre": "Punta Bandera",
+      "municipio": 805
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100722,
+    "fields": {
+      "nombre": "Río Bote",
+      "municipio": 805
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100723,
+    "fields": {
+      "nombre": "Río de las Vueltas",
+      "municipio": 805
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100724,
+    "fields": {
+      "nombre": "Río Guanaco",
+      "municipio": 805
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100725,
+    "fields": {
+      "nombre": "Río Mitre",
+      "municipio": 805
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100726,
+    "fields": {
+      "nombre": "Yacimiento Fortaleza",
+      "municipio": 805
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100727,
+    "fields": {
+      "nombre": "Boca Toma",
+      "municipio": 819
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100728,
+    "fields": {
+      "nombre": "Bajada del Durazno",
+      "municipio": 827
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100729,
+    "fields": {
+      "nombre": "Cascada del Agrio",
+      "municipio": 827
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100730,
+    "fields": {
+      "nombre": "Chacayco",
+      "municipio": 827
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100731,
+    "fields": {
+      "nombre": "Chenque Cura",
+      "municipio": 827
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100732,
+    "fields": {
+      "nombre": "Colipilli Abajo",
+      "municipio": 827
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100733,
+    "fields": {
+      "nombre": "Colipilli Arriba",
+      "municipio": 827
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100734,
+    "fields": {
+      "nombre": "Hualcupén Abajo",
+      "municipio": 827
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100735,
+    "fields": {
+      "nombre": "Hualcupén Arriba",
+      "municipio": 827
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100736,
+    "fields": {
+      "nombre": "Las Máquinas",
+      "municipio": 827
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100737,
+    "fields": {
+      "nombre": "Millán Currical",
+      "municipio": 827
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100738,
+    "fields": {
+      "nombre": "Moncol",
+      "municipio": 827
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100739,
+    "fields": {
+      "nombre": "Naunauco",
+      "municipio": 827
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100740,
+    "fields": {
+      "nombre": "Paraje La Y",
+      "municipio": 827
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100741,
+    "fields": {
+      "nombre": "Paso de Pichachén",
+      "municipio": 827
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100742,
+    "fields": {
+      "nombre": "Puerta de Trolope",
+      "municipio": 827
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100743,
+    "fields": {
+      "nombre": "Rahueco",
+      "municipio": 827
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100744,
+    "fields": {
+      "nombre": "Ranquilón",
+      "municipio": 827
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100745,
+    "fields": {
+      "nombre": "Taquimilán",
+      "municipio": 827
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100746,
+    "fields": {
+      "nombre": "Taquimilán Centro",
+      "municipio": 827
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100747,
+    "fields": {
+      "nombre": "Tralahue",
+      "municipio": 827
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100748,
+    "fields": {
+      "nombre": "Tres Chorros",
+      "municipio": 827
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100749,
+    "fields": {
+      "nombre": "Valle de las Damas",
+      "municipio": 827
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100750,
+    "fields": {
+      "nombre": "Vilu Mallín",
+      "municipio": 827
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100751,
+    "fields": {
+      "nombre": "Bajada Moreno",
+      "municipio": 829
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100752,
+    "fields": {
+      "nombre": "Blancuntre",
+      "municipio": 829
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100753,
+    "fields": {
+      "nombre": "Colelache",
+      "municipio": 829
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100754,
+    "fields": {
+      "nombre": "El Escorial",
+      "municipio": 829
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100755,
+    "fields": {
+      "nombre": "Pampa de Sacanana",
+      "municipio": 829
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100756,
+    "fields": {
+      "nombre": "Pampa Marrauf",
+      "municipio": 829
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100757,
+    "fields": {
+      "nombre": "Taquetrén",
+      "municipio": 829
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100758,
+    "fields": {
+      "nombre": "Yala Laubat",
+      "municipio": 829
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100759,
+    "fields": {
+      "nombre": "Carpinchorí",
+      "municipio": 830
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100760,
+    "fields": {
+      "nombre": "Colonia Oficial 15",
+      "municipio": 830
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100761,
+    "fields": {
+      "nombre": "Colonia Santa Lucía",
+      "municipio": 830
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100762,
+    "fields": {
+      "nombre": "Don Gonzalo",
+      "municipio": 830
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100763,
+    "fields": {
+      "nombre": "El Gato",
+      "municipio": 830
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100764,
+    "fields": {
+      "nombre": "La Calandria",
+      "municipio": 830
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100765,
+    "fields": {
+      "nombre": "Loma Limpia",
+      "municipio": 830
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100766,
+    "fields": {
+      "nombre": "Miñones",
+      "municipio": 830
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100767,
+    "fields": {
+      "nombre": "Sauce Norte",
+      "municipio": 830
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100768,
+    "fields": {
+      "nombre": "Bajo de Olmos",
+      "municipio": 831
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100769,
+    "fields": {
+      "nombre": "Barranca Yaco",
+      "municipio": 831
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100770,
+    "fields": {
+      "nombre": "Belén",
+      "municipio": 831
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100771,
+    "fields": {
+      "nombre": "Cañada de Jume",
+      "municipio": 831
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100772,
+    "fields": {
+      "nombre": "Cañada Martel",
+      "municipio": 831
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100773,
+    "fields": {
+      "nombre": "Colonia Hogar",
+      "municipio": 831
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100774,
+    "fields": {
+      "nombre": "La Maza",
+      "municipio": 831
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100775,
+    "fields": {
+      "nombre": "La Paz",
+      "municipio": 831
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100776,
+    "fields": {
+      "nombre": "La Tuna",
+      "municipio": 831
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100777,
+    "fields": {
+      "nombre": "Las Bandurrias",
+      "municipio": 831
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100778,
+    "fields": {
+      "nombre": "Las Barrancas",
+      "municipio": 831
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100779,
+    "fields": {
+      "nombre": "Los Chañares",
+      "municipio": 831
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100780,
+    "fields": {
+      "nombre": "Los Cometierra",
+      "municipio": 831
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100781,
+    "fields": {
+      "nombre": "Macha",
+      "municipio": 831
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100782,
+    "fields": {
+      "nombre": "Mula Muerta",
+      "municipio": 831
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100783,
+    "fields": {
+      "nombre": "Pinto",
+      "municipio": 831
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100784,
+    "fields": {
+      "nombre": "Puesto del Rosario",
+      "municipio": 831
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100785,
+    "fields": {
+      "nombre": "San Jorge",
+      "municipio": 831
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100786,
+    "fields": {
+      "nombre": "San Juan",
+      "municipio": 831
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100787,
+    "fields": {
+      "nombre": "San Pellegrino",
+      "municipio": 831
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100788,
+    "fields": {
+      "nombre": "San Salvador",
+      "municipio": 831
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100789,
+    "fields": {
+      "nombre": "Santa María",
+      "municipio": 831
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100790,
+    "fields": {
+      "nombre": "Tintinaco",
+      "municipio": 831
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100791,
+    "fields": {
+      "nombre": "Aguada de Mulas",
+      "municipio": 834
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100792,
+    "fields": {
+      "nombre": "Cajón de Ginebra Chico",
+      "municipio": 834
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100793,
+    "fields": {
+      "nombre": "Cajón de Ginebra Grande",
+      "municipio": 834
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100794,
+    "fields": {
+      "nombre": "Campo El Arroyo",
+      "municipio": 834
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100795,
+    "fields": {
+      "nombre": "Canquel",
+      "municipio": 834
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100796,
+    "fields": {
+      "nombre": "Cerro Cóndor",
+      "municipio": 834
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100797,
+    "fields": {
+      "nombre": "El Pajarito",
+      "municipio": 834
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100798,
+    "fields": {
+      "nombre": "El Sombrero",
+      "municipio": 834
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100799,
+    "fields": {
+      "nombre": "La Payanca",
+      "municipio": 834
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100800,
+    "fields": {
+      "nombre": "Laguna Colorada",
+      "municipio": 834
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100801,
+    "fields": {
+      "nombre": "Laguna de la Bombilla",
+      "municipio": 834
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100802,
+    "fields": {
+      "nombre": "Las Horquetas",
+      "municipio": 834
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100803,
+    "fields": {
+      "nombre": "Los Adobes",
+      "municipio": 834
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100804,
+    "fields": {
+      "nombre": "Mallín Angosto",
+      "municipio": 834
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100805,
+    "fields": {
+      "nombre": "Paso Berwin",
+      "municipio": 834
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100806,
+    "fields": {
+      "nombre": "Puesto Rechiné",
+      "municipio": 834
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100807,
+    "fields": {
+      "nombre": "Sierra Cuadrada",
+      "municipio": 834
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100808,
+    "fields": {
+      "nombre": "Toro Hosco",
+      "municipio": 834
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100809,
+    "fields": {
+      "nombre": "Cañadón Grande",
+      "municipio": 836
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100810,
+    "fields": {
+      "nombre": "Colonia Pastoril Cushamen",
+      "municipio": 836
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100811,
+    "fields": {
+      "nombre": "Costa de Lepá",
+      "municipio": 836
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100812,
+    "fields": {
+      "nombre": "Costa del Chubut",
+      "municipio": 836
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100813,
+    "fields": {
+      "nombre": "El Mallín de Currumil",
+      "municipio": 836
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100814,
+    "fields": {
+      "nombre": "El Mayoco",
+      "municipio": 836
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100815,
+    "fields": {
+      "nombre": "El Mirador",
+      "municipio": 836
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100816,
+    "fields": {
+      "nombre": "El Molle",
+      "municipio": 836
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100817,
+    "fields": {
+      "nombre": "El Portezuelo",
+      "municipio": 836
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100818,
+    "fields": {
+      "nombre": "El Tropezón",
+      "municipio": 836
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100819,
+    "fields": {
+      "nombre": "El Turbio",
+      "municipio": 836
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100820,
+    "fields": {
+      "nombre": "Fitamiche",
+      "municipio": 836
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100821,
+    "fields": {
+      "nombre": "Fitirhuin",
+      "municipio": 836
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100822,
+    "fields": {
+      "nombre": "Fofo Cahuel",
+      "municipio": 836
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100823,
+    "fields": {
+      "nombre": "La Cancha",
+      "municipio": 836
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100824,
+    "fields": {
+      "nombre": "La Confluencia",
+      "municipio": 836
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100825,
+    "fields": {
+      "nombre": "Lago Cholila",
+      "municipio": 836
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100826,
+    "fields": {
+      "nombre": "Lago Lezama",
+      "municipio": 836
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100827,
+    "fields": {
+      "nombre": "Leleque",
+      "municipio": 836
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100828,
+    "fields": {
+      "nombre": "Lepá",
+      "municipio": 836
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100829,
+    "fields": {
+      "nombre": "Ranquilhuau",
+      "municipio": 836
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100830,
+    "fields": {
+      "nombre": "Chacay Este",
+      "municipio": 852
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100831,
+    "fields": {
+      "nombre": "Chacay Oeste",
+      "municipio": 852
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100832,
+    "fields": {
+      "nombre": "Chacras de Telsen",
+      "municipio": 852
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100833,
+    "fields": {
+      "nombre": "Colonia Agrícola Sepaucal",
+      "municipio": 852
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100834,
+    "fields": {
+      "nombre": "Laguna de la Vaca",
+      "municipio": 852
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100835,
+    "fields": {
+      "nombre": "Laguna Fría",
+      "municipio": 852
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100836,
+    "fields": {
+      "nombre": "Paso Moreno",
+      "municipio": 852
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100837,
+    "fields": {
+      "nombre": "Telsen",
+      "municipio": 852
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100838,
+    "fields": {
+      "nombre": "Tres Banderas",
+      "municipio": 852
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100839,
+    "fields": {
+      "nombre": "20 de Febrero",
+      "municipio": 857
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100840,
+    "fields": {
+      "nombre": "Castañares",
+      "municipio": 857
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100841,
+    "fields": {
+      "nombre": "El Guayacán",
+      "municipio": 857
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100842,
+    "fields": {
+      "nombre": "Entre Ríos",
+      "municipio": 857
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100843,
+    "fields": {
+      "nombre": "Estación Ampascachi",
+      "municipio": 857
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100844,
+    "fields": {
+      "nombre": "La Represa",
+      "municipio": 857
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100845,
+    "fields": {
+      "nombre": "Las Curtiembres",
+      "municipio": 857
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100846,
+    "fields": {
+      "nombre": "Morales",
+      "municipio": 857
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100847,
+    "fields": {
+      "nombre": "San Nicolás",
+      "municipio": 857
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100848,
+    "fields": {
+      "nombre": "Alto Blanco",
+      "municipio": 858
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100849,
+    "fields": {
+      "nombre": "Barrancas",
+      "municipio": 858
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100850,
+    "fields": {
+      "nombre": "Charlone",
+      "municipio": 858
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100851,
+    "fields": {
+      "nombre": "Chosmes",
+      "municipio": 858
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100852,
+    "fields": {
+      "nombre": "Donado",
+      "municipio": 858
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100853,
+    "fields": {
+      "nombre": "El Charco",
+      "municipio": 858
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100854,
+    "fields": {
+      "nombre": "El Lechuzo",
+      "municipio": 858
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100855,
+    "fields": {
+      "nombre": "Gorgonta",
+      "municipio": 858
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100856,
+    "fields": {
+      "nombre": "Huejeda",
+      "municipio": 858
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100857,
+    "fields": {
+      "nombre": "Juan Wenceslao Gez",
+      "municipio": 858
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100858,
+    "fields": {
+      "nombre": "La Costa",
+      "municipio": 858
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100859,
+    "fields": {
+      "nombre": "La Cumbrera",
+      "municipio": 858
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100860,
+    "fields": {
+      "nombre": "La Seña",
+      "municipio": 858
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100861,
+    "fields": {
+      "nombre": "Las Horquetas",
+      "municipio": 858
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100862,
+    "fields": {
+      "nombre": "Mataco",
+      "municipio": 858
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100863,
+    "fields": {
+      "nombre": "Mosmota",
+      "municipio": 858
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100864,
+    "fields": {
+      "nombre": "Paso de las Vacas",
+      "municipio": 858
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100865,
+    "fields": {
+      "nombre": "Pescadores",
+      "municipio": 858
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100866,
+    "fields": {
+      "nombre": "Pozo del Chañar",
+      "municipio": 858
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100867,
+    "fields": {
+      "nombre": "Santa Rosa",
+      "municipio": 858
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100868,
+    "fields": {
+      "nombre": "Santo Domingo",
+      "municipio": 858
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100869,
+    "fields": {
+      "nombre": "Suyuque",
+      "municipio": 858
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100870,
+    "fields": {
+      "nombre": "Suyuque Nuevo",
+      "municipio": 858
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100871,
+    "fields": {
+      "nombre": "Varela",
+      "municipio": 858
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100872,
+    "fields": {
+      "nombre": "Colonia San Emilio",
+      "municipio": 867
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100873,
+    "fields": {
+      "nombre": "Colonia Santafesina",
+      "municipio": 867
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100874,
+    "fields": {
+      "nombre": "Bella Unión",
+      "municipio": 871
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100875,
+    "fields": {
+      "nombre": "Colonia Las Tunas",
+      "municipio": 871
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100876,
+    "fields": {
+      "nombre": "Estación Santa Ana",
+      "municipio": 871
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100877,
+    "fields": {
+      "nombre": "Fortuna",
+      "municipio": 871
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100878,
+    "fields": {
+      "nombre": "Albardón",
+      "municipio": 879
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100879,
+    "fields": {
+      "nombre": "Arroyo Las Lechiguanas",
+      "municipio": 879
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100880,
+    "fields": {
+      "nombre": "Arroyo Sepultura",
+      "municipio": 879
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100881,
+    "fields": {
+      "nombre": "Buena Vista",
+      "municipio": 879
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100882,
+    "fields": {
+      "nombre": "Campo La Coraza",
+      "municipio": 879
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100883,
+    "fields": {
+      "nombre": "Cle",
+      "municipio": 879
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100884,
+    "fields": {
+      "nombre": "Cuatro Manos",
+      "municipio": 879
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100885,
+    "fields": {
+      "nombre": "González Calderón",
+      "municipio": 879
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100886,
+    "fields": {
+      "nombre": "La Cuadra",
+      "municipio": 879
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100887,
+    "fields": {
+      "nombre": "Monte Redondo",
+      "municipio": 879
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100888,
+    "fields": {
+      "nombre": "Punta del Monte",
+      "municipio": 879
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100889,
+    "fields": {
+      "nombre": "Sauce",
+      "municipio": 879
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100890,
+    "fields": {
+      "nombre": "Tres Bocas",
+      "municipio": 879
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100891,
+    "fields": {
+      "nombre": "Vizcachas",
+      "municipio": 879
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100892,
+    "fields": {
+      "nombre": "Algarrobito 1ro.",
+      "municipio": 897
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100893,
+    "fields": {
+      "nombre": "Betbeder",
+      "municipio": 897
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100894,
+    "fields": {
+      "nombre": "Campo Micheloud",
+      "municipio": 897
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100895,
+    "fields": {
+      "nombre": "Colonia La Esperanza",
+      "municipio": 897
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100896,
+    "fields": {
+      "nombre": "Colonia La Llave",
+      "municipio": 897
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100897,
+    "fields": {
+      "nombre": "Colonia Oficial 21",
+      "municipio": 897
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100898,
+    "fields": {
+      "nombre": "Crucesitas Séptima",
+      "municipio": 897
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100899,
+    "fields": {
+      "nombre": "Crucesitas Tercera",
+      "municipio": 897
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100900,
+    "fields": {
+      "nombre": "Don Cristóbal Segundo",
+      "municipio": 897
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100901,
+    "fields": {
+      "nombre": "La Corvina",
+      "municipio": 897
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100902,
+    "fields": {
+      "nombre": "La Ilusión",
+      "municipio": 897
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100903,
+    "fields": {
+      "nombre": "La Tablada",
+      "municipio": 897
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100904,
+    "fields": {
+      "nombre": "Sauce",
+      "municipio": 897
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100905,
+    "fields": {
+      "nombre": "25 de Mayo de Banegas",
+      "municipio": 926
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100906,
+    "fields": {
+      "nombre": "25 de Mayo Sur",
+      "municipio": 926
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100907,
+    "fields": {
+      "nombre": "Alto Bello",
+      "municipio": 926
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100908,
+    "fields": {
+      "nombre": "Ancaján",
+      "municipio": 926
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100909,
+    "fields": {
+      "nombre": "Bajo Hondo",
+      "municipio": 926
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100910,
+    "fields": {
+      "nombre": "Cerro Chico",
+      "municipio": 926
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100911,
+    "fields": {
+      "nombre": "Chañar Pozo",
+      "municipio": 926
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100912,
+    "fields": {
+      "nombre": "Choya",
+      "municipio": 926
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100913,
+    "fields": {
+      "nombre": "Dique La Punta",
+      "municipio": 926
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100914,
+    "fields": {
+      "nombre": "El Desmonte",
+      "municipio": 926
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100915,
+    "fields": {
+      "nombre": "El Mojoncito",
+      "municipio": 926
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100916,
+    "fields": {
+      "nombre": "El Puestito",
+      "municipio": 926
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100917,
+    "fields": {
+      "nombre": "El Rodeo",
+      "municipio": 926
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100918,
+    "fields": {
+      "nombre": "El Salvador",
+      "municipio": 926
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100919,
+    "fields": {
+      "nombre": "El Tacial",
+      "municipio": 926
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100920,
+    "fields": {
+      "nombre": "Estación La Punta",
+      "municipio": 926
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100921,
+    "fields": {
+      "nombre": "Guatana",
+      "municipio": 926
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100922,
+    "fields": {
+      "nombre": "Kilómetro 18",
+      "municipio": 926
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100923,
+    "fields": {
+      "nombre": "Kilómetro 55",
+      "municipio": 926
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100924,
+    "fields": {
+      "nombre": "La Barranquita",
+      "municipio": 926
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100925,
+    "fields": {
+      "nombre": "La Buena Estrella",
+      "municipio": 926
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100926,
+    "fields": {
+      "nombre": "La Represa",
+      "municipio": 926
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100927,
+    "fields": {
+      "nombre": "La Suerte",
+      "municipio": 926
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100928,
+    "fields": {
+      "nombre": "La Vuelta",
+      "municipio": 926
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100929,
+    "fields": {
+      "nombre": "Laprida",
+      "municipio": 926
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100930,
+    "fields": {
+      "nombre": "Las Iguanas",
+      "municipio": 926
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100931,
+    "fields": {
+      "nombre": "Las Peñas",
+      "municipio": 926
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100932,
+    "fields": {
+      "nombre": "Las Tejas",
+      "municipio": 926
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100933,
+    "fields": {
+      "nombre": "Los Ralos",
+      "municipio": 926
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100934,
+    "fields": {
+      "nombre": "Palo Parado",
+      "municipio": 926
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100935,
+    "fields": {
+      "nombre": "Pozancones",
+      "municipio": 926
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100936,
+    "fields": {
+      "nombre": "Pozo del Campo",
+      "municipio": 926
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100937,
+    "fields": {
+      "nombre": "Pozo del Simbol",
+      "municipio": 926
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100938,
+    "fields": {
+      "nombre": "Puerta de Chávez",
+      "municipio": 926
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100939,
+    "fields": {
+      "nombre": "San Antonio de las Flores",
+      "municipio": 926
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100940,
+    "fields": {
+      "nombre": "San Juan",
+      "municipio": 926
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100941,
+    "fields": {
+      "nombre": "San Justo",
+      "municipio": 926
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100942,
+    "fields": {
+      "nombre": "San Miguel",
+      "municipio": 926
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100943,
+    "fields": {
+      "nombre": "San Pedro",
+      "municipio": 926
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100944,
+    "fields": {
+      "nombre": "San Rafael",
+      "municipio": 926
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100945,
+    "fields": {
+      "nombre": "Santa Cruz",
+      "municipio": 926
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100946,
+    "fields": {
+      "nombre": "Santa Lucía",
+      "municipio": 926
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100947,
+    "fields": {
+      "nombre": "Shishi Pozo",
+      "municipio": 926
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100948,
+    "fields": {
+      "nombre": "Sinchi Caña",
+      "municipio": 926
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100949,
+    "fields": {
+      "nombre": "Sobremonte",
+      "municipio": 926
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100950,
+    "fields": {
+      "nombre": "Sol de Mayo",
+      "municipio": 926
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100951,
+    "fields": {
+      "nombre": "Tapso",
+      "municipio": 926
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100952,
+    "fields": {
+      "nombre": "Tusca Pozo",
+      "municipio": 926
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100953,
+    "fields": {
+      "nombre": "Villa Adela",
+      "municipio": 926
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100954,
+    "fields": {
+      "nombre": "Villa Elvira",
+      "municipio": 926
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100955,
+    "fields": {
+      "nombre": "Villa La Punta",
+      "municipio": 926
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100956,
+    "fields": {
+      "nombre": "Villa Mercedes",
+      "municipio": 926
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100957,
+    "fields": {
+      "nombre": "Alto de Rumiarco",
+      "municipio": 929
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100958,
+    "fields": {
+      "nombre": "El Infiernillo",
+      "municipio": 929
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100959,
+    "fields": {
+      "nombre": "La Bolsa",
+      "municipio": 929
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100960,
+    "fields": {
+      "nombre": "La Ciénaga",
+      "municipio": 929
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100961,
+    "fields": {
+      "nombre": "Las Tacanas",
+      "municipio": 929
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100962,
+    "fields": {
+      "nombre": "Ovejería",
+      "municipio": 929
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100963,
+    "fields": {
+      "nombre": "Agua del Capataz",
+      "municipio": 948
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100964,
+    "fields": {
+      "nombre": "Alto del Algarrobal",
+      "municipio": 948
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100965,
+    "fields": {
+      "nombre": "Arístides Villanueva",
+      "municipio": 948
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100966,
+    "fields": {
+      "nombre": "Cañada Amarilla",
+      "municipio": 948
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100967,
+    "fields": {
+      "nombre": "Cañada Seca",
+      "municipio": 948
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100968,
+    "fields": {
+      "nombre": "Cañon del Atuel",
+      "municipio": 948
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100969,
+    "fields": {
+      "nombre": "Colonia Bombal y Tabanera",
+      "municipio": 948
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100970,
+    "fields": {
+      "nombre": "Colonia Colomer",
+      "municipio": 948
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100971,
+    "fields": {
+      "nombre": "Colonia El Usillal",
+      "municipio": 948
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100972,
+    "fields": {
+      "nombre": "Colonia Elena",
+      "municipio": 948
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100973,
+    "fields": {
+      "nombre": "Colonia Española",
+      "municipio": 948
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100974,
+    "fields": {
+      "nombre": "Colonia Gelman",
+      "municipio": 948
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100975,
+    "fields": {
+      "nombre": "Colonia Jáuregui",
+      "municipio": 948
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100976,
+    "fields": {
+      "nombre": "Colonia López",
+      "municipio": 948
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100977,
+    "fields": {
+      "nombre": "Colonia Real del Padre",
+      "municipio": 948
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100978,
+    "fields": {
+      "nombre": "Colonia Rusa",
+      "municipio": 948
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100979,
+    "fields": {
+      "nombre": "Cuesta de los Terneros",
+      "municipio": 948
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100980,
+    "fields": {
+      "nombre": "Cueva del Indio",
+      "municipio": 948
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100981,
+    "fields": {
+      "nombre": "Dique Agua del Toro",
+      "municipio": 948
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100982,
+    "fields": {
+      "nombre": "Dique Los Reyunos",
+      "municipio": 948
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100983,
+    "fields": {
+      "nombre": "El Algarrobal",
+      "municipio": 948
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100984,
+    "fields": {
+      "nombre": "El Balde",
+      "municipio": 948
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100985,
+    "fields": {
+      "nombre": "El Cerrito",
+      "municipio": 948
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100986,
+    "fields": {
+      "nombre": "El Desvío",
+      "municipio": 948
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100987,
+    "fields": {
+      "nombre": "El Escorial",
+      "municipio": 948
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100988,
+    "fields": {
+      "nombre": "El Vencedor",
+      "municipio": 948
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100989,
+    "fields": {
+      "nombre": "El Vidalino",
+      "municipio": 948
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100990,
+    "fields": {
+      "nombre": "Estación El Nihuil",
+      "municipio": 948
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100991,
+    "fields": {
+      "nombre": "Estación El Sosneado",
+      "municipio": 948
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100992,
+    "fields": {
+      "nombre": "Guadales",
+      "municipio": 948
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100993,
+    "fields": {
+      "nombre": "Huaca Co",
+      "municipio": 948
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100994,
+    "fields": {
+      "nombre": "La Guevarina",
+      "municipio": 948
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100995,
+    "fields": {
+      "nombre": "La Horqueta",
+      "municipio": 948
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100996,
+    "fields": {
+      "nombre": "La Llave Sur",
+      "municipio": 948
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100997,
+    "fields": {
+      "nombre": "La Llave Vieja",
+      "municipio": 948
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100998,
+    "fields": {
+      "nombre": "La Nora",
+      "municipio": 948
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 100999,
+    "fields": {
+      "nombre": "La Pichana",
+      "municipio": 948
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101000,
+    "fields": {
+      "nombre": "La Ripiera",
+      "municipio": 948
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101001,
+    "fields": {
+      "nombre": "La Tosca",
+      "municipio": 948
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101002,
+    "fields": {
+      "nombre": "La Vasconia",
+      "municipio": 948
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101003,
+    "fields": {
+      "nombre": "Las Aguaditas",
+      "municipio": 948
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101004,
+    "fields": {
+      "nombre": "Las Malvinas Norte",
+      "municipio": 948
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101005,
+    "fields": {
+      "nombre": "Las Malvinas Sur",
+      "municipio": 948
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101006,
+    "fields": {
+      "nombre": "Las Paredes",
+      "municipio": 948
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101007,
+    "fields": {
+      "nombre": "Los Buitres",
+      "municipio": 948
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101008,
+    "fields": {
+      "nombre": "Los Claveles",
+      "municipio": 948
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101009,
+    "fields": {
+      "nombre": "Los Embanques",
+      "municipio": 948
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101010,
+    "fields": {
+      "nombre": "Los Parlamentos",
+      "municipio": 948
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101011,
+    "fields": {
+      "nombre": "Los Pejecitos",
+      "municipio": 948
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101012,
+    "fields": {
+      "nombre": "Los Pocitos",
+      "municipio": 948
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101013,
+    "fields": {
+      "nombre": "Los Sifones",
+      "municipio": 948
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101014,
+    "fields": {
+      "nombre": "Los Tableros",
+      "municipio": 948
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101015,
+    "fields": {
+      "nombre": "Los Terneros",
+      "municipio": 948
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101016,
+    "fields": {
+      "nombre": "Los Toldos",
+      "municipio": 948
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101017,
+    "fields": {
+      "nombre": "Minas El Sosneado",
+      "municipio": 948
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101018,
+    "fields": {
+      "nombre": "Planta de Azufre",
+      "municipio": 948
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101019,
+    "fields": {
+      "nombre": "Presa El Tigre",
+      "municipio": 948
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101020,
+    "fields": {
+      "nombre": "Refugio General Soler",
+      "municipio": 948
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101021,
+    "fields": {
+      "nombre": "Resolana",
+      "municipio": 948
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101022,
+    "fields": {
+      "nombre": "Rincón del Atuel",
+      "municipio": 948
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101023,
+    "fields": {
+      "nombre": "Rincón del Indio",
+      "municipio": 948
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101024,
+    "fields": {
+      "nombre": "Salinas El Diamante",
+      "municipio": 948
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101025,
+    "fields": {
+      "nombre": "Santa Teresa",
+      "municipio": 948
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101026,
+    "fields": {
+      "nombre": "Soitué",
+      "municipio": 948
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101027,
+    "fields": {
+      "nombre": "Termas El Sosneado",
+      "municipio": 948
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101028,
+    "fields": {
+      "nombre": "Valle Grande",
+      "municipio": 948
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101029,
+    "fields": {
+      "nombre": "Boca Riacho Pilagá",
+      "municipio": 1113
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101030,
+    "fields": {
+      "nombre": "Cañada Doce",
+      "municipio": 1113
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101031,
+    "fields": {
+      "nombre": "Colonia Dalmacia",
+      "municipio": 1113
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101032,
+    "fields": {
+      "nombre": "Colonia Ituzaingó",
+      "municipio": 1113
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101033,
+    "fields": {
+      "nombre": "Colonia Presidente Yrigoyen",
+      "municipio": 1113
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101034,
+    "fields": {
+      "nombre": "El Angelito",
+      "municipio": 1113
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101035,
+    "fields": {
+      "nombre": "Isla 25 de Mayo",
+      "municipio": 1113
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101036,
+    "fields": {
+      "nombre": "Loma Clavel",
+      "municipio": 1113
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101037,
+    "fields": {
+      "nombre": "Mariano Boedo",
+      "municipio": 1113
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101038,
+    "fields": {
+      "nombre": "Mojón de Fierro",
+      "municipio": 1113
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101039,
+    "fields": {
+      "nombre": "Puerto Dalmacia",
+      "municipio": 1113
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101040,
+    "fields": {
+      "nombre": "San Alberto",
+      "municipio": 1113
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101041,
+    "fields": {
+      "nombre": "Timbo Porá",
+      "municipio": 1113
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101042,
+    "fields": {
+      "nombre": "Tres Marías",
+      "municipio": 1113
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101043,
+    "fields": {
+      "nombre": "Corcovado Sur",
+      "municipio": 1114
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101044,
+    "fields": {
+      "nombre": "Costa del Gualjaina",
+      "municipio": 1114
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101045,
+    "fields": {
+      "nombre": "El Molle",
+      "municipio": 1114
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101046,
+    "fields": {
+      "nombre": "La Payanca",
+      "municipio": 1114
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101047,
+    "fields": {
+      "nombre": "Lago Engaño",
+      "municipio": 1114
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101048,
+    "fields": {
+      "nombre": "Lago Guacho",
+      "municipio": 1114
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101049,
+    "fields": {
+      "nombre": "Loco Trapial",
+      "municipio": 1114
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101050,
+    "fields": {
+      "nombre": "Pampa de Agnia",
+      "municipio": 1114
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101051,
+    "fields": {
+      "nombre": "Piedra Parada",
+      "municipio": 1114
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101052,
+    "fields": {
+      "nombre": "Agua del Overo",
+      "municipio": 1116
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101053,
+    "fields": {
+      "nombre": "Aguada Florencio",
+      "municipio": 1116
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101054,
+    "fields": {
+      "nombre": "Bajada de los Molles",
+      "municipio": 1116
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101055,
+    "fields": {
+      "nombre": "Caichihué",
+      "municipio": 1116
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101056,
+    "fields": {
+      "nombre": "Catán Lil",
+      "municipio": 1116
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101057,
+    "fields": {
+      "nombre": "Chacayco",
+      "municipio": 1116
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101058,
+    "fields": {
+      "nombre": "Chacayco Sur",
+      "municipio": 1116
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101059,
+    "fields": {
+      "nombre": "Costa del Catán Lil",
+      "municipio": 1116
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101060,
+    "fields": {
+      "nombre": "El Marucho",
+      "municipio": 1116
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101061,
+    "fields": {
+      "nombre": "El Salitral",
+      "municipio": 1116
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101062,
+    "fields": {
+      "nombre": "Espinazo del Zorro",
+      "municipio": 1116
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101063,
+    "fields": {
+      "nombre": "Fortín 1° de Mayo",
+      "municipio": 1116
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101064,
+    "fields": {
+      "nombre": "La Amarga",
+      "municipio": 1116
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101065,
+    "fields": {
+      "nombre": "La Bomba",
+      "municipio": 1116
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101066,
+    "fields": {
+      "nombre": "La Negra",
+      "municipio": 1116
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101067,
+    "fields": {
+      "nombre": "Las Cortaderas",
+      "municipio": 1116
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101068,
+    "fields": {
+      "nombre": "Media Luna",
+      "municipio": 1116
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101069,
+    "fields": {
+      "nombre": "Ojo de Agua",
+      "municipio": 1116
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101070,
+    "fields": {
+      "nombre": "Rincón del Peral",
+      "municipio": 1116
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101071,
+    "fields": {
+      "nombre": "9 de Julio",
+      "municipio": 1138
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101072,
+    "fields": {
+      "nombre": "Bañadero",
+      "municipio": 1138
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101073,
+    "fields": {
+      "nombre": "Cabo 1° Noroña",
+      "municipio": 1138
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101074,
+    "fields": {
+      "nombre": "Campo Hardy",
+      "municipio": 1138
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101075,
+    "fields": {
+      "nombre": "Campo San Rafael",
+      "municipio": 1138
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101076,
+    "fields": {
+      "nombre": "Centro Forestal Pirané",
+      "municipio": 1138
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101077,
+    "fields": {
+      "nombre": "Colonia 15",
+      "municipio": 1138
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101078,
+    "fields": {
+      "nombre": "Colonia 5 de Octubre",
+      "municipio": 1138
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101079,
+    "fields": {
+      "nombre": "Colonia El Alba",
+      "municipio": 1138
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101080,
+    "fields": {
+      "nombre": "Colonia El Chajá",
+      "municipio": 1138
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101081,
+    "fields": {
+      "nombre": "Colonia El Desaguadero",
+      "municipio": 1138
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101082,
+    "fields": {
+      "nombre": "Colonia El Olvido",
+      "municipio": 1138
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101083,
+    "fields": {
+      "nombre": "Colonia El Palmar",
+      "municipio": 1138
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101084,
+    "fields": {
+      "nombre": "Colonia El Progreso",
+      "municipio": 1138
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101085,
+    "fields": {
+      "nombre": "Colonia El Rincón",
+      "municipio": 1138
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101086,
+    "fields": {
+      "nombre": "Colonia El Zapallito",
+      "municipio": 1138
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101087,
+    "fields": {
+      "nombre": "Colonia Itatí",
+      "municipio": 1138
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101088,
+    "fields": {
+      "nombre": "Colonia La Disciplina",
+      "municipio": 1138
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101089,
+    "fields": {
+      "nombre": "Colonia La Unión",
+      "municipio": 1138
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101090,
+    "fields": {
+      "nombre": "Colonia Para Todos",
+      "municipio": 1138
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101091,
+    "fields": {
+      "nombre": "Colonia Potrero Norte",
+      "municipio": 1138
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101092,
+    "fields": {
+      "nombre": "Colonia Rigonato",
+      "municipio": 1138
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101093,
+    "fields": {
+      "nombre": "Colonia Roda",
+      "municipio": 1138
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101094,
+    "fields": {
+      "nombre": "Colonia Santa Cruz",
+      "municipio": 1138
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101095,
+    "fields": {
+      "nombre": "Colonia Weitzel",
+      "municipio": 1138
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101096,
+    "fields": {
+      "nombre": "Copo Blanco",
+      "municipio": 1138
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101097,
+    "fields": {
+      "nombre": "Costa Riacho Alazán",
+      "municipio": 1138
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101098,
+    "fields": {
+      "nombre": "El Bellaco",
+      "municipio": 1138
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101099,
+    "fields": {
+      "nombre": "El Bosquecillo",
+      "municipio": 1138
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101100,
+    "fields": {
+      "nombre": "El Coatí",
+      "municipio": 1138
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101101,
+    "fields": {
+      "nombre": "El Corralito",
+      "municipio": 1138
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101102,
+    "fields": {
+      "nombre": "El Gato",
+      "municipio": 1138
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101103,
+    "fields": {
+      "nombre": "El Piquete",
+      "municipio": 1138
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101104,
+    "fields": {
+      "nombre": "El Poí",
+      "municipio": 1138
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101105,
+    "fields": {
+      "nombre": "El Resguardo",
+      "municipio": 1138
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101106,
+    "fields": {
+      "nombre": "El Saladillo",
+      "municipio": 1138
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101107,
+    "fields": {
+      "nombre": "El Salado",
+      "municipio": 1138
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101108,
+    "fields": {
+      "nombre": "Ibagay",
+      "municipio": 1138
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101109,
+    "fields": {
+      "nombre": "Kilómetro 142",
+      "municipio": 1138
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101110,
+    "fields": {
+      "nombre": "Kilómetro 224",
+      "municipio": 1138
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101111,
+    "fields": {
+      "nombre": "La Blanca",
+      "municipio": 1138
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101112,
+    "fields": {
+      "nombre": "La Esperanza",
+      "municipio": 1138
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101113,
+    "fields": {
+      "nombre": "La Floresta",
+      "municipio": 1138
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101114,
+    "fields": {
+      "nombre": "La Loma",
+      "municipio": 1138
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101115,
+    "fields": {
+      "nombre": "La Lomita",
+      "municipio": 1138
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101116,
+    "fields": {
+      "nombre": "La Picadita",
+      "municipio": 1138
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101117,
+    "fields": {
+      "nombre": "La Sirena",
+      "municipio": 1138
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101118,
+    "fields": {
+      "nombre": "La Unión Sur",
+      "municipio": 1138
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101119,
+    "fields": {
+      "nombre": "Las Cañitas",
+      "municipio": 1138
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101120,
+    "fields": {
+      "nombre": "Loma Alberdi",
+      "municipio": 1138
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101121,
+    "fields": {
+      "nombre": "Loma El Quebranto",
+      "municipio": 1138
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101122,
+    "fields": {
+      "nombre": "Loma Senés",
+      "municipio": 1138
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101123,
+    "fields": {
+      "nombre": "Los Matacos",
+      "municipio": 1138
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101124,
+    "fields": {
+      "nombre": "Lote 11",
+      "municipio": 1138
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101125,
+    "fields": {
+      "nombre": "Lote 17 Legua A",
+      "municipio": 1138
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101126,
+    "fields": {
+      "nombre": "Lote 219",
+      "municipio": 1138
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101127,
+    "fields": {
+      "nombre": "Lote 9",
+      "municipio": 1138
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101128,
+    "fields": {
+      "nombre": "Mercedes Cué",
+      "municipio": 1138
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101129,
+    "fields": {
+      "nombre": "Monte Quemado",
+      "municipio": 1138
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101130,
+    "fields": {
+      "nombre": "Murúa",
+      "municipio": 1138
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101131,
+    "fields": {
+      "nombre": "Pilagás III",
+      "municipio": 1138
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101132,
+    "fields": {
+      "nombre": "Racedo Escobar",
+      "municipio": 1138
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101133,
+    "fields": {
+      "nombre": "Salvación",
+      "municipio": 1138
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101134,
+    "fields": {
+      "nombre": "Basualdo",
+      "municipio": 1152
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101135,
+    "fields": {
+      "nombre": "Colonia Oficial 18",
+      "municipio": 1152
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101136,
+    "fields": {
+      "nombre": "Estación La Esmeralda",
+      "municipio": 1152
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101137,
+    "fields": {
+      "nombre": "Garat",
+      "municipio": 1152
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101138,
+    "fields": {
+      "nombre": "La Esmeralda",
+      "municipio": 1152
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101139,
+    "fields": {
+      "nombre": "La Hierra",
+      "municipio": 1152
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101140,
+    "fields": {
+      "nombre": "La Te",
+      "municipio": 1152
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101141,
+    "fields": {
+      "nombre": "Las Mulitas",
+      "municipio": 1152
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101142,
+    "fields": {
+      "nombre": "Paso Puente de Hierro",
+      "municipio": 1152
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101143,
+    "fields": {
+      "nombre": "Rincón de Mesa",
+      "municipio": 1152
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101144,
+    "fields": {
+      "nombre": "Cascada Los Alerces",
+      "municipio": 1156
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101145,
+    "fields": {
+      "nombre": "El Balcón",
+      "municipio": 1156
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101146,
+    "fields": {
+      "nombre": "El Foyel",
+      "municipio": 1156
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101147,
+    "fields": {
+      "nombre": "El Manso",
+      "municipio": 1156
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101148,
+    "fields": {
+      "nombre": "Fonck Chico",
+      "municipio": 1156
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101149,
+    "fields": {
+      "nombre": "Fonck Grande",
+      "municipio": 1156
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101150,
+    "fields": {
+      "nombre": "La Veranada",
+      "municipio": 1156
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101151,
+    "fields": {
+      "nombre": "Lago Escondido",
+      "municipio": 1156
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101152,
+    "fields": {
+      "nombre": "Lago Guillelmo",
+      "municipio": 1156
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101153,
+    "fields": {
+      "nombre": "Lago Hess",
+      "municipio": 1156
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101154,
+    "fields": {
+      "nombre": "Lago Martín",
+      "municipio": 1156
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101155,
+    "fields": {
+      "nombre": "Lago Roca",
+      "municipio": 1156
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101156,
+    "fields": {
+      "nombre": "Lago Steffen",
+      "municipio": 1156
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101157,
+    "fields": {
+      "nombre": "Laguna Los Moscos",
+      "municipio": 1156
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101158,
+    "fields": {
+      "nombre": "Manso Inferior",
+      "municipio": 1156
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101159,
+    "fields": {
+      "nombre": "Pampa del Toro",
+      "municipio": 1156
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101160,
+    "fields": {
+      "nombre": "Pampa Linda",
+      "municipio": 1156
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101161,
+    "fields": {
+      "nombre": "Paso del Manso",
+      "municipio": 1156
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101162,
+    "fields": {
+      "nombre": "Playa Negra",
+      "municipio": 1156
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101163,
+    "fields": {
+      "nombre": "Quimey Mahuida",
+      "municipio": 1156
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101164,
+    "fields": {
+      "nombre": "Río Villegas",
+      "municipio": 1156
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101165,
+    "fields": {
+      "nombre": "Villa Mascardi",
+      "municipio": 1156
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101166,
+    "fields": {
+      "nombre": "Agua de Cabrera",
+      "municipio": 1157
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101167,
+    "fields": {
+      "nombre": "Agua de los Novillos",
+      "municipio": 1157
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101168,
+    "fields": {
+      "nombre": "Agua de Pérez",
+      "municipio": 1157
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101169,
+    "fields": {
+      "nombre": "Agua del Toro",
+      "municipio": 1157
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101170,
+    "fields": {
+      "nombre": "Agua Nueva",
+      "municipio": 1157
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101171,
+    "fields": {
+      "nombre": "Buta Billón",
+      "municipio": 1157
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101172,
+    "fields": {
+      "nombre": "Camulcó",
+      "municipio": 1157
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101173,
+    "fields": {
+      "nombre": "Cañadón Amarillo",
+      "municipio": 1157
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101174,
+    "fields": {
+      "nombre": "Castillos de Pincheira",
+      "municipio": 1157
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101175,
+    "fields": {
+      "nombre": "Caverna de las Brujas",
+      "municipio": 1157
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101176,
+    "fields": {
+      "nombre": "Cerro Fortunoso",
+      "municipio": 1157
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101177,
+    "fields": {
+      "nombre": "Chalahuén",
+      "municipio": 1157
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101178,
+    "fields": {
+      "nombre": "Coehue Co",
+      "municipio": 1157
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101179,
+    "fields": {
+      "nombre": "Coihueco",
+      "municipio": 1157
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101180,
+    "fields": {
+      "nombre": "Coihueco Norte",
+      "municipio": 1157
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101181,
+    "fields": {
+      "nombre": "Cristo de la Quebrada",
+      "municipio": 1157
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101182,
+    "fields": {
+      "nombre": "Desfiladero Bayo",
+      "municipio": 1157
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101183,
+    "fields": {
+      "nombre": "Dique Blas Brisoli",
+      "municipio": 1157
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101184,
+    "fields": {
+      "nombre": "El Alambrado",
+      "municipio": 1157
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101185,
+    "fields": {
+      "nombre": "El Carapacho",
+      "municipio": 1157
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101186,
+    "fields": {
+      "nombre": "El Chacay",
+      "municipio": 1157
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101187,
+    "fields": {
+      "nombre": "El Clavado",
+      "municipio": 1157
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101188,
+    "fields": {
+      "nombre": "El Corcovo",
+      "municipio": 1157
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101189,
+    "fields": {
+      "nombre": "El Salitral",
+      "municipio": 1157
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101190,
+    "fields": {
+      "nombre": "El Vatro",
+      "municipio": 1157
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101191,
+    "fields": {
+      "nombre": "El Zampal",
+      "municipio": 1157
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101192,
+    "fields": {
+      "nombre": "Fortín Malal Hue",
+      "municipio": 1157
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101193,
+    "fields": {
+      "nombre": "Invernada del Viejo",
+      "municipio": 1157
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101194,
+    "fields": {
+      "nombre": "Jagüel del Mayo",
+      "municipio": 1157
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101195,
+    "fields": {
+      "nombre": "La Batra",
+      "municipio": 1157
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101196,
+    "fields": {
+      "nombre": "La Cantera",
+      "municipio": 1157
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101197,
+    "fields": {
+      "nombre": "La Cortadera",
+      "municipio": 1157
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101198,
+    "fields": {
+      "nombre": "La Matancilla",
+      "municipio": 1157
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101199,
+    "fields": {
+      "nombre": "La Pasarela",
+      "municipio": 1157
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101200,
+    "fields": {
+      "nombre": "La Salinilla",
+      "municipio": 1157
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101201,
+    "fields": {
+      "nombre": "La Valenciana",
+      "municipio": 1157
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101202,
+    "fields": {
+      "nombre": "Laguna La Niña Encantada",
+      "municipio": 1157
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101203,
+    "fields": {
+      "nombre": "Las Loicas",
+      "municipio": 1157
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101204,
+    "fields": {
+      "nombre": "Los Cavaos",
+      "municipio": 1157
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101205,
+    "fields": {
+      "nombre": "Los Frisos",
+      "municipio": 1157
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101206,
+    "fields": {
+      "nombre": "Los Molles",
+      "municipio": 1157
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101207,
+    "fields": {
+      "nombre": "Los Relinchos",
+      "municipio": 1157
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101208,
+    "fields": {
+      "nombre": "Malal del Medio",
+      "municipio": 1157
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101209,
+    "fields": {
+      "nombre": "Manqui Malal",
+      "municipio": 1157
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101210,
+    "fields": {
+      "nombre": "Mechanquil",
+      "municipio": 1157
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101211,
+    "fields": {
+      "nombre": "Mina Ethel",
+      "municipio": 1157
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101212,
+    "fields": {
+      "nombre": "Mina Las Lajas",
+      "municipio": 1157
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101213,
+    "fields": {
+      "nombre": "Minacar",
+      "municipio": 1157
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101214,
+    "fields": {
+      "nombre": "ñire Co",
+      "municipio": 1157
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101215,
+    "fields": {
+      "nombre": "Paso de las Damas",
+      "municipio": 1157
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101216,
+    "fields": {
+      "nombre": "Paso Pehuenche",
+      "municipio": 1157
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101217,
+    "fields": {
+      "nombre": "Paso Vergara",
+      "municipio": 1157
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101218,
+    "fields": {
+      "nombre": "Pata Mora",
+      "municipio": 1157
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101219,
+    "fields": {
+      "nombre": "Poti Malal",
+      "municipio": 1157
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101220,
+    "fields": {
+      "nombre": "Puente Amarillo",
+      "municipio": 1157
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101221,
+    "fields": {
+      "nombre": "Puntilla de Huincan",
+      "municipio": 1157
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101222,
+    "fields": {
+      "nombre": "Rincón de Correa",
+      "municipio": 1157
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101223,
+    "fields": {
+      "nombre": "Río Barrancas",
+      "municipio": 1157
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101224,
+    "fields": {
+      "nombre": "Río Grande",
+      "municipio": 1157
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101225,
+    "fields": {
+      "nombre": "Termas Cajón Grande",
+      "municipio": 1157
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101226,
+    "fields": {
+      "nombre": "Termas del Azufre",
+      "municipio": 1157
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101227,
+    "fields": {
+      "nombre": "Campo Ampurdán",
+      "municipio": 1160
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101228,
+    "fields": {
+      "nombre": "Colonia El Arbol",
+      "municipio": 1160
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101229,
+    "fields": {
+      "nombre": "Colonia El Guanaco",
+      "municipio": 1160
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101230,
+    "fields": {
+      "nombre": "Colonia El Noy",
+      "municipio": 1160
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101231,
+    "fields": {
+      "nombre": "Colonia La Providencia",
+      "municipio": 1160
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101232,
+    "fields": {
+      "nombre": "Colonia San Eugenio",
+      "municipio": 1160
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101233,
+    "fields": {
+      "nombre": "Colonia San Miguel",
+      "municipio": 1160
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101234,
+    "fields": {
+      "nombre": "Colonia Santa Ana",
+      "municipio": 1160
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101235,
+    "fields": {
+      "nombre": "Colonia Santa Clara",
+      "municipio": 1160
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101236,
+    "fields": {
+      "nombre": "Colonia Santa Cristina",
+      "municipio": 1160
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101237,
+    "fields": {
+      "nombre": "Colonia Santa Rosa",
+      "municipio": 1160
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101238,
+    "fields": {
+      "nombre": "Curapaligüe",
+      "municipio": 1160
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101239,
+    "fields": {
+      "nombre": "El Paraíso",
+      "municipio": 1160
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101240,
+    "fields": {
+      "nombre": "Fray Cayetano Rodríguez",
+      "municipio": 1160
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101241,
+    "fields": {
+      "nombre": "Gavilán",
+      "municipio": 1160
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101242,
+    "fields": {
+      "nombre": "Guardia Vieja",
+      "municipio": 1160
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101243,
+    "fields": {
+      "nombre": "Kilómetro 545",
+      "municipio": 1160
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101244,
+    "fields": {
+      "nombre": "La Amalia",
+      "municipio": 1160
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101245,
+    "fields": {
+      "nombre": "La Emilia",
+      "municipio": 1160
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101246,
+    "fields": {
+      "nombre": "Laguna del Monte",
+      "municipio": 1160
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101247,
+    "fields": {
+      "nombre": "Las Tres Colonias Unidas",
+      "municipio": 1160
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101248,
+    "fields": {
+      "nombre": "Miguel Salas",
+      "municipio": 1160
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101249,
+    "fields": {
+      "nombre": "Ruiz Díaz de Guzmán",
+      "municipio": 1160
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101250,
+    "fields": {
+      "nombre": "Salguero",
+      "municipio": 1160
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101251,
+    "fields": {
+      "nombre": "Vivero",
+      "municipio": 1160
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101252,
+    "fields": {
+      "nombre": "Campo Battiston",
+      "municipio": 1187
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101253,
+    "fields": {
+      "nombre": "Campo Bertoglio",
+      "municipio": 1187
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101254,
+    "fields": {
+      "nombre": "Campo Boaglio",
+      "municipio": 1187
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101255,
+    "fields": {
+      "nombre": "Campo Caprivi",
+      "municipio": 1187
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101256,
+    "fields": {
+      "nombre": "Campo del Bel",
+      "municipio": 1187
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101257,
+    "fields": {
+      "nombre": "Campo Janon",
+      "municipio": 1187
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101258,
+    "fields": {
+      "nombre": "Campo La Ramada",
+      "municipio": 1187
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101259,
+    "fields": {
+      "nombre": "Campo La Rosa",
+      "municipio": 1187
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101260,
+    "fields": {
+      "nombre": "Campo Macagno",
+      "municipio": 1187
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101261,
+    "fields": {
+      "nombre": "Campo Marengo",
+      "municipio": 1187
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101262,
+    "fields": {
+      "nombre": "Campo Martolino",
+      "municipio": 1187
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101263,
+    "fields": {
+      "nombre": "Campo Nigro Norte",
+      "municipio": 1187
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101264,
+    "fields": {
+      "nombre": "Campo Nigro Sur",
+      "municipio": 1187
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101265,
+    "fields": {
+      "nombre": "Campo Perotti",
+      "municipio": 1187
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101266,
+    "fields": {
+      "nombre": "Campo Rossi",
+      "municipio": 1187
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101267,
+    "fields": {
+      "nombre": "Campo San Alfredo",
+      "municipio": 1187
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101268,
+    "fields": {
+      "nombre": "Campo Scarafiocca",
+      "municipio": 1187
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101269,
+    "fields": {
+      "nombre": "Capilla de Rodríguez",
+      "municipio": 1187
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101270,
+    "fields": {
+      "nombre": "Capilla Garzón",
+      "municipio": 1187
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101271,
+    "fields": {
+      "nombre": "Colonia Bella Vista",
+      "municipio": 1187
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101272,
+    "fields": {
+      "nombre": "Colonia Lola",
+      "municipio": 1187
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101273,
+    "fields": {
+      "nombre": "Colonia Los Tamarindos",
+      "municipio": 1187
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101274,
+    "fields": {
+      "nombre": "Colonia Santa Catalina",
+      "municipio": 1187
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101275,
+    "fields": {
+      "nombre": "El Chilo",
+      "municipio": 1187
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101276,
+    "fields": {
+      "nombre": "Las Selvas",
+      "municipio": 1187
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101277,
+    "fields": {
+      "nombre": "Paso Las Selvas",
+      "municipio": 1187
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101278,
+    "fields": {
+      "nombre": "Paso de Jama",
+      "municipio": 1208
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101279,
+    "fields": {
+      "nombre": "Paso Incahuasi",
+      "municipio": 1221
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101280,
+    "fields": {
+      "nombre": "Paso Sico",
+      "municipio": 1221
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101281,
+    "fields": {
+      "nombre": "Arroyo Corpen",
+      "municipio": 1223
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101282,
+    "fields": {
+      "nombre": "Dos Lagunas",
+      "municipio": 1223
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101283,
+    "fields": {
+      "nombre": "El Tordillo",
+      "municipio": 1223
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101284,
+    "fields": {
+      "nombre": "Isla Pavón",
+      "municipio": 1223
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101285,
+    "fields": {
+      "nombre": "La Barrancosa",
+      "municipio": 1223
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101286,
+    "fields": {
+      "nombre": "La Julia",
+      "municipio": 1223
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101287,
+    "fields": {
+      "nombre": "Laguna Grande",
+      "municipio": 1223
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101288,
+    "fields": {
+      "nombre": "Le Marchand",
+      "municipio": 1223
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101289,
+    "fields": {
+      "nombre": "Monte León",
+      "municipio": 1223
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101290,
+    "fields": {
+      "nombre": "Puerto de Punta Quilla",
+      "municipio": 1223
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101291,
+    "fields": {
+      "nombre": "Rincón Grande",
+      "municipio": 1223
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101292,
+    "fields": {
+      "nombre": "Río Chico",
+      "municipio": 1223
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101293,
+    "fields": {
+      "nombre": "San Francisco de Paula",
+      "municipio": 1223
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101294,
+    "fields": {
+      "nombre": "Baños de Incachuli",
+      "municipio": 1224
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101295,
+    "fields": {
+      "nombre": "Cardonal",
+      "municipio": 1224
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101296,
+    "fields": {
+      "nombre": "Casa de la Quesera",
+      "municipio": 1224
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101297,
+    "fields": {
+      "nombre": "Corralitos",
+      "municipio": 1224
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101298,
+    "fields": {
+      "nombre": "Cortadera",
+      "municipio": 1224
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101299,
+    "fields": {
+      "nombre": "El Cajón",
+      "municipio": 1224
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101300,
+    "fields": {
+      "nombre": "El Mojón",
+      "municipio": 1224
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101301,
+    "fields": {
+      "nombre": "El Rodeo",
+      "municipio": 1224
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101302,
+    "fields": {
+      "nombre": "El Saladillo",
+      "municipio": 1224
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101303,
+    "fields": {
+      "nombre": "El Sausalito",
+      "municipio": 1224
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101304,
+    "fields": {
+      "nombre": "El Talao",
+      "municipio": 1224
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101305,
+    "fields": {
+      "nombre": "El Trigal",
+      "municipio": 1224
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101306,
+    "fields": {
+      "nombre": "Esquina Azul",
+      "municipio": 1224
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101307,
+    "fields": {
+      "nombre": "Esquina de Guardia",
+      "municipio": 1224
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101308,
+    "fields": {
+      "nombre": "Esquina del Tolar",
+      "municipio": 1224
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101309,
+    "fields": {
+      "nombre": "Matancillas",
+      "municipio": 1224
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101310,
+    "fields": {
+      "nombre": "Piscuno",
+      "municipio": 1224
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101311,
+    "fields": {
+      "nombre": "Potrerillos",
+      "municipio": 1224
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101312,
+    "fields": {
+      "nombre": "Rangel",
+      "municipio": 1224
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101313,
+    "fields": {
+      "nombre": "Tipán",
+      "municipio": 1224
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101314,
+    "fields": {
+      "nombre": "Cueva de las Manos",
+      "municipio": 1225
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101315,
+    "fields": {
+      "nombre": "El Pluma",
+      "municipio": 1225
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101316,
+    "fields": {
+      "nombre": "El Portezuelo",
+      "municipio": 1225
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101317,
+    "fields": {
+      "nombre": "Ingeniero Pallavicini",
+      "municipio": 1225
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101318,
+    "fields": {
+      "nombre": "La Manchuria",
+      "municipio": 1225
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101319,
+    "fields": {
+      "nombre": "Lago Ghio",
+      "municipio": 1225
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101320,
+    "fields": {
+      "nombre": "Paso Río Jeinemeni",
+      "municipio": 1225
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101321,
+    "fields": {
+      "nombre": "Paso Rodolfo Roballos",
+      "municipio": 1225
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101322,
+    "fields": {
+      "nombre": "Bella Vista",
+      "municipio": 1226
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101323,
+    "fields": {
+      "nombre": "Cabo Domingo",
+      "municipio": 1226
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101324,
+    "fields": {
+      "nombre": "Cabo Peñas",
+      "municipio": 1226
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101325,
+    "fields": {
+      "nombre": "Cruz del Sur",
+      "municipio": 1226
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101326,
+    "fields": {
+      "nombre": "Cullen",
+      "municipio": 1226
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101327,
+    "fields": {
+      "nombre": "Hito 1",
+      "municipio": 1226
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101328,
+    "fields": {
+      "nombre": "Laguna de la Suerte",
+      "municipio": 1226
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101329,
+    "fields": {
+      "nombre": "Paso San Sebastián",
+      "municipio": 1226
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101330,
+    "fields": {
+      "nombre": "Puerto Páramo Chico",
+      "municipio": 1226
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101331,
+    "fields": {
+      "nombre": "Punta María",
+      "municipio": 1226
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101332,
+    "fields": {
+      "nombre": "Salvador Molina",
+      "municipio": 1226
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101333,
+    "fields": {
+      "nombre": "San Sebastián",
+      "municipio": 1226
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101334,
+    "fields": {
+      "nombre": "Yacimiento Cordón Alfa",
+      "municipio": 1226
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101335,
+    "fields": {
+      "nombre": "Abra Grande",
+      "municipio": 1227
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101336,
+    "fields": {
+      "nombre": "Ahí Veremos",
+      "municipio": 1227
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101337,
+    "fields": {
+      "nombre": "Alto Pozo",
+      "municipio": 1227
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101338,
+    "fields": {
+      "nombre": "Antajé",
+      "municipio": 1227
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101339,
+    "fields": {
+      "nombre": "Ardiles",
+      "municipio": 1227
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101340,
+    "fields": {
+      "nombre": "Ardiles de la Costa",
+      "municipio": 1227
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101341,
+    "fields": {
+      "nombre": "Bajo Grande",
+      "municipio": 1227
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101342,
+    "fields": {
+      "nombre": "Campo Verde",
+      "municipio": 1227
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101343,
+    "fields": {
+      "nombre": "Cañada Escobar",
+      "municipio": 1227
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101344,
+    "fields": {
+      "nombre": "Cerrillos",
+      "municipio": 1227
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101345,
+    "fields": {
+      "nombre": "Chaupi Pozo",
+      "municipio": 1227
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101346,
+    "fields": {
+      "nombre": "Clodomira",
+      "municipio": 1227
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101347,
+    "fields": {
+      "nombre": "Colonia Argentina",
+      "municipio": 1227
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101348,
+    "fields": {
+      "nombre": "Colonia Gamara",
+      "municipio": 1227
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101349,
+    "fields": {
+      "nombre": "Colonia María Luisa",
+      "municipio": 1227
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101350,
+    "fields": {
+      "nombre": "Cuyoj",
+      "municipio": 1227
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101351,
+    "fields": {
+      "nombre": "El Aibé",
+      "municipio": 1227
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101352,
+    "fields": {
+      "nombre": "El Alambrado",
+      "municipio": 1227
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101353,
+    "fields": {
+      "nombre": "El Barrial",
+      "municipio": 1227
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101354,
+    "fields": {
+      "nombre": "El Favorito",
+      "municipio": 1227
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101355,
+    "fields": {
+      "nombre": "Esquina Pozo",
+      "municipio": 1227
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101356,
+    "fields": {
+      "nombre": "Guaycurú",
+      "municipio": 1227
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101357,
+    "fields": {
+      "nombre": "Huilla Catina",
+      "municipio": 1227
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101358,
+    "fields": {
+      "nombre": "Huyamampa",
+      "municipio": 1227
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101359,
+    "fields": {
+      "nombre": "Jumi Pozo",
+      "municipio": 1227
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101360,
+    "fields": {
+      "nombre": "Jumialito",
+      "municipio": 1227
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101361,
+    "fields": {
+      "nombre": "La Aurora",
+      "municipio": 1227
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101362,
+    "fields": {
+      "nombre": "La Chejchila",
+      "municipio": 1227
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101363,
+    "fields": {
+      "nombre": "La Dársena",
+      "municipio": 1227
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101364,
+    "fields": {
+      "nombre": "La Falda",
+      "municipio": 1227
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101365,
+    "fields": {
+      "nombre": "La Granja",
+      "municipio": 1227
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101366,
+    "fields": {
+      "nombre": "La Quisca",
+      "municipio": 1227
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101367,
+    "fields": {
+      "nombre": "Las Abras",
+      "municipio": 1227
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101368,
+    "fields": {
+      "nombre": "Las Chacras",
+      "municipio": 1227
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101369,
+    "fields": {
+      "nombre": "Las Zanjas",
+      "municipio": 1227
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101370,
+    "fields": {
+      "nombre": "Los Acosta",
+      "municipio": 1227
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101371,
+    "fields": {
+      "nombre": "Los Ángeles",
+      "municipio": 1227
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101372,
+    "fields": {
+      "nombre": "Los Díaz",
+      "municipio": 1227
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101373,
+    "fields": {
+      "nombre": "Los Gallardo",
+      "municipio": 1227
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101374,
+    "fields": {
+      "nombre": "Los Gómez",
+      "municipio": 1227
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101375,
+    "fields": {
+      "nombre": "Los Herrera",
+      "municipio": 1227
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101376,
+    "fields": {
+      "nombre": "Los Quiroga",
+      "municipio": 1227
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101377,
+    "fields": {
+      "nombre": "Los Soria",
+      "municipio": 1227
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101378,
+    "fields": {
+      "nombre": "Los Tunales",
+      "municipio": 1227
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101379,
+    "fields": {
+      "nombre": "Mistolito",
+      "municipio": 1227
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101380,
+    "fields": {
+      "nombre": "Negra Muerta",
+      "municipio": 1227
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101381,
+    "fields": {
+      "nombre": "Nueva Líbano",
+      "municipio": 1227
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101382,
+    "fields": {
+      "nombre": "Ojo de Agua",
+      "municipio": 1227
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101383,
+    "fields": {
+      "nombre": "Palmares",
+      "municipio": 1227
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101384,
+    "fields": {
+      "nombre": "Palmita de Gerez",
+      "municipio": 1227
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101385,
+    "fields": {
+      "nombre": "Pampa Mayo",
+      "municipio": 1227
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101386,
+    "fields": {
+      "nombre": "Quita Punco",
+      "municipio": 1227
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101387,
+    "fields": {
+      "nombre": "Rumioj",
+      "municipio": 1227
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101388,
+    "fields": {
+      "nombre": "Salina Huyamampa",
+      "municipio": 1227
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101389,
+    "fields": {
+      "nombre": "San Felipe",
+      "municipio": 1227
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101390,
+    "fields": {
+      "nombre": "San Isidro",
+      "municipio": 1227
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101391,
+    "fields": {
+      "nombre": "San José",
+      "municipio": 1227
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101392,
+    "fields": {
+      "nombre": "San Juan",
+      "municipio": 1227
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101393,
+    "fields": {
+      "nombre": "San Lorenzo",
+      "municipio": 1227
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101394,
+    "fields": {
+      "nombre": "San Nicolás",
+      "municipio": 1227
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101395,
+    "fields": {
+      "nombre": "San Roque",
+      "municipio": 1227
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101396,
+    "fields": {
+      "nombre": "Santa Elena",
+      "municipio": 1227
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101397,
+    "fields": {
+      "nombre": "Sauce Bajada",
+      "municipio": 1227
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101398,
+    "fields": {
+      "nombre": "Siete Árboles",
+      "municipio": 1227
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101399,
+    "fields": {
+      "nombre": "Simbol Cañada",
+      "municipio": 1227
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101400,
+    "fields": {
+      "nombre": "Simbolar",
+      "municipio": 1227
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101401,
+    "fields": {
+      "nombre": "Suri Pozo",
+      "municipio": 1227
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101402,
+    "fields": {
+      "nombre": "Tramo 16",
+      "municipio": 1227
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101403,
+    "fields": {
+      "nombre": "Tramo 20",
+      "municipio": 1227
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101404,
+    "fields": {
+      "nombre": "Tramo 26",
+      "municipio": 1227
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101405,
+    "fields": {
+      "nombre": "Vaca Muerta",
+      "municipio": 1227
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101406,
+    "fields": {
+      "nombre": "Valdivia",
+      "municipio": 1227
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101407,
+    "fields": {
+      "nombre": "Laguna Blanca",
+      "municipio": 1303
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101408,
+    "fields": {
+      "nombre": "Nueva Lubecka",
+      "municipio": 1303
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101409,
+    "fields": {
+      "nombre": "Centinela",
+      "municipio": 1304
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101410,
+    "fields": {
+      "nombre": "El Cruce",
+      "municipio": 1304
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101411,
+    "fields": {
+      "nombre": "El Paraíso",
+      "municipio": 1304
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101412,
+    "fields": {
+      "nombre": "La Cacheura",
+      "municipio": 1304
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101413,
+    "fields": {
+      "nombre": "La Capilla",
+      "municipio": 1304
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101414,
+    "fields": {
+      "nombre": "Las Tunas",
+      "municipio": 1304
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101415,
+    "fields": {
+      "nombre": "Anecón Grande",
+      "municipio": 1305
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101416,
+    "fields": {
+      "nombre": "Cañadón Chileno",
+      "municipio": 1305
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101417,
+    "fields": {
+      "nombre": "Casa de Piedra",
+      "municipio": 1305
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101418,
+    "fields": {
+      "nombre": "Cerro Alto",
+      "municipio": 1305
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101419,
+    "fields": {
+      "nombre": "Comallo Arriba",
+      "municipio": 1305
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101420,
+    "fields": {
+      "nombre": "Coquelén",
+      "municipio": 1305
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101421,
+    "fields": {
+      "nombre": "Laguna Blanca",
+      "municipio": 1305
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101422,
+    "fields": {
+      "nombre": "Las Mellizas",
+      "municipio": 1305
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101423,
+    "fields": {
+      "nombre": "Mallín Grande",
+      "municipio": 1305
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101424,
+    "fields": {
+      "nombre": "Neneo Rucá",
+      "municipio": 1305
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101425,
+    "fields": {
+      "nombre": "ñirihuau Arriba",
+      "municipio": 1305
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101426,
+    "fields": {
+      "nombre": "Perito Moreno",
+      "municipio": 1305
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101427,
+    "fields": {
+      "nombre": "Peumayén",
+      "municipio": 1305
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101428,
+    "fields": {
+      "nombre": "Pichi Leufú",
+      "municipio": 1305
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101429,
+    "fields": {
+      "nombre": "Pichi Leufú Abajo",
+      "municipio": 1305
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101430,
+    "fields": {
+      "nombre": "Pilcaniyeu Viejo",
+      "municipio": 1305
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101431,
+    "fields": {
+      "nombre": "Pilquiniyeu del Limay",
+      "municipio": 1305
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101432,
+    "fields": {
+      "nombre": "Villa Llanquín",
+      "municipio": 1305
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101433,
+    "fields": {
+      "nombre": "11 de Octubre",
+      "municipio": 1307
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101434,
+    "fields": {
+      "nombre": "Agua del Cajón",
+      "municipio": 1307
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101435,
+    "fields": {
+      "nombre": "Aguada Baguales",
+      "municipio": 1307
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101436,
+    "fields": {
+      "nombre": "Centenario",
+      "municipio": 1307
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101437,
+    "fields": {
+      "nombre": "Cerro Challacó",
+      "municipio": 1307
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101438,
+    "fields": {
+      "nombre": "Challacó",
+      "municipio": 1307
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101439,
+    "fields": {
+      "nombre": "Dique Loma de la Lata",
+      "municipio": 1307
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101440,
+    "fields": {
+      "nombre": "La Angostura de Mari Menuco",
+      "municipio": 1307
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101441,
+    "fields": {
+      "nombre": "La Península",
+      "municipio": 1307
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101442,
+    "fields": {
+      "nombre": "Lindero Atravesado",
+      "municipio": 1307
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101443,
+    "fields": {
+      "nombre": "Loma de la Lata",
+      "municipio": 1307
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101444,
+    "fields": {
+      "nombre": "Mari Menuco",
+      "municipio": 1307
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101445,
+    "fields": {
+      "nombre": "Pampa de las Liebres",
+      "municipio": 1307
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101446,
+    "fields": {
+      "nombre": "Planicie Banderita",
+      "municipio": 1307
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101447,
+    "fields": {
+      "nombre": "Villa del Sol",
+      "municipio": 1307
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101448,
+    "fields": {
+      "nombre": "Barrio Costa Magna",
+      "municipio": 1308
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101449,
+    "fields": {
+      "nombre": "Dique Punta Negra",
+      "municipio": 1308
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101450,
+    "fields": {
+      "nombre": "Dique Ullum",
+      "municipio": 1308
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101451,
+    "fields": {
+      "nombre": "Hualilán",
+      "municipio": 1308
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101452,
+    "fields": {
+      "nombre": "La Banderita",
+      "municipio": 1308
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101453,
+    "fields": {
+      "nombre": "La Ciénaga",
+      "municipio": 1308
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101454,
+    "fields": {
+      "nombre": "La Invernada",
+      "municipio": 1308
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101455,
+    "fields": {
+      "nombre": "Quebrada de los Gauchos",
+      "municipio": 1308
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101456,
+    "fields": {
+      "nombre": "Talacasto",
+      "municipio": 1308
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101457,
+    "fields": {
+      "nombre": "Termas de Talacasto",
+      "municipio": 1308
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101458,
+    "fields": {
+      "nombre": "Agua Amarga",
+      "municipio": 1309
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101459,
+    "fields": {
+      "nombre": "Anchoris",
+      "municipio": 1309
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101460,
+    "fields": {
+      "nombre": "Ancón",
+      "municipio": 1309
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101461,
+    "fields": {
+      "nombre": "El Trébol",
+      "municipio": 1309
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101462,
+    "fields": {
+      "nombre": "El Zampalito",
+      "municipio": 1309
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101463,
+    "fields": {
+      "nombre": "Gualtallary",
+      "municipio": 1309
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101464,
+    "fields": {
+      "nombre": "La Carrera",
+      "municipio": 1309
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101465,
+    "fields": {
+      "nombre": "Las Cuevas",
+      "municipio": 1309
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101466,
+    "fields": {
+      "nombre": "Las Pircas",
+      "municipio": 1309
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101467,
+    "fields": {
+      "nombre": "Ojo de Agua",
+      "municipio": 1309
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101468,
+    "fields": {
+      "nombre": "Río de las Tunas",
+      "municipio": 1309
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101469,
+    "fields": {
+      "nombre": "Santa Clara",
+      "municipio": 1309
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101470,
+    "fields": {
+      "nombre": "Zapata",
+      "municipio": 1309
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101471,
+    "fields": {
+      "nombre": "Bahía Bustamante",
+      "municipio": 1310
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101472,
+    "fields": {
+      "nombre": "Caleta Visser",
+      "municipio": 1310
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101473,
+    "fields": {
+      "nombre": "Cerro Dragón",
+      "municipio": 1310
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101474,
+    "fields": {
+      "nombre": "El Tordillo",
+      "municipio": 1310
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101475,
+    "fields": {
+      "nombre": "El Trébol",
+      "municipio": 1310
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101476,
+    "fields": {
+      "nombre": "Escalante",
+      "municipio": 1310
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101477,
+    "fields": {
+      "nombre": "Holdich",
+      "municipio": 1310
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101478,
+    "fields": {
+      "nombre": "Kilómetro 96",
+      "municipio": 1310
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101479,
+    "fields": {
+      "nombre": "Manantiales Behr",
+      "municipio": 1310
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101480,
+    "fields": {
+      "nombre": "Pampa de Salamanca",
+      "municipio": 1310
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101481,
+    "fields": {
+      "nombre": "Pampa del Castillo",
+      "municipio": 1310
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101482,
+    "fields": {
+      "nombre": "Paso Arroqui",
+      "municipio": 1310
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101483,
+    "fields": {
+      "nombre": "Pico de Salamanca",
+      "municipio": 1310
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101484,
+    "fields": {
+      "nombre": "Rocas Coloradas",
+      "municipio": 1310
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101485,
+    "fields": {
+      "nombre": "Baños de Queñi",
+      "municipio": 1312
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101486,
+    "fields": {
+      "nombre": "Caleufú",
+      "municipio": 1312
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101487,
+    "fields": {
+      "nombre": "Casa de Piedra",
+      "municipio": 1312
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101488,
+    "fields": {
+      "nombre": "Chapelco",
+      "municipio": 1312
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101489,
+    "fields": {
+      "nombre": "Dique Alicurá",
+      "municipio": 1312
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101490,
+    "fields": {
+      "nombre": "Filo Hua Hum",
+      "municipio": 1312
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101491,
+    "fields": {
+      "nombre": "Hua Hum",
+      "municipio": 1312
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101492,
+    "fields": {
+      "nombre": "Lago Escondido",
+      "municipio": 1312
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101493,
+    "fields": {
+      "nombre": "Lago Falkner",
+      "municipio": 1312
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101494,
+    "fields": {
+      "nombre": "Lago Filo Hua Hum",
+      "municipio": 1312
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101495,
+    "fields": {
+      "nombre": "Lago Hermoso",
+      "municipio": 1312
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101496,
+    "fields": {
+      "nombre": "Lago Nuevo",
+      "municipio": 1312
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101497,
+    "fields": {
+      "nombre": "Lago Villarino",
+      "municipio": 1312
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101498,
+    "fields": {
+      "nombre": "Las Bandurrias",
+      "municipio": 1312
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101499,
+    "fields": {
+      "nombre": "Nonthué",
+      "municipio": 1312
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101500,
+    "fields": {
+      "nombre": "Paso Córdoba",
+      "municipio": 1312
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101501,
+    "fields": {
+      "nombre": "Quechu Quina",
+      "municipio": 1312
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101502,
+    "fields": {
+      "nombre": "Queñi",
+      "municipio": 1312
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101503,
+    "fields": {
+      "nombre": "Quila Quina",
+      "municipio": 1312
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101504,
+    "fields": {
+      "nombre": "Quilanlahue",
+      "municipio": 1312
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101505,
+    "fields": {
+      "nombre": "Río Chachín",
+      "municipio": 1312
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101506,
+    "fields": {
+      "nombre": "Ruca ñire",
+      "municipio": 1312
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101507,
+    "fields": {
+      "nombre": "Trompul",
+      "municipio": 1312
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101508,
+    "fields": {
+      "nombre": "Villa Lago Meliquina",
+      "municipio": 1312
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101509,
+    "fields": {
+      "nombre": "Villa Río Hermoso",
+      "municipio": 1312
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101510,
+    "fields": {
+      "nombre": "Yuco",
+      "municipio": 1312
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101511,
+    "fields": {
+      "nombre": "Atreucó",
+      "municipio": 1313
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101512,
+    "fields": {
+      "nombre": "Atreucó Arriba",
+      "municipio": 1313
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101513,
+    "fields": {
+      "nombre": "Aucapán",
+      "municipio": 1313
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101514,
+    "fields": {
+      "nombre": "Aucapán Abajo",
+      "municipio": 1313
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101515,
+    "fields": {
+      "nombre": "Auquinco",
+      "municipio": 1313
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101516,
+    "fields": {
+      "nombre": "Bahía Canicul",
+      "municipio": 1313
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101517,
+    "fields": {
+      "nombre": "Catricurá",
+      "municipio": 1313
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101518,
+    "fields": {
+      "nombre": "Chiquilihuin",
+      "municipio": 1313
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101519,
+    "fields": {
+      "nombre": "Confluencia del Malleo",
+      "municipio": 1313
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101520,
+    "fields": {
+      "nombre": "Costa del Malleo",
+      "municipio": 1313
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101521,
+    "fields": {
+      "nombre": "Currhué Chico",
+      "municipio": 1313
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101522,
+    "fields": {
+      "nombre": "Currhué Grande",
+      "municipio": 1313
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101523,
+    "fields": {
+      "nombre": "El Contra",
+      "municipio": 1313
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101524,
+    "fields": {
+      "nombre": "Huilqui Menuco",
+      "municipio": 1313
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101525,
+    "fields": {
+      "nombre": "Lago Paimún",
+      "municipio": 1313
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101526,
+    "fields": {
+      "nombre": "Lago Tromen",
+      "municipio": 1313
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101527,
+    "fields": {
+      "nombre": "Laguna Verde",
+      "municipio": 1313
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101528,
+    "fields": {
+      "nombre": "Malleo",
+      "municipio": 1313
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101529,
+    "fields": {
+      "nombre": "Nahuel Mapi Abajo",
+      "municipio": 1313
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101530,
+    "fields": {
+      "nombre": "Nahuel Mapi Arriba",
+      "municipio": 1313
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101531,
+    "fields": {
+      "nombre": "Pampa del Malleo",
+      "municipio": 1313
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101532,
+    "fields": {
+      "nombre": "Pampa Grande",
+      "municipio": 1313
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101533,
+    "fields": {
+      "nombre": "Paso de Carirriñe",
+      "municipio": 1313
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101534,
+    "fields": {
+      "nombre": "Paso Mamuil Malal",
+      "municipio": 1313
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101535,
+    "fields": {
+      "nombre": "Puerto Arturo",
+      "municipio": 1313
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101536,
+    "fields": {
+      "nombre": "Puerto Boquete",
+      "municipio": 1313
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101537,
+    "fields": {
+      "nombre": "Puerto Canoa",
+      "municipio": 1313
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101538,
+    "fields": {
+      "nombre": "Puerto La Unión",
+      "municipio": 1313
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101539,
+    "fields": {
+      "nombre": "Puerto Pesquero",
+      "municipio": 1313
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101540,
+    "fields": {
+      "nombre": "Termas de Epulafquen Lahuen Co",
+      "municipio": 1313
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101541,
+    "fields": {
+      "nombre": "Acequiones",
+      "municipio": 1325
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101542,
+    "fields": {
+      "nombre": "Casa de Tejas",
+      "municipio": 1325
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101543,
+    "fields": {
+      "nombre": "El Brete",
+      "municipio": 1325
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101544,
+    "fields": {
+      "nombre": "Hornillos",
+      "municipio": 1325
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101545,
+    "fields": {
+      "nombre": "La Cañada",
+      "municipio": 1325
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101546,
+    "fields": {
+      "nombre": "La Esperanza",
+      "municipio": 1325
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101547,
+    "fields": {
+      "nombre": "Las Arcas",
+      "municipio": 1325
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101548,
+    "fields": {
+      "nombre": "Leocadio Paz",
+      "municipio": 1325
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101549,
+    "fields": {
+      "nombre": "Pozo Largo",
+      "municipio": 1325
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101550,
+    "fields": {
+      "nombre": "San Isidro",
+      "municipio": 1325
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101551,
+    "fields": {
+      "nombre": "San José",
+      "municipio": 1325
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101552,
+    "fields": {
+      "nombre": "Unquillal",
+      "municipio": 1325
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101553,
+    "fields": {
+      "nombre": "Bajo de la Calandria",
+      "municipio": 1326
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101554,
+    "fields": {
+      "nombre": "El Molino",
+      "municipio": 1326
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101555,
+    "fields": {
+      "nombre": "Kilómetro 899",
+      "municipio": 1326
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101556,
+    "fields": {
+      "nombre": "La Pepita",
+      "municipio": 1326
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101557,
+    "fields": {
+      "nombre": "Pichi Mahuida",
+      "municipio": 1326
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101558,
+    "fields": {
+      "nombre": "Salitral Grande",
+      "municipio": 1326
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101559,
+    "fields": {
+      "nombre": "Ancocha",
+      "municipio": 1327
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101560,
+    "fields": {
+      "nombre": "Brea Loma",
+      "municipio": 1327
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101561,
+    "fields": {
+      "nombre": "Chilca La Loma",
+      "municipio": 1327
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101562,
+    "fields": {
+      "nombre": "Codo Viejo",
+      "municipio": 1327
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101563,
+    "fields": {
+      "nombre": "Collera Huarcana",
+      "municipio": 1327
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101564,
+    "fields": {
+      "nombre": "El Boquerón",
+      "municipio": 1327
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101565,
+    "fields": {
+      "nombre": "El Dorado",
+      "municipio": 1327
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101566,
+    "fields": {
+      "nombre": "El Hoyón",
+      "municipio": 1327
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101567,
+    "fields": {
+      "nombre": "El Peral",
+      "municipio": 1327
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101568,
+    "fields": {
+      "nombre": "Estación Atamisqui",
+      "municipio": 1327
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101569,
+    "fields": {
+      "nombre": "Guanaco Sombriana",
+      "municipio": 1327
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101570,
+    "fields": {
+      "nombre": "Huajla",
+      "municipio": 1327
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101571,
+    "fields": {
+      "nombre": "Isla Verde",
+      "municipio": 1327
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101572,
+    "fields": {
+      "nombre": "Juanillo",
+      "municipio": 1327
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101573,
+    "fields": {
+      "nombre": "Lomitas",
+      "municipio": 1327
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101574,
+    "fields": {
+      "nombre": "Los Mollares",
+      "municipio": 1327
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101575,
+    "fields": {
+      "nombre": "Los Peraltas",
+      "municipio": 1327
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101576,
+    "fields": {
+      "nombre": "Los Tolozos",
+      "municipio": 1327
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101577,
+    "fields": {
+      "nombre": "Medellín",
+      "municipio": 1327
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101578,
+    "fields": {
+      "nombre": "Paloma",
+      "municipio": 1327
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101579,
+    "fields": {
+      "nombre": "Puente del Saladillo",
+      "municipio": 1327
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101580,
+    "fields": {
+      "nombre": "Puerta Grande",
+      "municipio": 1327
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101581,
+    "fields": {
+      "nombre": "San Dionisio",
+      "municipio": 1327
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101582,
+    "fields": {
+      "nombre": "San Gregorio",
+      "municipio": 1327
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101583,
+    "fields": {
+      "nombre": "San José",
+      "municipio": 1327
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101584,
+    "fields": {
+      "nombre": "Santa Isabel",
+      "municipio": 1327
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101585,
+    "fields": {
+      "nombre": "Sauce",
+      "municipio": 1327
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101586,
+    "fields": {
+      "nombre": "Shillpi",
+      "municipio": 1327
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101587,
+    "fields": {
+      "nombre": "Simbol Pozo",
+      "municipio": 1327
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101588,
+    "fields": {
+      "nombre": "Soconcho",
+      "municipio": 1327
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101589,
+    "fields": {
+      "nombre": "Tasigasta",
+      "municipio": 1327
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101590,
+    "fields": {
+      "nombre": "Ventura Pampa",
+      "municipio": 1327
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101591,
+    "fields": {
+      "nombre": "Campo Bernardi",
+      "municipio": 1328
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101592,
+    "fields": {
+      "nombre": "Campo Zamo",
+      "municipio": 1328
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101593,
+    "fields": {
+      "nombre": "Caraguatay",
+      "municipio": 1328
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101594,
+    "fields": {
+      "nombre": "Cerrito",
+      "municipio": 1328
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101595,
+    "fields": {
+      "nombre": "El 21",
+      "municipio": 1328
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101596,
+    "fields": {
+      "nombre": "El 50",
+      "municipio": 1328
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101597,
+    "fields": {
+      "nombre": "El Bonete",
+      "municipio": 1328
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101598,
+    "fields": {
+      "nombre": "Espín",
+      "municipio": 1328
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101599,
+    "fields": {
+      "nombre": "Kilómetro 38",
+      "municipio": 1328
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101600,
+    "fields": {
+      "nombre": "La Guampita",
+      "municipio": 1328
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101601,
+    "fields": {
+      "nombre": "Las Gamas",
+      "municipio": 1328
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101602,
+    "fields": {
+      "nombre": "Olgivie",
+      "municipio": 1328
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101603,
+    "fields": {
+      "nombre": "Embarcadero Bahía Mansa",
+      "municipio": 1329
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101604,
+    "fields": {
+      "nombre": "Lago Verde",
+      "municipio": 1329
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101605,
+    "fields": {
+      "nombre": "Los Tepúes",
+      "municipio": 1329
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101606,
+    "fields": {
+      "nombre": "Mallín Grande",
+      "municipio": 1329
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101607,
+    "fields": {
+      "nombre": "Playa El Francés",
+      "municipio": 1329
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101608,
+    "fields": {
+      "nombre": "Puerto Bustillo",
+      "municipio": 1329
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101609,
+    "fields": {
+      "nombre": "Puerto Cañero",
+      "municipio": 1329
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101610,
+    "fields": {
+      "nombre": "Puerto Chucao",
+      "municipio": 1329
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101611,
+    "fields": {
+      "nombre": "Puerto Mermoud",
+      "municipio": 1329
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101612,
+    "fields": {
+      "nombre": "Puerto Sagrario",
+      "municipio": 1329
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101613,
+    "fields": {
+      "nombre": "Punta Matos",
+      "municipio": 1329
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101614,
+    "fields": {
+      "nombre": "Villa Futalaufquen",
+      "municipio": 1329
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101615,
+    "fields": {
+      "nombre": "El Portillo",
+      "municipio": 1333
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101616,
+    "fields": {
+      "nombre": "El Totoral",
+      "municipio": 1333
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101617,
+    "fields": {
+      "nombre": "El Totoral Sur",
+      "municipio": 1333
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101618,
+    "fields": {
+      "nombre": "La Primavera",
+      "municipio": 1333
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101619,
+    "fields": {
+      "nombre": "La Remonta",
+      "municipio": 1333
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101620,
+    "fields": {
+      "nombre": "Las Pintadas",
+      "municipio": 1333
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101621,
+    "fields": {
+      "nombre": "Los Árboles",
+      "municipio": 1333
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101622,
+    "fields": {
+      "nombre": "Los Chacales",
+      "municipio": 1333
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101623,
+    "fields": {
+      "nombre": "Portillo de los Piuquenes",
+      "municipio": 1333
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101624,
+    "fields": {
+      "nombre": "San Pablo",
+      "municipio": 1333
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101625,
+    "fields": {
+      "nombre": "Valle Manantiales",
+      "municipio": 1333
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101626,
+    "fields": {
+      "nombre": "Barrio El Favorito",
+      "municipio": 1335
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101627,
+    "fields": {
+      "nombre": "Cañada Rica II",
+      "municipio": 1335
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101628,
+    "fields": {
+      "nombre": "Comunidad 7 de Junio",
+      "municipio": 1335
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101629,
+    "fields": {
+      "nombre": "Comunidad Aborigen Wichi",
+      "municipio": 1335
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101630,
+    "fields": {
+      "nombre": "Comunidad Wichi Oblitaj",
+      "municipio": 1335
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101631,
+    "fields": {
+      "nombre": "El Alambrado",
+      "municipio": 1335
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101632,
+    "fields": {
+      "nombre": "El Algarrobo",
+      "municipio": 1335
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101633,
+    "fields": {
+      "nombre": "El Breal",
+      "municipio": 1335
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101634,
+    "fields": {
+      "nombre": "El Chivil",
+      "municipio": 1335
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101635,
+    "fields": {
+      "nombre": "El Divisadero",
+      "municipio": 1335
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101636,
+    "fields": {
+      "nombre": "El Estanque",
+      "municipio": 1335
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101637,
+    "fields": {
+      "nombre": "El Milagro",
+      "municipio": 1335
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101638,
+    "fields": {
+      "nombre": "El Palmarcito",
+      "municipio": 1335
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101639,
+    "fields": {
+      "nombre": "El Potrillo",
+      "municipio": 1335
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101640,
+    "fields": {
+      "nombre": "El Quebracho",
+      "municipio": 1335
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101641,
+    "fields": {
+      "nombre": "El Rosario",
+      "municipio": 1335
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101642,
+    "fields": {
+      "nombre": "El Silencio",
+      "municipio": 1335
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101643,
+    "fields": {
+      "nombre": "El Sol",
+      "municipio": 1335
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101644,
+    "fields": {
+      "nombre": "El Tabique",
+      "municipio": 1335
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101645,
+    "fields": {
+      "nombre": "El Tronquito",
+      "municipio": 1335
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101646,
+    "fields": {
+      "nombre": "El Tucumancito",
+      "municipio": 1335
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101647,
+    "fields": {
+      "nombre": "Ex Misión San Martín",
+      "municipio": 1335
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101648,
+    "fields": {
+      "nombre": "La Brea",
+      "municipio": 1335
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101649,
+    "fields": {
+      "nombre": "La Mocha",
+      "municipio": 1335
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101650,
+    "fields": {
+      "nombre": "La Pampa",
+      "municipio": 1335
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101651,
+    "fields": {
+      "nombre": "Las Cañitas",
+      "municipio": 1335
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101652,
+    "fields": {
+      "nombre": "Las Palmitas",
+      "municipio": 1335
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101653,
+    "fields": {
+      "nombre": "Lecherón",
+      "municipio": 1335
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101654,
+    "fields": {
+      "nombre": "Lote 1",
+      "municipio": 1335
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101655,
+    "fields": {
+      "nombre": "Lote 8",
+      "municipio": 1335
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101656,
+    "fields": {
+      "nombre": "Misión San Andrés",
+      "municipio": 1335
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101657,
+    "fields": {
+      "nombre": "Palmar Largo",
+      "municipio": 1335
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101658,
+    "fields": {
+      "nombre": "Palo Seco",
+      "municipio": 1335
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101659,
+    "fields": {
+      "nombre": "Picada San Martín",
+      "municipio": 1335
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101660,
+    "fields": {
+      "nombre": "Pozo Caballo",
+      "municipio": 1335
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101661,
+    "fields": {
+      "nombre": "Pozo Cercado",
+      "municipio": 1335
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101662,
+    "fields": {
+      "nombre": "Pozo del Oso",
+      "municipio": 1335
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101663,
+    "fields": {
+      "nombre": "Pozo La Chiva",
+      "municipio": 1335
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101664,
+    "fields": {
+      "nombre": "Puesto El Sótano",
+      "municipio": 1335
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101665,
+    "fields": {
+      "nombre": "Río Seco",
+      "municipio": 1335
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101666,
+    "fields": {
+      "nombre": "San Martín",
+      "municipio": 1335
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101667,
+    "fields": {
+      "nombre": "Santa Teresa",
+      "municipio": 1335
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101668,
+    "fields": {
+      "nombre": "Tres Palmas",
+      "municipio": 1335
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101669,
+    "fields": {
+      "nombre": "Tres Pozos",
+      "municipio": 1335
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101670,
+    "fields": {
+      "nombre": "Villa Devoto",
+      "municipio": 1335
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101671,
+    "fields": {
+      "nombre": "Altos del Valle",
+      "municipio": 1336
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101672,
+    "fields": {
+      "nombre": "Bahía Buen Suceso",
+      "municipio": 1336
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101673,
+    "fields": {
+      "nombre": "Bahía Ensenada",
+      "municipio": 1336
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101674,
+    "fields": {
+      "nombre": "Bahía Sloggett",
+      "municipio": 1336
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101675,
+    "fields": {
+      "nombre": "Cabo San Diego",
+      "municipio": 1336
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101676,
+    "fields": {
+      "nombre": "Cabo San Pío",
+      "municipio": 1336
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101677,
+    "fields": {
+      "nombre": "Cerro Castor",
+      "municipio": 1336
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101678,
+    "fields": {
+      "nombre": "Escarpados",
+      "municipio": 1336
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101679,
+    "fields": {
+      "nombre": "Glaciar Martial",
+      "municipio": 1336
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101680,
+    "fields": {
+      "nombre": "Lago Roca",
+      "municipio": 1336
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101681,
+    "fields": {
+      "nombre": "Laguna Escondida",
+      "municipio": 1336
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101682,
+    "fields": {
+      "nombre": "Lapataia",
+      "municipio": 1336
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101683,
+    "fields": {
+      "nombre": "Parador Pampa de los Indios",
+      "municipio": 1336
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101684,
+    "fields": {
+      "nombre": "Paso Garibaldi",
+      "municipio": 1336
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101685,
+    "fields": {
+      "nombre": "Puerto Almanza",
+      "municipio": 1336
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101686,
+    "fields": {
+      "nombre": "Puerto Cook",
+      "municipio": 1336
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101687,
+    "fields": {
+      "nombre": "Puerto Donato",
+      "municipio": 1336
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101688,
+    "fields": {
+      "nombre": "Puerto Español",
+      "municipio": 1336
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101689,
+    "fields": {
+      "nombre": "Puerto Parry",
+      "municipio": 1336
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101690,
+    "fields": {
+      "nombre": "Puerto Remolino",
+      "municipio": 1336
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101691,
+    "fields": {
+      "nombre": "Rancho Hambre",
+      "municipio": 1336
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101692,
+    "fields": {
+      "nombre": "Río Moat",
+      "municipio": 1336
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101693,
+    "fields": {
+      "nombre": "Río Pipo",
+      "municipio": 1336
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101694,
+    "fields": {
+      "nombre": "Tierra Mayor",
+      "municipio": 1336
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101695,
+    "fields": {
+      "nombre": "Valle Hermoso",
+      "municipio": 1336
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101696,
+    "fields": {
+      "nombre": "Albardón",
+      "municipio": 1337
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101697,
+    "fields": {
+      "nombre": "Anga",
+      "municipio": 1337
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101698,
+    "fields": {
+      "nombre": "Barrancas",
+      "municipio": 1337
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101699,
+    "fields": {
+      "nombre": "Bordo Pampa",
+      "municipio": 1337
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101700,
+    "fields": {
+      "nombre": "Campos de Cejas",
+      "municipio": 1337
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101701,
+    "fields": {
+      "nombre": "Cantera Los Telares",
+      "municipio": 1337
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101702,
+    "fields": {
+      "nombre": "Carreta Paso",
+      "municipio": 1337
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101703,
+    "fields": {
+      "nombre": "Chañar Sinuchay",
+      "municipio": 1337
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101704,
+    "fields": {
+      "nombre": "Chilca Juliana",
+      "municipio": 1337
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101705,
+    "fields": {
+      "nombre": "Chira",
+      "municipio": 1337
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101706,
+    "fields": {
+      "nombre": "El Candelario",
+      "municipio": 1337
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101707,
+    "fields": {
+      "nombre": "El Simbolar",
+      "municipio": 1337
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101708,
+    "fields": {
+      "nombre": "Guerra",
+      "municipio": 1337
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101709,
+    "fields": {
+      "nombre": "La Bajada",
+      "municipio": 1337
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101710,
+    "fields": {
+      "nombre": "La Centella",
+      "municipio": 1337
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101711,
+    "fields": {
+      "nombre": "La Paliza",
+      "municipio": 1337
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101712,
+    "fields": {
+      "nombre": "La Ramada",
+      "municipio": 1337
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101713,
+    "fields": {
+      "nombre": "Lomas Blancas",
+      "municipio": 1337
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101714,
+    "fields": {
+      "nombre": "Los Cerrillos",
+      "municipio": 1337
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101715,
+    "fields": {
+      "nombre": "Los Telares",
+      "municipio": 1337
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101716,
+    "fields": {
+      "nombre": "Lote 1",
+      "municipio": 1337
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101717,
+    "fields": {
+      "nombre": "Malota",
+      "municipio": 1337
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101718,
+    "fields": {
+      "nombre": "Mistol Pozo",
+      "municipio": 1337
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101719,
+    "fields": {
+      "nombre": "Navarro",
+      "municipio": 1337
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101720,
+    "fields": {
+      "nombre": "Nueva Loma",
+      "municipio": 1337
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101721,
+    "fields": {
+      "nombre": "Rubia Paso",
+      "municipio": 1337
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101722,
+    "fields": {
+      "nombre": "Sabagasta",
+      "municipio": 1337
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101723,
+    "fields": {
+      "nombre": "Santa Lucía",
+      "municipio": 1337
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101724,
+    "fields": {
+      "nombre": "Santa Rosa",
+      "municipio": 1337
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101725,
+    "fields": {
+      "nombre": "Sitkioj",
+      "municipio": 1337
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101726,
+    "fields": {
+      "nombre": "Taco Isla",
+      "municipio": 1337
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101727,
+    "fields": {
+      "nombre": "Taco Totorayoj",
+      "municipio": 1337
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101728,
+    "fields": {
+      "nombre": "Totora",
+      "municipio": 1337
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101729,
+    "fields": {
+      "nombre": "Vaca Human",
+      "municipio": 1337
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101730,
+    "fields": {
+      "nombre": "Verón",
+      "municipio": 1337
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101731,
+    "fields": {
+      "nombre": "Villa Salavina",
+      "municipio": 1337
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101732,
+    "fields": {
+      "nombre": "Yacu Hurmana",
+      "municipio": 1337
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101733,
+    "fields": {
+      "nombre": "9 de Julio",
+      "municipio": 1340
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101734,
+    "fields": {
+      "nombre": "Puerto Laharrague",
+      "municipio": 1340
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101735,
+    "fields": {
+      "nombre": "Arroyo Blanco",
+      "municipio": 1341
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101736,
+    "fields": {
+      "nombre": "Cajón del Curi Leuvú",
+      "municipio": 1341
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101737,
+    "fields": {
+      "nombre": "Cerro Bayo",
+      "municipio": 1341
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101738,
+    "fields": {
+      "nombre": "Cerro Waile",
+      "municipio": 1341
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101739,
+    "fields": {
+      "nombre": "Chacay Melehue",
+      "municipio": 1341
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101740,
+    "fields": {
+      "nombre": "Chapua",
+      "municipio": 1341
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101741,
+    "fields": {
+      "nombre": "El Ciénago",
+      "municipio": 1341
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101742,
+    "fields": {
+      "nombre": "La Salada",
+      "municipio": 1341
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101743,
+    "fields": {
+      "nombre": "Lago Tromen",
+      "municipio": 1341
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101744,
+    "fields": {
+      "nombre": "Laguna de Palao",
+      "municipio": 1341
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101745,
+    "fields": {
+      "nombre": "Laguna Fea",
+      "municipio": 1341
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101746,
+    "fields": {
+      "nombre": "Laguna Huara Co",
+      "municipio": 1341
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101747,
+    "fields": {
+      "nombre": "Laguna Negra",
+      "municipio": 1341
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101748,
+    "fields": {
+      "nombre": "Laguna Polco",
+      "municipio": 1341
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101749,
+    "fields": {
+      "nombre": "Leuto Caballo",
+      "municipio": 1341
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101750,
+    "fields": {
+      "nombre": "Los Barros",
+      "municipio": 1341
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101751,
+    "fields": {
+      "nombre": "Pampa del Rayo",
+      "municipio": 1341
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101752,
+    "fields": {
+      "nombre": "Capón Bonito",
+      "municipio": 1342
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101753,
+    "fields": {
+      "nombre": "Puerto Azara",
+      "municipio": 1342
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101754,
+    "fields": {
+      "nombre": "Tres Lunas",
+      "municipio": 1343
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101755,
+    "fields": {
+      "nombre": "Araza",
+      "municipio": 1344
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101756,
+    "fields": {
+      "nombre": "El Cruce Pindaytí",
+      "municipio": 1344
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101757,
+    "fields": {
+      "nombre": "Kilómetro 198",
+      "municipio": 1344
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101758,
+    "fields": {
+      "nombre": "Kilómetro 218",
+      "municipio": 1344
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101759,
+    "fields": {
+      "nombre": "Las Yerbas",
+      "municipio": 1344
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101760,
+    "fields": {
+      "nombre": "Mavalle Pindaytí",
+      "municipio": 1344
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101761,
+    "fields": {
+      "nombre": "Picada Propaganda",
+      "municipio": 1344
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101762,
+    "fields": {
+      "nombre": "Salto Piedras Blancas",
+      "municipio": 1344
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101763,
+    "fields": {
+      "nombre": "Tamanduá",
+      "municipio": 1344
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101764,
+    "fields": {
+      "nombre": "Tres Arroyos",
+      "municipio": 1344
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101765,
+    "fields": {
+      "nombre": "Colonia Florida",
+      "municipio": 1345
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101766,
+    "fields": {
+      "nombre": "El Tigre",
+      "municipio": 1345
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101767,
+    "fields": {
+      "nombre": "José Luis",
+      "municipio": 1345
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101768,
+    "fields": {
+      "nombre": "La Divisa",
+      "municipio": 1345
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101769,
+    "fields": {
+      "nombre": "Salto Chávez",
+      "municipio": 1345
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101770,
+    "fields": {
+      "nombre": "Sierra de Oro",
+      "municipio": 1345
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101771,
+    "fields": {
+      "nombre": "Yerbal Viejo",
+      "municipio": 1345
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101772,
+    "fields": {
+      "nombre": "Almafuerte",
+      "municipio": 1346
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101773,
+    "fields": {
+      "nombre": "Cascuda",
+      "municipio": 1346
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101774,
+    "fields": {
+      "nombre": "Colonia Milagro",
+      "municipio": 1346
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101775,
+    "fields": {
+      "nombre": "El Portón",
+      "municipio": 1346
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101776,
+    "fields": {
+      "nombre": "Indumar",
+      "municipio": 1346
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101777,
+    "fields": {
+      "nombre": "Saltito II",
+      "municipio": 1346
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101778,
+    "fields": {
+      "nombre": "Bella Vista",
+      "municipio": 1348
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101779,
+    "fields": {
+      "nombre": "La Invernada",
+      "municipio": 1348
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101780,
+    "fields": {
+      "nombre": "Villa Venecia",
+      "municipio": 1348
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101781,
+    "fields": {
+      "nombre": "Colonia Mártires",
+      "municipio": 1349
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101782,
+    "fields": {
+      "nombre": "Tacuaruzú",
+      "municipio": 1350
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101783,
+    "fields": {
+      "nombre": "San Cristóbal",
+      "municipio": 1351
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101784,
+    "fields": {
+      "nombre": "El Tigre",
+      "municipio": 1354
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101785,
+    "fields": {
+      "nombre": "Puerto San Isidro",
+      "municipio": 1354
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101786,
+    "fields": {
+      "nombre": "Puerto San Lucas",
+      "municipio": 1354
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101787,
+    "fields": {
+      "nombre": "San Isidro",
+      "municipio": 1354
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101788,
+    "fields": {
+      "nombre": "San Lucas",
+      "municipio": 1354
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101789,
+    "fields": {
+      "nombre": "Aguaray Guazú",
+      "municipio": 1355
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101790,
+    "fields": {
+      "nombre": "Colonia Cunci",
+      "municipio": 1355
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101791,
+    "fields": {
+      "nombre": "Colonia Delicia",
+      "municipio": 1355
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101792,
+    "fields": {
+      "nombre": "Colonia Delicia Durán",
+      "municipio": 1355
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101793,
+    "fields": {
+      "nombre": "Yacutingá",
+      "municipio": 1355
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101794,
+    "fields": {
+      "nombre": "Cuatro Bocas",
+      "municipio": 1356
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101795,
+    "fields": {
+      "nombre": "Parejá",
+      "municipio": 1356
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101796,
+    "fields": {
+      "nombre": "Puerto Victoria",
+      "municipio": 1356
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101797,
+    "fields": {
+      "nombre": "Kilómetro 48",
+      "municipio": 1358
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101798,
+    "fields": {
+      "nombre": "Bajo Pepirí",
+      "municipio": 1359
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101799,
+    "fields": {
+      "nombre": "Facundo Quiroga",
+      "municipio": 1359
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101800,
+    "fields": {
+      "nombre": "Horquetas",
+      "municipio": 1359
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101801,
+    "fields": {
+      "nombre": "11 de Septiembre",
+      "municipio": 1360
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101802,
+    "fields": {
+      "nombre": "28 de Diciembre",
+      "municipio": 1360
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101803,
+    "fields": {
+      "nombre": "Arroyo Verde",
+      "municipio": 1360
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101804,
+    "fields": {
+      "nombre": "Caballero",
+      "municipio": 1360
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101805,
+    "fields": {
+      "nombre": "Kilómetro 511",
+      "municipio": 1360
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101806,
+    "fields": {
+      "nombre": "La Blanquita",
+      "municipio": 1360
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101807,
+    "fields": {
+      "nombre": "María Soledad",
+      "municipio": 1360
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101808,
+    "fields": {
+      "nombre": "Paso Andresito",
+      "municipio": 1360
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101809,
+    "fields": {
+      "nombre": "Península",
+      "municipio": 1360
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101810,
+    "fields": {
+      "nombre": "Puerto Península",
+      "municipio": 1360
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101811,
+    "fields": {
+      "nombre": "San Martín",
+      "municipio": 1360
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101812,
+    "fields": {
+      "nombre": "Soberanía",
+      "municipio": 1360
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101813,
+    "fields": {
+      "nombre": "Yacutinga",
+      "municipio": 1360
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101814,
+    "fields": {
+      "nombre": "Arroyo Bonito",
+      "municipio": 1361
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101815,
+    "fields": {
+      "nombre": "Colonia La Flor",
+      "municipio": 1361
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101816,
+    "fields": {
+      "nombre": "Colonia Paraíso",
+      "municipio": 1361
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101817,
+    "fields": {
+      "nombre": "Colonia Primavera",
+      "municipio": 1361
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101818,
+    "fields": {
+      "nombre": "El Botón",
+      "municipio": 1361
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101819,
+    "fields": {
+      "nombre": "Fray Luis Beltrán",
+      "municipio": 1361
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101820,
+    "fields": {
+      "nombre": "Guabichú",
+      "municipio": 1361
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101821,
+    "fields": {
+      "nombre": "La Bonita",
+      "municipio": 1361
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101822,
+    "fields": {
+      "nombre": "Mariano Moreno",
+      "municipio": 1361
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101823,
+    "fields": {
+      "nombre": "Martín Güemes",
+      "municipio": 1361
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101824,
+    "fields": {
+      "nombre": "Mesa Redonda",
+      "municipio": 1361
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101825,
+    "fields": {
+      "nombre": "Monteagudo",
+      "municipio": 1361
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101826,
+    "fields": {
+      "nombre": "Nueva",
+      "municipio": 1361
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101827,
+    "fields": {
+      "nombre": "Paraje Manuel Belgrano",
+      "municipio": 1361
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101828,
+    "fields": {
+      "nombre": "Pepirí Miní",
+      "municipio": 1361
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101829,
+    "fields": {
+      "nombre": "Picada Guaraní",
+      "municipio": 1361
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101830,
+    "fields": {
+      "nombre": "Puerto Mata Ojos",
+      "municipio": 1361
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101831,
+    "fields": {
+      "nombre": "Puerto Paraíso",
+      "municipio": 1361
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101832,
+    "fields": {
+      "nombre": "Río Yaboty",
+      "municipio": 1361
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101833,
+    "fields": {
+      "nombre": "Cuatro Bocas",
+      "municipio": 1362
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101834,
+    "fields": {
+      "nombre": "El Trescientos",
+      "municipio": 1362
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101835,
+    "fields": {
+      "nombre": "Puerto Helvecia",
+      "municipio": 1362
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101836,
+    "fields": {
+      "nombre": "Puerto Segundo",
+      "municipio": 1362
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101837,
+    "fields": {
+      "nombre": "Puerto Yrigoyen",
+      "municipio": 1362
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101838,
+    "fields": {
+      "nombre": "Cataratas del Iguazú",
+      "municipio": 1363
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101839,
+    "fields": {
+      "nombre": "Puerto Península",
+      "municipio": 1363
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101840,
+    "fields": {
+      "nombre": "Arroyo Falso",
+      "municipio": 1364
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101841,
+    "fields": {
+      "nombre": "Colonia Gobernador Lanusse",
+      "municipio": 1364
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101842,
+    "fields": {
+      "nombre": "El Susto",
+      "municipio": 1364
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101843,
+    "fields": {
+      "nombre": "Tupí Cuá",
+      "municipio": 1364
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101844,
+    "fields": {
+      "nombre": "Colonia Finlandesa",
+      "municipio": 1365
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101845,
+    "fields": {
+      "nombre": "Picada Sueca",
+      "municipio": 1365
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101846,
+    "fields": {
+      "nombre": "Colonia Tarancó",
+      "municipio": 1366
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101847,
+    "fields": {
+      "nombre": "General Güemes",
+      "municipio": 1366
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101848,
+    "fields": {
+      "nombre": "Picada Belgrano",
+      "municipio": 1366
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101849,
+    "fields": {
+      "nombre": "Picada Polaca",
+      "municipio": 1366
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101850,
+    "fields": {
+      "nombre": "Kilómetro 32",
+      "municipio": 1367
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101851,
+    "fields": {
+      "nombre": "Colonia El Chatón",
+      "municipio": 1368
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101852,
+    "fields": {
+      "nombre": "El Chatón",
+      "municipio": 1368
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101853,
+    "fields": {
+      "nombre": "Colonia Alemana",
+      "municipio": 1369
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101854,
+    "fields": {
+      "nombre": "Picada Galitziana",
+      "municipio": 1369
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101855,
+    "fields": {
+      "nombre": "El Porvenir",
+      "municipio": 1370
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101856,
+    "fields": {
+      "nombre": "Kilómetro 12",
+      "municipio": 1371
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101857,
+    "fields": {
+      "nombre": "Kilómetro 20",
+      "municipio": 1371
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101858,
+    "fields": {
+      "nombre": "Puerto Paranay",
+      "municipio": 1371
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101859,
+    "fields": {
+      "nombre": "3 de Mayo",
+      "municipio": 1372
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101860,
+    "fields": {
+      "nombre": "Colonia Luján",
+      "municipio": 1372
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101861,
+    "fields": {
+      "nombre": "Puerto Garuhapé",
+      "municipio": 1372
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101862,
+    "fields": {
+      "nombre": "Puerto Pescador",
+      "municipio": 1372
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101863,
+    "fields": {
+      "nombre": "Salto 3 de Mayo",
+      "municipio": 1372
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101864,
+    "fields": {
+      "nombre": "Colonia Flora",
+      "municipio": 1373
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101865,
+    "fields": {
+      "nombre": "Puerto Mineral",
+      "municipio": 1373
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101866,
+    "fields": {
+      "nombre": "Oro Verde",
+      "municipio": 1374
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101867,
+    "fields": {
+      "nombre": "Puerto Oro Verde",
+      "municipio": 1374
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101868,
+    "fields": {
+      "nombre": "Cuchilla",
+      "municipio": 1375
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101869,
+    "fields": {
+      "nombre": "Cuña Pirú",
+      "municipio": 1375
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101870,
+    "fields": {
+      "nombre": "Avellaneda",
+      "municipio": 1376
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101871,
+    "fields": {
+      "nombre": "Monte Quemado",
+      "municipio": 1376
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101872,
+    "fields": {
+      "nombre": "Pozo de la Mula",
+      "municipio": 1376
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101873,
+    "fields": {
+      "nombre": "Puente Viejo",
+      "municipio": 1376
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101874,
+    "fields": {
+      "nombre": "Puerto Montecarlo",
+      "municipio": 1376
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101875,
+    "fields": {
+      "nombre": "Kilómetro 22",
+      "municipio": 1377
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101876,
+    "fields": {
+      "nombre": "Kilómetro 60",
+      "municipio": 1377
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101877,
+    "fields": {
+      "nombre": "Piray",
+      "municipio": 1377
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101878,
+    "fields": {
+      "nombre": "Villa Ojo de Agua",
+      "municipio": 1377
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101879,
+    "fields": {
+      "nombre": "Barra Bonita",
+      "municipio": 1378
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101880,
+    "fields": {
+      "nombre": "Picada Guaraypo",
+      "municipio": 1378
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101881,
+    "fields": {
+      "nombre": "Picada Internacional",
+      "municipio": 1378
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101882,
+    "fields": {
+      "nombre": "Villa Unión",
+      "municipio": 1378
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101883,
+    "fields": {
+      "nombre": "Yerbal Viejo",
+      "municipio": 1378
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101884,
+    "fields": {
+      "nombre": "La Divisa",
+      "municipio": 1379
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101885,
+    "fields": {
+      "nombre": "Seguín",
+      "municipio": 1379
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101886,
+    "fields": {
+      "nombre": "Yaza",
+      "municipio": 1379
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101887,
+    "fields": {
+      "nombre": "Picada Yapeyú",
+      "municipio": 1381
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101888,
+    "fields": {
+      "nombre": "Villa Armonía",
+      "municipio": 1381
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101889,
+    "fields": {
+      "nombre": "Villa Sommer",
+      "municipio": 1381
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101890,
+    "fields": {
+      "nombre": "Guayabera",
+      "municipio": 1383
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101891,
+    "fields": {
+      "nombre": "Villa Sarubb",
+      "municipio": 1383
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101892,
+    "fields": {
+      "nombre": "La Línea",
+      "municipio": 1384
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101893,
+    "fields": {
+      "nombre": "Mariano Moreno",
+      "municipio": 1384
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101894,
+    "fields": {
+      "nombre": "Mbororé",
+      "municipio": 1384
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101895,
+    "fields": {
+      "nombre": "Colonia Naranjito",
+      "municipio": 1385
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101896,
+    "fields": {
+      "nombre": "Puerto Maní",
+      "municipio": 1386
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101897,
+    "fields": {
+      "nombre": "ñacanguazú",
+      "municipio": 1387
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101898,
+    "fields": {
+      "nombre": "Puerto España",
+      "municipio": 1387
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101899,
+    "fields": {
+      "nombre": "Santa Rosa",
+      "municipio": 1388
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101900,
+    "fields": {
+      "nombre": "Colonia Sol de Mayo",
+      "municipio": 1389
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101901,
+    "fields": {
+      "nombre": "Flora",
+      "municipio": 1389
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101902,
+    "fields": {
+      "nombre": "Puerto Oasis",
+      "municipio": 1389
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101903,
+    "fields": {
+      "nombre": "Saltos del Tabay",
+      "municipio": 1389
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101904,
+    "fields": {
+      "nombre": "Tabay",
+      "municipio": 1389
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101905,
+    "fields": {
+      "nombre": "El Bonito",
+      "municipio": 1390
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101906,
+    "fields": {
+      "nombre": "Invernada de Itacaruaré",
+      "municipio": 1391
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101907,
+    "fields": {
+      "nombre": "La Arrocera",
+      "municipio": 1391
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101908,
+    "fields": {
+      "nombre": "Panambí",
+      "municipio": 1392
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101909,
+    "fields": {
+      "nombre": "Cerro 60",
+      "municipio": 1393
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101910,
+    "fields": {
+      "nombre": "Durán",
+      "municipio": 1393
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101911,
+    "fields": {
+      "nombre": "El Polvorín",
+      "municipio": 1393
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101912,
+    "fields": {
+      "nombre": "Forestal San Antonio",
+      "municipio": 1393
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101913,
+    "fields": {
+      "nombre": "Juanita",
+      "municipio": 1393
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101914,
+    "fields": {
+      "nombre": "Mondorí",
+      "municipio": 1393
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101915,
+    "fields": {
+      "nombre": "Nuestra Señora de Itatí",
+      "municipio": 1393
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101916,
+    "fields": {
+      "nombre": "Tres Vecinos",
+      "municipio": 1393
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101917,
+    "fields": {
+      "nombre": "Barra Bonita",
+      "municipio": 1394
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101918,
+    "fields": {
+      "nombre": "Barra Machado",
+      "municipio": 1394
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101919,
+    "fields": {
+      "nombre": "Colonia Aracaguá",
+      "municipio": 1394
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101920,
+    "fields": {
+      "nombre": "El Barrerito",
+      "municipio": 1394
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101921,
+    "fields": {
+      "nombre": "La Uva",
+      "municipio": 1394
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101922,
+    "fields": {
+      "nombre": "Libertad",
+      "municipio": 1394
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101923,
+    "fields": {
+      "nombre": "Tres Bocas",
+      "municipio": 1394
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101924,
+    "fields": {
+      "nombre": "Aparecida",
+      "municipio": 1395
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101925,
+    "fields": {
+      "nombre": "Chafaríz",
+      "municipio": 1395
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101926,
+    "fields": {
+      "nombre": "Colonia Progreso",
+      "municipio": 1395
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101927,
+    "fields": {
+      "nombre": "El Palmital",
+      "municipio": 1395
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101928,
+    "fields": {
+      "nombre": "Flor de Mayo",
+      "municipio": 1395
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101929,
+    "fields": {
+      "nombre": "Kilómetro 11",
+      "municipio": 1395
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101930,
+    "fields": {
+      "nombre": "Las Limas",
+      "municipio": 1395
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101931,
+    "fields": {
+      "nombre": "Macaco",
+      "municipio": 1395
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101932,
+    "fields": {
+      "nombre": "Puerto Alicia",
+      "municipio": 1395
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101933,
+    "fields": {
+      "nombre": "Puerto Aurora",
+      "municipio": 1395
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101934,
+    "fields": {
+      "nombre": "Puerto Londero",
+      "municipio": 1395
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101935,
+    "fields": {
+      "nombre": "Abra Ancha",
+      "municipio": 1396
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101936,
+    "fields": {
+      "nombre": "Agua Fría",
+      "municipio": 1396
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101937,
+    "fields": {
+      "nombre": "Bajada de Rahue",
+      "municipio": 1396
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101938,
+    "fields": {
+      "nombre": "Carri Lil",
+      "municipio": 1396
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101939,
+    "fields": {
+      "nombre": "Currumil Quillén",
+      "municipio": 1396
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101940,
+    "fields": {
+      "nombre": "Kilca",
+      "municipio": 1396
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101941,
+    "fields": {
+      "nombre": "Lago Hui Hui",
+      "municipio": 1396
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101942,
+    "fields": {
+      "nombre": "Lago Pilhué",
+      "municipio": 1396
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101943,
+    "fields": {
+      "nombre": "Lago Quillén",
+      "municipio": 1396
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101944,
+    "fields": {
+      "nombre": "Lago Rucachoroi",
+      "municipio": 1396
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101945,
+    "fields": {
+      "nombre": "Lonco Mula",
+      "municipio": 1396
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101946,
+    "fields": {
+      "nombre": "Nompehuén",
+      "municipio": 1396
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101947,
+    "fields": {
+      "nombre": "ñorquinco",
+      "municipio": 1396
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101948,
+    "fields": {
+      "nombre": "Paso de Reigolil",
+      "municipio": 1396
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101949,
+    "fields": {
+      "nombre": "Paso del Arco",
+      "municipio": 1396
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101950,
+    "fields": {
+      "nombre": "Poipucón",
+      "municipio": 1396
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101951,
+    "fields": {
+      "nombre": "Puerto Lussich",
+      "municipio": 1396
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101952,
+    "fields": {
+      "nombre": "Pulmari",
+      "municipio": 1396
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101953,
+    "fields": {
+      "nombre": "Quilachanquil",
+      "municipio": 1396
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101954,
+    "fields": {
+      "nombre": "Quillén",
+      "municipio": 1396
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101955,
+    "fields": {
+      "nombre": "Rahue",
+      "municipio": 1396
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101956,
+    "fields": {
+      "nombre": "Rancahue",
+      "municipio": 1396
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101957,
+    "fields": {
+      "nombre": "Rincón de la Media Luna",
+      "municipio": 1396
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101958,
+    "fields": {
+      "nombre": "Río Kilca",
+      "municipio": 1396
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101959,
+    "fields": {
+      "nombre": "Rucachoroi",
+      "municipio": 1396
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101960,
+    "fields": {
+      "nombre": "Argentina",
+      "municipio": 1399
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101961,
+    "fields": {
+      "nombre": "Campo Contardi",
+      "municipio": 1399
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101962,
+    "fields": {
+      "nombre": "Casares",
+      "municipio": 1399
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101963,
+    "fields": {
+      "nombre": "Colonia Hermelinda",
+      "municipio": 1399
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101964,
+    "fields": {
+      "nombre": "Colonia Libertad",
+      "municipio": 1399
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101965,
+    "fields": {
+      "nombre": "El Tropezón",
+      "municipio": 1399
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101966,
+    "fields": {
+      "nombre": "Kilómetro 764",
+      "municipio": 1399
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101967,
+    "fields": {
+      "nombre": "La Romelia",
+      "municipio": 1399
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101968,
+    "fields": {
+      "nombre": "Las Promesas",
+      "municipio": 1399
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101969,
+    "fields": {
+      "nombre": "Lote 24",
+      "municipio": 1399
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101970,
+    "fields": {
+      "nombre": "Malbrán",
+      "municipio": 1399
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101971,
+    "fields": {
+      "nombre": "Quebrachitos",
+      "municipio": 1399
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101972,
+    "fields": {
+      "nombre": "Villa General Mitre",
+      "municipio": 1399
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101973,
+    "fields": {
+      "nombre": "Cajón de Almanza",
+      "municipio": 1400
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101974,
+    "fields": {
+      "nombre": "Campana Mahuida",
+      "municipio": 1400
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101975,
+    "fields": {
+      "nombre": "Hualcupén Arriba",
+      "municipio": 1400
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101976,
+    "fields": {
+      "nombre": "Huarenchenque",
+      "municipio": 1400
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101977,
+    "fields": {
+      "nombre": "Huncal",
+      "municipio": 1400
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101978,
+    "fields": {
+      "nombre": "Mallín del Toro",
+      "municipio": 1400
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101979,
+    "fields": {
+      "nombre": "Pichaihué",
+      "municipio": 1400
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101980,
+    "fields": {
+      "nombre": "Pilmatué",
+      "municipio": 1400
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101981,
+    "fields": {
+      "nombre": "Quintuco",
+      "municipio": 1400
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101982,
+    "fields": {
+      "nombre": "Riscos Bayos",
+      "municipio": 1400
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101983,
+    "fields": {
+      "nombre": "14 de Mayo",
+      "municipio": 1401
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101984,
+    "fields": {
+      "nombre": "Alto de Fierro",
+      "municipio": 1401
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101985,
+    "fields": {
+      "nombre": "Campo Grande",
+      "municipio": 1401
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101986,
+    "fields": {
+      "nombre": "Caña Cruz",
+      "municipio": 1401
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101987,
+    "fields": {
+      "nombre": "El Eje de Candelaria",
+      "municipio": 1401
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101988,
+    "fields": {
+      "nombre": "El Guanaco",
+      "municipio": 1401
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101989,
+    "fields": {
+      "nombre": "El Mojón",
+      "municipio": 1401
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101990,
+    "fields": {
+      "nombre": "La Barraca",
+      "municipio": 1401
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101991,
+    "fields": {
+      "nombre": "La Cañada",
+      "municipio": 1401
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101992,
+    "fields": {
+      "nombre": "La Penca",
+      "municipio": 1401
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101993,
+    "fields": {
+      "nombre": "La Piedra Blanca",
+      "municipio": 1401
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101994,
+    "fields": {
+      "nombre": "La Victoria Este",
+      "municipio": 1401
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101995,
+    "fields": {
+      "nombre": "La Victoria Oeste",
+      "municipio": 1401
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101996,
+    "fields": {
+      "nombre": "Los Eucaliptos",
+      "municipio": 1401
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101997,
+    "fields": {
+      "nombre": "Pozo de las Ollas",
+      "municipio": 1401
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101998,
+    "fields": {
+      "nombre": "Pozo del MIstol",
+      "municipio": 1401
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 101999,
+    "fields": {
+      "nombre": "Punta del Monte",
+      "municipio": 1401
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102000,
+    "fields": {
+      "nombre": "Santa Isabel",
+      "municipio": 1401
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102001,
+    "fields": {
+      "nombre": "Aguada de las Vacas",
+      "municipio": 1402
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102002,
+    "fields": {
+      "nombre": "Aguada Lastra",
+      "municipio": 1402
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102003,
+    "fields": {
+      "nombre": "Aguada Pichana",
+      "municipio": 1402
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102004,
+    "fields": {
+      "nombre": "Auca Mahuida",
+      "municipio": 1402
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102005,
+    "fields": {
+      "nombre": "Bajada del Mono",
+      "municipio": 1402
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102006,
+    "fields": {
+      "nombre": "Barranca del Palo",
+      "municipio": 1402
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102007,
+    "fields": {
+      "nombre": "Cañadón Nogales",
+      "municipio": 1402
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102008,
+    "fields": {
+      "nombre": "Las Bayas",
+      "municipio": 1402
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102009,
+    "fields": {
+      "nombre": "Los Jagüelitos",
+      "municipio": 1402
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102010,
+    "fields": {
+      "nombre": "Los Pilares",
+      "municipio": 1402
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102011,
+    "fields": {
+      "nombre": "Paso de los Indios",
+      "municipio": 1402
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102012,
+    "fields": {
+      "nombre": "Pozo Cabado",
+      "municipio": 1402
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102013,
+    "fields": {
+      "nombre": "Presa Los Chihuidos",
+      "municipio": 1402
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102014,
+    "fields": {
+      "nombre": "Punta Carranza",
+      "municipio": 1402
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102015,
+    "fields": {
+      "nombre": "Punta de Agua",
+      "municipio": 1402
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102016,
+    "fields": {
+      "nombre": "Punta de Sierra",
+      "municipio": 1402
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102017,
+    "fields": {
+      "nombre": "Sierra Chata",
+      "municipio": 1402
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102018,
+    "fields": {
+      "nombre": "Tratayen",
+      "municipio": 1402
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102019,
+    "fields": {
+      "nombre": "Dique El Chañar",
+      "municipio": 1403
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102020,
+    "fields": {
+      "nombre": "El Cruce",
+      "municipio": 1403
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102021,
+    "fields": {
+      "nombre": "Aguada Toledo",
+      "municipio": 1411
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102022,
+    "fields": {
+      "nombre": "Dique Arroyito",
+      "municipio": 1411
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102023,
+    "fields": {
+      "nombre": "Los Bastos",
+      "municipio": 1411
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102024,
+    "fields": {
+      "nombre": "Aquihueco",
+      "municipio": 1414
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102025,
+    "fields": {
+      "nombre": "Cancha Huinganco",
+      "municipio": 1414
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102026,
+    "fields": {
+      "nombre": "Campo Grande",
+      "municipio": 1415
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102027,
+    "fields": {
+      "nombre": "La Rinconada",
+      "municipio": 1415
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102028,
+    "fields": {
+      "nombre": "Los Baños",
+      "municipio": 1415
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102029,
+    "fields": {
+      "nombre": "Mamuil Malal",
+      "municipio": 1415
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102030,
+    "fields": {
+      "nombre": "San Cabao",
+      "municipio": 1415
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102031,
+    "fields": {
+      "nombre": "Cerro Chapelco",
+      "municipio": 1416
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102032,
+    "fields": {
+      "nombre": "Puente Blanco",
+      "municipio": 1416
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102033,
+    "fields": {
+      "nombre": "Puerto Lerin",
+      "municipio": 1416
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102034,
+    "fields": {
+      "nombre": "Villa Lago Lolog",
+      "municipio": 1416
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102035,
+    "fields": {
+      "nombre": "Cerro Bayo",
+      "municipio": 1417
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102036,
+    "fields": {
+      "nombre": "Cumelén",
+      "municipio": 1417
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102037,
+    "fields": {
+      "nombre": "Puerto Manzano",
+      "municipio": 1417
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102038,
+    "fields": {
+      "nombre": "Puerto Quetrihue",
+      "municipio": 1417
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102039,
+    "fields": {
+      "nombre": "Camalón",
+      "municipio": 1418
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102040,
+    "fields": {
+      "nombre": "Curamallín",
+      "municipio": 1418
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102041,
+    "fields": {
+      "nombre": "Huaraco",
+      "municipio": 1418
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102042,
+    "fields": {
+      "nombre": "La Primavera",
+      "municipio": 1418
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102043,
+    "fields": {
+      "nombre": "Nahueve",
+      "municipio": 1418
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102044,
+    "fields": {
+      "nombre": "Pailaleche",
+      "municipio": 1418
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102045,
+    "fields": {
+      "nombre": "Charra Ruca",
+      "municipio": 1419
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102046,
+    "fields": {
+      "nombre": "El Manzano",
+      "municipio": 1419
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102047,
+    "fields": {
+      "nombre": "Lagunas de Epulafquen",
+      "municipio": 1420
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102048,
+    "fields": {
+      "nombre": "Paso de Lumabia",
+      "municipio": 1420
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102049,
+    "fields": {
+      "nombre": "Lileo",
+      "municipio": 1421
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102050,
+    "fields": {
+      "nombre": "Los Chacayes",
+      "municipio": 1421
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102051,
+    "fields": {
+      "nombre": "Paso Buta Mallín",
+      "municipio": 1421
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102052,
+    "fields": {
+      "nombre": "Tierras Blancas",
+      "municipio": 1421
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102053,
+    "fields": {
+      "nombre": "Buta Co",
+      "municipio": 1426
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102054,
+    "fields": {
+      "nombre": "Huara Co",
+      "municipio": 1426
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102055,
+    "fields": {
+      "nombre": "Aguada Chacayco",
+      "municipio": 1427
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102056,
+    "fields": {
+      "nombre": "Auquinco",
+      "municipio": 1427
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102057,
+    "fields": {
+      "nombre": "El Portón",
+      "municipio": 1427
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102058,
+    "fields": {
+      "nombre": "La Tungar",
+      "municipio": 1427
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102059,
+    "fields": {
+      "nombre": "Las Chacras",
+      "municipio": 1427
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102060,
+    "fields": {
+      "nombre": "Pampa Tril",
+      "municipio": 1427
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102061,
+    "fields": {
+      "nombre": "Ramblón Colorado",
+      "municipio": 1427
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102062,
+    "fields": {
+      "nombre": "Ranquil Vega",
+      "municipio": 1427
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102063,
+    "fields": {
+      "nombre": "Termas Buta Ranquil",
+      "municipio": 1427
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102064,
+    "fields": {
+      "nombre": "Puesto Hernández",
+      "municipio": 1428
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102065,
+    "fields": {
+      "nombre": "Puesto Molina",
+      "municipio": 1428
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102066,
+    "fields": {
+      "nombre": "Agrio del Medio",
+      "municipio": 1429
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102067,
+    "fields": {
+      "nombre": "Bajada Vieja",
+      "municipio": 1429
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102068,
+    "fields": {
+      "nombre": "Villa del Agrio",
+      "municipio": 1429
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102069,
+    "fields": {
+      "nombre": "Los Hornos",
+      "municipio": 1431
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102070,
+    "fields": {
+      "nombre": "Barda Negra",
+      "municipio": 1432
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102071,
+    "fields": {
+      "nombre": "Carro Quebrado",
+      "municipio": 1432
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102072,
+    "fields": {
+      "nombre": "El Chenque",
+      "municipio": 1432
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102073,
+    "fields": {
+      "nombre": "El Manzano",
+      "municipio": 1432
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102074,
+    "fields": {
+      "nombre": "La Amarga",
+      "municipio": 1432
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102075,
+    "fields": {
+      "nombre": "Laguna Blanca",
+      "municipio": 1432
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102076,
+    "fields": {
+      "nombre": "Laguna Miranda",
+      "municipio": 1432
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102077,
+    "fields": {
+      "nombre": "Mina Chita",
+      "municipio": 1432
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102078,
+    "fields": {
+      "nombre": "ñireco",
+      "municipio": 1432
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102079,
+    "fields": {
+      "nombre": "Paso de los Indios",
+      "municipio": 1432
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102080,
+    "fields": {
+      "nombre": "La Angostura",
+      "municipio": 1433
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102081,
+    "fields": {
+      "nombre": "Lonco Luan",
+      "municipio": 1433
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102082,
+    "fields": {
+      "nombre": "Paso de Icalma",
+      "municipio": 1433
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102083,
+    "fields": {
+      "nombre": "Villa Unión",
+      "municipio": 1433
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102084,
+    "fields": {
+      "nombre": "5ta Brigada",
+      "municipio": 1434
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102085,
+    "fields": {
+      "nombre": "Caldenadas",
+      "municipio": 1434
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102086,
+    "fields": {
+      "nombre": "Chalanta",
+      "municipio": 1434
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102087,
+    "fields": {
+      "nombre": "Colonia Don Antonio",
+      "municipio": 1434
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102088,
+    "fields": {
+      "nombre": "Colonia Zubelzú",
+      "municipio": 1434
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102089,
+    "fields": {
+      "nombre": "Coronel Alzogaray",
+      "municipio": 1434
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102090,
+    "fields": {
+      "nombre": "Country Club Los Caldenes",
+      "municipio": 1434
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102091,
+    "fields": {
+      "nombre": "Cramer",
+      "municipio": 1434
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102092,
+    "fields": {
+      "nombre": "El Mangrullo",
+      "municipio": 1434
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102093,
+    "fields": {
+      "nombre": "La Aguada",
+      "municipio": 1434
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102094,
+    "fields": {
+      "nombre": "La Angelina",
+      "municipio": 1434
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102095,
+    "fields": {
+      "nombre": "La Esquina",
+      "municipio": 1434
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102096,
+    "fields": {
+      "nombre": "La Portada",
+      "municipio": 1434
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102097,
+    "fields": {
+      "nombre": "Las Isletas",
+      "municipio": 1434
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102098,
+    "fields": {
+      "nombre": "Las Vizcacheras",
+      "municipio": 1434
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102099,
+    "fields": {
+      "nombre": "Liborio Luna",
+      "municipio": 1434
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102100,
+    "fields": {
+      "nombre": "Nueva Escocia",
+      "municipio": 1434
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102101,
+    "fields": {
+      "nombre": "Pedernera",
+      "municipio": 1434
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102102,
+    "fields": {
+      "nombre": "Río Quinto",
+      "municipio": 1434
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102103,
+    "fields": {
+      "nombre": "Sovén",
+      "municipio": 1434
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102104,
+    "fields": {
+      "nombre": "Travesía",
+      "municipio": 1434
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102105,
+    "fields": {
+      "nombre": "Villa Reynolds",
+      "municipio": 1434
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102106,
+    "fields": {
+      "nombre": "Agua de Canale",
+      "municipio": 1436
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102107,
+    "fields": {
+      "nombre": "Labra",
+      "municipio": 1436
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102108,
+    "fields": {
+      "nombre": "Dique Portezuelo Grande",
+      "municipio": 1439
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102109,
+    "fields": {
+      "nombre": "Butaco",
+      "municipio": 1440
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102110,
+    "fields": {
+      "nombre": "Coyuco",
+      "municipio": 1440
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102111,
+    "fields": {
+      "nombre": "Coyuco Abajo",
+      "municipio": 1440
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102112,
+    "fields": {
+      "nombre": "Huinganco",
+      "municipio": 1440
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102113,
+    "fields": {
+      "nombre": "Lulonco",
+      "municipio": 1440
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102114,
+    "fields": {
+      "nombre": "Caepe Malal",
+      "municipio": 1441
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102115,
+    "fields": {
+      "nombre": "Agua Dulce",
+      "municipio": 1442
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102116,
+    "fields": {
+      "nombre": "Aguada de Castro",
+      "municipio": 1442
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102117,
+    "fields": {
+      "nombre": "Bajada de Carrizo",
+      "municipio": 1442
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102118,
+    "fields": {
+      "nombre": "Coihueco",
+      "municipio": 1442
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102119,
+    "fields": {
+      "nombre": "La Continental",
+      "municipio": 1442
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102120,
+    "fields": {
+      "nombre": "Paso Huitrín",
+      "municipio": 1442
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102121,
+    "fields": {
+      "nombre": "Trahuncura",
+      "municipio": 1442
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102122,
+    "fields": {
+      "nombre": "El Mirador",
+      "municipio": 1443
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102123,
+    "fields": {
+      "nombre": "Guañaco Abajo",
+      "municipio": 1444
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102124,
+    "fields": {
+      "nombre": "Guañaco Arriba",
+      "municipio": 1444
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102125,
+    "fields": {
+      "nombre": "El Pino",
+      "municipio": 1445
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102126,
+    "fields": {
+      "nombre": "La Fragua",
+      "municipio": 1445
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102127,
+    "fields": {
+      "nombre": "Pichi Neuquén",
+      "municipio": 1445
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102128,
+    "fields": {
+      "nombre": "Aguas Calientes",
+      "municipio": 1446
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102129,
+    "fields": {
+      "nombre": "Ailinco",
+      "municipio": 1446
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102130,
+    "fields": {
+      "nombre": "Cajón del Atreuco",
+      "municipio": 1446
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102131,
+    "fields": {
+      "nombre": "Colomichicó",
+      "municipio": 1446
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102132,
+    "fields": {
+      "nombre": "Invernada Vieja",
+      "municipio": 1446
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102133,
+    "fields": {
+      "nombre": "Las Olletas",
+      "municipio": 1446
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102134,
+    "fields": {
+      "nombre": "Los Bolillos",
+      "municipio": 1446
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102135,
+    "fields": {
+      "nombre": "Matancilla",
+      "municipio": 1446
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102136,
+    "fields": {
+      "nombre": "Bella Vista",
+      "municipio": 1447
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102137,
+    "fields": {
+      "nombre": "Cayanta",
+      "municipio": 1447
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102138,
+    "fields": {
+      "nombre": "Crucero Catriel",
+      "municipio": 1448
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102139,
+    "fields": {
+      "nombre": "Rincón Colorado",
+      "municipio": 1448
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102140,
+    "fields": {
+      "nombre": "Limay Centro",
+      "municipio": 1449
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102141,
+    "fields": {
+      "nombre": "Villa Unión",
+      "municipio": 1449
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102142,
+    "fields": {
+      "nombre": "Covunco Abajo",
+      "municipio": 1452
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102143,
+    "fields": {
+      "nombre": "Paraje La Patagonia",
+      "municipio": 1452
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102144,
+    "fields": {
+      "nombre": "Covunco Arriba",
+      "municipio": 1453
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102145,
+    "fields": {
+      "nombre": "Mallín del Muerto",
+      "municipio": 1453
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102146,
+    "fields": {
+      "nombre": "Santo Domingo",
+      "municipio": 1454
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102147,
+    "fields": {
+      "nombre": "Los Pozones",
+      "municipio": 1455
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102148,
+    "fields": {
+      "nombre": "Villa Puente Picún Leufú",
+      "municipio": 1455
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102149,
+    "fields": {
+      "nombre": "Amieva",
+      "municipio": 1456
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102150,
+    "fields": {
+      "nombre": "Árbol Solo",
+      "municipio": 1456
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102151,
+    "fields": {
+      "nombre": "Bajo del Durazno",
+      "municipio": 1456
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102152,
+    "fields": {
+      "nombre": "Bella Estancia",
+      "municipio": 1456
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102153,
+    "fields": {
+      "nombre": "Buen Orden",
+      "municipio": 1456
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102154,
+    "fields": {
+      "nombre": "Cabeza de Vaca",
+      "municipio": 1456
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102155,
+    "fields": {
+      "nombre": "Cañada de Vilan",
+      "municipio": 1456
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102156,
+    "fields": {
+      "nombre": "Divisadero",
+      "municipio": 1456
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102157,
+    "fields": {
+      "nombre": "El Barrial",
+      "municipio": 1456
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102158,
+    "fields": {
+      "nombre": "El Dichoso",
+      "municipio": 1456
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102159,
+    "fields": {
+      "nombre": "El Jarillal",
+      "municipio": 1456
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102160,
+    "fields": {
+      "nombre": "El Milagro",
+      "municipio": 1456
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102161,
+    "fields": {
+      "nombre": "El Ramblón",
+      "municipio": 1456
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102162,
+    "fields": {
+      "nombre": "El Recodo",
+      "municipio": 1456
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102163,
+    "fields": {
+      "nombre": "El Sociego",
+      "municipio": 1456
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102164,
+    "fields": {
+      "nombre": "Hualtarán",
+      "municipio": 1456
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102165,
+    "fields": {
+      "nombre": "La Perlita",
+      "municipio": 1456
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102166,
+    "fields": {
+      "nombre": "Las Brisas",
+      "municipio": 1456
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102167,
+    "fields": {
+      "nombre": "Las Lagunitas",
+      "municipio": 1456
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102168,
+    "fields": {
+      "nombre": "Lomas Blancas",
+      "municipio": 1456
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102169,
+    "fields": {
+      "nombre": "Los Araditos",
+      "municipio": 1456
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102170,
+    "fields": {
+      "nombre": "Los Cerrillos",
+      "municipio": 1456
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102171,
+    "fields": {
+      "nombre": "Los Chañares",
+      "municipio": 1456
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102172,
+    "fields": {
+      "nombre": "Los Ramblones",
+      "municipio": 1456
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102173,
+    "fields": {
+      "nombre": "Naranjo Esquina",
+      "municipio": 1456
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102174,
+    "fields": {
+      "nombre": "Pozo Cavado",
+      "municipio": 1456
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102175,
+    "fields": {
+      "nombre": "Pozo del Tala",
+      "municipio": 1456
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102176,
+    "fields": {
+      "nombre": "Represa del Carmen",
+      "municipio": 1456
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102177,
+    "fields": {
+      "nombre": "San Antonio",
+      "municipio": 1456
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102178,
+    "fields": {
+      "nombre": "San Isidro",
+      "municipio": 1456
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102179,
+    "fields": {
+      "nombre": "San Pedro",
+      "municipio": 1456
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102180,
+    "fields": {
+      "nombre": "Santa Rosa del Gigante",
+      "municipio": 1456
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102181,
+    "fields": {
+      "nombre": "Toro Negro",
+      "municipio": 1456
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102182,
+    "fields": {
+      "nombre": "Los Terrones",
+      "municipio": 1457
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102183,
+    "fields": {
+      "nombre": "Mina Los Gigantes",
+      "municipio": 1457
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102184,
+    "fields": {
+      "nombre": "Puesto Pedernera",
+      "municipio": 1457
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102185,
+    "fields": {
+      "nombre": "Quebrada de Luna",
+      "municipio": 1457
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102186,
+    "fields": {
+      "nombre": "Río Yuspe",
+      "municipio": 1457
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102187,
+    "fields": {
+      "nombre": "Acosta",
+      "municipio": 1459
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102188,
+    "fields": {
+      "nombre": "Carahuasi",
+      "municipio": 1459
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102189,
+    "fields": {
+      "nombre": "Casa de Arco",
+      "municipio": 1459
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102190,
+    "fields": {
+      "nombre": "El Cebilar",
+      "municipio": 1459
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102191,
+    "fields": {
+      "nombre": "La Bodeguita",
+      "municipio": 1459
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102192,
+    "fields": {
+      "nombre": "Las Juntas",
+      "municipio": 1459
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102193,
+    "fields": {
+      "nombre": "Los Sauces",
+      "municipio": 1459
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102194,
+    "fields": {
+      "nombre": "Pampa Grande",
+      "municipio": 1459
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102195,
+    "fields": {
+      "nombre": "Santa Bárbara",
+      "municipio": 1459
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102196,
+    "fields": {
+      "nombre": "Sauce Redondo",
+      "municipio": 1459
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102197,
+    "fields": {
+      "nombre": "Vaquería",
+      "municipio": 1459
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102198,
+    "fields": {
+      "nombre": "Bahía Rosas",
+      "municipio": 1462
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102199,
+    "fields": {
+      "nombre": "Bajada de Echandi",
+      "municipio": 1462
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102200,
+    "fields": {
+      "nombre": "El Espigón",
+      "municipio": 1462
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102201,
+    "fields": {
+      "nombre": "El Paso",
+      "municipio": 1462
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102202,
+    "fields": {
+      "nombre": "Faro Belén",
+      "municipio": 1462
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102203,
+    "fields": {
+      "nombre": "La Boca",
+      "municipio": 1462
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102204,
+    "fields": {
+      "nombre": "Colonia Santa Gregoria",
+      "municipio": 1463
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102205,
+    "fields": {
+      "nombre": "La Usina",
+      "municipio": 1469
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102206,
+    "fields": {
+      "nombre": "Cajón del Azul",
+      "municipio": 1470
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102207,
+    "fields": {
+      "nombre": "Cerro Perito Moreno",
+      "municipio": 1470
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102208,
+    "fields": {
+      "nombre": "Costa del Río Azul",
+      "municipio": 1470
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102209,
+    "fields": {
+      "nombre": "Cuesta del Ternero",
+      "municipio": 1470
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102210,
+    "fields": {
+      "nombre": "El Rincón",
+      "municipio": 1470
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102211,
+    "fields": {
+      "nombre": "Río Foyel",
+      "municipio": 1470
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102212,
+    "fields": {
+      "nombre": "Bahía López",
+      "municipio": 1471
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102213,
+    "fields": {
+      "nombre": "Paso de Pérez Rosales",
+      "municipio": 1471
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102214,
+    "fields": {
+      "nombre": "Puerto Alegre",
+      "municipio": 1471
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102215,
+    "fields": {
+      "nombre": "Puerto Blest",
+      "municipio": 1471
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102216,
+    "fields": {
+      "nombre": "Puerto Frías",
+      "municipio": 1471
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102217,
+    "fields": {
+      "nombre": "Puerto Llao Llao",
+      "municipio": 1471
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102218,
+    "fields": {
+      "nombre": "Villa Tacul",
+      "municipio": 1471
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102219,
+    "fields": {
+      "nombre": "Colonia Santa Rosa",
+      "municipio": 1472
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102220,
+    "fields": {
+      "nombre": "Colonia Santa Teresita",
+      "municipio": 1472
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102221,
+    "fields": {
+      "nombre": "Comandante Martín Guerrico",
+      "municipio": 1473
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102222,
+    "fields": {
+      "nombre": "Colonia Ceferino Namuncurá",
+      "municipio": 1476
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102223,
+    "fields": {
+      "nombre": "La Parra",
+      "municipio": 1477
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102224,
+    "fields": {
+      "nombre": "Colonia Confluencia",
+      "municipio": 1478
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102225,
+    "fields": {
+      "nombre": "Cuatro Esquinas",
+      "municipio": 1478
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102226,
+    "fields": {
+      "nombre": "Rentería",
+      "municipio": 1478
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102227,
+    "fields": {
+      "nombre": "Arroyo Ñancay",
+      "municipio": 1482
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102228,
+    "fields": {
+      "nombre": "Berisso",
+      "municipio": 1482
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102229,
+    "fields": {
+      "nombre": "Colonia Italiana",
+      "municipio": 1482
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102230,
+    "fields": {
+      "nombre": "Colonia Las Flores",
+      "municipio": 1482
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102231,
+    "fields": {
+      "nombre": "Colonia Las Piedritas",
+      "municipio": 1482
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102232,
+    "fields": {
+      "nombre": "Colonia Stauber",
+      "municipio": 1482
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102233,
+    "fields": {
+      "nombre": "Costa de San Antonio",
+      "municipio": 1482
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102234,
+    "fields": {
+      "nombre": "Costa Las Masitas",
+      "municipio": 1482
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102235,
+    "fields": {
+      "nombre": "Costa Uruguay Sur",
+      "municipio": 1482
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102236,
+    "fields": {
+      "nombre": "El Nuevo Rincón",
+      "municipio": 1482
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102237,
+    "fields": {
+      "nombre": "El Sauce",
+      "municipio": 1482
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102238,
+    "fields": {
+      "nombre": "Gualeyancito",
+      "municipio": 1482
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102239,
+    "fields": {
+      "nombre": "La Peregrina",
+      "municipio": 1482
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102240,
+    "fields": {
+      "nombre": "Palavecino",
+      "municipio": 1482
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102241,
+    "fields": {
+      "nombre": "Pehuajó al Sud",
+      "municipio": 1482
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102242,
+    "fields": {
+      "nombre": "Pehuajó Norte",
+      "municipio": 1482
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102243,
+    "fields": {
+      "nombre": "Perdices",
+      "municipio": 1482
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102244,
+    "fields": {
+      "nombre": "Sarandí",
+      "municipio": 1482
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102245,
+    "fields": {
+      "nombre": "Villa Lila",
+      "municipio": 1482
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102246,
+    "fields": {
+      "nombre": "Casa de Piedra",
+      "municipio": 1483
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102247,
+    "fields": {
+      "nombre": "Aguada Troncoso",
+      "municipio": 1488
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102248,
+    "fields": {
+      "nombre": "Arroyo Las Minas",
+      "municipio": 1488
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102249,
+    "fields": {
+      "nombre": "Chacay Huarruca",
+      "municipio": 1488
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102250,
+    "fields": {
+      "nombre": "Chenqueniyen",
+      "municipio": 1488
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102251,
+    "fields": {
+      "nombre": "Fitalancao",
+      "municipio": 1488
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102252,
+    "fields": {
+      "nombre": "Fitamiche",
+      "municipio": 1488
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102253,
+    "fields": {
+      "nombre": "Futa Ruin",
+      "municipio": 1488
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102254,
+    "fields": {
+      "nombre": "Lipetrén",
+      "municipio": 1488
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102255,
+    "fields": {
+      "nombre": "Mamuel Choique",
+      "municipio": 1488
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102256,
+    "fields": {
+      "nombre": "Mina Pico Quemado",
+      "municipio": 1488
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102257,
+    "fields": {
+      "nombre": "ñorquinco Sur",
+      "municipio": 1488
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102258,
+    "fields": {
+      "nombre": "Ojos de Agua",
+      "municipio": 1488
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102259,
+    "fields": {
+      "nombre": "Río Chico",
+      "municipio": 1488
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102260,
+    "fields": {
+      "nombre": "Río Chico Abajo",
+      "municipio": 1488
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102261,
+    "fields": {
+      "nombre": "Colonia El Gualicho",
+      "municipio": 1489
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102262,
+    "fields": {
+      "nombre": "Colonia Reig",
+      "municipio": 1489
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102263,
+    "fields": {
+      "nombre": "Coronel Eugenio del Busto",
+      "municipio": 1489
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102264,
+    "fields": {
+      "nombre": "Juan de Garay",
+      "municipio": 1489
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102265,
+    "fields": {
+      "nombre": "Kilómetro 829",
+      "municipio": 1489
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102266,
+    "fields": {
+      "nombre": "Kilómetro 839",
+      "municipio": 1489
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102267,
+    "fields": {
+      "nombre": "Bolsa del Gualicho",
+      "municipio": 1491
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102268,
+    "fields": {
+      "nombre": "Cinco Chañares",
+      "municipio": 1491
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102269,
+    "fields": {
+      "nombre": "El Tanque",
+      "municipio": 1491
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102270,
+    "fields": {
+      "nombre": "Laguna Cortés",
+      "municipio": 1491
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102271,
+    "fields": {
+      "nombre": "Mancha Blanca",
+      "municipio": 1491
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102272,
+    "fields": {
+      "nombre": "Piedras Coloradas",
+      "municipio": 1491
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102273,
+    "fields": {
+      "nombre": "Saladar",
+      "municipio": 1491
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102274,
+    "fields": {
+      "nombre": "Salina del Gualicho",
+      "municipio": 1491
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102275,
+    "fields": {
+      "nombre": "Mina Gonzalito",
+      "municipio": 1492
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102276,
+    "fields": {
+      "nombre": "Mina Sierra Grande",
+      "municipio": 1492
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102277,
+    "fields": {
+      "nombre": "Aguada Cecilio",
+      "municipio": 1493
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102278,
+    "fields": {
+      "nombre": "Arroyo Los Berros",
+      "municipio": 1493
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102279,
+    "fields": {
+      "nombre": "Arroyo Salado",
+      "municipio": 1493
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102280,
+    "fields": {
+      "nombre": "Arroyo Ventana",
+      "municipio": 1493
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102281,
+    "fields": {
+      "nombre": "Campana Mahuida",
+      "municipio": 1493
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102282,
+    "fields": {
+      "nombre": "Chipauquil",
+      "municipio": 1493
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102283,
+    "fields": {
+      "nombre": "Colonia Macachín",
+      "municipio": 1493
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102284,
+    "fields": {
+      "nombre": "El Tembrao",
+      "municipio": 1493
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102285,
+    "fields": {
+      "nombre": "El Valle",
+      "municipio": 1493
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102286,
+    "fields": {
+      "nombre": "La Calera",
+      "municipio": 1493
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102287,
+    "fields": {
+      "nombre": "La Carolina",
+      "municipio": 1493
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102288,
+    "fields": {
+      "nombre": "Lonco Vaca",
+      "municipio": 1493
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102289,
+    "fields": {
+      "nombre": "Musters",
+      "municipio": 1493
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102290,
+    "fields": {
+      "nombre": "Nahuel Niyeu",
+      "municipio": 1493
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102291,
+    "fields": {
+      "nombre": "Numuco",
+      "municipio": 1493
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102292,
+    "fields": {
+      "nombre": "Paja Alta",
+      "municipio": 1493
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102293,
+    "fields": {
+      "nombre": "Sierra Pailemán",
+      "municipio": 1493
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102294,
+    "fields": {
+      "nombre": "Teniente Maza",
+      "municipio": 1493
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102295,
+    "fields": {
+      "nombre": "Tromenco",
+      "municipio": 1493
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102296,
+    "fields": {
+      "nombre": "Cabo Irigoyen",
+      "municipio": 1498
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102297,
+    "fields": {
+      "nombre": "Cabo San Pablo",
+      "municipio": 1498
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102298,
+    "fields": {
+      "nombre": "Lago Fagnano",
+      "municipio": 1498
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102299,
+    "fields": {
+      "nombre": "Lago Yehuín",
+      "municipio": 1498
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102300,
+    "fields": {
+      "nombre": "Río Ewan",
+      "municipio": 1498
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102301,
+    "fields": {
+      "nombre": "Villa Marina",
+      "municipio": 1498
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102302,
+    "fields": {
+      "nombre": "Adán Quiroga",
+      "municipio": 1499
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102303,
+    "fields": {
+      "nombre": "Agua Negra",
+      "municipio": 1499
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102304,
+    "fields": {
+      "nombre": "Alto de Mogna",
+      "municipio": 1499
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102305,
+    "fields": {
+      "nombre": "Bella Vista",
+      "municipio": 1499
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102306,
+    "fields": {
+      "nombre": "Boca de la Quebrada",
+      "municipio": 1499
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102307,
+    "fields": {
+      "nombre": "Ciénagas",
+      "municipio": 1499
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102308,
+    "fields": {
+      "nombre": "Cruz de Piedra",
+      "municipio": 1499
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102309,
+    "fields": {
+      "nombre": "Dique Cauquenes",
+      "municipio": 1499
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102310,
+    "fields": {
+      "nombre": "Dique Pachimoco",
+      "municipio": 1499
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102311,
+    "fields": {
+      "nombre": "El Volcán",
+      "municipio": 1499
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102312,
+    "fields": {
+      "nombre": "Gualcamayo",
+      "municipio": 1499
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102313,
+    "fields": {
+      "nombre": "Huerta de Huachi",
+      "municipio": 1499
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102314,
+    "fields": {
+      "nombre": "La Ciénaga",
+      "municipio": 1499
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102315,
+    "fields": {
+      "nombre": "La Ciénaga de Cumillango",
+      "municipio": 1499
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102316,
+    "fields": {
+      "nombre": "La Frontera",
+      "municipio": 1499
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102317,
+    "fields": {
+      "nombre": "Las Aguaditas",
+      "municipio": 1499
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102318,
+    "fields": {
+      "nombre": "Los Puestos",
+      "municipio": 1499
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102319,
+    "fields": {
+      "nombre": "Matías Sánchez",
+      "municipio": 1499
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102320,
+    "fields": {
+      "nombre": "Mina Gualcamayo",
+      "municipio": 1499
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102321,
+    "fields": {
+      "nombre": "Niquivil Viejo",
+      "municipio": 1499
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102322,
+    "fields": {
+      "nombre": "Panacán",
+      "municipio": 1499
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102323,
+    "fields": {
+      "nombre": "Portón Grande",
+      "municipio": 1499
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102324,
+    "fields": {
+      "nombre": "Punta del Agua",
+      "municipio": 1499
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102325,
+    "fields": {
+      "nombre": "San Roque",
+      "municipio": 1499
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102326,
+    "fields": {
+      "nombre": "Tucunuco",
+      "municipio": 1499
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102327,
+    "fields": {
+      "nombre": "Banco Ortellado",
+      "municipio": 1500
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102328,
+    "fields": {
+      "nombre": "Banco Payaguá",
+      "municipio": 1500
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102329,
+    "fields": {
+      "nombre": "Colonia Cano",
+      "municipio": 1500
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102330,
+    "fields": {
+      "nombre": "Colonia El Naranjito",
+      "municipio": 1500
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102331,
+    "fields": {
+      "nombre": "Colonia Laguna Gobernador",
+      "municipio": 1500
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102332,
+    "fields": {
+      "nombre": "Colonia San Antonio",
+      "municipio": 1500
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102333,
+    "fields": {
+      "nombre": "Esterito",
+      "municipio": 1500
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102334,
+    "fields": {
+      "nombre": "Guayacanty",
+      "municipio": 1500
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102335,
+    "fields": {
+      "nombre": "Kilómetro 100",
+      "municipio": 1500
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102336,
+    "fields": {
+      "nombre": "Kilómetro 117",
+      "municipio": 1500
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102337,
+    "fields": {
+      "nombre": "Paraje Mbiguá",
+      "municipio": 1500
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102338,
+    "fields": {
+      "nombre": "Paso Polenta",
+      "municipio": 1500
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102339,
+    "fields": {
+      "nombre": "Posta del Salado",
+      "municipio": 1500
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102340,
+    "fields": {
+      "nombre": "Potrero de los Caballos",
+      "municipio": 1500
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102341,
+    "fields": {
+      "nombre": "Puerta Misión",
+      "municipio": 1500
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102342,
+    "fields": {
+      "nombre": "Puerto Aquino",
+      "municipio": 1500
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102343,
+    "fields": {
+      "nombre": "Riacho Lindo",
+      "municipio": 1500
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102344,
+    "fields": {
+      "nombre": "San Isidro",
+      "municipio": 1500
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102345,
+    "fields": {
+      "nombre": "Soldado E. Sosa",
+      "municipio": 1500
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102346,
+    "fields": {
+      "nombre": "Tatané",
+      "municipio": 1500
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102347,
+    "fields": {
+      "nombre": "Tres Mojones",
+      "municipio": 1500
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102348,
+    "fields": {
+      "nombre": "Agua Dulce",
+      "municipio": 1503
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102349,
+    "fields": {
+      "nombre": "Barreto",
+      "municipio": 1503
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102350,
+    "fields": {
+      "nombre": "Campo Anchorena",
+      "municipio": 1503
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102351,
+    "fields": {
+      "nombre": "Campo La Chantada",
+      "municipio": 1503
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102352,
+    "fields": {
+      "nombre": "Campo La Zulema",
+      "municipio": 1503
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102353,
+    "fields": {
+      "nombre": "Campo Mayol",
+      "municipio": 1503
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102354,
+    "fields": {
+      "nombre": "Campo San Juan",
+      "municipio": 1503
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102355,
+    "fields": {
+      "nombre": "Colonia Alto Verde",
+      "municipio": 1503
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102356,
+    "fields": {
+      "nombre": "Colonia Campo Albano",
+      "municipio": 1503
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102357,
+    "fields": {
+      "nombre": "Colonia Dolores",
+      "municipio": 1503
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102358,
+    "fields": {
+      "nombre": "Colonia La Celina",
+      "municipio": 1503
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102359,
+    "fields": {
+      "nombre": "Colonia La Florida",
+      "municipio": 1503
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102360,
+    "fields": {
+      "nombre": "Colonia La Legua",
+      "municipio": 1503
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102361,
+    "fields": {
+      "nombre": "Colonia La Monona",
+      "municipio": 1503
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102362,
+    "fields": {
+      "nombre": "Colonia Las Merceditas",
+      "municipio": 1503
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102363,
+    "fields": {
+      "nombre": "Colonia Maipú",
+      "municipio": 1503
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102364,
+    "fields": {
+      "nombre": "Colonia María Angelina",
+      "municipio": 1503
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102365,
+    "fields": {
+      "nombre": "Colonia Santa Clara",
+      "municipio": 1503
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102366,
+    "fields": {
+      "nombre": "Colonia Santa Paula",
+      "municipio": 1503
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102367,
+    "fields": {
+      "nombre": "Colonia Santo Tomás",
+      "municipio": 1503
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102368,
+    "fields": {
+      "nombre": "Godino",
+      "municipio": 1503
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102369,
+    "fields": {
+      "nombre": "La Cremería",
+      "municipio": 1503
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102370,
+    "fields": {
+      "nombre": "La ñatita",
+      "municipio": 1503
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102371,
+    "fields": {
+      "nombre": "Manantiales",
+      "municipio": 1503
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102372,
+    "fields": {
+      "nombre": "Olmos",
+      "municipio": 1503
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102373,
+    "fields": {
+      "nombre": "Paso El Álamo",
+      "municipio": 1503
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102374,
+    "fields": {
+      "nombre": "Paso Gardien",
+      "municipio": 1503
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102375,
+    "fields": {
+      "nombre": "Pavín",
+      "municipio": 1503
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102376,
+    "fields": {
+      "nombre": "Donato Álvarez",
+      "municipio": 1504
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102377,
+    "fields": {
+      "nombre": "El Bajo de Marapa",
+      "municipio": 1504
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102378,
+    "fields": {
+      "nombre": "La Calera",
+      "municipio": 1504
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102379,
+    "fields": {
+      "nombre": "Los Alamitos",
+      "municipio": 1504
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102380,
+    "fields": {
+      "nombre": "Los Arroyos",
+      "municipio": 1504
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102381,
+    "fields": {
+      "nombre": "Marapa",
+      "municipio": 1504
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102382,
+    "fields": {
+      "nombre": "Naranjo Esquina",
+      "municipio": 1504
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102383,
+    "fields": {
+      "nombre": "Puente del Medio",
+      "municipio": 1504
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102384,
+    "fields": {
+      "nombre": "Yaquilo",
+      "municipio": 1504
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102385,
+    "fields": {
+      "nombre": "Bella Vista",
+      "municipio": 1505
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102386,
+    "fields": {
+      "nombre": "Cabo Curioso",
+      "municipio": 1505
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102387,
+    "fields": {
+      "nombre": "Cabo Dañoso",
+      "municipio": 1505
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102388,
+    "fields": {
+      "nombre": "El Salado",
+      "municipio": 1505
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102389,
+    "fields": {
+      "nombre": "Juan José Albornoz",
+      "municipio": 1505
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102390,
+    "fields": {
+      "nombre": "Makenke",
+      "municipio": 1505
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102391,
+    "fields": {
+      "nombre": "Manantial Espejo",
+      "municipio": 1505
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102392,
+    "fields": {
+      "nombre": "Mina Marta",
+      "municipio": 1505
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102393,
+    "fields": {
+      "nombre": "Playa de los Caracoles",
+      "municipio": 1505
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102394,
+    "fields": {
+      "nombre": "Playa Grande",
+      "municipio": 1505
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102395,
+    "fields": {
+      "nombre": "Playa La Mina",
+      "municipio": 1505
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102396,
+    "fields": {
+      "nombre": "Tres Cerros",
+      "municipio": 1505
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102397,
+    "fields": {
+      "nombre": "Agua Sucia",
+      "municipio": 1506
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102398,
+    "fields": {
+      "nombre": "El Bordo",
+      "municipio": 1506
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102399,
+    "fields": {
+      "nombre": "Las Flacas",
+      "municipio": 1506
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102400,
+    "fields": {
+      "nombre": "El Porvenir",
+      "municipio": 1507
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102401,
+    "fields": {
+      "nombre": "El Vencido",
+      "municipio": 1507
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102402,
+    "fields": {
+      "nombre": "Kilómetro 1152",
+      "municipio": 1507
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102403,
+    "fields": {
+      "nombre": "Mangrullo",
+      "municipio": 1507
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102404,
+    "fields": {
+      "nombre": "La Unión",
+      "municipio": 1508
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102405,
+    "fields": {
+      "nombre": "Palo a Pique",
+      "municipio": 1508
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102406,
+    "fields": {
+      "nombre": "Balbuena",
+      "municipio": 1509
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102407,
+    "fields": {
+      "nombre": "Campos del Norte",
+      "municipio": 1509
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102408,
+    "fields": {
+      "nombre": "Chorroarín",
+      "municipio": 1509
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102409,
+    "fields": {
+      "nombre": "Curva del Turco",
+      "municipio": 1509
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102410,
+    "fields": {
+      "nombre": "El Algarrobal",
+      "municipio": 1509
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102411,
+    "fields": {
+      "nombre": "El Cóndor",
+      "municipio": 1509
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102412,
+    "fields": {
+      "nombre": "El Destierro",
+      "municipio": 1509
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102413,
+    "fields": {
+      "nombre": "El Retiro",
+      "municipio": 1509
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102414,
+    "fields": {
+      "nombre": "El Valle",
+      "municipio": 1509
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102415,
+    "fields": {
+      "nombre": "Independencia",
+      "municipio": 1509
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102416,
+    "fields": {
+      "nombre": "Kilómetro 1088",
+      "municipio": 1509
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102417,
+    "fields": {
+      "nombre": "Kilómetro 90",
+      "municipio": 1509
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102418,
+    "fields": {
+      "nombre": "La Argentina",
+      "municipio": 1509
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102419,
+    "fields": {
+      "nombre": "La Floresta",
+      "municipio": 1509
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102420,
+    "fields": {
+      "nombre": "La Providencia",
+      "municipio": 1509
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102421,
+    "fields": {
+      "nombre": "Laguna Blanca",
+      "municipio": 1509
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102422,
+    "fields": {
+      "nombre": "Laguna Verde",
+      "municipio": 1509
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102423,
+    "fields": {
+      "nombre": "Las Catitas",
+      "municipio": 1509
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102424,
+    "fields": {
+      "nombre": "Los Tapires",
+      "municipio": 1509
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102425,
+    "fields": {
+      "nombre": "Puesto del Medio",
+      "municipio": 1509
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102426,
+    "fields": {
+      "nombre": "San Ignacio",
+      "municipio": 1509
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102427,
+    "fields": {
+      "nombre": "San Juan",
+      "municipio": 1509
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102428,
+    "fields": {
+      "nombre": "Santa Cecilia",
+      "municipio": 1509
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102429,
+    "fields": {
+      "nombre": "Santa Laura",
+      "municipio": 1509
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102430,
+    "fields": {
+      "nombre": "Santa Rita",
+      "municipio": 1509
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102431,
+    "fields": {
+      "nombre": "Santa Teresa",
+      "municipio": 1509
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102432,
+    "fields": {
+      "nombre": "Santo Domingo",
+      "municipio": 1509
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102433,
+    "fields": {
+      "nombre": "Simbolito",
+      "municipio": 1509
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102434,
+    "fields": {
+      "nombre": "Cabeza de Anta",
+      "municipio": 1510
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102435,
+    "fields": {
+      "nombre": "El Líbano",
+      "municipio": 1510
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102436,
+    "fields": {
+      "nombre": "El Piquete",
+      "municipio": 1510
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102437,
+    "fields": {
+      "nombre": "El Rey",
+      "municipio": 1510
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102438,
+    "fields": {
+      "nombre": "Estancia Vieja del Rey",
+      "municipio": 1510
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102439,
+    "fields": {
+      "nombre": "La Florida",
+      "municipio": 1510
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102440,
+    "fields": {
+      "nombre": "La Misión",
+      "municipio": 1510
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102441,
+    "fields": {
+      "nombre": "Las Víboras",
+      "municipio": 1510
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102442,
+    "fields": {
+      "nombre": "Los Pozos",
+      "municipio": 1510
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102443,
+    "fields": {
+      "nombre": "Miraflores",
+      "municipio": 1510
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102444,
+    "fields": {
+      "nombre": "Paso de la Cruz",
+      "municipio": 1510
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102445,
+    "fields": {
+      "nombre": "Saladillo de Juárez",
+      "municipio": 1510
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102446,
+    "fields": {
+      "nombre": "Agua de los Loros",
+      "municipio": 1511
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102447,
+    "fields": {
+      "nombre": "Buena Vista",
+      "municipio": 1511
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102448,
+    "fields": {
+      "nombre": "Las Cortaderas",
+      "municipio": 1511
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102449,
+    "fields": {
+      "nombre": "Piul",
+      "municipio": 1511
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102450,
+    "fields": {
+      "nombre": "Potrero de Payogasta",
+      "municipio": 1511
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102451,
+    "fields": {
+      "nombre": "Tonco",
+      "municipio": 1511
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102452,
+    "fields": {
+      "nombre": "Chimpa",
+      "municipio": 1512
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102453,
+    "fields": {
+      "nombre": "Chuscha",
+      "municipio": 1512
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102454,
+    "fields": {
+      "nombre": "Divisadero",
+      "municipio": 1512
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102455,
+    "fields": {
+      "nombre": "La Punilla",
+      "municipio": 1512
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102456,
+    "fields": {
+      "nombre": "Las Conchas",
+      "municipio": 1512
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102457,
+    "fields": {
+      "nombre": "Yacochuya Norte",
+      "municipio": 1512
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102458,
+    "fields": {
+      "nombre": "Yacochuya Sur",
+      "municipio": 1512
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102459,
+    "fields": {
+      "nombre": "Cañada de la Orqueta",
+      "municipio": 1513
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102460,
+    "fields": {
+      "nombre": "Chamical",
+      "municipio": 1513
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102461,
+    "fields": {
+      "nombre": "La Quesera",
+      "municipio": 1513
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102462,
+    "fields": {
+      "nombre": "La Troja",
+      "municipio": 1513
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102463,
+    "fields": {
+      "nombre": "El Carmen",
+      "municipio": 1514
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102464,
+    "fields": {
+      "nombre": "El Molino",
+      "municipio": 1514
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102465,
+    "fields": {
+      "nombre": "El Zanjón",
+      "municipio": 1514
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102466,
+    "fields": {
+      "nombre": "Espelta",
+      "municipio": 1514
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102467,
+    "fields": {
+      "nombre": "Humaitá",
+      "municipio": 1514
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102468,
+    "fields": {
+      "nombre": "La Isla",
+      "municipio": 1514
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102469,
+    "fields": {
+      "nombre": "La Tablada",
+      "municipio": 1514
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102470,
+    "fields": {
+      "nombre": "Los Pinos",
+      "municipio": 1514
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102471,
+    "fields": {
+      "nombre": "Santa Elena",
+      "municipio": 1514
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102472,
+    "fields": {
+      "nombre": "Villa Sarmiento",
+      "municipio": 1514
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102473,
+    "fields": {
+      "nombre": "Cantera Mogote",
+      "municipio": 1515
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102474,
+    "fields": {
+      "nombre": "El Ceibal",
+      "municipio": 1515
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102475,
+    "fields": {
+      "nombre": "El Huaico",
+      "municipio": 1515
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102476,
+    "fields": {
+      "nombre": "La Capilla",
+      "municipio": 1515
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102477,
+    "fields": {
+      "nombre": "Las Pircas",
+      "municipio": 1515
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102478,
+    "fields": {
+      "nombre": "Las Tienditas",
+      "municipio": 1515
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102479,
+    "fields": {
+      "nombre": "Sumalao",
+      "municipio": 1515
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102480,
+    "fields": {
+      "nombre": "Agua Negra",
+      "municipio": 1516
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102481,
+    "fields": {
+      "nombre": "Bella Vista",
+      "municipio": 1516
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102482,
+    "fields": {
+      "nombre": "Chivilme",
+      "municipio": 1516
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102483,
+    "fields": {
+      "nombre": "Cuesta del Obispo",
+      "municipio": 1516
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102484,
+    "fields": {
+      "nombre": "El Maray",
+      "municipio": 1516
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102485,
+    "fields": {
+      "nombre": "El Nogalar",
+      "municipio": 1516
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102486,
+    "fields": {
+      "nombre": "El Simbolar",
+      "municipio": 1516
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102487,
+    "fields": {
+      "nombre": "La Zanja",
+      "municipio": 1516
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102488,
+    "fields": {
+      "nombre": "Las Moras",
+      "municipio": 1516
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102489,
+    "fields": {
+      "nombre": "Piedra del Molino",
+      "municipio": 1516
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102490,
+    "fields": {
+      "nombre": "Potrero Díaz",
+      "municipio": 1516
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102491,
+    "fields": {
+      "nombre": "Pulares",
+      "municipio": 1516
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102492,
+    "fields": {
+      "nombre": "San Fernando de Escoipe",
+      "municipio": 1516
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102493,
+    "fields": {
+      "nombre": "San Martín",
+      "municipio": 1516
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102494,
+    "fields": {
+      "nombre": "Santa Ana",
+      "municipio": 1516
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102495,
+    "fields": {
+      "nombre": "Villa Fanny",
+      "municipio": 1516
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102496,
+    "fields": {
+      "nombre": "Calvimonte",
+      "municipio": 1517
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102497,
+    "fields": {
+      "nombre": "Kilómetro 1094",
+      "municipio": 1518
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102498,
+    "fields": {
+      "nombre": "Ojo de Agua",
+      "municipio": 1518
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102499,
+    "fields": {
+      "nombre": "El Ceibal",
+      "municipio": 1519
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102500,
+    "fields": {
+      "nombre": "El Prado",
+      "municipio": 1519
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102501,
+    "fields": {
+      "nombre": "Los Noques",
+      "municipio": 1519
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102502,
+    "fields": {
+      "nombre": "Acambuco",
+      "municipio": 1520
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102503,
+    "fields": {
+      "nombre": "Campo Largo",
+      "municipio": 1520
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102504,
+    "fields": {
+      "nombre": "Curva de Juan",
+      "municipio": 1520
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102505,
+    "fields": {
+      "nombre": "Dique Itiyuro",
+      "municipio": 1520
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102506,
+    "fields": {
+      "nombre": "El Chorrillo",
+      "municipio": 1520
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102507,
+    "fields": {
+      "nombre": "Las Maravillas",
+      "municipio": 1520
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102508,
+    "fields": {
+      "nombre": "Salta Jollín",
+      "municipio": 1520
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102509,
+    "fields": {
+      "nombre": "Timboirenda",
+      "municipio": 1520
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102510,
+    "fields": {
+      "nombre": "Colonia Zanja del Tigre",
+      "municipio": 1521
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102511,
+    "fields": {
+      "nombre": "El Carpintero",
+      "municipio": 1521
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102512,
+    "fields": {
+      "nombre": "El Desengaño",
+      "municipio": 1521
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102513,
+    "fields": {
+      "nombre": "El Tastil",
+      "municipio": 1521
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102514,
+    "fields": {
+      "nombre": "La Emboscada",
+      "municipio": 1521
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102515,
+    "fields": {
+      "nombre": "La Quena",
+      "municipio": 1521
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102516,
+    "fields": {
+      "nombre": "Las Llanas",
+      "municipio": 1521
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102517,
+    "fields": {
+      "nombre": "Luna Muerta",
+      "municipio": 1521
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102518,
+    "fields": {
+      "nombre": "Media Luna",
+      "municipio": 1521
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102519,
+    "fields": {
+      "nombre": "Monte Carmelo",
+      "municipio": 1521
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102520,
+    "fields": {
+      "nombre": "Monte Seco",
+      "municipio": 1521
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102521,
+    "fields": {
+      "nombre": "San Ignacio",
+      "municipio": 1521
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102522,
+    "fields": {
+      "nombre": "Senda Hachada",
+      "municipio": 1521
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102523,
+    "fields": {
+      "nombre": "El Castigado",
+      "municipio": 1522
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102524,
+    "fields": {
+      "nombre": "El Pescadito",
+      "municipio": 1522
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102525,
+    "fields": {
+      "nombre": "El Traslado",
+      "municipio": 1522
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102526,
+    "fields": {
+      "nombre": "San Martín de Zopota",
+      "municipio": 1522
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102527,
+    "fields": {
+      "nombre": "Aguay",
+      "municipio": 1523
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102528,
+    "fields": {
+      "nombre": "Antonio Quijarro",
+      "municipio": 1523
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102529,
+    "fields": {
+      "nombre": "Madrejones",
+      "municipio": 1523
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102530,
+    "fields": {
+      "nombre": "El Algarrobal",
+      "municipio": 1524
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102531,
+    "fields": {
+      "nombre": "Macueta",
+      "municipio": 1524
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102532,
+    "fields": {
+      "nombre": "Bobadal",
+      "municipio": 1525
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102533,
+    "fields": {
+      "nombre": "El Sauzal",
+      "municipio": 1525
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102534,
+    "fields": {
+      "nombre": "Nifwotaj",
+      "municipio": 1525
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102535,
+    "fields": {
+      "nombre": "Tonono",
+      "municipio": 1525
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102536,
+    "fields": {
+      "nombre": "Yariguarenda",
+      "municipio": 1525
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102537,
+    "fields": {
+      "nombre": "Abra de Araguyoc",
+      "municipio": 1526
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102538,
+    "fields": {
+      "nombre": "Abra del Sauce",
+      "municipio": 1526
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102539,
+    "fields": {
+      "nombre": "Agua Blanca",
+      "municipio": 1526
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102540,
+    "fields": {
+      "nombre": "Alisar del Porongal",
+      "municipio": 1526
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102541,
+    "fields": {
+      "nombre": "Campo Carrera",
+      "municipio": 1526
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102542,
+    "fields": {
+      "nombre": "Casa Grande",
+      "municipio": 1526
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102543,
+    "fields": {
+      "nombre": "Chañar",
+      "municipio": 1526
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102544,
+    "fields": {
+      "nombre": "Chiyayoc",
+      "municipio": 1526
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102545,
+    "fields": {
+      "nombre": "Colanzulí",
+      "municipio": 1526
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102546,
+    "fields": {
+      "nombre": "El Alfarcito",
+      "municipio": 1526
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102547,
+    "fields": {
+      "nombre": "Huayra Huasi",
+      "municipio": 1526
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102548,
+    "fields": {
+      "nombre": "La Mesada",
+      "municipio": 1526
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102549,
+    "fields": {
+      "nombre": "La Mesada Grande",
+      "municipio": 1526
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102550,
+    "fields": {
+      "nombre": "Las Capillas",
+      "municipio": 1526
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102551,
+    "fields": {
+      "nombre": "Las Higueras",
+      "municipio": 1526
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102552,
+    "fields": {
+      "nombre": "Las Trancas",
+      "municipio": 1526
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102553,
+    "fields": {
+      "nombre": "Matancillas de San Antonio",
+      "municipio": 1526
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102554,
+    "fields": {
+      "nombre": "Matancillas del Valle Delgado",
+      "municipio": 1526
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102555,
+    "fields": {
+      "nombre": "Porongal",
+      "municipio": 1526
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102556,
+    "fields": {
+      "nombre": "Río Grande",
+      "municipio": 1526
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102557,
+    "fields": {
+      "nombre": "Sala Escuya",
+      "municipio": 1526
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102558,
+    "fields": {
+      "nombre": "San Juan",
+      "municipio": 1526
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102559,
+    "fields": {
+      "nombre": "Tacupampa",
+      "municipio": 1526
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102560,
+    "fields": {
+      "nombre": "Valle Delgado",
+      "municipio": 1526
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102561,
+    "fields": {
+      "nombre": "Vizcarra",
+      "municipio": 1526
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102562,
+    "fields": {
+      "nombre": "Volcán Higueras",
+      "municipio": 1526
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102563,
+    "fields": {
+      "nombre": "Zapallar",
+      "municipio": 1526
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102564,
+    "fields": {
+      "nombre": "San Ignacio",
+      "municipio": 1527
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102565,
+    "fields": {
+      "nombre": "Tres Morros",
+      "municipio": 1527
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102566,
+    "fields": {
+      "nombre": "Alto de Sierra",
+      "municipio": 1528
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102567,
+    "fields": {
+      "nombre": "Campo Alegre",
+      "municipio": 1528
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102568,
+    "fields": {
+      "nombre": "El Gallinato",
+      "municipio": 1528
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102569,
+    "fields": {
+      "nombre": "La Despensa",
+      "municipio": 1528
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102570,
+    "fields": {
+      "nombre": "Mojotoro",
+      "municipio": 1528
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102571,
+    "fields": {
+      "nombre": "Tres Cruces",
+      "municipio": 1528
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102572,
+    "fields": {
+      "nombre": "Lesser",
+      "municipio": 1529
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102573,
+    "fields": {
+      "nombre": "Los Yacones",
+      "municipio": 1529
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102574,
+    "fields": {
+      "nombre": "Potrerillos",
+      "municipio": 1530
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102575,
+    "fields": {
+      "nombre": "El Brete",
+      "municipio": 1531
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102576,
+    "fields": {
+      "nombre": "Abra de Quirón",
+      "municipio": 1532
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102577,
+    "fields": {
+      "nombre": "Abra del Acay",
+      "municipio": 1532
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102578,
+    "fields": {
+      "nombre": "Abra del Gallo",
+      "municipio": 1532
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102579,
+    "fields": {
+      "nombre": "Acazoque",
+      "municipio": 1532
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102580,
+    "fields": {
+      "nombre": "Agua Amarga",
+      "municipio": 1532
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102581,
+    "fields": {
+      "nombre": "Agua de Castilla",
+      "municipio": 1532
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102582,
+    "fields": {
+      "nombre": "Carachi",
+      "municipio": 1532
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102583,
+    "fields": {
+      "nombre": "Cauchari",
+      "municipio": 1532
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102584,
+    "fields": {
+      "nombre": "Chorrillos",
+      "municipio": 1532
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102585,
+    "fields": {
+      "nombre": "Condorhuasi",
+      "municipio": 1532
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102586,
+    "fields": {
+      "nombre": "Corral Colorado",
+      "municipio": 1532
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102587,
+    "fields": {
+      "nombre": "Hurcuro",
+      "municipio": 1532
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102588,
+    "fields": {
+      "nombre": "Infiernillos",
+      "municipio": 1532
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102589,
+    "fields": {
+      "nombre": "La Polvorilla",
+      "municipio": 1532
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102590,
+    "fields": {
+      "nombre": "Laguna Seca",
+      "municipio": 1532
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102591,
+    "fields": {
+      "nombre": "Las Barrancas",
+      "municipio": 1532
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102592,
+    "fields": {
+      "nombre": "Las Pircas",
+      "municipio": 1532
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102593,
+    "fields": {
+      "nombre": "Los Colorados",
+      "municipio": 1532
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102594,
+    "fields": {
+      "nombre": "Los Patos",
+      "municipio": 1532
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102595,
+    "fields": {
+      "nombre": "Mina La Poma",
+      "municipio": 1532
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102596,
+    "fields": {
+      "nombre": "MIna Sijes",
+      "municipio": 1532
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102597,
+    "fields": {
+      "nombre": "Peña Alta",
+      "municipio": 1532
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102598,
+    "fields": {
+      "nombre": "Quebrada Grande",
+      "municipio": 1532
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102599,
+    "fields": {
+      "nombre": "Termas de Pompeya",
+      "municipio": 1532
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102600,
+    "fields": {
+      "nombre": "Tocomar",
+      "municipio": 1532
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102601,
+    "fields": {
+      "nombre": "Tolar Chico",
+      "municipio": 1532
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102602,
+    "fields": {
+      "nombre": "Caipe",
+      "municipio": 1533
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102603,
+    "fields": {
+      "nombre": "Cavi",
+      "municipio": 1533
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102604,
+    "fields": {
+      "nombre": "Chuculaqui",
+      "municipio": 1533
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102605,
+    "fields": {
+      "nombre": "Kilómetro 1506",
+      "municipio": 1533
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102606,
+    "fields": {
+      "nombre": "Mina Arita",
+      "municipio": 1533
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102607,
+    "fields": {
+      "nombre": "Mina Julia",
+      "municipio": 1533
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102608,
+    "fields": {
+      "nombre": "Mina La Casualidad",
+      "municipio": 1533
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102609,
+    "fields": {
+      "nombre": "Mina Taca Taca",
+      "municipio": 1533
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102610,
+    "fields": {
+      "nombre": "Quebrada del Agua",
+      "municipio": 1533
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102611,
+    "fields": {
+      "nombre": "Salar Santa María",
+      "municipio": 1533
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102612,
+    "fields": {
+      "nombre": "Socompa",
+      "municipio": 1533
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102613,
+    "fields": {
+      "nombre": "Taca Taca",
+      "municipio": 1533
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102614,
+    "fields": {
+      "nombre": "Unquillal",
+      "municipio": 1533
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102615,
+    "fields": {
+      "nombre": "Vega de Arizaro",
+      "municipio": 1533
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102616,
+    "fields": {
+      "nombre": "Vega de Olajaca",
+      "municipio": 1533
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102617,
+    "fields": {
+      "nombre": "Alto del Mistol",
+      "municipio": 1534
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102618,
+    "fields": {
+      "nombre": "Corral Quemado",
+      "municipio": 1534
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102619,
+    "fields": {
+      "nombre": "El Atamisqui",
+      "municipio": 1534
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102620,
+    "fields": {
+      "nombre": "El Bordo",
+      "municipio": 1534
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102621,
+    "fields": {
+      "nombre": "El Jardín",
+      "municipio": 1534
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102622,
+    "fields": {
+      "nombre": "El Porvenir",
+      "municipio": 1534
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102623,
+    "fields": {
+      "nombre": "El Rincón",
+      "municipio": 1534
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102624,
+    "fields": {
+      "nombre": "La Población",
+      "municipio": 1534
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102625,
+    "fields": {
+      "nombre": "Lagunita",
+      "municipio": 1534
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102626,
+    "fields": {
+      "nombre": "Los Rosales",
+      "municipio": 1534
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102627,
+    "fields": {
+      "nombre": "Paso de las Carreras",
+      "municipio": 1534
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102628,
+    "fields": {
+      "nombre": "Potrero",
+      "municipio": 1534
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102629,
+    "fields": {
+      "nombre": "Pringles",
+      "municipio": 1534
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102630,
+    "fields": {
+      "nombre": "Talamuyo",
+      "municipio": 1534
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102631,
+    "fields": {
+      "nombre": "Vallecito",
+      "municipio": 1534
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102632,
+    "fields": {
+      "nombre": "El Pastiadero",
+      "municipio": 1535
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102633,
+    "fields": {
+      "nombre": "El Talar",
+      "municipio": 1535
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102634,
+    "fields": {
+      "nombre": "Esteco",
+      "municipio": 1535
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102635,
+    "fields": {
+      "nombre": "La Aguadita",
+      "municipio": 1535
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102636,
+    "fields": {
+      "nombre": "Nogalito",
+      "municipio": 1535
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102637,
+    "fields": {
+      "nombre": "Paso El Durazno",
+      "municipio": 1535
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102638,
+    "fields": {
+      "nombre": "Punta de Agua",
+      "municipio": 1535
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102639,
+    "fields": {
+      "nombre": "Schneidewind",
+      "municipio": 1535
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102640,
+    "fields": {
+      "nombre": "Yatasto",
+      "municipio": 1535
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102641,
+    "fields": {
+      "nombre": "Las Juntas",
+      "municipio": 1536
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102642,
+    "fields": {
+      "nombre": "Peñas Azules",
+      "municipio": 1536
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102643,
+    "fields": {
+      "nombre": "Alumbre",
+      "municipio": 1537
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102644,
+    "fields": {
+      "nombre": "Brealito",
+      "municipio": 1537
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102645,
+    "fields": {
+      "nombre": "Colte",
+      "municipio": 1537
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102646,
+    "fields": {
+      "nombre": "Luracatao",
+      "municipio": 1537
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102647,
+    "fields": {
+      "nombre": "Monte Grande",
+      "municipio": 1537
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102648,
+    "fields": {
+      "nombre": "Seclantás Adentro",
+      "municipio": 1537
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102649,
+    "fields": {
+      "nombre": "Vallecito",
+      "municipio": 1537
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102650,
+    "fields": {
+      "nombre": "El Pelícano",
+      "municipio": 1538
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102651,
+    "fields": {
+      "nombre": "Algarrobal",
+      "municipio": 1539
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102652,
+    "fields": {
+      "nombre": "Chaguaral",
+      "municipio": 1539
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102653,
+    "fields": {
+      "nombre": "El Carmen",
+      "municipio": 1539
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102654,
+    "fields": {
+      "nombre": "El Mistol",
+      "municipio": 1539
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102655,
+    "fields": {
+      "nombre": "El Retiro",
+      "municipio": 1539
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102656,
+    "fields": {
+      "nombre": "El Totoral",
+      "municipio": 1539
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102657,
+    "fields": {
+      "nombre": "Esteban de Urizar",
+      "municipio": 1539
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102658,
+    "fields": {
+      "nombre": "Jerónimo Matorras",
+      "municipio": 1539
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102659,
+    "fields": {
+      "nombre": "Kilómetro 1281",
+      "municipio": 1539
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102660,
+    "fields": {
+      "nombre": "La Estrella",
+      "municipio": 1539
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102661,
+    "fields": {
+      "nombre": "La Jojoba",
+      "municipio": 1539
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102662,
+    "fields": {
+      "nombre": "Manuel Elordi",
+      "municipio": 1539
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102663,
+    "fields": {
+      "nombre": "Martínez del Tineo",
+      "municipio": 1539
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102664,
+    "fields": {
+      "nombre": "Pozo Cercado",
+      "municipio": 1539
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102665,
+    "fields": {
+      "nombre": "Pozo de Piedra",
+      "municipio": 1539
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102666,
+    "fields": {
+      "nombre": "Pozo Las Moras",
+      "municipio": 1539
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102667,
+    "fields": {
+      "nombre": "Yuchán",
+      "municipio": 1539
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102668,
+    "fields": {
+      "nombre": "Abra Grande",
+      "municipio": 1540
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102669,
+    "fields": {
+      "nombre": "Anta Muerta",
+      "municipio": 1540
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102670,
+    "fields": {
+      "nombre": "Candado Grande",
+      "municipio": 1540
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102671,
+    "fields": {
+      "nombre": "Colonia G",
+      "municipio": 1540
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102672,
+    "fields": {
+      "nombre": "El Cedral",
+      "municipio": 1540
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102673,
+    "fields": {
+      "nombre": "La Junta",
+      "municipio": 1540
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102674,
+    "fields": {
+      "nombre": "Las Quintas",
+      "municipio": 1540
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102675,
+    "fields": {
+      "nombre": "Parani",
+      "municipio": 1540
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102676,
+    "fields": {
+      "nombre": "Peña Colorada",
+      "municipio": 1540
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102677,
+    "fields": {
+      "nombre": "Quenoal",
+      "municipio": 1540
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102678,
+    "fields": {
+      "nombre": "Río Pescado",
+      "municipio": 1540
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102679,
+    "fields": {
+      "nombre": "San Agustín",
+      "municipio": 1540
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102680,
+    "fields": {
+      "nombre": "San Andrés",
+      "municipio": 1540
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102681,
+    "fields": {
+      "nombre": "Santa Cruz",
+      "municipio": 1540
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102682,
+    "fields": {
+      "nombre": "Santa María",
+      "municipio": 1540
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102683,
+    "fields": {
+      "nombre": "Solazuty",
+      "municipio": 1540
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102684,
+    "fields": {
+      "nombre": "Tablada",
+      "municipio": 1540
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102685,
+    "fields": {
+      "nombre": "Bajo Verde",
+      "municipio": 1542
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102686,
+    "fields": {
+      "nombre": "Balbuena",
+      "municipio": 1542
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102687,
+    "fields": {
+      "nombre": "Buena Vista",
+      "municipio": 1542
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102688,
+    "fields": {
+      "nombre": "Comunidad Lote 8",
+      "municipio": 1542
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102689,
+    "fields": {
+      "nombre": "Desemboque",
+      "municipio": 1542
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102690,
+    "fields": {
+      "nombre": "El Ciénego",
+      "municipio": 1542
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102691,
+    "fields": {
+      "nombre": "El Coleto",
+      "municipio": 1542
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102692,
+    "fields": {
+      "nombre": "El Colgao",
+      "municipio": 1542
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102693,
+    "fields": {
+      "nombre": "El Despunte",
+      "municipio": 1542
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102694,
+    "fields": {
+      "nombre": "El Espinillo",
+      "municipio": 1542
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102695,
+    "fields": {
+      "nombre": "El Gritao",
+      "municipio": 1542
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102696,
+    "fields": {
+      "nombre": "El Trampeadero",
+      "municipio": 1542
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102697,
+    "fields": {
+      "nombre": "Fortín Belgrano",
+      "municipio": 1542
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102698,
+    "fields": {
+      "nombre": "Fortín Resistencia",
+      "municipio": 1542
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102699,
+    "fields": {
+      "nombre": "La Brea",
+      "municipio": 1542
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102700,
+    "fields": {
+      "nombre": "La Colonia",
+      "municipio": 1542
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102701,
+    "fields": {
+      "nombre": "La Entrada",
+      "municipio": 1542
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102702,
+    "fields": {
+      "nombre": "La Esperanza",
+      "municipio": 1542
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102703,
+    "fields": {
+      "nombre": "La Mora",
+      "municipio": 1542
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102704,
+    "fields": {
+      "nombre": "La Salvación",
+      "municipio": 1542
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102705,
+    "fields": {
+      "nombre": "Las Almas",
+      "municipio": 1542
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102706,
+    "fields": {
+      "nombre": "Las Horquetas",
+      "municipio": 1542
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102707,
+    "fields": {
+      "nombre": "Las Juntas",
+      "municipio": 1542
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102708,
+    "fields": {
+      "nombre": "Lavalle",
+      "municipio": 1542
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102709,
+    "fields": {
+      "nombre": "Los Baldes",
+      "municipio": 1542
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102710,
+    "fields": {
+      "nombre": "Los Ranchitos",
+      "municipio": 1542
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102711,
+    "fields": {
+      "nombre": "Madrejones",
+      "municipio": 1542
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102712,
+    "fields": {
+      "nombre": "Misión Iwayayuk",
+      "municipio": 1542
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102713,
+    "fields": {
+      "nombre": "Palo Flojal",
+      "municipio": 1542
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102714,
+    "fields": {
+      "nombre": "Pozo del Algarrobo",
+      "municipio": 1542
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102715,
+    "fields": {
+      "nombre": "Pozo del Sauce",
+      "municipio": 1542
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102716,
+    "fields": {
+      "nombre": "Pozo El Chañar",
+      "municipio": 1542
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102717,
+    "fields": {
+      "nombre": "Puesto El Pancho",
+      "municipio": 1542
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102718,
+    "fields": {
+      "nombre": "San Patricio",
+      "municipio": 1542
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102719,
+    "fields": {
+      "nombre": "Aguas Muertas",
+      "municipio": 1543
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102720,
+    "fields": {
+      "nombre": "Alto Verde",
+      "municipio": 1543
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102721,
+    "fields": {
+      "nombre": "Ciervo Cansado",
+      "municipio": 1543
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102722,
+    "fields": {
+      "nombre": "El Algarrobal",
+      "municipio": 1543
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102723,
+    "fields": {
+      "nombre": "El Breal",
+      "municipio": 1543
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102724,
+    "fields": {
+      "nombre": "El Cocal",
+      "municipio": 1543
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102725,
+    "fields": {
+      "nombre": "El Destierro",
+      "municipio": 1543
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102726,
+    "fields": {
+      "nombre": "El Divisadero",
+      "municipio": 1543
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102727,
+    "fields": {
+      "nombre": "El Lecherón",
+      "municipio": 1543
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102728,
+    "fields": {
+      "nombre": "El Milagro",
+      "municipio": 1543
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102729,
+    "fields": {
+      "nombre": "El Mirador",
+      "municipio": 1543
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102730,
+    "fields": {
+      "nombre": "El Ocultar",
+      "municipio": 1543
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102731,
+    "fields": {
+      "nombre": "El Totoral",
+      "municipio": 1543
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102732,
+    "fields": {
+      "nombre": "El Vinalar",
+      "municipio": 1543
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102733,
+    "fields": {
+      "nombre": "La Esperanza Sur",
+      "municipio": 1543
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102734,
+    "fields": {
+      "nombre": "La Media Luna",
+      "municipio": 1543
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102735,
+    "fields": {
+      "nombre": "La Mora Sur",
+      "municipio": 1543
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102736,
+    "fields": {
+      "nombre": "La Toma",
+      "municipio": 1543
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102737,
+    "fields": {
+      "nombre": "Las Bolsas",
+      "municipio": 1543
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102738,
+    "fields": {
+      "nombre": "Las Tortugas",
+      "municipio": 1543
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102739,
+    "fields": {
+      "nombre": "Los Tres Pozos",
+      "municipio": 1543
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102740,
+    "fields": {
+      "nombre": "Misión San Felipe",
+      "municipio": 1543
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102741,
+    "fields": {
+      "nombre": "Pelícano Quemado",
+      "municipio": 1543
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102742,
+    "fields": {
+      "nombre": "Pozo El Camino",
+      "municipio": 1543
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102743,
+    "fields": {
+      "nombre": "Pozo Largo",
+      "municipio": 1543
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102744,
+    "fields": {
+      "nombre": "Pozo Verde",
+      "municipio": 1543
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102745,
+    "fields": {
+      "nombre": "San José",
+      "municipio": 1543
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102746,
+    "fields": {
+      "nombre": "San Manuel",
+      "municipio": 1543
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102747,
+    "fields": {
+      "nombre": "San Miguel Sur",
+      "municipio": 1543
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102748,
+    "fields": {
+      "nombre": "Ternera Atada",
+      "municipio": 1543
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102749,
+    "fields": {
+      "nombre": "Tres Horcones",
+      "municipio": 1543
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102750,
+    "fields": {
+      "nombre": "Tres Pozos",
+      "municipio": 1543
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102751,
+    "fields": {
+      "nombre": "Agua Verde",
+      "municipio": 1544
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102752,
+    "fields": {
+      "nombre": "Bajo Grande",
+      "municipio": 1544
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102753,
+    "fields": {
+      "nombre": "Bella Vista",
+      "municipio": 1544
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102754,
+    "fields": {
+      "nombre": "Campo Largo",
+      "municipio": 1544
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102755,
+    "fields": {
+      "nombre": "Divertidos",
+      "municipio": 1544
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102756,
+    "fields": {
+      "nombre": "El Pelícano",
+      "municipio": 1544
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102757,
+    "fields": {
+      "nombre": "El Reloj",
+      "municipio": 1544
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102758,
+    "fields": {
+      "nombre": "El Rosado",
+      "municipio": 1544
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102759,
+    "fields": {
+      "nombre": "El Zapallar",
+      "municipio": 1544
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102760,
+    "fields": {
+      "nombre": "La Curvita",
+      "municipio": 1544
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102761,
+    "fields": {
+      "nombre": "La Estrella",
+      "municipio": 1544
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102762,
+    "fields": {
+      "nombre": "La Gracia",
+      "municipio": 1544
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102763,
+    "fields": {
+      "nombre": "La Paz",
+      "municipio": 1544
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102764,
+    "fields": {
+      "nombre": "La Puntana",
+      "municipio": 1544
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102765,
+    "fields": {
+      "nombre": "La Vertiente",
+      "municipio": 1544
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102766,
+    "fields": {
+      "nombre": "Las Delicias",
+      "municipio": 1544
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102767,
+    "fields": {
+      "nombre": "Las Mojarras",
+      "municipio": 1544
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102768,
+    "fields": {
+      "nombre": "Las Vertientes",
+      "municipio": 1544
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102769,
+    "fields": {
+      "nombre": "Magdalena",
+      "municipio": 1544
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102770,
+    "fields": {
+      "nombre": "Misión San Luis",
+      "municipio": 1544
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102771,
+    "fields": {
+      "nombre": "Monte Carmelo",
+      "municipio": 1544
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102772,
+    "fields": {
+      "nombre": "Palmar 1",
+      "municipio": 1544
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102773,
+    "fields": {
+      "nombre": "Pozo El Anta",
+      "municipio": 1544
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102774,
+    "fields": {
+      "nombre": "Pozo El Bravo",
+      "municipio": 1544
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102775,
+    "fields": {
+      "nombre": "Pozo El Mulato",
+      "municipio": 1544
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102776,
+    "fields": {
+      "nombre": "Pozo El Tigre",
+      "municipio": 1544
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102777,
+    "fields": {
+      "nombre": "Pozo El Toro",
+      "municipio": 1544
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102778,
+    "fields": {
+      "nombre": "Pozo La China",
+      "municipio": 1544
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102779,
+    "fields": {
+      "nombre": "Rancho El ñato",
+      "municipio": 1544
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102780,
+    "fields": {
+      "nombre": "San Bernardo",
+      "municipio": 1544
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102781,
+    "fields": {
+      "nombre": "San Martín de la Ceiba",
+      "municipio": 1544
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102782,
+    "fields": {
+      "nombre": "San Miguel",
+      "municipio": 1544
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102783,
+    "fields": {
+      "nombre": "Aragón",
+      "municipio": 1545
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102784,
+    "fields": {
+      "nombre": "Bella Vista",
+      "municipio": 1545
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102785,
+    "fields": {
+      "nombre": "Canteros",
+      "municipio": 1545
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102786,
+    "fields": {
+      "nombre": "El Bordo",
+      "municipio": 1545
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102787,
+    "fields": {
+      "nombre": "La Almona",
+      "municipio": 1545
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102788,
+    "fields": {
+      "nombre": "La Costosa",
+      "municipio": 1545
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102789,
+    "fields": {
+      "nombre": "Las Colgadas",
+      "municipio": 1545
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102790,
+    "fields": {
+      "nombre": "Las Mercedes",
+      "municipio": 1545
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102791,
+    "fields": {
+      "nombre": "Puente de Plata",
+      "municipio": 1545
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102792,
+    "fields": {
+      "nombre": "Santa María",
+      "municipio": 1545
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102793,
+    "fields": {
+      "nombre": "Alfarcito",
+      "municipio": 1546
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102794,
+    "fields": {
+      "nombre": "Cachiñal",
+      "municipio": 1546
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102795,
+    "fields": {
+      "nombre": "Carrera Muerta",
+      "municipio": 1546
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102796,
+    "fields": {
+      "nombre": "Chorrillos",
+      "municipio": 1546
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102797,
+    "fields": {
+      "nombre": "Diego de Almagro",
+      "municipio": 1546
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102798,
+    "fields": {
+      "nombre": "El Alisal",
+      "municipio": 1546
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102799,
+    "fields": {
+      "nombre": "El Mollar",
+      "municipio": 1546
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102800,
+    "fields": {
+      "nombre": "El Palomar",
+      "municipio": 1546
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102801,
+    "fields": {
+      "nombre": "El Potrero",
+      "municipio": 1546
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102802,
+    "fields": {
+      "nombre": "El Rosal",
+      "municipio": 1546
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102803,
+    "fields": {
+      "nombre": "El Toro",
+      "municipio": 1546
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102804,
+    "fields": {
+      "nombre": "Encón Grande",
+      "municipio": 1546
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102805,
+    "fields": {
+      "nombre": "Gobernador Manuel Solá",
+      "municipio": 1546
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102806,
+    "fields": {
+      "nombre": "Incahuasi",
+      "municipio": 1546
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102807,
+    "fields": {
+      "nombre": "Ingeniero Maury",
+      "municipio": 1546
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102808,
+    "fields": {
+      "nombre": "La Encrucijada",
+      "municipio": 1546
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102809,
+    "fields": {
+      "nombre": "Las Cuevas",
+      "municipio": 1546
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102810,
+    "fields": {
+      "nombre": "Meseta",
+      "municipio": 1546
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102811,
+    "fields": {
+      "nombre": "Pascha",
+      "municipio": 1546
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102812,
+    "fields": {
+      "nombre": "Potrero de Linares",
+      "municipio": 1546
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102813,
+    "fields": {
+      "nombre": "Potrero de Uriburu",
+      "municipio": 1546
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102814,
+    "fields": {
+      "nombre": "Puerta Tastil",
+      "municipio": 1546
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102815,
+    "fields": {
+      "nombre": "Río Blanco",
+      "municipio": 1546
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102816,
+    "fields": {
+      "nombre": "Río Corralito",
+      "municipio": 1546
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102817,
+    "fields": {
+      "nombre": "San Bernardo de las Zorras",
+      "municipio": 1546
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102818,
+    "fields": {
+      "nombre": "Santa Rosa de Tastil",
+      "municipio": 1546
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102819,
+    "fields": {
+      "nombre": "Tacuara",
+      "municipio": 1546
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102820,
+    "fields": {
+      "nombre": "Tres Cruces",
+      "municipio": 1546
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102821,
+    "fields": {
+      "nombre": "Villa Angélica",
+      "municipio": 1546
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102822,
+    "fields": {
+      "nombre": "Cerro Negro de Tirao",
+      "municipio": 1547
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102823,
+    "fields": {
+      "nombre": "Corralito",
+      "municipio": 1547
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102824,
+    "fields": {
+      "nombre": "El Manzano",
+      "municipio": 1547
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102825,
+    "fields": {
+      "nombre": "El Molino",
+      "municipio": 1547
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102826,
+    "fields": {
+      "nombre": "El Timbó",
+      "municipio": 1547
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102827,
+    "fields": {
+      "nombre": "La Florida",
+      "municipio": 1547
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102828,
+    "fields": {
+      "nombre": "El Arremo",
+      "municipio": 1548
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102829,
+    "fields": {
+      "nombre": "El Carmen",
+      "municipio": 1548
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102830,
+    "fields": {
+      "nombre": "Guasamayo",
+      "municipio": 1548
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102831,
+    "fields": {
+      "nombre": "La Angostura",
+      "municipio": 1548
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102832,
+    "fields": {
+      "nombre": "La Arcadia",
+      "municipio": 1548
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102833,
+    "fields": {
+      "nombre": "La Cabaña",
+      "municipio": 1548
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102834,
+    "fields": {
+      "nombre": "Los Cardones",
+      "municipio": 1548
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102835,
+    "fields": {
+      "nombre": "Pucará",
+      "municipio": 1548
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102836,
+    "fields": {
+      "nombre": "Río Grande",
+      "municipio": 1548
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102837,
+    "fields": {
+      "nombre": "Santa Rosa",
+      "municipio": 1548
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102838,
+    "fields": {
+      "nombre": "Corralito",
+      "municipio": 1549
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102839,
+    "fields": {
+      "nombre": "San Antonio",
+      "municipio": 1549
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102840,
+    "fields": {
+      "nombre": "Arazay",
+      "municipio": 1550
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102841,
+    "fields": {
+      "nombre": "Baritú",
+      "municipio": 1550
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102842,
+    "fields": {
+      "nombre": "El Condado",
+      "municipio": 1550
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102843,
+    "fields": {
+      "nombre": "Espinillo",
+      "municipio": 1550
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102844,
+    "fields": {
+      "nombre": "La Misión",
+      "municipio": 1550
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102845,
+    "fields": {
+      "nombre": "Lipeo",
+      "municipio": 1550
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102846,
+    "fields": {
+      "nombre": "Azul Cuesta",
+      "municipio": 1551
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102847,
+    "fields": {
+      "nombre": "El Molino de Cuesta Azul",
+      "municipio": 1551
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102848,
+    "fields": {
+      "nombre": "El Pabellón",
+      "municipio": 1551
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102849,
+    "fields": {
+      "nombre": "Kelloticar",
+      "municipio": 1551
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102850,
+    "fields": {
+      "nombre": "Palca",
+      "municipio": 1551
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102851,
+    "fields": {
+      "nombre": "San Marcos Norte",
+      "municipio": 1551
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102852,
+    "fields": {
+      "nombre": "Trigo Huayco",
+      "municipio": 1551
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102853,
+    "fields": {
+      "nombre": "Abra de San Antonio",
+      "municipio": 1552
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102854,
+    "fields": {
+      "nombre": "Abra de Santa Cruz",
+      "municipio": 1552
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102855,
+    "fields": {
+      "nombre": "Antigal",
+      "municipio": 1552
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102856,
+    "fields": {
+      "nombre": "Barrio Nuevo",
+      "municipio": 1552
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102857,
+    "fields": {
+      "nombre": "Cañani",
+      "municipio": 1552
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102858,
+    "fields": {
+      "nombre": "El Puesto",
+      "municipio": 1552
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102859,
+    "fields": {
+      "nombre": "Hornillos",
+      "municipio": 1552
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102860,
+    "fields": {
+      "nombre": "La Falda",
+      "municipio": 1552
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102861,
+    "fields": {
+      "nombre": "La Huerta",
+      "municipio": 1552
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102862,
+    "fields": {
+      "nombre": "La Soledad",
+      "municipio": 1552
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102863,
+    "fields": {
+      "nombre": "Pucallpa",
+      "municipio": 1552
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102864,
+    "fields": {
+      "nombre": "Pucará",
+      "municipio": 1552
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102865,
+    "fields": {
+      "nombre": "San Felipe",
+      "municipio": 1552
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102866,
+    "fields": {
+      "nombre": "San Francisco de Tuctuca",
+      "municipio": 1552
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102867,
+    "fields": {
+      "nombre": "San José de Aguilar",
+      "municipio": 1552
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102868,
+    "fields": {
+      "nombre": "San Juan de Minas",
+      "municipio": 1552
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102869,
+    "fields": {
+      "nombre": "Santa Cruz de Aguilar",
+      "municipio": 1552
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102870,
+    "fields": {
+      "nombre": "Abrita Grande",
+      "municipio": 1553
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102871,
+    "fields": {
+      "nombre": "Acos",
+      "municipio": 1553
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102872,
+    "fields": {
+      "nombre": "Ahí Veremos",
+      "municipio": 1553
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102873,
+    "fields": {
+      "nombre": "Amapola",
+      "municipio": 1553
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102874,
+    "fields": {
+      "nombre": "Amicha",
+      "municipio": 1553
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102875,
+    "fields": {
+      "nombre": "Aragonés",
+      "municipio": 1553
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102876,
+    "fields": {
+      "nombre": "Bahoma",
+      "municipio": 1553
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102877,
+    "fields": {
+      "nombre": "Bajo Verde",
+      "municipio": 1553
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102878,
+    "fields": {
+      "nombre": "Barrialito",
+      "municipio": 1553
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102879,
+    "fields": {
+      "nombre": "Boca del Tigre",
+      "municipio": 1553
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102880,
+    "fields": {
+      "nombre": "Brea Puñuna",
+      "municipio": 1553
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102881,
+    "fields": {
+      "nombre": "Cabaña Los Laureles",
+      "municipio": 1553
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102882,
+    "fields": {
+      "nombre": "Cañada de la Costa",
+      "municipio": 1553
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102883,
+    "fields": {
+      "nombre": "Cañada de Robles",
+      "municipio": 1553
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102884,
+    "fields": {
+      "nombre": "Cañada de Tala Pozo",
+      "municipio": 1553
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102885,
+    "fields": {
+      "nombre": "Cañada del Monte",
+      "municipio": 1553
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102886,
+    "fields": {
+      "nombre": "Casilla del Medio",
+      "municipio": 1553
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102887,
+    "fields": {
+      "nombre": "Chañar Pozo de Abajo",
+      "municipio": 1553
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102888,
+    "fields": {
+      "nombre": "Chañar Pozo de Arriba",
+      "municipio": 1553
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102889,
+    "fields": {
+      "nombre": "Chañar Pozo del Medio",
+      "municipio": 1553
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102890,
+    "fields": {
+      "nombre": "Charco Viejo",
+      "municipio": 1553
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102891,
+    "fields": {
+      "nombre": "Chauchillas",
+      "municipio": 1553
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102892,
+    "fields": {
+      "nombre": "Colonia Tinco",
+      "municipio": 1553
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102893,
+    "fields": {
+      "nombre": "El Charco",
+      "municipio": 1553
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102894,
+    "fields": {
+      "nombre": "El Naranjito",
+      "municipio": 1553
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102895,
+    "fields": {
+      "nombre": "El Sauzal",
+      "municipio": 1553
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102896,
+    "fields": {
+      "nombre": "Galeano",
+      "municipio": 1553
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102897,
+    "fields": {
+      "nombre": "Gramilla",
+      "municipio": 1553
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102898,
+    "fields": {
+      "nombre": "Isla de Aragonés",
+      "municipio": 1553
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102899,
+    "fields": {
+      "nombre": "Isla de los Sotelo",
+      "municipio": 1553
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102900,
+    "fields": {
+      "nombre": "La Aguada",
+      "municipio": 1553
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102901,
+    "fields": {
+      "nombre": "La Donosa",
+      "municipio": 1553
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102902,
+    "fields": {
+      "nombre": "La Encrucijada",
+      "municipio": 1553
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102903,
+    "fields": {
+      "nombre": "La Florida",
+      "municipio": 1553
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102904,
+    "fields": {
+      "nombre": "La Nueva Donosa",
+      "municipio": 1553
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102905,
+    "fields": {
+      "nombre": "La Puerta",
+      "municipio": 1553
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102906,
+    "fields": {
+      "nombre": "La Reserva",
+      "municipio": 1553
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102907,
+    "fields": {
+      "nombre": "La Soledad",
+      "municipio": 1553
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102908,
+    "fields": {
+      "nombre": "Las Abras",
+      "municipio": 1553
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102909,
+    "fields": {
+      "nombre": "Las Cejas",
+      "municipio": 1553
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102910,
+    "fields": {
+      "nombre": "Las Zanjitas",
+      "municipio": 1553
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102911,
+    "fields": {
+      "nombre": "Lescanos",
+      "municipio": 1553
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102912,
+    "fields": {
+      "nombre": "Loma del Medio",
+      "municipio": 1553
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102913,
+    "fields": {
+      "nombre": "Loro Huasi",
+      "municipio": 1553
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102914,
+    "fields": {
+      "nombre": "Los Miranda",
+      "municipio": 1553
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102915,
+    "fields": {
+      "nombre": "Los Núñez",
+      "municipio": 1553
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102916,
+    "fields": {
+      "nombre": "Los Ovejeros",
+      "municipio": 1553
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102917,
+    "fields": {
+      "nombre": "Los Quebrachos",
+      "municipio": 1553
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102918,
+    "fields": {
+      "nombre": "Mansupa",
+      "municipio": 1553
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102919,
+    "fields": {
+      "nombre": "Palmas Redondas",
+      "municipio": 1553
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102920,
+    "fields": {
+      "nombre": "Poleo Pozo",
+      "municipio": 1553
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102921,
+    "fields": {
+      "nombre": "Pozo Grande",
+      "municipio": 1553
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102922,
+    "fields": {
+      "nombre": "Pozuelos",
+      "municipio": 1553
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102923,
+    "fields": {
+      "nombre": "Puesto del Retiro",
+      "municipio": 1553
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102924,
+    "fields": {
+      "nombre": "Puesto del Sauzal",
+      "municipio": 1553
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102925,
+    "fields": {
+      "nombre": "Puesto La Soledad",
+      "municipio": 1553
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102926,
+    "fields": {
+      "nombre": "Puesto San Antonio",
+      "municipio": 1553
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102927,
+    "fields": {
+      "nombre": "Rodeo de Valdez",
+      "municipio": 1553
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102928,
+    "fields": {
+      "nombre": "San Carlos",
+      "municipio": 1553
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102929,
+    "fields": {
+      "nombre": "San Lorenzo",
+      "municipio": 1553
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102930,
+    "fields": {
+      "nombre": "San Pablo",
+      "municipio": 1553
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102931,
+    "fields": {
+      "nombre": "Santa Felisa",
+      "municipio": 1553
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102932,
+    "fields": {
+      "nombre": "Sotelillo",
+      "municipio": 1553
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102933,
+    "fields": {
+      "nombre": "Sotelo",
+      "municipio": 1553
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102934,
+    "fields": {
+      "nombre": "Tagamampa",
+      "municipio": 1553
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102935,
+    "fields": {
+      "nombre": "Tala Pozo",
+      "municipio": 1553
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102936,
+    "fields": {
+      "nombre": "Taquello",
+      "municipio": 1553
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102937,
+    "fields": {
+      "nombre": "Termas de Río Hondo",
+      "municipio": 1553
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102938,
+    "fields": {
+      "nombre": "Villa Giménez",
+      "municipio": 1553
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102939,
+    "fields": {
+      "nombre": "Villa Río Hondo",
+      "municipio": 1553
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102940,
+    "fields": {
+      "nombre": "Villa Turística del Embalse de Rio Hondo",
+      "municipio": 1553
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102941,
+    "fields": {
+      "nombre": "Vinará",
+      "municipio": 1553
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102942,
+    "fields": {
+      "nombre": "Yutu Yaco",
+      "municipio": 1553
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102943,
+    "fields": {
+      "nombre": "Cumbre del Matadero",
+      "municipio": 1554
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102944,
+    "fields": {
+      "nombre": "Isla San José",
+      "municipio": 1554
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102945,
+    "fields": {
+      "nombre": "Isla San José Sur",
+      "municipio": 1554
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102946,
+    "fields": {
+      "nombre": "Villa Brava",
+      "municipio": 1554
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102947,
+    "fields": {
+      "nombre": "El Empalme",
+      "municipio": 1555
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102948,
+    "fields": {
+      "nombre": "El Saladero",
+      "municipio": 1555
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102949,
+    "fields": {
+      "nombre": "El Sauce",
+      "municipio": 1555
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102950,
+    "fields": {
+      "nombre": "Esquina",
+      "municipio": 1555
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102951,
+    "fields": {
+      "nombre": "Fernández",
+      "municipio": 1555
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102952,
+    "fields": {
+      "nombre": "La Argentina",
+      "municipio": 1555
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102953,
+    "fields": {
+      "nombre": "Bajo del Gualicho",
+      "municipio": 1557
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102954,
+    "fields": {
+      "nombre": "Centenario",
+      "municipio": 1557
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102955,
+    "fields": {
+      "nombre": "Fracasso",
+      "municipio": 1557
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102956,
+    "fields": {
+      "nombre": "Media Luna",
+      "municipio": 1557
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102957,
+    "fields": {
+      "nombre": "Paraje Larralde",
+      "municipio": 1557
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102958,
+    "fields": {
+      "nombre": "Paraje Villarino",
+      "municipio": 1557
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102959,
+    "fields": {
+      "nombre": "Puerto Lobos",
+      "municipio": 1557
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102960,
+    "fields": {
+      "nombre": "Puesto Valdés",
+      "municipio": 1557
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102961,
+    "fields": {
+      "nombre": "Punta Cantor",
+      "municipio": 1557
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102962,
+    "fields": {
+      "nombre": "Punta Delgada",
+      "municipio": 1557
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102963,
+    "fields": {
+      "nombre": "Punta Gales",
+      "municipio": 1557
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102964,
+    "fields": {
+      "nombre": "Punta Norte",
+      "municipio": 1557
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102965,
+    "fields": {
+      "nombre": "Riacho San José",
+      "municipio": 1557
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102966,
+    "fields": {
+      "nombre": "Apayerey",
+      "municipio": 1558
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102967,
+    "fields": {
+      "nombre": "Colonia 25 de Mayo",
+      "municipio": 1558
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102968,
+    "fields": {
+      "nombre": "Colonia Aborigen",
+      "municipio": 1558
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102969,
+    "fields": {
+      "nombre": "Colonia El Ceibo",
+      "municipio": 1558
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102970,
+    "fields": {
+      "nombre": "Colonia Santa Rosa",
+      "municipio": 1558
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102971,
+    "fields": {
+      "nombre": "El Pombero",
+      "municipio": 1558
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102972,
+    "fields": {
+      "nombre": "Isla Azul",
+      "municipio": 1558
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102973,
+    "fields": {
+      "nombre": "Julio Cué",
+      "municipio": 1558
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102974,
+    "fields": {
+      "nombre": "Laguna Gallo",
+      "municipio": 1558
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102975,
+    "fields": {
+      "nombre": "Laguna Toro",
+      "municipio": 1558
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102976,
+    "fields": {
+      "nombre": "Loma Zapatú",
+      "municipio": 1558
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102977,
+    "fields": {
+      "nombre": "Loro Cué",
+      "municipio": 1558
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102978,
+    "fields": {
+      "nombre": "Paso General Belgrano",
+      "municipio": 1558
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102979,
+    "fields": {
+      "nombre": "Punta Porá",
+      "municipio": 1558
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102980,
+    "fields": {
+      "nombre": "Rincón Grande",
+      "municipio": 1558
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102981,
+    "fields": {
+      "nombre": "San Blas",
+      "municipio": 1558
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102982,
+    "fields": {
+      "nombre": "San Carlos",
+      "municipio": 1558
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102983,
+    "fields": {
+      "nombre": "San Ramón",
+      "municipio": 1558
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102984,
+    "fields": {
+      "nombre": "Villa Hermosa",
+      "municipio": 1558
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102985,
+    "fields": {
+      "nombre": "Villa Real",
+      "municipio": 1558
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102986,
+    "fields": {
+      "nombre": "Villa Rural",
+      "municipio": 1558
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102987,
+    "fields": {
+      "nombre": "Bella Vista",
+      "municipio": 1560
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102988,
+    "fields": {
+      "nombre": "Cabo Buen Tiempo",
+      "municipio": 1560
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102989,
+    "fields": {
+      "nombre": "Cabo Vírgenes",
+      "municipio": 1560
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102990,
+    "fields": {
+      "nombre": "Camusú Aike",
+      "municipio": 1560
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102991,
+    "fields": {
+      "nombre": "Cancha Carrera",
+      "municipio": 1560
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102992,
+    "fields": {
+      "nombre": "Capitán Eyroa",
+      "municipio": 1560
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102993,
+    "fields": {
+      "nombre": "Cerro León",
+      "municipio": 1560
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102994,
+    "fields": {
+      "nombre": "Cerro Redondo",
+      "municipio": 1560
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102995,
+    "fields": {
+      "nombre": "Comodoro Py",
+      "municipio": 1560
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102996,
+    "fields": {
+      "nombre": "Coti Aike",
+      "municipio": 1560
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102997,
+    "fields": {
+      "nombre": "Diego Ritchie",
+      "municipio": 1560
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102998,
+    "fields": {
+      "nombre": "El Cóndor",
+      "municipio": 1560
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 102999,
+    "fields": {
+      "nombre": "El Zurdo",
+      "municipio": 1560
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103000,
+    "fields": {
+      "nombre": "Faro Coig",
+      "municipio": 1560
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103001,
+    "fields": {
+      "nombre": "Fuentes del Coyle",
+      "municipio": 1560
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103002,
+    "fields": {
+      "nombre": "Gobernador Lista",
+      "municipio": 1560
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103003,
+    "fields": {
+      "nombre": "Gobernador Mayer",
+      "municipio": 1560
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103004,
+    "fields": {
+      "nombre": "Gobernador Moyano",
+      "municipio": 1560
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103005,
+    "fields": {
+      "nombre": "Güer Aike",
+      "municipio": 1560
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103006,
+    "fields": {
+      "nombre": "Ingeniero Cappa",
+      "municipio": 1560
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103007,
+    "fields": {
+      "nombre": "Kilómetro 157",
+      "municipio": 1560
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103008,
+    "fields": {
+      "nombre": "Kilómetro 52",
+      "municipio": 1560
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103009,
+    "fields": {
+      "nombre": "Kilómetro 94",
+      "municipio": 1560
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103010,
+    "fields": {
+      "nombre": "La Esperanza",
+      "municipio": 1560
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103011,
+    "fields": {
+      "nombre": "Laguna Azul",
+      "municipio": 1560
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103012,
+    "fields": {
+      "nombre": "Las Horquetas",
+      "municipio": 1560
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103013,
+    "fields": {
+      "nombre": "Mina 3",
+      "municipio": 1560
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103014,
+    "fields": {
+      "nombre": "Monte Aymond",
+      "municipio": 1560
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103015,
+    "fields": {
+      "nombre": "Nicolás Kronlund",
+      "municipio": 1560
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103016,
+    "fields": {
+      "nombre": "Pali Aike",
+      "municipio": 1560
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103017,
+    "fields": {
+      "nombre": "Paso Bella Vista",
+      "municipio": 1560
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103018,
+    "fields": {
+      "nombre": "Paso El Zurdo",
+      "municipio": 1560
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103019,
+    "fields": {
+      "nombre": "Paso Laurita",
+      "municipio": 1560
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103020,
+    "fields": {
+      "nombre": "Paso Mina 1",
+      "municipio": 1560
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103021,
+    "fields": {
+      "nombre": "Piedra Buena",
+      "municipio": 1560
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103022,
+    "fields": {
+      "nombre": "Puente Blanco",
+      "municipio": 1560
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103023,
+    "fields": {
+      "nombre": "Puerto Coig",
+      "municipio": 1560
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103024,
+    "fields": {
+      "nombre": "Punta Dungeness",
+      "municipio": 1560
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103025,
+    "fields": {
+      "nombre": "Punta Loyola",
+      "municipio": 1560
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103026,
+    "fields": {
+      "nombre": "Tapi Aike",
+      "municipio": 1560
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103027,
+    "fields": {
+      "nombre": "Yacimiento María Inés",
+      "municipio": 1560
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103028,
+    "fields": {
+      "nombre": "Yacimiento Puesto Peter",
+      "municipio": 1560
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103029,
+    "fields": {
+      "nombre": "Agua Verde",
+      "municipio": 1561
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103030,
+    "fields": {
+      "nombre": "Bolsa de Palomo",
+      "municipio": 1561
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103031,
+    "fields": {
+      "nombre": "Campo Bandera",
+      "municipio": 1561
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103032,
+    "fields": {
+      "nombre": "Campo Grande",
+      "municipio": 1561
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103033,
+    "fields": {
+      "nombre": "Comunidad Aborigen Wichi Fwinafwas",
+      "municipio": 1561
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103034,
+    "fields": {
+      "nombre": "El 50",
+      "municipio": 1561
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103035,
+    "fields": {
+      "nombre": "El Chivil",
+      "municipio": 1561
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103036,
+    "fields": {
+      "nombre": "El Mistolar",
+      "municipio": 1561
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103037,
+    "fields": {
+      "nombre": "El Potrerito",
+      "municipio": 1561
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103038,
+    "fields": {
+      "nombre": "El Rosillo",
+      "municipio": 1561
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103039,
+    "fields": {
+      "nombre": "El Totoral",
+      "municipio": 1561
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103040,
+    "fields": {
+      "nombre": "El Trébol",
+      "municipio": 1561
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103041,
+    "fields": {
+      "nombre": "La Extranjera",
+      "municipio": 1561
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103042,
+    "fields": {
+      "nombre": "La Junta",
+      "municipio": 1561
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103043,
+    "fields": {
+      "nombre": "Pozo de los Patos",
+      "municipio": 1561
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103044,
+    "fields": {
+      "nombre": "Pozo El Yacaré",
+      "municipio": 1561
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103045,
+    "fields": {
+      "nombre": "Teniente General Rosendo M. Fraga",
+      "municipio": 1561
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103046,
+    "fields": {
+      "nombre": "Tres Palmitas",
+      "municipio": 1561
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103047,
+    "fields": {
+      "nombre": "Agua Amarga",
+      "municipio": 1562
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103048,
+    "fields": {
+      "nombre": "Baños del Salado",
+      "municipio": 1562
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103049,
+    "fields": {
+      "nombre": "Baños La Laja",
+      "municipio": 1562
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103050,
+    "fields": {
+      "nombre": "El Salado",
+      "municipio": 1562
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103051,
+    "fields": {
+      "nombre": "Las Tapias",
+      "municipio": 1562
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103052,
+    "fields": {
+      "nombre": "Tierra Adentro",
+      "municipio": 1562
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103053,
+    "fields": {
+      "nombre": "Guayamas",
+      "municipio": 1564
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103054,
+    "fields": {
+      "nombre": "Laguna Seca",
+      "municipio": 1564
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103055,
+    "fields": {
+      "nombre": "Las Chacras",
+      "municipio": 1564
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103056,
+    "fields": {
+      "nombre": "Las Liebres",
+      "municipio": 1564
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103057,
+    "fields": {
+      "nombre": "Mogote Corralitos",
+      "municipio": 1564
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103058,
+    "fields": {
+      "nombre": "Nikizanga",
+      "municipio": 1564
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103059,
+    "fields": {
+      "nombre": "Achango",
+      "municipio": 1565
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103060,
+    "fields": {
+      "nombre": "Agua del Godo",
+      "municipio": 1565
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103061,
+    "fields": {
+      "nombre": "Arrequintín",
+      "municipio": 1565
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103062,
+    "fields": {
+      "nombre": "Bañitos de Chollay",
+      "municipio": 1565
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103063,
+    "fields": {
+      "nombre": "Barreal Blanco",
+      "municipio": 1565
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103064,
+    "fields": {
+      "nombre": "Bauchaceta",
+      "municipio": 1565
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103065,
+    "fields": {
+      "nombre": "Buena Esperanza",
+      "municipio": 1565
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103066,
+    "fields": {
+      "nombre": "Campamento La Brea",
+      "municipio": 1565
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103067,
+    "fields": {
+      "nombre": "Campamento Pircas",
+      "municipio": 1565
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103068,
+    "fields": {
+      "nombre": "Campamento Soberado",
+      "municipio": 1565
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103069,
+    "fields": {
+      "nombre": "Campamento Veladero",
+      "municipio": 1565
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103070,
+    "fields": {
+      "nombre": "Campanario",
+      "municipio": 1565
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103071,
+    "fields": {
+      "nombre": "Campo de Chita",
+      "municipio": 1565
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103072,
+    "fields": {
+      "nombre": "Campo Pismanta",
+      "municipio": 1565
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103073,
+    "fields": {
+      "nombre": "Carrizalito",
+      "municipio": 1565
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103074,
+    "fields": {
+      "nombre": "Cerro Coronel",
+      "municipio": 1565
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103075,
+    "fields": {
+      "nombre": "Chinguillos",
+      "municipio": 1565
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103076,
+    "fields": {
+      "nombre": "Colangüil",
+      "municipio": 1565
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103077,
+    "fields": {
+      "nombre": "Colo Colo",
+      "municipio": 1565
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103078,
+    "fields": {
+      "nombre": "Dique Cuesta del Viento",
+      "municipio": 1565
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103079,
+    "fields": {
+      "nombre": "El Arenal",
+      "municipio": 1565
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103080,
+    "fields": {
+      "nombre": "El Carrizal",
+      "municipio": 1565
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103081,
+    "fields": {
+      "nombre": "El Lavadero",
+      "municipio": 1565
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103082,
+    "fields": {
+      "nombre": "El Llano",
+      "municipio": 1565
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103083,
+    "fields": {
+      "nombre": "Fierro Nuevo",
+      "municipio": 1565
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103084,
+    "fields": {
+      "nombre": "Fierro Viejo",
+      "municipio": 1565
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103085,
+    "fields": {
+      "nombre": "Guardia Vieja",
+      "municipio": 1565
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103086,
+    "fields": {
+      "nombre": "Junta de las Taguas",
+      "municipio": 1565
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103087,
+    "fields": {
+      "nombre": "Junta de los Champones",
+      "municipio": 1565
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103088,
+    "fields": {
+      "nombre": "La Chigua",
+      "municipio": 1565
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103089,
+    "fields": {
+      "nombre": "Llanos de San Guillermo",
+      "municipio": 1565
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103090,
+    "fields": {
+      "nombre": "Los Corrales",
+      "municipio": 1565
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103091,
+    "fields": {
+      "nombre": "Malimán",
+      "municipio": 1565
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103092,
+    "fields": {
+      "nombre": "Malimán de Arriba",
+      "municipio": 1565
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103093,
+    "fields": {
+      "nombre": "Mina Las Carachas",
+      "municipio": 1565
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103094,
+    "fields": {
+      "nombre": "Mina Veladero",
+      "municipio": 1565
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103095,
+    "fields": {
+      "nombre": "Minas de Pinto",
+      "municipio": 1565
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103096,
+    "fields": {
+      "nombre": "Paso del Agua Negra",
+      "municipio": 1565
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103097,
+    "fields": {
+      "nombre": "Paso Pascua Lama",
+      "municipio": 1565
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103098,
+    "fields": {
+      "nombre": "Quebrada de Alcaparrosa",
+      "municipio": 1565
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103099,
+    "fields": {
+      "nombre": "Tocota",
+      "municipio": 1565
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103100,
+    "fields": {
+      "nombre": "Zonda",
+      "municipio": 1565
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103101,
+    "fields": {
+      "nombre": "Agua Cercada",
+      "municipio": 1566
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103102,
+    "fields": {
+      "nombre": "Balde del Norte",
+      "municipio": 1566
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103103,
+    "fields": {
+      "nombre": "Baldes de Astica",
+      "municipio": 1566
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103104,
+    "fields": {
+      "nombre": "Baldes de la Chilca",
+      "municipio": 1566
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103105,
+    "fields": {
+      "nombre": "Baldes del Sur",
+      "municipio": 1566
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103106,
+    "fields": {
+      "nombre": "Colonia Los Valencianos",
+      "municipio": 1566
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103107,
+    "fields": {
+      "nombre": "Cuchillaco",
+      "municipio": 1566
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103108,
+    "fields": {
+      "nombre": "Ischigualasto",
+      "municipio": 1566
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103109,
+    "fields": {
+      "nombre": "La Majadita",
+      "municipio": 1566
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103110,
+    "fields": {
+      "nombre": "Las Juntas",
+      "municipio": 1566
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103111,
+    "fields": {
+      "nombre": "Las Salinas",
+      "municipio": 1566
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103112,
+    "fields": {
+      "nombre": "Los Bretes",
+      "municipio": 1566
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103113,
+    "fields": {
+      "nombre": "Rincón Chico",
+      "municipio": 1566
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103114,
+    "fields": {
+      "nombre": "San Antonio",
+      "municipio": 1566
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103115,
+    "fields": {
+      "nombre": "Agua Pinto",
+      "municipio": 1567
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103116,
+    "fields": {
+      "nombre": "Dique Los Caracoles",
+      "municipio": 1567
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103117,
+    "fields": {
+      "nombre": "Las Higueras",
+      "municipio": 1567
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103118,
+    "fields": {
+      "nombre": "Pachaco",
+      "municipio": 1567
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103119,
+    "fields": {
+      "nombre": "Portezuelo El Tambolar",
+      "municipio": 1567
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103120,
+    "fields": {
+      "nombre": "Barrio Planta Compresora de Gas",
+      "municipio": 1569
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103121,
+    "fields": {
+      "nombre": "Boca de la Travesía",
+      "municipio": 1569
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103122,
+    "fields": {
+      "nombre": "Colonia La Luisa",
+      "municipio": 1569
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103123,
+    "fields": {
+      "nombre": "Colonia San Juan",
+      "municipio": 1569
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103124,
+    "fields": {
+      "nombre": "La Chiquita",
+      "municipio": 1569
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103125,
+    "fields": {
+      "nombre": "Teniente General E. Frías",
+      "municipio": 1569
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103126,
+    "fields": {
+      "nombre": "Anta Muerta",
+      "municipio": 1570
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103127,
+    "fields": {
+      "nombre": "Balderrama",
+      "municipio": 1570
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103128,
+    "fields": {
+      "nombre": "Balderrama Sur",
+      "municipio": 1570
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103129,
+    "fields": {
+      "nombre": "El Jardín",
+      "municipio": 1570
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103130,
+    "fields": {
+      "nombre": "Macio Sud",
+      "municipio": 1570
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103131,
+    "fields": {
+      "nombre": "Cachi Yacu",
+      "municipio": 1571
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103132,
+    "fields": {
+      "nombre": "Caspi Cuchuna",
+      "municipio": 1571
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103133,
+    "fields": {
+      "nombre": "El Barreal",
+      "municipio": 1571
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103134,
+    "fields": {
+      "nombre": "El Bordo",
+      "municipio": 1571
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103135,
+    "fields": {
+      "nombre": "El Pantano",
+      "municipio": 1571
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103136,
+    "fields": {
+      "nombre": "La Majadilla",
+      "municipio": 1571
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103137,
+    "fields": {
+      "nombre": "La Providencia",
+      "municipio": 1571
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103138,
+    "fields": {
+      "nombre": "Loma Blanca",
+      "municipio": 1571
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103139,
+    "fields": {
+      "nombre": "Puesto de Luna",
+      "municipio": 1571
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103140,
+    "fields": {
+      "nombre": "Retiro",
+      "municipio": 1571
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103141,
+    "fields": {
+      "nombre": "Telares",
+      "municipio": 1571
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103142,
+    "fields": {
+      "nombre": "Agua Clara",
+      "municipio": 1573
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103143,
+    "fields": {
+      "nombre": "Ahí Veremos",
+      "municipio": 1573
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103144,
+    "fields": {
+      "nombre": "Bélgica",
+      "municipio": 1573
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103145,
+    "fields": {
+      "nombre": "Buenos Aires",
+      "municipio": 1573
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103146,
+    "fields": {
+      "nombre": "Cabeza del Toro",
+      "municipio": 1573
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103147,
+    "fields": {
+      "nombre": "Caloj Pozo",
+      "municipio": 1573
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103148,
+    "fields": {
+      "nombre": "Campo Bandera",
+      "municipio": 1573
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103149,
+    "fields": {
+      "nombre": "Consuelo",
+      "municipio": 1573
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103150,
+    "fields": {
+      "nombre": "Corral Quemado",
+      "municipio": 1573
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103151,
+    "fields": {
+      "nombre": "Cruz Bajada",
+      "municipio": 1573
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103152,
+    "fields": {
+      "nombre": "Cuatro Esquinas",
+      "municipio": 1573
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103153,
+    "fields": {
+      "nombre": "Dos Árboles",
+      "municipio": 1573
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103154,
+    "fields": {
+      "nombre": "El 60",
+      "municipio": 1573
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103155,
+    "fields": {
+      "nombre": "El Caburé",
+      "municipio": 1573
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103156,
+    "fields": {
+      "nombre": "El Ceibal",
+      "municipio": 1573
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103157,
+    "fields": {
+      "nombre": "El Corrido",
+      "municipio": 1573
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103158,
+    "fields": {
+      "nombre": "El Guayacán",
+      "municipio": 1573
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103159,
+    "fields": {
+      "nombre": "El Maján",
+      "municipio": 1573
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103160,
+    "fields": {
+      "nombre": "El Palmar",
+      "municipio": 1573
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103161,
+    "fields": {
+      "nombre": "El Puesto",
+      "municipio": 1573
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103162,
+    "fields": {
+      "nombre": "El Rincón",
+      "municipio": 1573
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103163,
+    "fields": {
+      "nombre": "El Simbol",
+      "municipio": 1573
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103164,
+    "fields": {
+      "nombre": "El Tunquelén",
+      "municipio": 1573
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103165,
+    "fields": {
+      "nombre": "El Valle",
+      "municipio": 1573
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103166,
+    "fields": {
+      "nombre": "El Yunchancito",
+      "municipio": 1573
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103167,
+    "fields": {
+      "nombre": "Esteco",
+      "municipio": 1573
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103168,
+    "fields": {
+      "nombre": "Guayacán Pozo",
+      "municipio": 1573
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103169,
+    "fields": {
+      "nombre": "Iskoy Pozo",
+      "municipio": 1573
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103170,
+    "fields": {
+      "nombre": "Itatí",
+      "municipio": 1573
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103171,
+    "fields": {
+      "nombre": "Kilómetro 1210",
+      "municipio": 1573
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103172,
+    "fields": {
+      "nombre": "Kilómetro 1255",
+      "municipio": 1573
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103173,
+    "fields": {
+      "nombre": "Kilómetro 1314",
+      "municipio": 1573
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103174,
+    "fields": {
+      "nombre": "Kilómetro 1342",
+      "municipio": 1573
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103175,
+    "fields": {
+      "nombre": "La Cañada",
+      "municipio": 1573
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103176,
+    "fields": {
+      "nombre": "La Candelaria",
+      "municipio": 1573
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103177,
+    "fields": {
+      "nombre": "La Firmeza",
+      "municipio": 1573
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103178,
+    "fields": {
+      "nombre": "La Fortuna Este",
+      "municipio": 1573
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103179,
+    "fields": {
+      "nombre": "La Salvación",
+      "municipio": 1573
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103180,
+    "fields": {
+      "nombre": "La Unión",
+      "municipio": 1573
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103181,
+    "fields": {
+      "nombre": "La Virtud",
+      "municipio": 1573
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103182,
+    "fields": {
+      "nombre": "Las Lomas",
+      "municipio": 1573
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103183,
+    "fields": {
+      "nombre": "Las Malvinas",
+      "municipio": 1573
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103184,
+    "fields": {
+      "nombre": "Los Morteros",
+      "municipio": 1573
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103185,
+    "fields": {
+      "nombre": "Los Pirpintos",
+      "municipio": 1573
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103186,
+    "fields": {
+      "nombre": "Los Pocitos",
+      "municipio": 1573
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103187,
+    "fields": {
+      "nombre": "Los Pozancones",
+      "municipio": 1573
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103188,
+    "fields": {
+      "nombre": "Los Tigres",
+      "municipio": 1573
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103189,
+    "fields": {
+      "nombre": "Lote 40",
+      "municipio": 1573
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103190,
+    "fields": {
+      "nombre": "Lote 43",
+      "municipio": 1573
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103191,
+    "fields": {
+      "nombre": "Luján",
+      "municipio": 1573
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103192,
+    "fields": {
+      "nombre": "Mailín",
+      "municipio": 1573
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103193,
+    "fields": {
+      "nombre": "Manga Bajada",
+      "municipio": 1573
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103194,
+    "fields": {
+      "nombre": "Monte Quemado",
+      "municipio": 1573
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103195,
+    "fields": {
+      "nombre": "Nueva Esperanza",
+      "municipio": 1573
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103196,
+    "fields": {
+      "nombre": "Paaj Pozo",
+      "municipio": 1573
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103197,
+    "fields": {
+      "nombre": "Pampa de los Guanacos",
+      "municipio": 1573
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103198,
+    "fields": {
+      "nombre": "Piruaj Bajo",
+      "municipio": 1573
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103199,
+    "fields": {
+      "nombre": "Puesto Córdoba",
+      "municipio": 1573
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103200,
+    "fields": {
+      "nombre": "Puestos Unidos",
+      "municipio": 1573
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103201,
+    "fields": {
+      "nombre": "Ranchillos",
+      "municipio": 1573
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103202,
+    "fields": {
+      "nombre": "Rincón del Valle",
+      "municipio": 1573
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103203,
+    "fields": {
+      "nombre": "Rumi Pozo",
+      "municipio": 1573
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103204,
+    "fields": {
+      "nombre": "San Bernardo",
+      "municipio": 1573
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103205,
+    "fields": {
+      "nombre": "San Carlos",
+      "municipio": 1573
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103206,
+    "fields": {
+      "nombre": "San Ignacio",
+      "municipio": 1573
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103207,
+    "fields": {
+      "nombre": "San Isidro",
+      "municipio": 1573
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103208,
+    "fields": {
+      "nombre": "San Javier",
+      "municipio": 1573
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103209,
+    "fields": {
+      "nombre": "San José",
+      "municipio": 1573
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103210,
+    "fields": {
+      "nombre": "San José del Boquerón",
+      "municipio": 1573
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103211,
+    "fields": {
+      "nombre": "San Pedro",
+      "municipio": 1573
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103212,
+    "fields": {
+      "nombre": "San Roque",
+      "municipio": 1573
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103213,
+    "fields": {
+      "nombre": "Santa Cruz",
+      "municipio": 1573
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103214,
+    "fields": {
+      "nombre": "Santa María",
+      "municipio": 1573
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103215,
+    "fields": {
+      "nombre": "Santa Rosa",
+      "municipio": 1573
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103216,
+    "fields": {
+      "nombre": "Santa Rosa Sur",
+      "municipio": 1573
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103217,
+    "fields": {
+      "nombre": "Santo Domingo",
+      "municipio": 1573
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103218,
+    "fields": {
+      "nombre": "Tasio",
+      "municipio": 1573
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103219,
+    "fields": {
+      "nombre": "Toro Pozo",
+      "municipio": 1573
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103220,
+    "fields": {
+      "nombre": "Tres Varones",
+      "municipio": 1573
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103221,
+    "fields": {
+      "nombre": "Urutaú",
+      "municipio": 1573
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103222,
+    "fields": {
+      "nombre": "Villa Matoque",
+      "municipio": 1573
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103223,
+    "fields": {
+      "nombre": "Vinal Pozo",
+      "municipio": 1573
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103224,
+    "fields": {
+      "nombre": "Vinal Suni",
+      "municipio": 1573
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103225,
+    "fields": {
+      "nombre": "Campo Costa",
+      "municipio": 1574
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103226,
+    "fields": {
+      "nombre": "Campo Crespo",
+      "municipio": 1574
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103227,
+    "fields": {
+      "nombre": "Campo Las Chacras",
+      "municipio": 1574
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103228,
+    "fields": {
+      "nombre": "Campo Los Galgos",
+      "municipio": 1574
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103229,
+    "fields": {
+      "nombre": "Campo San Elias",
+      "municipio": 1574
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103230,
+    "fields": {
+      "nombre": "Campo Santa Elena",
+      "municipio": 1574
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103231,
+    "fields": {
+      "nombre": "Campo Santa Rita",
+      "municipio": 1574
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103232,
+    "fields": {
+      "nombre": "Campo Vionnet",
+      "municipio": 1574
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103233,
+    "fields": {
+      "nombre": "Colonia 10 de Mayo",
+      "municipio": 1574
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103234,
+    "fields": {
+      "nombre": "Colonia 25 de Mayo",
+      "municipio": 1574
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103235,
+    "fields": {
+      "nombre": "Colonia Corral de Guardia",
+      "municipio": 1574
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103236,
+    "fields": {
+      "nombre": "Colonia Corral del Bajo",
+      "municipio": 1574
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103237,
+    "fields": {
+      "nombre": "Colonia El Balquín",
+      "municipio": 1574
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103238,
+    "fields": {
+      "nombre": "Colonia El Dorado",
+      "municipio": 1574
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103239,
+    "fields": {
+      "nombre": "Colonia El Piquillín",
+      "municipio": 1574
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103240,
+    "fields": {
+      "nombre": "Colonia La Celina",
+      "municipio": 1574
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103241,
+    "fields": {
+      "nombre": "Colonia La Concordia",
+      "municipio": 1574
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103242,
+    "fields": {
+      "nombre": "Colonia La Esperanza",
+      "municipio": 1574
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103243,
+    "fields": {
+      "nombre": "Colonia La Leoncita",
+      "municipio": 1574
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103244,
+    "fields": {
+      "nombre": "Colonia La Lola",
+      "municipio": 1574
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103245,
+    "fields": {
+      "nombre": "Colonia La Unión",
+      "municipio": 1574
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103246,
+    "fields": {
+      "nombre": "Colonia La Verde",
+      "municipio": 1574
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103247,
+    "fields": {
+      "nombre": "Colonia Norte",
+      "municipio": 1574
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103248,
+    "fields": {
+      "nombre": "Colonia Pico Chaco",
+      "municipio": 1574
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103249,
+    "fields": {
+      "nombre": "Colonia Yanzi",
+      "municipio": 1574
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103250,
+    "fields": {
+      "nombre": "Cuatro Caminos",
+      "municipio": 1574
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103251,
+    "fields": {
+      "nombre": "El Descanso",
+      "municipio": 1574
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103252,
+    "fields": {
+      "nombre": "El Ucle",
+      "municipio": 1574
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103253,
+    "fields": {
+      "nombre": "La Herradura",
+      "municipio": 1574
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103254,
+    "fields": {
+      "nombre": "La Luisita",
+      "municipio": 1574
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103255,
+    "fields": {
+      "nombre": "La Tigra",
+      "municipio": 1574
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103256,
+    "fields": {
+      "nombre": "Laguna Helvecia",
+      "municipio": 1574
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103257,
+    "fields": {
+      "nombre": "Las Lagunitas",
+      "municipio": 1574
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103258,
+    "fields": {
+      "nombre": "Los Corralitos",
+      "municipio": 1574
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103259,
+    "fields": {
+      "nombre": "Potro Muerto",
+      "municipio": 1574
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103260,
+    "fields": {
+      "nombre": "Ramón J. Cárcano",
+      "municipio": 1574
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103261,
+    "fields": {
+      "nombre": "San Eusebio",
+      "municipio": 1574
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103262,
+    "fields": {
+      "nombre": "San Severo",
+      "municipio": 1574
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103263,
+    "fields": {
+      "nombre": "Árbol Solo",
+      "municipio": 1575
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103264,
+    "fields": {
+      "nombre": "Belgrano",
+      "municipio": 1575
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103265,
+    "fields": {
+      "nombre": "Bella Criolla",
+      "municipio": 1575
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103266,
+    "fields": {
+      "nombre": "Buena Vista",
+      "municipio": 1575
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103267,
+    "fields": {
+      "nombre": "Campo del Cisne",
+      "municipio": 1575
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103268,
+    "fields": {
+      "nombre": "Coronel Fernández",
+      "municipio": 1575
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103269,
+    "fields": {
+      "nombre": "Corral del Rey",
+      "municipio": 1575
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103270,
+    "fields": {
+      "nombre": "El Algarrobal",
+      "municipio": 1575
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103271,
+    "fields": {
+      "nombre": "El Bajo",
+      "municipio": 1575
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103272,
+    "fields": {
+      "nombre": "El Cerro",
+      "municipio": 1575
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103273,
+    "fields": {
+      "nombre": "El Desvío",
+      "municipio": 1575
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103274,
+    "fields": {
+      "nombre": "El Espartal",
+      "municipio": 1575
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103275,
+    "fields": {
+      "nombre": "El Mistol",
+      "municipio": 1575
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103276,
+    "fields": {
+      "nombre": "El Paraíso",
+      "municipio": 1575
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103277,
+    "fields": {
+      "nombre": "El Pueblito",
+      "municipio": 1575
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103278,
+    "fields": {
+      "nombre": "El Talar",
+      "municipio": 1575
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103279,
+    "fields": {
+      "nombre": "El Ucle",
+      "municipio": 1575
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103280,
+    "fields": {
+      "nombre": "Fuerte Viejo",
+      "municipio": 1575
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103281,
+    "fields": {
+      "nombre": "Gaucho de Güemes",
+      "municipio": 1575
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103282,
+    "fields": {
+      "nombre": "Horcos Tucucuna",
+      "municipio": 1575
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103283,
+    "fields": {
+      "nombre": "La Blanquita",
+      "municipio": 1575
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103284,
+    "fields": {
+      "nombre": "La Granada",
+      "municipio": 1575
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103285,
+    "fields": {
+      "nombre": "La Higuera",
+      "municipio": 1575
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103286,
+    "fields": {
+      "nombre": "La Trampa",
+      "municipio": 1575
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103287,
+    "fields": {
+      "nombre": "La Yerba",
+      "municipio": 1575
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103288,
+    "fields": {
+      "nombre": "Las Chicharras",
+      "municipio": 1575
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103289,
+    "fields": {
+      "nombre": "Los Algarrobos",
+      "municipio": 1575
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103290,
+    "fields": {
+      "nombre": "Media Luna",
+      "municipio": 1575
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103291,
+    "fields": {
+      "nombre": "Oratorio",
+      "municipio": 1575
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103292,
+    "fields": {
+      "nombre": "Paso de la Cina",
+      "municipio": 1575
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103293,
+    "fields": {
+      "nombre": "Paso de los Oscares",
+      "municipio": 1575
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103294,
+    "fields": {
+      "nombre": "Pozo del Monte",
+      "municipio": 1575
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103295,
+    "fields": {
+      "nombre": "Puerta del Monte",
+      "municipio": 1575
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103296,
+    "fields": {
+      "nombre": "Rama Paso",
+      "municipio": 1575
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103297,
+    "fields": {
+      "nombre": "Ramírez de Velazco",
+      "municipio": 1575
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103298,
+    "fields": {
+      "nombre": "Río Viejo",
+      "municipio": 1575
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103299,
+    "fields": {
+      "nombre": "Salinas",
+      "municipio": 1575
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103300,
+    "fields": {
+      "nombre": "San Carlos",
+      "municipio": 1575
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103301,
+    "fields": {
+      "nombre": "San Francisco",
+      "municipio": 1575
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103302,
+    "fields": {
+      "nombre": "San Juan",
+      "municipio": 1575
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103303,
+    "fields": {
+      "nombre": "San Nicolás",
+      "municipio": 1575
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103304,
+    "fields": {
+      "nombre": "Santa Ana",
+      "municipio": 1575
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103305,
+    "fields": {
+      "nombre": "Santa Rosa",
+      "municipio": 1575
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103306,
+    "fields": {
+      "nombre": "Sumampa",
+      "municipio": 1575
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103307,
+    "fields": {
+      "nombre": "Sumampa Viejo",
+      "municipio": 1575
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103308,
+    "fields": {
+      "nombre": "Taco Pozo",
+      "municipio": 1575
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103309,
+    "fields": {
+      "nombre": "Villa Quebracho",
+      "municipio": 1575
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103310,
+    "fields": {
+      "nombre": "El Zapallar",
+      "municipio": 1577
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103311,
+    "fields": {
+      "nombre": "La Aguada",
+      "municipio": 1577
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103312,
+    "fields": {
+      "nombre": "La Brea",
+      "municipio": 1577
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103313,
+    "fields": {
+      "nombre": "Dique La Florida",
+      "municipio": 1579
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103314,
+    "fields": {
+      "nombre": "El Balde",
+      "municipio": 1579
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103315,
+    "fields": {
+      "nombre": "El Totoral",
+      "municipio": 1579
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103316,
+    "fields": {
+      "nombre": "La Arenilla",
+      "municipio": 1579
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103317,
+    "fields": {
+      "nombre": "Las Pircas",
+      "municipio": 1579
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103318,
+    "fields": {
+      "nombre": "Los Tapiales",
+      "municipio": 1579
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103319,
+    "fields": {
+      "nombre": "Pampa del Tamboreo",
+      "municipio": 1579
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103320,
+    "fields": {
+      "nombre": "Paso del Rey",
+      "municipio": 1579
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103321,
+    "fields": {
+      "nombre": "Embalse La Toma",
+      "municipio": 1580
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103322,
+    "fields": {
+      "nombre": "El Churrasco",
+      "municipio": 1581
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103323,
+    "fields": {
+      "nombre": "El Sauce",
+      "municipio": 1581
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103324,
+    "fields": {
+      "nombre": "El Sifón",
+      "municipio": 1581
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103325,
+    "fields": {
+      "nombre": "Los Cóndores",
+      "municipio": 1581
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103326,
+    "fields": {
+      "nombre": "Dique Vulpiani",
+      "municipio": 1586
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103327,
+    "fields": {
+      "nombre": "La Estrechura",
+      "municipio": 1591
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103328,
+    "fields": {
+      "nombre": "El Cielito",
+      "municipio": 1593
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103329,
+    "fields": {
+      "nombre": "El Mirador",
+      "municipio": 1593
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103330,
+    "fields": {
+      "nombre": "Los Gatos",
+      "municipio": 1593
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103331,
+    "fields": {
+      "nombre": "Pozo del Carril",
+      "municipio": 1593
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103332,
+    "fields": {
+      "nombre": "Suyuque Viejo",
+      "municipio": 1593
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103333,
+    "fields": {
+      "nombre": "Boca del Tigre",
+      "municipio": 1595
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103334,
+    "fields": {
+      "nombre": "Chilca",
+      "municipio": 1596
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103335,
+    "fields": {
+      "nombre": "El Obraje",
+      "municipio": 1596
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103336,
+    "fields": {
+      "nombre": "Puesto de Uncos",
+      "municipio": 1596
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103337,
+    "fields": {
+      "nombre": "San Ramón",
+      "municipio": 1596
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103338,
+    "fields": {
+      "nombre": "Vizcachera",
+      "municipio": 1597
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103339,
+    "fields": {
+      "nombre": "El Chañar",
+      "municipio": 1598
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103340,
+    "fields": {
+      "nombre": "Rumi Huasi",
+      "municipio": 1598
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103341,
+    "fields": {
+      "nombre": "Cañada Honda",
+      "municipio": 1599
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103342,
+    "fields": {
+      "nombre": "Pampa de la Invernada",
+      "municipio": 1599
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103343,
+    "fields": {
+      "nombre": "Balcarce",
+      "municipio": 1601
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103344,
+    "fields": {
+      "nombre": "Piscu Yaco",
+      "municipio": 1601
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103345,
+    "fields": {
+      "nombre": "San Miguel",
+      "municipio": 1601
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103346,
+    "fields": {
+      "nombre": "El Recuerdo",
+      "municipio": 1602
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103347,
+    "fields": {
+      "nombre": "Las Canteras",
+      "municipio": 1603
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103348,
+    "fields": {
+      "nombre": "San Miguel Sur",
+      "municipio": 1605
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103349,
+    "fields": {
+      "nombre": "El Porvenir",
+      "municipio": 1606
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103350,
+    "fields": {
+      "nombre": "Las Rosas",
+      "municipio": 1606
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103351,
+    "fields": {
+      "nombre": "El Puesto",
+      "municipio": 1630
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103352,
+    "fields": {
+      "nombre": "Tala Verde",
+      "municipio": 1630
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103353,
+    "fields": {
+      "nombre": "Balneario Las Chacras",
+      "municipio": 1631
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103354,
+    "fields": {
+      "nombre": "El Estaquito",
+      "municipio": 1631
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103355,
+    "fields": {
+      "nombre": "Laguna Larga",
+      "municipio": 1631
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103356,
+    "fields": {
+      "nombre": "Pozo Frío",
+      "municipio": 1632
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103357,
+    "fields": {
+      "nombre": "El Paraíso",
+      "municipio": 1634
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103358,
+    "fields": {
+      "nombre": "Cañada del Tala",
+      "municipio": 1637
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103359,
+    "fields": {
+      "nombre": "El Cachi",
+      "municipio": 1637
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103360,
+    "fields": {
+      "nombre": "Isla Larga",
+      "municipio": 1637
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103361,
+    "fields": {
+      "nombre": "La Angostura",
+      "municipio": 1637
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103362,
+    "fields": {
+      "nombre": "La Estrechura",
+      "municipio": 1637
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103363,
+    "fields": {
+      "nombre": "La Majadilla",
+      "municipio": 1637
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103364,
+    "fields": {
+      "nombre": "La Toma",
+      "municipio": 1637
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103365,
+    "fields": {
+      "nombre": "Las Lomitas",
+      "municipio": 1637
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103366,
+    "fields": {
+      "nombre": "Las Masitas",
+      "municipio": 1637
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103367,
+    "fields": {
+      "nombre": "Los Álamos",
+      "municipio": 1637
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103368,
+    "fields": {
+      "nombre": "Los Socavones",
+      "municipio": 1637
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103369,
+    "fields": {
+      "nombre": "Puesto de Cejas",
+      "municipio": 1637
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103370,
+    "fields": {
+      "nombre": "Puesto de Fierro",
+      "municipio": 1637
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103371,
+    "fields": {
+      "nombre": "Puesto San José",
+      "municipio": 1637
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103372,
+    "fields": {
+      "nombre": "Río de Bustos",
+      "municipio": 1637
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103373,
+    "fields": {
+      "nombre": "San Vicente",
+      "municipio": 1637
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103374,
+    "fields": {
+      "nombre": "Santa Cruz",
+      "municipio": 1637
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103375,
+    "fields": {
+      "nombre": "Sauce Punco",
+      "municipio": 1637
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103376,
+    "fields": {
+      "nombre": "Totoralejos",
+      "municipio": 1637
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103377,
+    "fields": {
+      "nombre": "Quebrada de Lules",
+      "municipio": 1638
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103378,
+    "fields": {
+      "nombre": "Aguada Guzmán",
+      "municipio": 1639
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103379,
+    "fields": {
+      "nombre": "Bajada de Bravo",
+      "municipio": 1639
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103380,
+    "fields": {
+      "nombre": "Blancura Centro",
+      "municipio": 1639
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103381,
+    "fields": {
+      "nombre": "Carriyegua",
+      "municipio": 1639
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103382,
+    "fields": {
+      "nombre": "Cerro Policía",
+      "municipio": 1639
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103383,
+    "fields": {
+      "nombre": "Chasicó",
+      "municipio": 1639
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103384,
+    "fields": {
+      "nombre": "El Cuy",
+      "municipio": 1639
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103385,
+    "fields": {
+      "nombre": "Lonco Vaca",
+      "municipio": 1639
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103386,
+    "fields": {
+      "nombre": "Mencué",
+      "municipio": 1639
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103387,
+    "fields": {
+      "nombre": "Michihuao",
+      "municipio": 1639
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103388,
+    "fields": {
+      "nombre": "Naupa Huen",
+      "municipio": 1639
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103389,
+    "fields": {
+      "nombre": "Palenque Niyeu",
+      "municipio": 1639
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103390,
+    "fields": {
+      "nombre": "Pilahué",
+      "municipio": 1639
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103391,
+    "fields": {
+      "nombre": "Tricaco",
+      "municipio": 1639
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103392,
+    "fields": {
+      "nombre": "Valle Azul",
+      "municipio": 1639
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103393,
+    "fields": {
+      "nombre": "Averías",
+      "municipio": 1640
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103394,
+    "fields": {
+      "nombre": "Buen Paso",
+      "municipio": 1640
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103395,
+    "fields": {
+      "nombre": "Campo Lagar",
+      "municipio": 1640
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103396,
+    "fields": {
+      "nombre": "El Tobiano",
+      "municipio": 1640
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103397,
+    "fields": {
+      "nombre": "Estación Tacañitas",
+      "municipio": 1640
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103398,
+    "fields": {
+      "nombre": "Kilómetro 454",
+      "municipio": 1640
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103399,
+    "fields": {
+      "nombre": "Kilómetro 515",
+      "municipio": 1640
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103400,
+    "fields": {
+      "nombre": "La Nena",
+      "municipio": 1640
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103401,
+    "fields": {
+      "nombre": "La Paulina",
+      "municipio": 1640
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103402,
+    "fields": {
+      "nombre": "La Piamontesa",
+      "municipio": 1640
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103403,
+    "fields": {
+      "nombre": "La Salamanca",
+      "municipio": 1640
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103404,
+    "fields": {
+      "nombre": "La Simona",
+      "municipio": 1640
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103405,
+    "fields": {
+      "nombre": "Las Gamas",
+      "municipio": 1640
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103406,
+    "fields": {
+      "nombre": "Los Juríes",
+      "municipio": 1640
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103407,
+    "fields": {
+      "nombre": "Los Linares",
+      "municipio": 1640
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103408,
+    "fields": {
+      "nombre": "Lote 1",
+      "municipio": 1640
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103409,
+    "fields": {
+      "nombre": "Lote 15",
+      "municipio": 1640
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103410,
+    "fields": {
+      "nombre": "Lote 33",
+      "municipio": 1640
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103411,
+    "fields": {
+      "nombre": "Lote 46",
+      "municipio": 1640
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103412,
+    "fields": {
+      "nombre": "Mala Cara",
+      "municipio": 1640
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103413,
+    "fields": {
+      "nombre": "Miel de Palo",
+      "municipio": 1640
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103414,
+    "fields": {
+      "nombre": "Obraje Mailín",
+      "municipio": 1640
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103415,
+    "fields": {
+      "nombre": "Pozo del Medio",
+      "municipio": 1640
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103416,
+    "fields": {
+      "nombre": "Pozo Herrera",
+      "municipio": 1640
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103417,
+    "fields": {
+      "nombre": "Puni Tajo",
+      "municipio": 1640
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103418,
+    "fields": {
+      "nombre": "San Pablo",
+      "municipio": 1640
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103419,
+    "fields": {
+      "nombre": "Sanavirones",
+      "municipio": 1640
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103420,
+    "fields": {
+      "nombre": "Santa Ana",
+      "municipio": 1640
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103421,
+    "fields": {
+      "nombre": "Santa Elena",
+      "municipio": 1640
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103422,
+    "fields": {
+      "nombre": "Simbol Bajo",
+      "municipio": 1640
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103423,
+    "fields": {
+      "nombre": "Suncho Pozo",
+      "municipio": 1640
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103424,
+    "fields": {
+      "nombre": "Suncho Pozo Alto",
+      "municipio": 1640
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103425,
+    "fields": {
+      "nombre": "Suncho Pozo del Triunfo",
+      "municipio": 1640
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103426,
+    "fields": {
+      "nombre": "Taco Atún",
+      "municipio": 1640
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103427,
+    "fields": {
+      "nombre": "Toledo",
+      "municipio": 1640
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103428,
+    "fields": {
+      "nombre": "Tomás Young",
+      "municipio": 1640
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103429,
+    "fields": {
+      "nombre": "Tres Pozos",
+      "municipio": 1640
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103430,
+    "fields": {
+      "nombre": "Villa Carolina",
+      "municipio": 1640
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103431,
+    "fields": {
+      "nombre": "Villa Los Pocitos",
+      "municipio": 1640
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103432,
+    "fields": {
+      "nombre": "Vinal Esquina",
+      "municipio": 1640
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103433,
+    "fields": {
+      "nombre": "Beltrán",
+      "municipio": 1641
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103434,
+    "fields": {
+      "nombre": "Buey Muerto",
+      "municipio": 1641
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103435,
+    "fields": {
+      "nombre": "Chilca",
+      "municipio": 1641
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103436,
+    "fields": {
+      "nombre": "Colonia Jaime",
+      "municipio": 1641
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103437,
+    "fields": {
+      "nombre": "El Barrialito",
+      "municipio": 1641
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103438,
+    "fields": {
+      "nombre": "El Quebrachal",
+      "municipio": 1641
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103439,
+    "fields": {
+      "nombre": "El Refugio",
+      "municipio": 1641
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103440,
+    "fields": {
+      "nombre": "El Soler",
+      "municipio": 1641
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103441,
+    "fields": {
+      "nombre": "Fernández",
+      "municipio": 1641
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103442,
+    "fields": {
+      "nombre": "Higuera Chacra",
+      "municipio": 1641
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103443,
+    "fields": {
+      "nombre": "Ingeniero Forres",
+      "municipio": 1641
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103444,
+    "fields": {
+      "nombre": "Janta",
+      "municipio": 1641
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103445,
+    "fields": {
+      "nombre": "La Florida",
+      "municipio": 1641
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103446,
+    "fields": {
+      "nombre": "La Rivera",
+      "municipio": 1641
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103447,
+    "fields": {
+      "nombre": "Loaj",
+      "municipio": 1641
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103448,
+    "fields": {
+      "nombre": "Lomitas",
+      "municipio": 1641
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103449,
+    "fields": {
+      "nombre": "Los Arias",
+      "municipio": 1641
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103450,
+    "fields": {
+      "nombre": "Los Pereyra",
+      "municipio": 1641
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103451,
+    "fields": {
+      "nombre": "Los Romanos",
+      "municipio": 1641
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103452,
+    "fields": {
+      "nombre": "Los Troncos",
+      "municipio": 1641
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103453,
+    "fields": {
+      "nombre": "Mili",
+      "municipio": 1641
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103454,
+    "fields": {
+      "nombre": "Mirella",
+      "municipio": 1641
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103455,
+    "fields": {
+      "nombre": "Morcillo",
+      "municipio": 1641
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103456,
+    "fields": {
+      "nombre": "Nueva Industria",
+      "municipio": 1641
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103457,
+    "fields": {
+      "nombre": "Pozo Sumi",
+      "municipio": 1641
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103458,
+    "fields": {
+      "nombre": "Rosario",
+      "municipio": 1641
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103459,
+    "fields": {
+      "nombre": "San Ramón",
+      "municipio": 1641
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103460,
+    "fields": {
+      "nombre": "San Salvador",
+      "municipio": 1641
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103461,
+    "fields": {
+      "nombre": "Santo Domingo",
+      "municipio": 1641
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103462,
+    "fields": {
+      "nombre": "Villa Hipólita",
+      "municipio": 1641
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103463,
+    "fields": {
+      "nombre": "Villa Robles",
+      "municipio": 1641
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103464,
+    "fields": {
+      "nombre": "Vilmer",
+      "municipio": 1641
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103465,
+    "fields": {
+      "nombre": "Altautina",
+      "municipio": 1642
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103466,
+    "fields": {
+      "nombre": "Chua",
+      "municipio": 1642
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103467,
+    "fields": {
+      "nombre": "Ciénaga de Allende",
+      "municipio": 1642
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103468,
+    "fields": {
+      "nombre": "El Cóndor",
+      "municipio": 1642
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103469,
+    "fields": {
+      "nombre": "El Lindero",
+      "municipio": 1642
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103470,
+    "fields": {
+      "nombre": "El Volcán",
+      "municipio": 1642
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103471,
+    "fields": {
+      "nombre": "La Línea",
+      "municipio": 1642
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103472,
+    "fields": {
+      "nombre": "Las Oscuras",
+      "municipio": 1642
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103473,
+    "fields": {
+      "nombre": "Los Callejones",
+      "municipio": 1642
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103474,
+    "fields": {
+      "nombre": "Pachango",
+      "municipio": 1642
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103475,
+    "fields": {
+      "nombre": "Quebracho Solo",
+      "municipio": 1642
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103476,
+    "fields": {
+      "nombre": "Río Jaime",
+      "municipio": 1642
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103477,
+    "fields": {
+      "nombre": "San Jerónimo",
+      "municipio": 1642
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103478,
+    "fields": {
+      "nombre": "Sierrita",
+      "municipio": 1642
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103479,
+    "fields": {
+      "nombre": "Tasna",
+      "municipio": 1642
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103480,
+    "fields": {
+      "nombre": "Villa Rafael Benegas",
+      "municipio": 1642
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103481,
+    "fields": {
+      "nombre": "Alto Alegre",
+      "municipio": 1643
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103482,
+    "fields": {
+      "nombre": "Bartolomé de las Casas",
+      "municipio": 1643
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103483,
+    "fields": {
+      "nombre": "Bordo Santo",
+      "municipio": 1643
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103484,
+    "fields": {
+      "nombre": "Cacique Coquero",
+      "municipio": 1643
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103485,
+    "fields": {
+      "nombre": "Campo Alegre",
+      "municipio": 1643
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103486,
+    "fields": {
+      "nombre": "Campo Azcurra",
+      "municipio": 1643
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103487,
+    "fields": {
+      "nombre": "Campo del Cielo",
+      "municipio": 1643
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103488,
+    "fields": {
+      "nombre": "Chico Dowagan",
+      "municipio": 1643
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103489,
+    "fields": {
+      "nombre": "Colonia 14 de Mayo",
+      "municipio": 1643
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103490,
+    "fields": {
+      "nombre": "Colonia 20 de Junio",
+      "municipio": 1643
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103491,
+    "fields": {
+      "nombre": "Colonia Ceferino Namuncurá",
+      "municipio": 1643
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103492,
+    "fields": {
+      "nombre": "Colonia Dante Sandrelli",
+      "municipio": 1643
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103493,
+    "fields": {
+      "nombre": "Colonia El Cacuy",
+      "municipio": 1643
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103494,
+    "fields": {
+      "nombre": "Colonia El Catorce",
+      "municipio": 1643
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103495,
+    "fields": {
+      "nombre": "Colonia El Silencio",
+      "municipio": 1643
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103496,
+    "fields": {
+      "nombre": "Colonia Isla Sola",
+      "municipio": 1643
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103497,
+    "fields": {
+      "nombre": "Colonia Juanita",
+      "municipio": 1643
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103498,
+    "fields": {
+      "nombre": "Colonia La Media Luna",
+      "municipio": 1643
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103499,
+    "fields": {
+      "nombre": "Colonia La Preferida",
+      "municipio": 1643
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103500,
+    "fields": {
+      "nombre": "Colonia La Sierva",
+      "municipio": 1643
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103501,
+    "fields": {
+      "nombre": "Colonia Laka Wichi",
+      "municipio": 1643
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103502,
+    "fields": {
+      "nombre": "Colonia Las Choyas",
+      "municipio": 1643
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103503,
+    "fields": {
+      "nombre": "Colonia Napenay",
+      "municipio": 1643
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103504,
+    "fields": {
+      "nombre": "Colonia San Antonio",
+      "municipio": 1643
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103505,
+    "fields": {
+      "nombre": "Colonia San Isidro",
+      "municipio": 1643
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103506,
+    "fields": {
+      "nombre": "Colonia San Pablo",
+      "municipio": 1643
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103507,
+    "fields": {
+      "nombre": "Colonia San Pedro",
+      "municipio": 1643
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103508,
+    "fields": {
+      "nombre": "Colonia San Roque",
+      "municipio": 1643
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103509,
+    "fields": {
+      "nombre": "Colonia Santa Rosa",
+      "municipio": 1643
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103510,
+    "fields": {
+      "nombre": "Colonia Sarmiento",
+      "municipio": 1643
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103511,
+    "fields": {
+      "nombre": "Colonia Siete Quebrachos",
+      "municipio": 1643
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103512,
+    "fields": {
+      "nombre": "Colonia Tajerey",
+      "municipio": 1643
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103513,
+    "fields": {
+      "nombre": "Colonia Tatané",
+      "municipio": 1643
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103514,
+    "fields": {
+      "nombre": "Colonia Unión Escuelas",
+      "municipio": 1643
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103515,
+    "fields": {
+      "nombre": "Comunidad Aborigen Bartolomé de las Casas",
+      "municipio": 1643
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103516,
+    "fields": {
+      "nombre": "Crucero General Belgrano",
+      "municipio": 1643
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103517,
+    "fields": {
+      "nombre": "El Bellaco",
+      "municipio": 1643
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103518,
+    "fields": {
+      "nombre": "El Ceibal",
+      "municipio": 1643
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103519,
+    "fields": {
+      "nombre": "El Cogoik",
+      "municipio": 1643
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103520,
+    "fields": {
+      "nombre": "El Corredero",
+      "municipio": 1643
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103521,
+    "fields": {
+      "nombre": "El Descanso",
+      "municipio": 1643
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103522,
+    "fields": {
+      "nombre": "El Divisadero",
+      "municipio": 1643
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103523,
+    "fields": {
+      "nombre": "El Oculto",
+      "municipio": 1643
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103524,
+    "fields": {
+      "nombre": "El Pavao",
+      "municipio": 1643
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103525,
+    "fields": {
+      "nombre": "El Recreo",
+      "municipio": 1643
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103526,
+    "fields": {
+      "nombre": "El Simbolar Norte",
+      "municipio": 1643
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103527,
+    "fields": {
+      "nombre": "El Timbó",
+      "municipio": 1643
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103528,
+    "fields": {
+      "nombre": "Fortín Sargento 1º Leyes",
+      "municipio": 1643
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103529,
+    "fields": {
+      "nombre": "Isleta",
+      "municipio": 1643
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103530,
+    "fields": {
+      "nombre": "Juan G. Bazán",
+      "municipio": 1643
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103531,
+    "fields": {
+      "nombre": "Kilómetro 14",
+      "municipio": 1643
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103532,
+    "fields": {
+      "nombre": "Kilómetro 15",
+      "municipio": 1643
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103533,
+    "fields": {
+      "nombre": "Kilómetro 503",
+      "municipio": 1643
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103534,
+    "fields": {
+      "nombre": "Kilómetro 642",
+      "municipio": 1643
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103535,
+    "fields": {
+      "nombre": "La Estrella",
+      "municipio": 1643
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103536,
+    "fields": {
+      "nombre": "La Invernada",
+      "municipio": 1643
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103537,
+    "fields": {
+      "nombre": "La Lidia",
+      "municipio": 1643
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103538,
+    "fields": {
+      "nombre": "La Pampa",
+      "municipio": 1643
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103539,
+    "fields": {
+      "nombre": "La Soledad",
+      "municipio": 1643
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103540,
+    "fields": {
+      "nombre": "Lago Verde",
+      "municipio": 1643
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103541,
+    "fields": {
+      "nombre": "Laguna Acebal",
+      "municipio": 1643
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103542,
+    "fields": {
+      "nombre": "Las Mochas",
+      "municipio": 1643
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103543,
+    "fields": {
+      "nombre": "Loma San Pablo",
+      "municipio": 1643
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103544,
+    "fields": {
+      "nombre": "Los Claveles",
+      "municipio": 1643
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103545,
+    "fields": {
+      "nombre": "Los Jubilados",
+      "municipio": 1643
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103546,
+    "fields": {
+      "nombre": "Los Tres Reyes",
+      "municipio": 1643
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103547,
+    "fields": {
+      "nombre": "Maestra Blanca Gómez",
+      "municipio": 1643
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103548,
+    "fields": {
+      "nombre": "Palma Sola",
+      "municipio": 1643
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103549,
+    "fields": {
+      "nombre": "Paraje El Cruce",
+      "municipio": 1643
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103550,
+    "fields": {
+      "nombre": "Paraje La Pampa",
+      "municipio": 1643
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103551,
+    "fields": {
+      "nombre": "Paso Isleta",
+      "municipio": 1643
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103552,
+    "fields": {
+      "nombre": "Paso La Cruz",
+      "municipio": 1643
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103553,
+    "fields": {
+      "nombre": "Paso Naitek",
+      "municipio": 1643
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103554,
+    "fields": {
+      "nombre": "Posta Cambio Zalazar",
+      "municipio": 1643
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103555,
+    "fields": {
+      "nombre": "Posta Lencina",
+      "municipio": 1643
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103556,
+    "fields": {
+      "nombre": "Posta Sargento Cabral",
+      "municipio": 1643
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103557,
+    "fields": {
+      "nombre": "Pozo Hondo",
+      "municipio": 1643
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103558,
+    "fields": {
+      "nombre": "Pozo Largo",
+      "municipio": 1643
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103559,
+    "fields": {
+      "nombre": "Pozo Novagán",
+      "municipio": 1643
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103560,
+    "fields": {
+      "nombre": "Pozo Verde",
+      "municipio": 1643
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103561,
+    "fields": {
+      "nombre": "Puerto Lavalle",
+      "municipio": 1643
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103562,
+    "fields": {
+      "nombre": "Puesto Ramona",
+      "municipio": 1643
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103563,
+    "fields": {
+      "nombre": "Punta del Agua",
+      "municipio": 1643
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103564,
+    "fields": {
+      "nombre": "Ranero Cué",
+      "municipio": 1643
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103565,
+    "fields": {
+      "nombre": "Riacho de Oro",
+      "municipio": 1643
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103566,
+    "fields": {
+      "nombre": "Rincón Florido",
+      "municipio": 1643
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103567,
+    "fields": {
+      "nombre": "San Carlos",
+      "municipio": 1643
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103568,
+    "fields": {
+      "nombre": "San José",
+      "municipio": 1643
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103569,
+    "fields": {
+      "nombre": "San Martín I",
+      "municipio": 1643
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103570,
+    "fields": {
+      "nombre": "San Simón",
+      "municipio": 1643
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103571,
+    "fields": {
+      "nombre": "Santa Rosa",
+      "municipio": 1643
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103572,
+    "fields": {
+      "nombre": "Teniente Brown",
+      "municipio": 1643
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103573,
+    "fields": {
+      "nombre": "Tres Pozos",
+      "municipio": 1643
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103574,
+    "fields": {
+      "nombre": "Tres Pozos Sur",
+      "municipio": 1643
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103575,
+    "fields": {
+      "nombre": "Urbana Vieja",
+      "municipio": 1643
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103576,
+    "fields": {
+      "nombre": "Villa General Urquiza",
+      "municipio": 1643
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103577,
+    "fields": {
+      "nombre": "Castellano Plaza",
+      "municipio": 1644
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103578,
+    "fields": {
+      "nombre": "Campo Spagnolo",
+      "municipio": 1645
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103579,
+    "fields": {
+      "nombre": "Campo Albertengo",
+      "municipio": 1646
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103580,
+    "fields": {
+      "nombre": "Campo Chiodi",
+      "municipio": 1646
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103581,
+    "fields": {
+      "nombre": "Colonia Los Troncos",
+      "municipio": 1646
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103582,
+    "fields": {
+      "nombre": "Campo El Rafango",
+      "municipio": 1647
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103583,
+    "fields": {
+      "nombre": "Campo La Oriental",
+      "municipio": 1647
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103584,
+    "fields": {
+      "nombre": "Campo Santa Isabel",
+      "municipio": 1647
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103585,
+    "fields": {
+      "nombre": "Colonia San Antonio",
+      "municipio": 1647
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103586,
+    "fields": {
+      "nombre": "Iturraspe",
+      "municipio": 1647
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103587,
+    "fields": {
+      "nombre": "La California",
+      "municipio": 1647
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103588,
+    "fields": {
+      "nombre": "Colonia Candelaria",
+      "municipio": 1648
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103589,
+    "fields": {
+      "nombre": "Colonia Desmochado Afuera",
+      "municipio": 1648
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103590,
+    "fields": {
+      "nombre": "Colonia Las Flores",
+      "municipio": 1648
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103591,
+    "fields": {
+      "nombre": "Campo Rubiolo",
+      "municipio": 1650
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103592,
+    "fields": {
+      "nombre": "La Fronterita",
+      "municipio": 1650
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103593,
+    "fields": {
+      "nombre": "Campo Ambroggio",
+      "municipio": 1651
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103594,
+    "fields": {
+      "nombre": "Campo Ristorto",
+      "municipio": 1651
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103595,
+    "fields": {
+      "nombre": "Cañada El Cisne",
+      "municipio": 1651
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103596,
+    "fields": {
+      "nombre": "Colonia La Manuelita",
+      "municipio": 1651
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103597,
+    "fields": {
+      "nombre": "El Fortín",
+      "municipio": 1651
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103598,
+    "fields": {
+      "nombre": "Colonia Los Trojes",
+      "municipio": 1653
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103599,
+    "fields": {
+      "nombre": "Colonia Albertengo",
+      "municipio": 1654
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103600,
+    "fields": {
+      "nombre": "Colonia La Inés",
+      "municipio": 1654
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103601,
+    "fields": {
+      "nombre": "Coronel Rosetti",
+      "municipio": 1654
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103602,
+    "fields": {
+      "nombre": "Tarragona",
+      "municipio": 1654
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103603,
+    "fields": {
+      "nombre": "Colonia El Empalme",
+      "municipio": 1655
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103604,
+    "fields": {
+      "nombre": "La Escondida",
+      "municipio": 1655
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103605,
+    "fields": {
+      "nombre": "San Marcos de Venado Tuerto",
+      "municipio": 1655
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103606,
+    "fields": {
+      "nombre": "Campo Ballesteros",
+      "municipio": 1656
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103607,
+    "fields": {
+      "nombre": "Campo Chapino",
+      "municipio": 1656
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103608,
+    "fields": {
+      "nombre": "Campo Esperanza",
+      "municipio": 1657
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103609,
+    "fields": {
+      "nombre": "Campo Puerta",
+      "municipio": 1657
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103610,
+    "fields": {
+      "nombre": "Colonia El 25",
+      "municipio": 1657
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103611,
+    "fields": {
+      "nombre": "Campo Magnago",
+      "municipio": 1658
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103612,
+    "fields": {
+      "nombre": "Campo Moschen",
+      "municipio": 1658
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103613,
+    "fields": {
+      "nombre": "Campo Ramseyer",
+      "municipio": 1658
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103614,
+    "fields": {
+      "nombre": "Kilómetro 742",
+      "municipio": 1658
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103615,
+    "fields": {
+      "nombre": "Campo Leonhardt",
+      "municipio": 1660
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103616,
+    "fields": {
+      "nombre": "Doctor Barros Pazos",
+      "municipio": 1660
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103617,
+    "fields": {
+      "nombre": "La Lola",
+      "municipio": 1660
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103618,
+    "fields": {
+      "nombre": "Adela",
+      "municipio": 1661
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103619,
+    "fields": {
+      "nombre": "Campo Bello Norte",
+      "municipio": 1661
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103620,
+    "fields": {
+      "nombre": "Campo Bello Sur",
+      "municipio": 1661
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103621,
+    "fields": {
+      "nombre": "Campo Fantín",
+      "municipio": 1661
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103622,
+    "fields": {
+      "nombre": "Campo Piccoli",
+      "municipio": 1661
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103623,
+    "fields": {
+      "nombre": "Campo Yaccuzzi",
+      "municipio": 1661
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103624,
+    "fields": {
+      "nombre": "El Piave",
+      "municipio": 1661
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103625,
+    "fields": {
+      "nombre": "Kilómetro 403",
+      "municipio": 1661
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103626,
+    "fields": {
+      "nombre": "Kilómetro 407",
+      "municipio": 1661
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103627,
+    "fields": {
+      "nombre": "Las Mercedes",
+      "municipio": 1661
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103628,
+    "fields": {
+      "nombre": "Puerto Ocampo",
+      "municipio": 1661
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103629,
+    "fields": {
+      "nombre": "San Vicente",
+      "municipio": 1661
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103630,
+    "fields": {
+      "nombre": "Campo Carbonari",
+      "municipio": 1662
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103631,
+    "fields": {
+      "nombre": "Campo Cardini",
+      "municipio": 1662
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103632,
+    "fields": {
+      "nombre": "Campo Iadanza",
+      "municipio": 1662
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103633,
+    "fields": {
+      "nombre": "Campo Marinsalta",
+      "municipio": 1662
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103634,
+    "fields": {
+      "nombre": "Campo Torriglia",
+      "municipio": 1662
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103635,
+    "fields": {
+      "nombre": "Las Trojas",
+      "municipio": 1662
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103636,
+    "fields": {
+      "nombre": "Las Vascas",
+      "municipio": 1662
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103637,
+    "fields": {
+      "nombre": "Campo Barbero",
+      "municipio": 1663
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103638,
+    "fields": {
+      "nombre": "Balneario Laguna Paiva",
+      "municipio": 1664
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103639,
+    "fields": {
+      "nombre": "Balneario Esperanza",
+      "municipio": 1668
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103640,
+    "fields": {
+      "nombre": "Colonia Larrechea",
+      "municipio": 1668
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103641,
+    "fields": {
+      "nombre": "Colonia Pujol",
+      "municipio": 1668
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103642,
+    "fields": {
+      "nombre": "Rincón del Pintado",
+      "municipio": 1668
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103643,
+    "fields": {
+      "nombre": "San Wendelino",
+      "municipio": 1670
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103644,
+    "fields": {
+      "nombre": "Antonio Pini",
+      "municipio": 1671
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103645,
+    "fields": {
+      "nombre": "Campo Don Bosco",
+      "municipio": 1671
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103646,
+    "fields": {
+      "nombre": "Campo La Maruca",
+      "municipio": 1671
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103647,
+    "fields": {
+      "nombre": "Campo María Alicia",
+      "municipio": 1671
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103648,
+    "fields": {
+      "nombre": "Campo Pergolesi",
+      "municipio": 1671
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103649,
+    "fields": {
+      "nombre": "Colonia El Inca",
+      "municipio": 1671
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103650,
+    "fields": {
+      "nombre": "El Cacique",
+      "municipio": 1671
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103651,
+    "fields": {
+      "nombre": "El Palmar",
+      "municipio": 1671
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103652,
+    "fields": {
+      "nombre": "El Triángulo",
+      "municipio": 1671
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103653,
+    "fields": {
+      "nombre": "Los Charabones",
+      "municipio": 1671
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103654,
+    "fields": {
+      "nombre": "Tres Pozos",
+      "municipio": 1671
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103655,
+    "fields": {
+      "nombre": "Playa Mansa",
+      "municipio": 1672
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103656,
+    "fields": {
+      "nombre": "El Retiro",
+      "municipio": 1675
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103657,
+    "fields": {
+      "nombre": "Campo Caffaro",
+      "municipio": 1678
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103658,
+    "fields": {
+      "nombre": "Campo Grillo",
+      "municipio": 1678
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103659,
+    "fields": {
+      "nombre": "Campo Meshler",
+      "municipio": 1678
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103660,
+    "fields": {
+      "nombre": "Colonia El Bellaco",
+      "municipio": 1679
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103661,
+    "fields": {
+      "nombre": "San Francisco",
+      "municipio": 1679
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103662,
+    "fields": {
+      "nombre": "Vizcacheras",
+      "municipio": 1679
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103663,
+    "fields": {
+      "nombre": "Campo Mottura",
+      "municipio": 1680
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103664,
+    "fields": {
+      "nombre": "Campo Bessone",
+      "municipio": 1681
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103665,
+    "fields": {
+      "nombre": "Campo Althaus",
+      "municipio": 1682
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103666,
+    "fields": {
+      "nombre": "Campo Kaufmann",
+      "municipio": 1682
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103667,
+    "fields": {
+      "nombre": "Colonia Sager",
+      "municipio": 1682
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103668,
+    "fields": {
+      "nombre": "Colonia Wingeyer",
+      "municipio": 1682
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103669,
+    "fields": {
+      "nombre": "Costa del Toba",
+      "municipio": 1682
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103670,
+    "fields": {
+      "nombre": "El Gusano",
+      "municipio": 1682
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103671,
+    "fields": {
+      "nombre": "Campo Engler",
+      "municipio": 1683
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103672,
+    "fields": {
+      "nombre": "Campo La Vasconia",
+      "municipio": 1685
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103673,
+    "fields": {
+      "nombre": "Nueva Colonia Las Estacas",
+      "municipio": 1685
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103674,
+    "fields": {
+      "nombre": "Campo Ghiano",
+      "municipio": 1691
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103675,
+    "fields": {
+      "nombre": "Campo Riberi",
+      "municipio": 1691
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103676,
+    "fields": {
+      "nombre": "Campo Ulla",
+      "municipio": 1691
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103677,
+    "fields": {
+      "nombre": "Campo Durando",
+      "municipio": 1692
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103678,
+    "fields": {
+      "nombre": "Campo El Injerto",
+      "municipio": 1692
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103679,
+    "fields": {
+      "nombre": "Kilómetro 465",
+      "municipio": 1693
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103680,
+    "fields": {
+      "nombre": "Campo Baroni",
+      "municipio": 1694
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103681,
+    "fields": {
+      "nombre": "Colonia Doña Mariana",
+      "municipio": 1694
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103682,
+    "fields": {
+      "nombre": "Colonia Los Galpones",
+      "municipio": 1694
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103683,
+    "fields": {
+      "nombre": "El Aromal",
+      "municipio": 1694
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103684,
+    "fields": {
+      "nombre": "El Cristal",
+      "municipio": 1694
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103685,
+    "fields": {
+      "nombre": "Kilómetro 213",
+      "municipio": 1694
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103686,
+    "fields": {
+      "nombre": "La Hosca",
+      "municipio": 1694
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103687,
+    "fields": {
+      "nombre": "Las Aves",
+      "municipio": 1694
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103688,
+    "fields": {
+      "nombre": "Los Palmares",
+      "municipio": 1694
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103689,
+    "fields": {
+      "nombre": "Paraje La Cigüeña",
+      "municipio": 1694
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103690,
+    "fields": {
+      "nombre": "San Pedro",
+      "municipio": 1694
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103691,
+    "fields": {
+      "nombre": "Colonia Lussino",
+      "municipio": 1695
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103692,
+    "fields": {
+      "nombre": "Las Liebres",
+      "municipio": 1695
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103693,
+    "fields": {
+      "nombre": "Los Troncos",
+      "municipio": 1696
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103694,
+    "fields": {
+      "nombre": "Campo Charo",
+      "municipio": 1697
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103695,
+    "fields": {
+      "nombre": "Campo Gimbatti",
+      "municipio": 1697
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103696,
+    "fields": {
+      "nombre": "Campo Marinzalda",
+      "municipio": 1697
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103697,
+    "fields": {
+      "nombre": "Balneario Arequito",
+      "municipio": 1698
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103698,
+    "fields": {
+      "nombre": "Colonia La Posta",
+      "municipio": 1698
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103699,
+    "fields": {
+      "nombre": "La Viuda",
+      "municipio": 1698
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103700,
+    "fields": {
+      "nombre": "Cuatro Esquinas",
+      "municipio": 1700
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103701,
+    "fields": {
+      "nombre": "Campo Crenna",
+      "municipio": 1705
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103702,
+    "fields": {
+      "nombre": "Hansen",
+      "municipio": 1705
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103703,
+    "fields": {
+      "nombre": "Colonia Las Lonjas",
+      "municipio": 1708
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103704,
+    "fields": {
+      "nombre": "Colonia Los Prados",
+      "municipio": 1708
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103705,
+    "fields": {
+      "nombre": "Campo Baudino",
+      "municipio": 1709
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103706,
+    "fields": {
+      "nombre": "Campo Morello",
+      "municipio": 1709
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103707,
+    "fields": {
+      "nombre": "Campo La Nieva",
+      "municipio": 1710
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103708,
+    "fields": {
+      "nombre": "Aurelia Norte",
+      "municipio": 1711
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103709,
+    "fields": {
+      "nombre": "Campo Borgarello",
+      "municipio": 1712
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103710,
+    "fields": {
+      "nombre": "Campo Canavesio",
+      "municipio": 1712
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103711,
+    "fields": {
+      "nombre": "Casablanca",
+      "municipio": 1714
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103712,
+    "fields": {
+      "nombre": "Colonia Bigand",
+      "municipio": 1716
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103713,
+    "fields": {
+      "nombre": "Juan Manuel Estrada",
+      "municipio": 1717
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103714,
+    "fields": {
+      "nombre": "Mangoré",
+      "municipio": 1718
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103715,
+    "fields": {
+      "nombre": "Capilla Fassi",
+      "municipio": 1721
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103716,
+    "fields": {
+      "nombre": "Fidela",
+      "municipio": 1726
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103717,
+    "fields": {
+      "nombre": "Galisteo",
+      "municipio": 1727
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103718,
+    "fields": {
+      "nombre": "Kilómetro 483",
+      "municipio": 1728
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103719,
+    "fields": {
+      "nombre": "Hugentobler",
+      "municipio": 1729
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103720,
+    "fields": {
+      "nombre": "Colonia Reina Margarita",
+      "municipio": 1730
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103721,
+    "fields": {
+      "nombre": "Colonia Roccia",
+      "municipio": 1730
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103722,
+    "fields": {
+      "nombre": "Rodeo Chico",
+      "municipio": 1730
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103723,
+    "fields": {
+      "nombre": "Tres Colonias",
+      "municipio": 1730
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103724,
+    "fields": {
+      "nombre": "Campo Almendra",
+      "municipio": 1731
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103725,
+    "fields": {
+      "nombre": "Capilla Vottero",
+      "municipio": 1731
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103726,
+    "fields": {
+      "nombre": "Campo Giacosa",
+      "municipio": 1732
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103727,
+    "fields": {
+      "nombre": "Estación María Juana",
+      "municipio": 1733
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103728,
+    "fields": {
+      "nombre": "Mauá",
+      "municipio": 1734
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103729,
+    "fields": {
+      "nombre": "Campo Rivarossa",
+      "municipio": 1740
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103730,
+    "fields": {
+      "nombre": "Campo Piacenza",
+      "municipio": 1741
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103731,
+    "fields": {
+      "nombre": "Tacurales",
+      "municipio": 1743
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103732,
+    "fields": {
+      "nombre": "Campo Bertoni",
+      "municipio": 1744
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103733,
+    "fields": {
+      "nombre": "Kilómetro 501",
+      "municipio": 1747
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103734,
+    "fields": {
+      "nombre": "Campo Cuco",
+      "municipio": 1749
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103735,
+    "fields": {
+      "nombre": "Copacabana",
+      "municipio": 1749
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103736,
+    "fields": {
+      "nombre": "El Colorado",
+      "municipio": 1752
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103737,
+    "fields": {
+      "nombre": "Campo Fondato",
+      "municipio": 1753
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103738,
+    "fields": {
+      "nombre": "Oratorio Morante",
+      "municipio": 1754
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103739,
+    "fields": {
+      "nombre": "Tres Esquinas",
+      "municipio": 1754
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103740,
+    "fields": {
+      "nombre": "Campo Mugueta",
+      "municipio": 1755
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103741,
+    "fields": {
+      "nombre": "San Pedro",
+      "municipio": 1756
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103742,
+    "fields": {
+      "nombre": "Colonia Norte",
+      "municipio": 1758
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103743,
+    "fields": {
+      "nombre": "La Malagueña",
+      "municipio": 1760
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103744,
+    "fields": {
+      "nombre": "Francisco Paz",
+      "municipio": 1763
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103745,
+    "fields": {
+      "nombre": "Colonia Alberdi",
+      "municipio": 1765
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103746,
+    "fields": {
+      "nombre": "Cuatro Bocas",
+      "municipio": 1766
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103747,
+    "fields": {
+      "nombre": "Los Cerrillos",
+      "municipio": 1766
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103748,
+    "fields": {
+      "nombre": "Vuelta del Dorado",
+      "municipio": 1766
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103749,
+    "fields": {
+      "nombre": "San Joaquín",
+      "municipio": 1767
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103750,
+    "fields": {
+      "nombre": "Barrio SUPCE",
+      "municipio": 1768
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103751,
+    "fields": {
+      "nombre": "Campo del Medio",
+      "municipio": 1768
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103752,
+    "fields": {
+      "nombre": "Colonia Helvecia Oeste",
+      "municipio": 1768
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103753,
+    "fields": {
+      "nombre": "Colonia Helvecia Sur",
+      "municipio": 1768
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103754,
+    "fields": {
+      "nombre": "Colonia Norte",
+      "municipio": 1768
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103755,
+    "fields": {
+      "nombre": "El Laurel",
+      "municipio": 1768
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103756,
+    "fields": {
+      "nombre": "Las Cañas",
+      "municipio": 1768
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103757,
+    "fields": {
+      "nombre": "Algarrobos",
+      "municipio": 1769
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103758,
+    "fields": {
+      "nombre": "Parque El Ceibal",
+      "municipio": 1770
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103759,
+    "fields": {
+      "nombre": "Parque El Timbó",
+      "municipio": 1770
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103760,
+    "fields": {
+      "nombre": "La Picasa",
+      "municipio": 1771
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103761,
+    "fields": {
+      "nombre": "Campo Cullak",
+      "municipio": 1772
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103762,
+    "fields": {
+      "nombre": "Colonia Falucho",
+      "municipio": 1772
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103763,
+    "fields": {
+      "nombre": "El Abolengo",
+      "municipio": 1772
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103764,
+    "fields": {
+      "nombre": "El Cantor",
+      "municipio": 1773
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103765,
+    "fields": {
+      "nombre": "Rabiola",
+      "municipio": 1775
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103766,
+    "fields": {
+      "nombre": "Colonia La Argentina Chica",
+      "municipio": 1779
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103767,
+    "fields": {
+      "nombre": "Pueblo Viejo",
+      "municipio": 1779
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103768,
+    "fields": {
+      "nombre": "4 de Febrero",
+      "municipio": 1781
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103769,
+    "fields": {
+      "nombre": "El Jardín",
+      "municipio": 1781
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103770,
+    "fields": {
+      "nombre": "Santa Emilia",
+      "municipio": 1781
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103771,
+    "fields": {
+      "nombre": "Campo El Rincón",
+      "municipio": 1786
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103772,
+    "fields": {
+      "nombre": "Colonia Santa Lucía",
+      "municipio": 1787
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103773,
+    "fields": {
+      "nombre": "Campo Sierra",
+      "municipio": 1788
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103774,
+    "fields": {
+      "nombre": "Colonia Los Robles",
+      "municipio": 1790
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103775,
+    "fields": {
+      "nombre": "Cinco Esquinas",
+      "municipio": 1791
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103776,
+    "fields": {
+      "nombre": "Campo La Chingola",
+      "municipio": 1793
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103777,
+    "fields": {
+      "nombre": "Colonia Morgan",
+      "municipio": 1793
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103778,
+    "fields": {
+      "nombre": "Campo Langarica",
+      "municipio": 1794
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103779,
+    "fields": {
+      "nombre": "Campo Tardini",
+      "municipio": 1794
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103780,
+    "fields": {
+      "nombre": "Campo Gerardo",
+      "municipio": 1795
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103781,
+    "fields": {
+      "nombre": "Campo La Delia",
+      "municipio": 1795
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103782,
+    "fields": {
+      "nombre": "Campo Tazzioli",
+      "municipio": 1795
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103783,
+    "fields": {
+      "nombre": "Estación Teodelina",
+      "municipio": 1795
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103784,
+    "fields": {
+      "nombre": "Santa Juana",
+      "municipio": 1795
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103785,
+    "fields": {
+      "nombre": "Merceditas",
+      "municipio": 1796
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103786,
+    "fields": {
+      "nombre": "Campo Sager",
+      "municipio": 1797
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103787,
+    "fields": {
+      "nombre": "Campo Furrer",
+      "municipio": 1798
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103788,
+    "fields": {
+      "nombre": "El Ricardito",
+      "municipio": 1798
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103789,
+    "fields": {
+      "nombre": "La Diamela",
+      "municipio": 1798
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103790,
+    "fields": {
+      "nombre": "Campo Fiant",
+      "municipio": 1800
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103791,
+    "fields": {
+      "nombre": "Campo Hardy",
+      "municipio": 1800
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103792,
+    "fields": {
+      "nombre": "Campo Stangaferro",
+      "municipio": 1800
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103793,
+    "fields": {
+      "nombre": "Kilómetro 54",
+      "municipio": 1800
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103794,
+    "fields": {
+      "nombre": "Puerto Piracuacito",
+      "municipio": 1800
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103795,
+    "fields": {
+      "nombre": "Campo Morzán",
+      "municipio": 1801
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103796,
+    "fields": {
+      "nombre": "Colonia El Yaguaré",
+      "municipio": 1801
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103797,
+    "fields": {
+      "nombre": "Costa Rica",
+      "municipio": 1801
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103798,
+    "fields": {
+      "nombre": "Arroyo del Rey",
+      "municipio": 1803
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103799,
+    "fields": {
+      "nombre": "Campo Ubajó",
+      "municipio": 1803
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103800,
+    "fields": {
+      "nombre": "Kilómetro 41",
+      "municipio": 1803
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103801,
+    "fields": {
+      "nombre": "Los Lapachos",
+      "municipio": 1803
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103802,
+    "fields": {
+      "nombre": "Tres Bocas",
+      "municipio": 1803
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103803,
+    "fields": {
+      "nombre": "Tres Isletas",
+      "municipio": 1803
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103804,
+    "fields": {
+      "nombre": "Cuatro Bocas",
+      "municipio": 1804
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103805,
+    "fields": {
+      "nombre": "La Carola",
+      "municipio": 1804
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103806,
+    "fields": {
+      "nombre": "La Selva",
+      "municipio": 1804
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103807,
+    "fields": {
+      "nombre": "La Uno",
+      "municipio": 1804
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103808,
+    "fields": {
+      "nombre": "La Vanguardia",
+      "municipio": 1804
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103809,
+    "fields": {
+      "nombre": "Víctor Manuel",
+      "municipio": 1804
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103810,
+    "fields": {
+      "nombre": "Campo Bonazola",
+      "municipio": 1805
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103811,
+    "fields": {
+      "nombre": "Fortín Arenales",
+      "municipio": 1805
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103812,
+    "fields": {
+      "nombre": "La Británica",
+      "municipio": 1805
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103813,
+    "fields": {
+      "nombre": "Las Taperitas",
+      "municipio": 1805
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103814,
+    "fields": {
+      "nombre": "Siete Provincias",
+      "municipio": 1805
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103815,
+    "fields": {
+      "nombre": "Campo Mendoza",
+      "municipio": 1806
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103816,
+    "fields": {
+      "nombre": "Costa Itatí",
+      "municipio": 1806
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103817,
+    "fields": {
+      "nombre": "El Farolito",
+      "municipio": 1806
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103818,
+    "fields": {
+      "nombre": "La Esmeralda",
+      "municipio": 1806
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103819,
+    "fields": {
+      "nombre": "Las Amintas",
+      "municipio": 1806
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103820,
+    "fields": {
+      "nombre": "La Potasa",
+      "municipio": 1807
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103821,
+    "fields": {
+      "nombre": "La Hortensia",
+      "municipio": 1809
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103822,
+    "fields": {
+      "nombre": "Campo Redondo",
+      "municipio": 1810
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103823,
+    "fields": {
+      "nombre": "Colonia Piloto",
+      "municipio": 1810
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103824,
+    "fields": {
+      "nombre": "El Amargo",
+      "municipio": 1810
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103825,
+    "fields": {
+      "nombre": "Guasuncho",
+      "municipio": 1810
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103826,
+    "fields": {
+      "nombre": "Kilómetro 67",
+      "municipio": 1810
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103827,
+    "fields": {
+      "nombre": "Mocoví",
+      "municipio": 1810
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103828,
+    "fields": {
+      "nombre": "Nogués",
+      "municipio": 1811
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103829,
+    "fields": {
+      "nombre": "Ramal San Juan",
+      "municipio": 1811
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103830,
+    "fields": {
+      "nombre": "San Juan",
+      "municipio": 1811
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103831,
+    "fields": {
+      "nombre": "Campo Mosca",
+      "municipio": 1812
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103832,
+    "fields": {
+      "nombre": "Campo Ubino",
+      "municipio": 1812
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103833,
+    "fields": {
+      "nombre": "Campo Calcaterra",
+      "municipio": 1814
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103834,
+    "fields": {
+      "nombre": "El Ensayo",
+      "municipio": 1814
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103835,
+    "fields": {
+      "nombre": "La Germania",
+      "municipio": 1814
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103836,
+    "fields": {
+      "nombre": "Berreta",
+      "municipio": 1815
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103837,
+    "fields": {
+      "nombre": "Campo Medina",
+      "municipio": 1816
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103838,
+    "fields": {
+      "nombre": "Carcaraes",
+      "municipio": 1817
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103839,
+    "fields": {
+      "nombre": "Campo Rasetto",
+      "municipio": 1819
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103840,
+    "fields": {
+      "nombre": "Colonia El Carmen",
+      "municipio": 1819
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103841,
+    "fields": {
+      "nombre": "Loma Partida",
+      "municipio": 1821
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103842,
+    "fields": {
+      "nombre": "San Estanislao",
+      "municipio": 1821
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103843,
+    "fields": {
+      "nombre": "Paraje Cabal",
+      "municipio": 1824
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103844,
+    "fields": {
+      "nombre": "Los Bretes",
+      "municipio": 1825
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103845,
+    "fields": {
+      "nombre": "Estación Emilia",
+      "municipio": 1827
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103846,
+    "fields": {
+      "nombre": "Aromos",
+      "municipio": 1828
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103847,
+    "fields": {
+      "nombre": "Setúbal",
+      "municipio": 1829
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103848,
+    "fields": {
+      "nombre": "Balneario Esperanza",
+      "municipio": 1830
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103849,
+    "fields": {
+      "nombre": "Iriondo",
+      "municipio": 1830
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103850,
+    "fields": {
+      "nombre": "Rincón de Ávila",
+      "municipio": 1830
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103851,
+    "fields": {
+      "nombre": "Colonia Cavour",
+      "municipio": 1831
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103852,
+    "fields": {
+      "nombre": "La Teresita",
+      "municipio": 1832
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103853,
+    "fields": {
+      "nombre": "Grutly Norte",
+      "municipio": 1837
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103854,
+    "fields": {
+      "nombre": "Colonia Nueva Centro",
+      "municipio": 1839
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103855,
+    "fields": {
+      "nombre": "Colonia Nueva Norte",
+      "municipio": 1839
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103856,
+    "fields": {
+      "nombre": "Estación Humboldt",
+      "municipio": 1839
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103857,
+    "fields": {
+      "nombre": "Cantón de Zárate",
+      "municipio": 1848
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103858,
+    "fields": {
+      "nombre": "Las Higueritas",
+      "municipio": 1850
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103859,
+    "fields": {
+      "nombre": "La Vigilancia",
+      "municipio": 1851
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103860,
+    "fields": {
+      "nombre": "La Penca",
+      "municipio": 1852
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103861,
+    "fields": {
+      "nombre": "Campo Colla",
+      "municipio": 1853
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103862,
+    "fields": {
+      "nombre": "Coronel Rodríguez",
+      "municipio": 1853
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103863,
+    "fields": {
+      "nombre": "Santa María Centro",
+      "municipio": 1854
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103864,
+    "fields": {
+      "nombre": "Santa María Norte",
+      "municipio": 1855
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103865,
+    "fields": {
+      "nombre": "Colonia La Rinconada",
+      "municipio": 1857
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103866,
+    "fields": {
+      "nombre": "Soutomayor",
+      "municipio": 1857
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103867,
+    "fields": {
+      "nombre": "Nueva Italia",
+      "municipio": 1858
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103868,
+    "fields": {
+      "nombre": "Campo El Dormido",
+      "municipio": 1859
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103869,
+    "fields": {
+      "nombre": "El Salitral",
+      "municipio": 1859
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103870,
+    "fields": {
+      "nombre": "Fortín Seis",
+      "municipio": 1859
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103871,
+    "fields": {
+      "nombre": "Fortín Tacurú",
+      "municipio": 1859
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103872,
+    "fields": {
+      "nombre": "Cañada de las Víboras",
+      "municipio": 1860
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103873,
+    "fields": {
+      "nombre": "El Faro",
+      "municipio": 1860
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103874,
+    "fields": {
+      "nombre": "Kilómetro 468",
+      "municipio": 1860
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103875,
+    "fields": {
+      "nombre": "Juan de Garay",
+      "municipio": 1861
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103876,
+    "fields": {
+      "nombre": "Kilómetro 293",
+      "municipio": 1861
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103877,
+    "fields": {
+      "nombre": "Independencia",
+      "municipio": 1862
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103878,
+    "fields": {
+      "nombre": "Kilómetro 312",
+      "municipio": 1862
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103879,
+    "fields": {
+      "nombre": "La Florida",
+      "municipio": 1862
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103880,
+    "fields": {
+      "nombre": "Las Norias",
+      "municipio": 1862
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103881,
+    "fields": {
+      "nombre": "Campo Contarde",
+      "municipio": 1864
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103882,
+    "fields": {
+      "nombre": "Campo Las Mellizas",
+      "municipio": 1864
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103883,
+    "fields": {
+      "nombre": "Campo Los Claveles",
+      "municipio": 1864
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103884,
+    "fields": {
+      "nombre": "Colonia El Mate",
+      "municipio": 1864
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103885,
+    "fields": {
+      "nombre": "El Pirincho",
+      "municipio": 1864
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103886,
+    "fields": {
+      "nombre": "El Tunalito",
+      "municipio": 1864
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103887,
+    "fields": {
+      "nombre": "Sin Pereza",
+      "municipio": 1864
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103888,
+    "fields": {
+      "nombre": "La Curva",
+      "municipio": 1865
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103889,
+    "fields": {
+      "nombre": "Los Quebrachales",
+      "municipio": 1865
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103890,
+    "fields": {
+      "nombre": "Colonia Belgrano",
+      "municipio": 1866
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103891,
+    "fields": {
+      "nombre": "Colonia El Almagro",
+      "municipio": 1866
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103892,
+    "fields": {
+      "nombre": "Colonia El Dichoso",
+      "municipio": 1866
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103893,
+    "fields": {
+      "nombre": "Colonia La Avanzada",
+      "municipio": 1866
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103894,
+    "fields": {
+      "nombre": "Fortín Atahualpa",
+      "municipio": 1866
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103895,
+    "fields": {
+      "nombre": "La Hiedra",
+      "municipio": 1866
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103896,
+    "fields": {
+      "nombre": "Los Guasunchos",
+      "municipio": 1866
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103897,
+    "fields": {
+      "nombre": "Padre Pedro Iturralde",
+      "municipio": 1866
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103898,
+    "fields": {
+      "nombre": "San Isidoro",
+      "municipio": 1866
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103899,
+    "fields": {
+      "nombre": "Colonia Escribano",
+      "municipio": 1872
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103900,
+    "fields": {
+      "nombre": "Campo La Elvira",
+      "municipio": 1881
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103901,
+    "fields": {
+      "nombre": "El Lucero",
+      "municipio": 1883
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103902,
+    "fields": {
+      "nombre": "La Alicia",
+      "municipio": 1883
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103903,
+    "fields": {
+      "nombre": "Los Trebolares",
+      "municipio": 1883
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103904,
+    "fields": {
+      "nombre": "Achaval Rodríguez",
+      "municipio": 1884
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103905,
+    "fields": {
+      "nombre": "Colonia El Paguaycito",
+      "municipio": 1884
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103906,
+    "fields": {
+      "nombre": "La Christiani",
+      "municipio": 1885
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103907,
+    "fields": {
+      "nombre": "San Rafael",
+      "municipio": 1885
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103908,
+    "fields": {
+      "nombre": "Colonia Iztueta",
+      "municipio": 1886
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103909,
+    "fields": {
+      "nombre": "Colonia Torres",
+      "municipio": 1886
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103910,
+    "fields": {
+      "nombre": "La Clara",
+      "municipio": 1886
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103911,
+    "fields": {
+      "nombre": "La Frontera",
+      "municipio": 1886
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103912,
+    "fields": {
+      "nombre": "Colonia Mallmann",
+      "municipio": 1889
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103913,
+    "fields": {
+      "nombre": "Colonia Adolfo Alsina",
+      "municipio": 1890
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103914,
+    "fields": {
+      "nombre": "Campo Dalmasso",
+      "municipio": 1891
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103915,
+    "fields": {
+      "nombre": "Colonia Dos Rosas y La Legua",
+      "municipio": 1892
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103916,
+    "fields": {
+      "nombre": "Campo La Aurora",
+      "municipio": 1893
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103917,
+    "fields": {
+      "nombre": "La Esperanza",
+      "municipio": 1893
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103918,
+    "fields": {
+      "nombre": "Campo Massoni",
+      "municipio": 1894
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103919,
+    "fields": {
+      "nombre": "El Colonial",
+      "municipio": 1894
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103920,
+    "fields": {
+      "nombre": "El Tigre",
+      "municipio": 1894
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103921,
+    "fields": {
+      "nombre": "La Costa",
+      "municipio": 1894
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103922,
+    "fields": {
+      "nombre": "Colonia Clara",
+      "municipio": 1896
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103923,
+    "fields": {
+      "nombre": "Campo El Mataco",
+      "municipio": 1898
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103924,
+    "fields": {
+      "nombre": "Monte Las Avispas Negras",
+      "municipio": 1899
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103925,
+    "fields": {
+      "nombre": "Colonia Muchtnik",
+      "municipio": 1901
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103926,
+    "fields": {
+      "nombre": "Colonia Wavelberg",
+      "municipio": 1901
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103927,
+    "fields": {
+      "nombre": "Colonia El Algarrobal",
+      "municipio": 1902
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103928,
+    "fields": {
+      "nombre": "Campo Marengo",
+      "municipio": 1903
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103929,
+    "fields": {
+      "nombre": "La Sarita",
+      "municipio": 1903
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103930,
+    "fields": {
+      "nombre": "Monte Oscuridad",
+      "municipio": 1903
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103931,
+    "fields": {
+      "nombre": "Colonia Alcorta",
+      "municipio": 1906
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103932,
+    "fields": {
+      "nombre": "Portugalete",
+      "municipio": 1906
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103933,
+    "fields": {
+      "nombre": "Estación Santurce",
+      "municipio": 1907
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103934,
+    "fields": {
+      "nombre": "Rincón del Quebracho",
+      "municipio": 1908
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103935,
+    "fields": {
+      "nombre": "Estación Rincón del Quebracho",
+      "municipio": 1909
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103936,
+    "fields": {
+      "nombre": "María Eugenia",
+      "municipio": 1909
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103937,
+    "fields": {
+      "nombre": "Petronila",
+      "municipio": 1909
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103938,
+    "fields": {
+      "nombre": "Campo Botto",
+      "municipio": 1910
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103939,
+    "fields": {
+      "nombre": "La Gloria",
+      "municipio": 1910
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103940,
+    "fields": {
+      "nombre": "Colonia Alejandra",
+      "municipio": 1911
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103941,
+    "fields": {
+      "nombre": "Colonia La María",
+      "municipio": 1911
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103942,
+    "fields": {
+      "nombre": "El Ceibo",
+      "municipio": 1911
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103943,
+    "fields": {
+      "nombre": "El Progreso",
+      "municipio": 1911
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103944,
+    "fields": {
+      "nombre": "Los Corralitos",
+      "municipio": 1911
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103945,
+    "fields": {
+      "nombre": "Los Cuervos",
+      "municipio": 1911
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103946,
+    "fields": {
+      "nombre": "Los Jacintos",
+      "municipio": 1911
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103947,
+    "fields": {
+      "nombre": "Pájaro Blanco",
+      "municipio": 1911
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103948,
+    "fields": {
+      "nombre": "Villa San Antonio",
+      "municipio": 1911
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103949,
+    "fields": {
+      "nombre": "Campo Berli",
+      "municipio": 1913
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103950,
+    "fields": {
+      "nombre": "Campo Huber",
+      "municipio": 1913
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103951,
+    "fields": {
+      "nombre": "Colonia San Roque",
+      "municipio": 1913
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103952,
+    "fields": {
+      "nombre": "El 94",
+      "municipio": 1913
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103953,
+    "fields": {
+      "nombre": "Balneario Arocena",
+      "municipio": 1915
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103954,
+    "fields": {
+      "nombre": "Campo Piaggio",
+      "municipio": 1916
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103955,
+    "fields": {
+      "nombre": "Campo Genero",
+      "municipio": 1917
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103956,
+    "fields": {
+      "nombre": "Las Pencas",
+      "municipio": 1920
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103957,
+    "fields": {
+      "nombre": "Arroyo del Monje",
+      "municipio": 1921
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103958,
+    "fields": {
+      "nombre": "Oroño",
+      "municipio": 1922
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103959,
+    "fields": {
+      "nombre": "Colonia San José",
+      "municipio": 1926
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103960,
+    "fields": {
+      "nombre": "Colonia Angeloni",
+      "municipio": 1931
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103961,
+    "fields": {
+      "nombre": "Luciano Leiva",
+      "municipio": 1931
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103962,
+    "fields": {
+      "nombre": "La Clorinda",
+      "municipio": 1932
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103963,
+    "fields": {
+      "nombre": "La Camila",
+      "municipio": 1936
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103964,
+    "fields": {
+      "nombre": "Colonia La Mora",
+      "municipio": 1937
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103965,
+    "fields": {
+      "nombre": "La Rinconada",
+      "municipio": 1937
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103966,
+    "fields": {
+      "nombre": "Miguel Escalada",
+      "municipio": 1939
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103967,
+    "fields": {
+      "nombre": "Colonia La Hosca",
+      "municipio": 1940
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103968,
+    "fields": {
+      "nombre": "La Clara",
+      "municipio": 1940
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103969,
+    "fields": {
+      "nombre": "San Juan",
+      "municipio": 1941
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103970,
+    "fields": {
+      "nombre": "Villa Lastenia",
+      "municipio": 1941
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103971,
+    "fields": {
+      "nombre": "Colonia Ovejita",
+      "municipio": 1942
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103972,
+    "fields": {
+      "nombre": "Laguna del Platero",
+      "municipio": 1942
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103973,
+    "fields": {
+      "nombre": "La Cabaña",
+      "municipio": 1944
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103974,
+    "fields": {
+      "nombre": "La Negra",
+      "municipio": 1944
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103975,
+    "fields": {
+      "nombre": "Laguna del Plata",
+      "municipio": 1944
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103976,
+    "fields": {
+      "nombre": "Colonia Sol de Mayo",
+      "municipio": 1945
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103977,
+    "fields": {
+      "nombre": "Campo Risso",
+      "municipio": 1950
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103978,
+    "fields": {
+      "nombre": "Carcaraes",
+      "municipio": 1953
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103979,
+    "fields": {
+      "nombre": "Campo La Celia",
+      "municipio": 1954
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103980,
+    "fields": {
+      "nombre": "Maizales",
+      "municipio": 1954
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103981,
+    "fields": {
+      "nombre": "Colonia La Francia",
+      "municipio": 1955
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103982,
+    "fields": {
+      "nombre": "Campo Busso",
+      "municipio": 1956
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103983,
+    "fields": {
+      "nombre": "Campo María Teresa",
+      "municipio": 1956
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103984,
+    "fields": {
+      "nombre": "Campo Nicoli",
+      "municipio": 1956
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103985,
+    "fields": {
+      "nombre": "Campo Cravero",
+      "municipio": 1957
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103986,
+    "fields": {
+      "nombre": "Campo Oroño",
+      "municipio": 1958
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103987,
+    "fields": {
+      "nombre": "Campo Seveso",
+      "municipio": 1960
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103988,
+    "fields": {
+      "nombre": "Colonia Las Yerbas",
+      "municipio": 1960
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103989,
+    "fields": {
+      "nombre": "Campo Castro",
+      "municipio": 1962
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103990,
+    "fields": {
+      "nombre": "Santa Anita",
+      "municipio": 1963
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103991,
+    "fields": {
+      "nombre": "Campo La Unión",
+      "municipio": 1964
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103992,
+    "fields": {
+      "nombre": "Bajo Las Liebres",
+      "municipio": 1965
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103993,
+    "fields": {
+      "nombre": "Campo El 51",
+      "municipio": 1965
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103994,
+    "fields": {
+      "nombre": "Campo La Caledonia",
+      "municipio": 1966
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103995,
+    "fields": {
+      "nombre": "Campo Las Mellizas",
+      "municipio": 1966
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103996,
+    "fields": {
+      "nombre": "Campo Donnet",
+      "municipio": 1967
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103997,
+    "fields": {
+      "nombre": "Campo El Danubio",
+      "municipio": 1967
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103998,
+    "fields": {
+      "nombre": "Campo Oitana",
+      "municipio": 1967
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 103999,
+    "fields": {
+      "nombre": "Las Mellizas",
+      "municipio": 1968
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104000,
+    "fields": {
+      "nombre": "Kilómetro 375",
+      "municipio": 1969
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104001,
+    "fields": {
+      "nombre": "El Campanal",
+      "municipio": 1970
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104002,
+    "fields": {
+      "nombre": "El Chañar",
+      "municipio": 1970
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104003,
+    "fields": {
+      "nombre": "El Histórico",
+      "municipio": 1970
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104004,
+    "fields": {
+      "nombre": "Fortín Chilcas",
+      "municipio": 1970
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104005,
+    "fields": {
+      "nombre": "Kilómetro 48",
+      "municipio": 1970
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104006,
+    "fields": {
+      "nombre": "Kilómetro 70",
+      "municipio": 1970
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104007,
+    "fields": {
+      "nombre": "La Cigüeña",
+      "municipio": 1970
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104008,
+    "fields": {
+      "nombre": "La Sarnosa",
+      "municipio": 1970
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104009,
+    "fields": {
+      "nombre": "Lote 12",
+      "municipio": 1970
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104010,
+    "fields": {
+      "nombre": "Kilómetro 320",
+      "municipio": 1971
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104011,
+    "fields": {
+      "nombre": "La Loca",
+      "municipio": 1971
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104012,
+    "fields": {
+      "nombre": "Los Tres Pozos",
+      "municipio": 1971
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104013,
+    "fields": {
+      "nombre": "Campo María Rosa",
+      "municipio": 1972
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104014,
+    "fields": {
+      "nombre": "Florida",
+      "municipio": 1973
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104015,
+    "fields": {
+      "nombre": "Montenegro",
+      "municipio": 1973
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104016,
+    "fields": {
+      "nombre": "Campo Giauque",
+      "municipio": 1974
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104017,
+    "fields": {
+      "nombre": "Campo Rotella",
+      "municipio": 1974
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104018,
+    "fields": {
+      "nombre": "Campo San José",
+      "municipio": 1974
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104019,
+    "fields": {
+      "nombre": "Campo Taleb",
+      "municipio": 1974
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104020,
+    "fields": {
+      "nombre": "El 38",
+      "municipio": 1974
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104021,
+    "fields": {
+      "nombre": "El 44",
+      "municipio": 1974
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104022,
+    "fields": {
+      "nombre": "El Palmar",
+      "municipio": 1974
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104023,
+    "fields": {
+      "nombre": "El Peludo",
+      "municipio": 1974
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104024,
+    "fields": {
+      "nombre": "Kilómetro 13",
+      "municipio": 1974
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104025,
+    "fields": {
+      "nombre": "El ñacurutú",
+      "municipio": 1975
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104026,
+    "fields": {
+      "nombre": "Kilómetro 392",
+      "municipio": 1975
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104027,
+    "fields": {
+      "nombre": "La Blanca",
+      "municipio": 1975
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104028,
+    "fields": {
+      "nombre": "La Sombrilla",
+      "municipio": 1975
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104029,
+    "fields": {
+      "nombre": "La Viruela",
+      "municipio": 1975
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104030,
+    "fields": {
+      "nombre": "Kilómetro 28",
+      "municipio": 1976
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104031,
+    "fields": {
+      "nombre": "Paraje Los Tábanos",
+      "municipio": 1976
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104032,
+    "fields": {
+      "nombre": "Campo Colnaghi",
+      "municipio": 1977
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104033,
+    "fields": {
+      "nombre": "Campo Molassi",
+      "municipio": 1977
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104034,
+    "fields": {
+      "nombre": "Campo Pavicich",
+      "municipio": 1977
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104035,
+    "fields": {
+      "nombre": "Colonia Las Margaritas",
+      "municipio": 1977
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104036,
+    "fields": {
+      "nombre": "El ñandubay",
+      "municipio": 1977
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104037,
+    "fields": {
+      "nombre": "La Nicolosa",
+      "municipio": 1977
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104038,
+    "fields": {
+      "nombre": "La Rosario",
+      "municipio": 1977
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104039,
+    "fields": {
+      "nombre": "San Eugenio",
+      "municipio": 1977
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104040,
+    "fields": {
+      "nombre": "Guaycurú",
+      "municipio": 1978
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104041,
+    "fields": {
+      "nombre": "Kilómetro 282",
+      "municipio": 1978
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104042,
+    "fields": {
+      "nombre": "Kilómetro 293",
+      "municipio": 1978
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104043,
+    "fields": {
+      "nombre": "Lote 127",
+      "municipio": 1978
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104044,
+    "fields": {
+      "nombre": "Alberto Gerchunoff",
+      "municipio": 1981
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104045,
+    "fields": {
+      "nombre": "Colonia Barreros",
+      "municipio": 1981
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104046,
+    "fields": {
+      "nombre": "Colonia Genacito",
+      "municipio": 1981
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104047,
+    "fields": {
+      "nombre": "Colonia La Joya",
+      "municipio": 1981
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104048,
+    "fields": {
+      "nombre": "Colonia Levin",
+      "municipio": 1981
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104049,
+    "fields": {
+      "nombre": "Colonia Lucienville",
+      "municipio": 1981
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104050,
+    "fields": {
+      "nombre": "Colonia Santa Teresita",
+      "municipio": 1981
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104051,
+    "fields": {
+      "nombre": "Colonia Tuyutí",
+      "municipio": 1981
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104052,
+    "fields": {
+      "nombre": "Isla Juanicó",
+      "municipio": 1981
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104053,
+    "fields": {
+      "nombre": "Agustina Libarona",
+      "municipio": 1984
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104054,
+    "fields": {
+      "nombre": "Ahí Veremos",
+      "municipio": 1984
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104055,
+    "fields": {
+      "nombre": "Anca Overa",
+      "municipio": 1984
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104056,
+    "fields": {
+      "nombre": "Campo Alegre",
+      "municipio": 1984
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104057,
+    "fields": {
+      "nombre": "Campo Gallo",
+      "municipio": 1984
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104058,
+    "fields": {
+      "nombre": "Chañarito",
+      "municipio": 1984
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104059,
+    "fields": {
+      "nombre": "Colonia El Negrito",
+      "municipio": 1984
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104060,
+    "fields": {
+      "nombre": "Coronel Manuel L. Rico",
+      "municipio": 1984
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104061,
+    "fields": {
+      "nombre": "Donadeu",
+      "municipio": 1984
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104062,
+    "fields": {
+      "nombre": "El Bajo",
+      "municipio": 1984
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104063,
+    "fields": {
+      "nombre": "El Cadillal",
+      "municipio": 1984
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104064,
+    "fields": {
+      "nombre": "El Fisco",
+      "municipio": 1984
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104065,
+    "fields": {
+      "nombre": "El Milagro",
+      "municipio": 1984
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104066,
+    "fields": {
+      "nombre": "El Porvenir",
+      "municipio": 1984
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104067,
+    "fields": {
+      "nombre": "El Remanso",
+      "municipio": 1984
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104068,
+    "fields": {
+      "nombre": "El Setenta",
+      "municipio": 1984
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104069,
+    "fields": {
+      "nombre": "El Simbolar",
+      "municipio": 1984
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104070,
+    "fields": {
+      "nombre": "Esteros",
+      "municipio": 1984
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104071,
+    "fields": {
+      "nombre": "Huachana",
+      "municipio": 1984
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104072,
+    "fields": {
+      "nombre": "Ingrata Norte",
+      "municipio": 1984
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104073,
+    "fields": {
+      "nombre": "Ingrata Sur",
+      "municipio": 1984
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104074,
+    "fields": {
+      "nombre": "Jumial Grande",
+      "municipio": 1984
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104075,
+    "fields": {
+      "nombre": "La Frontera",
+      "municipio": 1984
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104076,
+    "fields": {
+      "nombre": "La Manga",
+      "municipio": 1984
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104077,
+    "fields": {
+      "nombre": "La Paloma",
+      "municipio": 1984
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104078,
+    "fields": {
+      "nombre": "Las Carpas",
+      "municipio": 1984
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104079,
+    "fields": {
+      "nombre": "Las Cejas",
+      "municipio": 1984
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104080,
+    "fields": {
+      "nombre": "Lote 48",
+      "municipio": 1984
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104081,
+    "fields": {
+      "nombre": "Lote 87",
+      "municipio": 1984
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104082,
+    "fields": {
+      "nombre": "Maninioj",
+      "municipio": 1984
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104083,
+    "fields": {
+      "nombre": "Milagros",
+      "municipio": 1984
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104084,
+    "fields": {
+      "nombre": "Monte Rico",
+      "municipio": 1984
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104085,
+    "fields": {
+      "nombre": "Noqueoj",
+      "municipio": 1984
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104086,
+    "fields": {
+      "nombre": "Nueva Esperanza",
+      "municipio": 1984
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104087,
+    "fields": {
+      "nombre": "Pasma",
+      "municipio": 1984
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104088,
+    "fields": {
+      "nombre": "Pozo Grande",
+      "municipio": 1984
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104089,
+    "fields": {
+      "nombre": "Pozo Limpio",
+      "municipio": 1984
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104090,
+    "fields": {
+      "nombre": "Pozo Muerto",
+      "municipio": 1984
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104091,
+    "fields": {
+      "nombre": "Pozo Salado",
+      "municipio": 1984
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104092,
+    "fields": {
+      "nombre": "Ranchitos",
+      "municipio": 1984
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104093,
+    "fields": {
+      "nombre": "Río Muerto",
+      "municipio": 1984
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104094,
+    "fields": {
+      "nombre": "Sachayoj",
+      "municipio": 1984
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104095,
+    "fields": {
+      "nombre": "Saladillo",
+      "municipio": 1984
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104096,
+    "fields": {
+      "nombre": "San Antonio",
+      "municipio": 1984
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104097,
+    "fields": {
+      "nombre": "San Francisco",
+      "municipio": 1984
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104098,
+    "fields": {
+      "nombre": "San Ramón",
+      "municipio": 1984
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104099,
+    "fields": {
+      "nombre": "Santa Cruz",
+      "municipio": 1984
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104100,
+    "fields": {
+      "nombre": "Santa Rosa",
+      "municipio": 1984
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104101,
+    "fields": {
+      "nombre": "Sol de Mayo",
+      "municipio": 1984
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104102,
+    "fields": {
+      "nombre": "Tacanitas",
+      "municipio": 1984
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104103,
+    "fields": {
+      "nombre": "Taco Pozo",
+      "municipio": 1984
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104104,
+    "fields": {
+      "nombre": "Toro Pozo",
+      "municipio": 1984
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104105,
+    "fields": {
+      "nombre": "Villa Palmar",
+      "municipio": 1984
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104106,
+    "fields": {
+      "nombre": "Cerro Bola",
+      "municipio": 1985
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104107,
+    "fields": {
+      "nombre": "El Balde Viejo",
+      "municipio": 1985
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104108,
+    "fields": {
+      "nombre": "El Cadillo",
+      "municipio": 1985
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104109,
+    "fields": {
+      "nombre": "El Quemado",
+      "municipio": 1985
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104110,
+    "fields": {
+      "nombre": "La Aguadita",
+      "municipio": 1985
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104111,
+    "fields": {
+      "nombre": "La Guanaca",
+      "municipio": 1985
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104112,
+    "fields": {
+      "nombre": "La Mudana",
+      "municipio": 1985
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104113,
+    "fields": {
+      "nombre": "La Patria",
+      "municipio": 1985
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104114,
+    "fields": {
+      "nombre": "La Tablada",
+      "municipio": 1985
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104115,
+    "fields": {
+      "nombre": "Los Medanitos",
+      "municipio": 1985
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104116,
+    "fields": {
+      "nombre": "Mogigasta",
+      "municipio": 1985
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104117,
+    "fields": {
+      "nombre": "Piedritas Rosadas",
+      "municipio": 1985
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104118,
+    "fields": {
+      "nombre": "Puesto Los Dos Pozos",
+      "municipio": 1985
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104119,
+    "fields": {
+      "nombre": "Represa del Tala",
+      "municipio": 1985
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104120,
+    "fields": {
+      "nombre": "San Tiburcio",
+      "municipio": 1985
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104121,
+    "fields": {
+      "nombre": "Agua Blanca",
+      "municipio": 1992
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104122,
+    "fields": {
+      "nombre": "Barrio Los Pinos",
+      "municipio": 1992
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104123,
+    "fields": {
+      "nombre": "Barrio Luján",
+      "municipio": 1992
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104124,
+    "fields": {
+      "nombre": "Colonia 3",
+      "municipio": 1992
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104125,
+    "fields": {
+      "nombre": "Colonia 5",
+      "municipio": 1992
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104126,
+    "fields": {
+      "nombre": "Colonia 6",
+      "municipio": 1992
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104127,
+    "fields": {
+      "nombre": "Colonia 8",
+      "municipio": 1992
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104128,
+    "fields": {
+      "nombre": "Colonia Sobrecasas",
+      "municipio": 1992
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104129,
+    "fields": {
+      "nombre": "Colonia Tres y Cuatro",
+      "municipio": 1992
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104130,
+    "fields": {
+      "nombre": "Guayal",
+      "municipio": 1992
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104131,
+    "fields": {
+      "nombre": "Kilómetro 102",
+      "municipio": 1992
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104132,
+    "fields": {
+      "nombre": "La Banda",
+      "municipio": 1992
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104133,
+    "fields": {
+      "nombre": "La Rinconada",
+      "municipio": 1992
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104134,
+    "fields": {
+      "nombre": "Los Laureles Norte",
+      "municipio": 1992
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104135,
+    "fields": {
+      "nombre": "Montañita",
+      "municipio": 1992
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104136,
+    "fields": {
+      "nombre": "Monte Grande",
+      "municipio": 1992
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104137,
+    "fields": {
+      "nombre": "San Gabriel del Monte",
+      "municipio": 1992
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104138,
+    "fields": {
+      "nombre": "Sauce Huascho",
+      "municipio": 1992
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104139,
+    "fields": {
+      "nombre": "Tres Almacenes",
+      "municipio": 1992
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104140,
+    "fields": {
+      "nombre": "Alto del Puesto",
+      "municipio": 1993
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104141,
+    "fields": {
+      "nombre": "Campo Bello",
+      "municipio": 1993
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104142,
+    "fields": {
+      "nombre": "Campo Grande",
+      "municipio": 1993
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104143,
+    "fields": {
+      "nombre": "Cara Huasi",
+      "municipio": 1993
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104144,
+    "fields": {
+      "nombre": "Casas Viejas",
+      "municipio": 1993
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104145,
+    "fields": {
+      "nombre": "Chacras Viejas",
+      "municipio": 1993
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104146,
+    "fields": {
+      "nombre": "El Barranquero",
+      "municipio": 1993
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104147,
+    "fields": {
+      "nombre": "El Mistol",
+      "municipio": 1993
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104148,
+    "fields": {
+      "nombre": "El Palacho",
+      "municipio": 1993
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104149,
+    "fields": {
+      "nombre": "El Sauzal",
+      "municipio": 1993
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104150,
+    "fields": {
+      "nombre": "Ichipuca",
+      "municipio": 1993
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104151,
+    "fields": {
+      "nombre": "Kilómetro 15",
+      "municipio": 1993
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104152,
+    "fields": {
+      "nombre": "La Cañada (comuna Graneros)",
+      "municipio": 1993
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104153,
+    "fields": {
+      "nombre": "La Concepción",
+      "municipio": 1993
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104154,
+    "fields": {
+      "nombre": "Los Agudos",
+      "municipio": 1993
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104155,
+    "fields": {
+      "nombre": "Los Díaz",
+      "municipio": 1993
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104156,
+    "fields": {
+      "nombre": "Los Gramajos",
+      "municipio": 1993
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104157,
+    "fields": {
+      "nombre": "Nueva Trinidad",
+      "municipio": 1993
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104158,
+    "fields": {
+      "nombre": "Pozo del Arbolito",
+      "municipio": 1993
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104159,
+    "fields": {
+      "nombre": "Pozo Jume",
+      "municipio": 1993
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104160,
+    "fields": {
+      "nombre": "Pueblo Nuevo",
+      "municipio": 1993
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104161,
+    "fields": {
+      "nombre": "Taco Rodeo",
+      "municipio": 1993
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104162,
+    "fields": {
+      "nombre": "Tala Sacha",
+      "municipio": 1993
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104163,
+    "fields": {
+      "nombre": "Casas Viejas",
+      "municipio": 1994
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104164,
+    "fields": {
+      "nombre": "Huaico",
+      "municipio": 1994
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104165,
+    "fields": {
+      "nombre": "Huanca Loma",
+      "municipio": 1994
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104166,
+    "fields": {
+      "nombre": "La Posta",
+      "municipio": 1994
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104167,
+    "fields": {
+      "nombre": "Pozo de la Esquina",
+      "municipio": 1994
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104168,
+    "fields": {
+      "nombre": "El Ceibal",
+      "municipio": 1995
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104169,
+    "fields": {
+      "nombre": "La Bolsa",
+      "municipio": 1995
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104170,
+    "fields": {
+      "nombre": "María Elena",
+      "municipio": 1995
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104171,
+    "fields": {
+      "nombre": "2 de Abril",
+      "municipio": 1996
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104172,
+    "fields": {
+      "nombre": "El Tuscal",
+      "municipio": 1996
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104173,
+    "fields": {
+      "nombre": "Santa Rosa",
+      "municipio": 1996
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104174,
+    "fields": {
+      "nombre": "La Aguadita",
+      "municipio": 1997
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104175,
+    "fields": {
+      "nombre": "Antonio de Biedma",
+      "municipio": 1998
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104176,
+    "fields": {
+      "nombre": "Bahía del Fondo",
+      "municipio": 1998
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104177,
+    "fields": {
+      "nombre": "Bahía Laura",
+      "municipio": 1998
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104178,
+    "fields": {
+      "nombre": "Bahía Oso Marino",
+      "municipio": 1998
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104179,
+    "fields": {
+      "nombre": "Bahía Uruguay",
+      "municipio": 1998
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104180,
+    "fields": {
+      "nombre": "Bosques Petrificados",
+      "municipio": 1998
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104181,
+    "fields": {
+      "nombre": "Cabo Blanco",
+      "municipio": 1998
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104182,
+    "fields": {
+      "nombre": "Cañadón del Puerto",
+      "municipio": 1998
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104183,
+    "fields": {
+      "nombre": "Cerro Blanco",
+      "municipio": 1998
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104184,
+    "fields": {
+      "nombre": "Cerro Negro",
+      "municipio": 1998
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104185,
+    "fields": {
+      "nombre": "Cerro Vanguardia",
+      "municipio": 1998
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104186,
+    "fields": {
+      "nombre": "Gobernador Moyano",
+      "municipio": 1998
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104187,
+    "fields": {
+      "nombre": "Koluel Kaike",
+      "municipio": 1998
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104188,
+    "fields": {
+      "nombre": "La Cabaña",
+      "municipio": 1998
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104189,
+    "fields": {
+      "nombre": "La Lobería",
+      "municipio": 1998
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104190,
+    "fields": {
+      "nombre": "Los Monos",
+      "municipio": 1998
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104191,
+    "fields": {
+      "nombre": "Mazarredo",
+      "municipio": 1998
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104192,
+    "fields": {
+      "nombre": "Médanos Negros",
+      "municipio": 1998
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104193,
+    "fields": {
+      "nombre": "Minerales",
+      "municipio": 1998
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104194,
+    "fields": {
+      "nombre": "Monte Loayza",
+      "municipio": 1998
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104195,
+    "fields": {
+      "nombre": "Pampa Alta",
+      "municipio": 1998
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104196,
+    "fields": {
+      "nombre": "Piedra Clavada",
+      "municipio": 1998
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104197,
+    "fields": {
+      "nombre": "Playa Alsina",
+      "municipio": 1998
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104198,
+    "fields": {
+      "nombre": "Playa La Escondida",
+      "municipio": 1998
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104199,
+    "fields": {
+      "nombre": "Playa La Golondrina",
+      "municipio": 1998
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104200,
+    "fields": {
+      "nombre": "Playa La Zaranda",
+      "municipio": 1998
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104201,
+    "fields": {
+      "nombre": "Playa Punta Maqueda",
+      "municipio": 1998
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104202,
+    "fields": {
+      "nombre": "Punta Buque",
+      "municipio": 1998
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104203,
+    "fields": {
+      "nombre": "Ramón Lista",
+      "municipio": 1998
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104204,
+    "fields": {
+      "nombre": "San José",
+      "municipio": 1998
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104205,
+    "fields": {
+      "nombre": "Tehuelches",
+      "municipio": 1998
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104206,
+    "fields": {
+      "nombre": "Laguna de Robles",
+      "municipio": 1999
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104207,
+    "fields": {
+      "nombre": "Las Colas",
+      "municipio": 1999
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104208,
+    "fields": {
+      "nombre": "Las Zanjas",
+      "municipio": 1999
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104209,
+    "fields": {
+      "nombre": "Cañada de Alzogaray",
+      "municipio": 2000
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104210,
+    "fields": {
+      "nombre": "El Espinillo",
+      "municipio": 2000
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104211,
+    "fields": {
+      "nombre": "El Naranjito",
+      "municipio": 2000
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104212,
+    "fields": {
+      "nombre": "Fagalde",
+      "municipio": 2000
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104213,
+    "fields": {
+      "nombre": "La Calera",
+      "municipio": 2000
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104214,
+    "fields": {
+      "nombre": "La Marta",
+      "municipio": 2000
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104215,
+    "fields": {
+      "nombre": "Mariño",
+      "municipio": 2000
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104216,
+    "fields": {
+      "nombre": "San José",
+      "municipio": 2000
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104217,
+    "fields": {
+      "nombre": "Taco Palta",
+      "municipio": 2000
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104218,
+    "fields": {
+      "nombre": "Taquello",
+      "municipio": 2000
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104219,
+    "fields": {
+      "nombre": "El Sunchal",
+      "municipio": 2001
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104220,
+    "fields": {
+      "nombre": "Las Corzuelas",
+      "municipio": 2001
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104221,
+    "fields": {
+      "nombre": "Tranquitas",
+      "municipio": 2001
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104222,
+    "fields": {
+      "nombre": "Agua Blanca",
+      "municipio": 2002
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104223,
+    "fields": {
+      "nombre": "El 14",
+      "municipio": 2002
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104224,
+    "fields": {
+      "nombre": "El Morao",
+      "municipio": 2002
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104225,
+    "fields": {
+      "nombre": "El Puestito de Arriba",
+      "municipio": 2002
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104226,
+    "fields": {
+      "nombre": "El Rodeo de Arriba",
+      "municipio": 2002
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104227,
+    "fields": {
+      "nombre": "Kilómetro 37",
+      "municipio": 2002
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104228,
+    "fields": {
+      "nombre": "Las Higueras",
+      "municipio": 2002
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104229,
+    "fields": {
+      "nombre": "Loma Grande",
+      "municipio": 2002
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104230,
+    "fields": {
+      "nombre": "Pozo Cavado",
+      "municipio": 2002
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104231,
+    "fields": {
+      "nombre": "Requelme",
+      "municipio": 2002
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104232,
+    "fields": {
+      "nombre": "San José de Arriba",
+      "municipio": 2002
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104233,
+    "fields": {
+      "nombre": "Santa María",
+      "municipio": 2002
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104234,
+    "fields": {
+      "nombre": "Alta Gracia",
+      "municipio": 2003
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104235,
+    "fields": {
+      "nombre": "El Cadillal",
+      "municipio": 2003
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104236,
+    "fields": {
+      "nombre": "El Matal",
+      "municipio": 2003
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104237,
+    "fields": {
+      "nombre": "El Mollar",
+      "municipio": 2003
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104238,
+    "fields": {
+      "nombre": "La Ciénaga",
+      "municipio": 2003
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104239,
+    "fields": {
+      "nombre": "Villa Los Britos",
+      "municipio": 2003
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104240,
+    "fields": {
+      "nombre": "El Triunfo",
+      "municipio": 2004
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104241,
+    "fields": {
+      "nombre": "Kilómetro 770",
+      "municipio": 2004
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104242,
+    "fields": {
+      "nombre": "Paso de la Patria",
+      "municipio": 2004
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104243,
+    "fields": {
+      "nombre": "Puerta Alegre",
+      "municipio": 2004
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104244,
+    "fields": {
+      "nombre": "El Once",
+      "municipio": 2005
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104245,
+    "fields": {
+      "nombre": "La Soledad",
+      "municipio": 2005
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104246,
+    "fields": {
+      "nombre": "La Tuna",
+      "municipio": 2005
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104247,
+    "fields": {
+      "nombre": "La Virginia",
+      "municipio": 2005
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104248,
+    "fields": {
+      "nombre": "Los Mendoza",
+      "municipio": 2005
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104249,
+    "fields": {
+      "nombre": "Pozo 43",
+      "municipio": 2005
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104250,
+    "fields": {
+      "nombre": "Puesto del Medio",
+      "municipio": 2005
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104251,
+    "fields": {
+      "nombre": "San Carlos",
+      "municipio": 2005
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104252,
+    "fields": {
+      "nombre": "San Fernando",
+      "municipio": 2005
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104253,
+    "fields": {
+      "nombre": "San Miguel",
+      "municipio": 2005
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104254,
+    "fields": {
+      "nombre": "Santa Rosa",
+      "municipio": 2005
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104255,
+    "fields": {
+      "nombre": "Tala Pozo",
+      "municipio": 2005
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104256,
+    "fields": {
+      "nombre": "Villa Dolores",
+      "municipio": 2005
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104257,
+    "fields": {
+      "nombre": "Villa María",
+      "municipio": 2005
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104258,
+    "fields": {
+      "nombre": "El Barco",
+      "municipio": 2006
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104259,
+    "fields": {
+      "nombre": "El Sinquial",
+      "municipio": 2006
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104260,
+    "fields": {
+      "nombre": "La Cruz de Arriba",
+      "municipio": 2006
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104261,
+    "fields": {
+      "nombre": "Los Banegas",
+      "municipio": 2006
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104262,
+    "fields": {
+      "nombre": "San Patricio",
+      "municipio": 2006
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104263,
+    "fields": {
+      "nombre": "Villa Nueva",
+      "municipio": 2006
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104264,
+    "fields": {
+      "nombre": "Alto de Taruca",
+      "municipio": 2007
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104265,
+    "fields": {
+      "nombre": "El Churqui",
+      "municipio": 2007
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104266,
+    "fields": {
+      "nombre": "El Rincón",
+      "municipio": 2007
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104267,
+    "fields": {
+      "nombre": "El Tajamar",
+      "municipio": 2007
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104268,
+    "fields": {
+      "nombre": "La Toma",
+      "municipio": 2007
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104269,
+    "fields": {
+      "nombre": "Agua de la Peña",
+      "municipio": 2008
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104270,
+    "fields": {
+      "nombre": "Agua Negra",
+      "municipio": 2008
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104271,
+    "fields": {
+      "nombre": "Alto de Medinas",
+      "municipio": 2008
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104272,
+    "fields": {
+      "nombre": "El Ojo",
+      "municipio": 2008
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104273,
+    "fields": {
+      "nombre": "El Tipal",
+      "municipio": 2008
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104274,
+    "fields": {
+      "nombre": "La Rinconada",
+      "municipio": 2008
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104275,
+    "fields": {
+      "nombre": "Las Lajitas",
+      "municipio": 2008
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104276,
+    "fields": {
+      "nombre": "Los Chorrillos",
+      "municipio": 2008
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104277,
+    "fields": {
+      "nombre": "Colonia 3 Sur",
+      "municipio": 2009
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104278,
+    "fields": {
+      "nombre": "Colonia 4 Sur",
+      "municipio": 2009
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104279,
+    "fields": {
+      "nombre": "Colonia 9 Sur",
+      "municipio": 2009
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104280,
+    "fields": {
+      "nombre": "Pueblo de Dios",
+      "municipio": 2009
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104281,
+    "fields": {
+      "nombre": "San Miguelito",
+      "municipio": 2009
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104282,
+    "fields": {
+      "nombre": "Los Decima",
+      "municipio": 2010
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104283,
+    "fields": {
+      "nombre": "Arenales",
+      "municipio": 2011
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104284,
+    "fields": {
+      "nombre": "Carbón Pozo",
+      "municipio": 2011
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104285,
+    "fields": {
+      "nombre": "Agua Dulce",
+      "municipio": 2012
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104286,
+    "fields": {
+      "nombre": "Camas Amontonadas",
+      "municipio": 2012
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104287,
+    "fields": {
+      "nombre": "Colonia San Vicente",
+      "municipio": 2012
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104288,
+    "fields": {
+      "nombre": "El Empalme (comuna El Naranjito)",
+      "municipio": 2012
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104289,
+    "fields": {
+      "nombre": "El Tala",
+      "municipio": 2012
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104290,
+    "fields": {
+      "nombre": "La Favorita",
+      "municipio": 2012
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104291,
+    "fields": {
+      "nombre": "Colonia 10",
+      "municipio": 2013
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104292,
+    "fields": {
+      "nombre": "Colonia 2",
+      "municipio": 2013
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104293,
+    "fields": {
+      "nombre": "Colonia 3",
+      "municipio": 2013
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104294,
+    "fields": {
+      "nombre": "Colonia 4",
+      "municipio": 2013
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104295,
+    "fields": {
+      "nombre": "Colonia 8",
+      "municipio": 2013
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104296,
+    "fields": {
+      "nombre": "Colonia 9",
+      "municipio": 2013
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104297,
+    "fields": {
+      "nombre": "El Talar",
+      "municipio": 2013
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104298,
+    "fields": {
+      "nombre": "San José",
+      "municipio": 2014
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104299,
+    "fields": {
+      "nombre": "Santa Luisa",
+      "municipio": 2014
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104300,
+    "fields": {
+      "nombre": "Los Bulacios",
+      "municipio": 2015
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104301,
+    "fields": {
+      "nombre": "Villa Los Ponce",
+      "municipio": 2015
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104302,
+    "fields": {
+      "nombre": "Blanco Pozo",
+      "municipio": 2016
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104303,
+    "fields": {
+      "nombre": "El Sinqueal",
+      "municipio": 2016
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104304,
+    "fields": {
+      "nombre": "Los Cajales",
+      "municipio": 2016
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104305,
+    "fields": {
+      "nombre": "Los Lapachitos",
+      "municipio": 2017
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104306,
+    "fields": {
+      "nombre": "Los Pérez",
+      "municipio": 2017
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104307,
+    "fields": {
+      "nombre": "San Agustín",
+      "municipio": 2017
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104308,
+    "fields": {
+      "nombre": "Cañete",
+      "municipio": 2018
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104309,
+    "fields": {
+      "nombre": "Colonia 6 Sur",
+      "municipio": 2018
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104310,
+    "fields": {
+      "nombre": "Lolita Norte",
+      "municipio": 2018
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104311,
+    "fields": {
+      "nombre": "Lolita Sur",
+      "municipio": 2018
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104312,
+    "fields": {
+      "nombre": "Árbol Solo",
+      "municipio": 2019
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104313,
+    "fields": {
+      "nombre": "Campo La Flor",
+      "municipio": 2019
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104314,
+    "fields": {
+      "nombre": "Colonia 2 Sur",
+      "municipio": 2019
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104315,
+    "fields": {
+      "nombre": "Colonia Moyano",
+      "municipio": 2019
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104316,
+    "fields": {
+      "nombre": "El Ceibo",
+      "municipio": 2019
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104317,
+    "fields": {
+      "nombre": "El Empalme (comuna Ranchillos y San Miguel)",
+      "municipio": 2019
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104318,
+    "fields": {
+      "nombre": "Las Cejas",
+      "municipio": 2019
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104319,
+    "fields": {
+      "nombre": "Ranchillos Viejo",
+      "municipio": 2019
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104320,
+    "fields": {
+      "nombre": "San Miguel",
+      "municipio": 2019
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104321,
+    "fields": {
+      "nombre": "Colonia Elisa",
+      "municipio": 2020
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104322,
+    "fields": {
+      "nombre": "El Carmen",
+      "municipio": 2020
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104323,
+    "fields": {
+      "nombre": "Los Porceles",
+      "municipio": 2020
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104324,
+    "fields": {
+      "nombre": "Cochuna",
+      "municipio": 2021
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104325,
+    "fields": {
+      "nombre": "Cortaderas",
+      "municipio": 2021
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104326,
+    "fields": {
+      "nombre": "Dique El Molino",
+      "municipio": 2021
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104327,
+    "fields": {
+      "nombre": "Dique Villa Lola",
+      "municipio": 2021
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104328,
+    "fields": {
+      "nombre": "El Clavillo",
+      "municipio": 2021
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104329,
+    "fields": {
+      "nombre": "El Potrerillo",
+      "municipio": 2021
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104330,
+    "fields": {
+      "nombre": "El Remate",
+      "municipio": 2021
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104331,
+    "fields": {
+      "nombre": "El Solco",
+      "municipio": 2021
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104332,
+    "fields": {
+      "nombre": "La Calera",
+      "municipio": 2021
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104333,
+    "fields": {
+      "nombre": "Las Banderitas",
+      "municipio": 2021
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104334,
+    "fields": {
+      "nombre": "Las Lechiguanas",
+      "municipio": 2021
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104335,
+    "fields": {
+      "nombre": "Las Lenguas",
+      "municipio": 2021
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104336,
+    "fields": {
+      "nombre": "Los Chorizos",
+      "municipio": 2021
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104337,
+    "fields": {
+      "nombre": "Los Pinos",
+      "municipio": 2021
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104338,
+    "fields": {
+      "nombre": "Muyo",
+      "municipio": 2021
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104339,
+    "fields": {
+      "nombre": "Piedra Grande",
+      "municipio": 2021
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104340,
+    "fields": {
+      "nombre": "Saladillo",
+      "municipio": 2021
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104341,
+    "fields": {
+      "nombre": "Carreta Quemada",
+      "municipio": 2022
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104342,
+    "fields": {
+      "nombre": "El Ceibal",
+      "municipio": 2022
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104343,
+    "fields": {
+      "nombre": "La Refalada",
+      "municipio": 2022
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104344,
+    "fields": {
+      "nombre": "Los Gucheas",
+      "municipio": 2022
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104345,
+    "fields": {
+      "nombre": "Monte Rico Viejo",
+      "municipio": 2022
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104346,
+    "fields": {
+      "nombre": "Cochamoye",
+      "municipio": 2023
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104347,
+    "fields": {
+      "nombre": "Finca León Cornet",
+      "municipio": 2023
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104348,
+    "fields": {
+      "nombre": "Gastonilla (comuna Arcadia)",
+      "municipio": 2023
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104349,
+    "fields": {
+      "nombre": "Gastonilla (comuna Gastona y Belicha)",
+      "municipio": 2023
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104350,
+    "fields": {
+      "nombre": "La Aguada",
+      "municipio": 2023
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104351,
+    "fields": {
+      "nombre": "Las Faldas",
+      "municipio": 2023
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104352,
+    "fields": {
+      "nombre": "Llampa",
+      "municipio": 2023
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104353,
+    "fields": {
+      "nombre": "Belicha Huaico",
+      "municipio": 2024
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104354,
+    "fields": {
+      "nombre": "El Milagro",
+      "municipio": 2025
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104355,
+    "fields": {
+      "nombre": "La Esperanza",
+      "municipio": 2025
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104356,
+    "fields": {
+      "nombre": "La Nueva Esperanza",
+      "municipio": 2025
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104357,
+    "fields": {
+      "nombre": "San Carlos",
+      "municipio": 2025
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104358,
+    "fields": {
+      "nombre": "Colonia Yucumanita",
+      "municipio": 2026
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104359,
+    "fields": {
+      "nombre": "Humaitá",
+      "municipio": 2026
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104360,
+    "fields": {
+      "nombre": "San Ramón",
+      "municipio": 2026
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104361,
+    "fields": {
+      "nombre": "Yucumanita",
+      "municipio": 2026
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104362,
+    "fields": {
+      "nombre": "Amumpa",
+      "municipio": 2027
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104363,
+    "fields": {
+      "nombre": "Árboles Grandes",
+      "municipio": 2027
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104364,
+    "fields": {
+      "nombre": "Barrancas",
+      "municipio": 2027
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104365,
+    "fields": {
+      "nombre": "Belén",
+      "municipio": 2027
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104366,
+    "fields": {
+      "nombre": "Chañarcito",
+      "municipio": 2027
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104367,
+    "fields": {
+      "nombre": "El Espinal",
+      "municipio": 2027
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104368,
+    "fields": {
+      "nombre": "La Esperanza",
+      "municipio": 2027
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104369,
+    "fields": {
+      "nombre": "La Loma",
+      "municipio": 2027
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104370,
+    "fields": {
+      "nombre": "Las Ánimas",
+      "municipio": 2027
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104371,
+    "fields": {
+      "nombre": "Las Lomitas",
+      "municipio": 2027
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104372,
+    "fields": {
+      "nombre": "Los Cercos",
+      "municipio": 2027
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104373,
+    "fields": {
+      "nombre": "Los Ruiz",
+      "municipio": 2027
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104374,
+    "fields": {
+      "nombre": "Los Sauces",
+      "municipio": 2027
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104375,
+    "fields": {
+      "nombre": "Sol de Mayo",
+      "municipio": 2027
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104376,
+    "fields": {
+      "nombre": "Tres Pozos",
+      "municipio": 2027
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104377,
+    "fields": {
+      "nombre": "Villa Pujio",
+      "municipio": 2027
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104378,
+    "fields": {
+      "nombre": "Alto Verde",
+      "municipio": 2028
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104379,
+    "fields": {
+      "nombre": "Chañaritos",
+      "municipio": 2028
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104380,
+    "fields": {
+      "nombre": "El Achico",
+      "municipio": 2028
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104381,
+    "fields": {
+      "nombre": "El Cruce",
+      "municipio": 2028
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104382,
+    "fields": {
+      "nombre": "El Jardín",
+      "municipio": 2028
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104383,
+    "fields": {
+      "nombre": "El Paraíso",
+      "municipio": 2028
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104384,
+    "fields": {
+      "nombre": "El Puestito",
+      "municipio": 2028
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104385,
+    "fields": {
+      "nombre": "El Sesteadero",
+      "municipio": 2028
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104386,
+    "fields": {
+      "nombre": "El Simbol",
+      "municipio": 2028
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104387,
+    "fields": {
+      "nombre": "La Cañada (comuna Taco Ralo)",
+      "municipio": 2028
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104388,
+    "fields": {
+      "nombre": "La Chilca",
+      "municipio": 2028
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104389,
+    "fields": {
+      "nombre": "La Iguana",
+      "municipio": 2028
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104390,
+    "fields": {
+      "nombre": "La Paloma",
+      "municipio": 2028
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104391,
+    "fields": {
+      "nombre": "Los Cuenca",
+      "municipio": 2028
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104392,
+    "fields": {
+      "nombre": "Los Gómez",
+      "municipio": 2028
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104393,
+    "fields": {
+      "nombre": "Los Mistoles",
+      "municipio": 2028
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104394,
+    "fields": {
+      "nombre": "Los Ortíz",
+      "municipio": 2028
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104395,
+    "fields": {
+      "nombre": "Los Vázquez",
+      "municipio": 2028
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104396,
+    "fields": {
+      "nombre": "Pozo del Quebracho",
+      "municipio": 2028
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104397,
+    "fields": {
+      "nombre": "Pozo Hondo",
+      "municipio": 2028
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104398,
+    "fields": {
+      "nombre": "Puesto Los Pérez",
+      "municipio": 2028
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104399,
+    "fields": {
+      "nombre": "Ramos",
+      "municipio": 2028
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104400,
+    "fields": {
+      "nombre": "Sauce Huacho",
+      "municipio": 2028
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104401,
+    "fields": {
+      "nombre": "Villa Páez",
+      "municipio": 2028
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104402,
+    "fields": {
+      "nombre": "Viltrán",
+      "municipio": 2028
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104403,
+    "fields": {
+      "nombre": "Yapachín",
+      "municipio": 2028
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104404,
+    "fields": {
+      "nombre": "Dique de Escaba",
+      "municipio": 2029
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104405,
+    "fields": {
+      "nombre": "El Chorro",
+      "municipio": 2029
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104406,
+    "fields": {
+      "nombre": "El Mollar",
+      "municipio": 2029
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104407,
+    "fields": {
+      "nombre": "Escaba de Abajo",
+      "municipio": 2029
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104408,
+    "fields": {
+      "nombre": "Escaba de Arriba",
+      "municipio": 2029
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104409,
+    "fields": {
+      "nombre": "Villa de Escaba",
+      "municipio": 2029
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104410,
+    "fields": {
+      "nombre": "Alto Los Graneros",
+      "municipio": 2030
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104411,
+    "fields": {
+      "nombre": "Los Guayacanes",
+      "municipio": 2030
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104412,
+    "fields": {
+      "nombre": "Talamuyo",
+      "municipio": 2030
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104413,
+    "fields": {
+      "nombre": "Alto del Puesto",
+      "municipio": 2031
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104414,
+    "fields": {
+      "nombre": "El Huayco",
+      "municipio": 2031
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104415,
+    "fields": {
+      "nombre": "Kilómetro 9",
+      "municipio": 2031
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104416,
+    "fields": {
+      "nombre": "La Florida",
+      "municipio": 2031
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104417,
+    "fields": {
+      "nombre": "La Salvación",
+      "municipio": 2031
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104418,
+    "fields": {
+      "nombre": "Yanimas",
+      "municipio": 2031
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104419,
+    "fields": {
+      "nombre": "Bajastiné",
+      "municipio": 2032
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104420,
+    "fields": {
+      "nombre": "El Jardín",
+      "municipio": 2032
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104421,
+    "fields": {
+      "nombre": "Potrerillo",
+      "municipio": 2032
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104422,
+    "fields": {
+      "nombre": "Pueblo Viejo",
+      "municipio": 2032
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104423,
+    "fields": {
+      "nombre": "El Suncho",
+      "municipio": 2033
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104424,
+    "fields": {
+      "nombre": "Huacra",
+      "municipio": 2033
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104425,
+    "fields": {
+      "nombre": "Las Moreras",
+      "municipio": 2033
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104426,
+    "fields": {
+      "nombre": "La Tala Grande",
+      "municipio": 2034
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104427,
+    "fields": {
+      "nombre": "Puesto Nuevo",
+      "municipio": 2034
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104428,
+    "fields": {
+      "nombre": "El 25",
+      "municipio": 2035
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104429,
+    "fields": {
+      "nombre": "Villa Batiruana",
+      "municipio": 2035
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104430,
+    "fields": {
+      "nombre": "Agua Dulce",
+      "municipio": 2036
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104431,
+    "fields": {
+      "nombre": "Cóndor Huasi",
+      "municipio": 2036
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104432,
+    "fields": {
+      "nombre": "El Chilcal",
+      "municipio": 2036
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104433,
+    "fields": {
+      "nombre": "Fronterita",
+      "municipio": 2036
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104434,
+    "fields": {
+      "nombre": "La Soledad",
+      "municipio": 2036
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104435,
+    "fields": {
+      "nombre": "Laguna Blanca",
+      "municipio": 2036
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104436,
+    "fields": {
+      "nombre": "Lote de Agua Dulce",
+      "municipio": 2036
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104437,
+    "fields": {
+      "nombre": "Lotes de Agua Dulce",
+      "municipio": 2036
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104438,
+    "fields": {
+      "nombre": "Orán",
+      "municipio": 2036
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104439,
+    "fields": {
+      "nombre": "Talacocha",
+      "municipio": 2036
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104440,
+    "fields": {
+      "nombre": "Tusca Pozo",
+      "municipio": 2036
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104441,
+    "fields": {
+      "nombre": "Campo El Quimil",
+      "municipio": 2037
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104442,
+    "fields": {
+      "nombre": "Cañada de Viclos",
+      "municipio": 2037
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104443,
+    "fields": {
+      "nombre": "El Mojón",
+      "municipio": 2037
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104444,
+    "fields": {
+      "nombre": "El Suncho",
+      "municipio": 2037
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104445,
+    "fields": {
+      "nombre": "Mujer Muerta",
+      "municipio": 2037
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104446,
+    "fields": {
+      "nombre": "Rinconada",
+      "municipio": 2037
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104447,
+    "fields": {
+      "nombre": "Viclos",
+      "municipio": 2037
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104448,
+    "fields": {
+      "nombre": "El Sunchal (comuna Esquina y Mancopa)",
+      "municipio": 2038
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104449,
+    "fields": {
+      "nombre": "Erín",
+      "municipio": 2038
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104450,
+    "fields": {
+      "nombre": "Los Tucanes",
+      "municipio": 2038
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104451,
+    "fields": {
+      "nombre": "Mancopa Chico",
+      "municipio": 2038
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104452,
+    "fields": {
+      "nombre": "Las Tusquitas",
+      "municipio": 2039
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104453,
+    "fields": {
+      "nombre": "Melón",
+      "municipio": 2039
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104454,
+    "fields": {
+      "nombre": "Tres Pozos",
+      "municipio": 2039
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104455,
+    "fields": {
+      "nombre": "4 Sauces",
+      "municipio": 2040
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104456,
+    "fields": {
+      "nombre": "El Mollar (comuna Bella Vista)",
+      "municipio": 2040
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104457,
+    "fields": {
+      "nombre": "Casa de Tabla",
+      "municipio": 2041
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104458,
+    "fields": {
+      "nombre": "Chañar Muyo",
+      "municipio": 2041
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104459,
+    "fields": {
+      "nombre": "La Brea",
+      "municipio": 2041
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104460,
+    "fields": {
+      "nombre": "Las Cañadas",
+      "municipio": 2041
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104461,
+    "fields": {
+      "nombre": "Los Gómez Chico",
+      "municipio": 2041
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104462,
+    "fields": {
+      "nombre": "Los Juárez",
+      "municipio": 2041
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104463,
+    "fields": {
+      "nombre": "Los Lunarejos",
+      "municipio": 2041
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104464,
+    "fields": {
+      "nombre": "Nueva España",
+      "municipio": 2041
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104465,
+    "fields": {
+      "nombre": "Agua Salada",
+      "municipio": 2042
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104466,
+    "fields": {
+      "nombre": "Arroyo Mista",
+      "municipio": 2042
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104467,
+    "fields": {
+      "nombre": "Campo Azul",
+      "municipio": 2042
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104468,
+    "fields": {
+      "nombre": "Carancho Pozo",
+      "municipio": 2042
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104469,
+    "fields": {
+      "nombre": "El Mollar (comuna Los Puestos)",
+      "municipio": 2042
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104470,
+    "fields": {
+      "nombre": "Guardamonte",
+      "municipio": 2042
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104471,
+    "fields": {
+      "nombre": "La Florida",
+      "municipio": 2042
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104472,
+    "fields": {
+      "nombre": "Las Encrucijadas",
+      "municipio": 2042
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104473,
+    "fields": {
+      "nombre": "Los Britos",
+      "municipio": 2042
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104474,
+    "fields": {
+      "nombre": "Los Décima",
+      "municipio": 2042
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104475,
+    "fields": {
+      "nombre": "Los Díaz",
+      "municipio": 2042
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104476,
+    "fields": {
+      "nombre": "Los Gramajo",
+      "municipio": 2042
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104477,
+    "fields": {
+      "nombre": "Los Herrera",
+      "municipio": 2042
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104478,
+    "fields": {
+      "nombre": "Molle Pozo",
+      "municipio": 2042
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104479,
+    "fields": {
+      "nombre": "Monte Bello",
+      "municipio": 2042
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104480,
+    "fields": {
+      "nombre": "Puesto Chico",
+      "municipio": 2042
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104481,
+    "fields": {
+      "nombre": "El Ceibal",
+      "municipio": 2043
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104482,
+    "fields": {
+      "nombre": "La Encantada",
+      "municipio": 2044
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104483,
+    "fields": {
+      "nombre": "Paso de la Valentina",
+      "municipio": 2044
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104484,
+    "fields": {
+      "nombre": "Agua Azul",
+      "municipio": 2045
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104485,
+    "fields": {
+      "nombre": "El Cortaderal",
+      "municipio": 2045
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104486,
+    "fields": {
+      "nombre": "El Cruce",
+      "municipio": 2045
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104487,
+    "fields": {
+      "nombre": "La Encrucijada",
+      "municipio": 2045
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104488,
+    "fields": {
+      "nombre": "Las Mercedes",
+      "municipio": 2045
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104489,
+    "fields": {
+      "nombre": "Loma Verde",
+      "municipio": 2045
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104490,
+    "fields": {
+      "nombre": "Los Campero",
+      "municipio": 2045
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104491,
+    "fields": {
+      "nombre": "Los Fernández",
+      "municipio": 2045
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104492,
+    "fields": {
+      "nombre": "Puma Pozo",
+      "municipio": 2045
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104493,
+    "fields": {
+      "nombre": "Romera Pozo",
+      "municipio": 2045
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104494,
+    "fields": {
+      "nombre": "San Nicolás",
+      "municipio": 2045
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104495,
+    "fields": {
+      "nombre": "El Vizcacheral",
+      "municipio": 2046
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104496,
+    "fields": {
+      "nombre": "Los Quemados",
+      "municipio": 2046
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104497,
+    "fields": {
+      "nombre": "Los Zelayas",
+      "municipio": 2046
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104498,
+    "fields": {
+      "nombre": "Mista",
+      "municipio": 2046
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104499,
+    "fields": {
+      "nombre": "San Antonio",
+      "municipio": 2046
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104500,
+    "fields": {
+      "nombre": "Santa Teresita",
+      "municipio": 2046
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104501,
+    "fields": {
+      "nombre": "Vilca Pozo",
+      "municipio": 2046
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104502,
+    "fields": {
+      "nombre": "Loma Bola",
+      "municipio": 2047
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104503,
+    "fields": {
+      "nombre": "Malvinas",
+      "municipio": 2048
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104504,
+    "fields": {
+      "nombre": "Santa Bárbara",
+      "municipio": 2048
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104505,
+    "fields": {
+      "nombre": "El Duraznillo",
+      "municipio": 2049
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104506,
+    "fields": {
+      "nombre": "El Nogalito",
+      "municipio": 2049
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104507,
+    "fields": {
+      "nombre": "Mala Mala",
+      "municipio": 2049
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104508,
+    "fields": {
+      "nombre": "Potrero de las Tablas",
+      "municipio": 2049
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104509,
+    "fields": {
+      "nombre": "Alto Verde",
+      "municipio": 2050
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104510,
+    "fields": {
+      "nombre": "Arenillas",
+      "municipio": 2050
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104511,
+    "fields": {
+      "nombre": "La Ciénaga",
+      "municipio": 2050
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104512,
+    "fields": {
+      "nombre": "Los Robles",
+      "municipio": 2050
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104513,
+    "fields": {
+      "nombre": "Rincón de Valderrama",
+      "municipio": 2050
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104514,
+    "fields": {
+      "nombre": "Los Tirantes",
+      "municipio": 2052
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104515,
+    "fields": {
+      "nombre": "Pueblo Viejo",
+      "municipio": 2052
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104516,
+    "fields": {
+      "nombre": "Yacuchina",
+      "municipio": 2052
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104517,
+    "fields": {
+      "nombre": "Don Manuel",
+      "municipio": 2053
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104518,
+    "fields": {
+      "nombre": "El Churqui",
+      "municipio": 2053
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104519,
+    "fields": {
+      "nombre": "Orán",
+      "municipio": 2053
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104520,
+    "fields": {
+      "nombre": "Huasa Pampa",
+      "municipio": 2054
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104521,
+    "fields": {
+      "nombre": "Ibatín",
+      "municipio": 2054
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104522,
+    "fields": {
+      "nombre": "La Costa",
+      "municipio": 2054
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104523,
+    "fields": {
+      "nombre": "Los Escobar",
+      "municipio": 2054
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104524,
+    "fields": {
+      "nombre": "Los Nísperos",
+      "municipio": 2054
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104525,
+    "fields": {
+      "nombre": "Los Rojos",
+      "municipio": 2054
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104526,
+    "fields": {
+      "nombre": "Pilco",
+      "municipio": 2054
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104527,
+    "fields": {
+      "nombre": "Yonopongo",
+      "municipio": 2054
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104528,
+    "fields": {
+      "nombre": "El Indio",
+      "municipio": 2055
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104529,
+    "fields": {
+      "nombre": "El Nogalar",
+      "municipio": 2055
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104530,
+    "fields": {
+      "nombre": "Fin del Mundo",
+      "municipio": 2055
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104531,
+    "fields": {
+      "nombre": "La Ramadita",
+      "municipio": 2055
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104532,
+    "fields": {
+      "nombre": "Las Mesadas",
+      "municipio": 2055
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104533,
+    "fields": {
+      "nombre": "Pasada Honda",
+      "municipio": 2055
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104534,
+    "fields": {
+      "nombre": "Peña del Naranjal",
+      "municipio": 2055
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104535,
+    "fields": {
+      "nombre": "El 47",
+      "municipio": 2057
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104536,
+    "fields": {
+      "nombre": "Playa Larga",
+      "municipio": 2057
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104537,
+    "fields": {
+      "nombre": "La Florida",
+      "municipio": 2059
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104538,
+    "fields": {
+      "nombre": "Toma La Horqueta",
+      "municipio": 2059
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104539,
+    "fields": {
+      "nombre": "Toma Los Reales",
+      "municipio": 2059
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104540,
+    "fields": {
+      "nombre": "Santa Rita",
+      "municipio": 2060
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104541,
+    "fields": {
+      "nombre": "El Rincón",
+      "municipio": 2061
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104542,
+    "fields": {
+      "nombre": "El Rodeito",
+      "municipio": 2061
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104543,
+    "fields": {
+      "nombre": "Los Ríos",
+      "municipio": 2061
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104544,
+    "fields": {
+      "nombre": "Los Toneles",
+      "municipio": 2061
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104545,
+    "fields": {
+      "nombre": "Mal Paso",
+      "municipio": 2061
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104546,
+    "fields": {
+      "nombre": "Las Ánimas",
+      "municipio": 2062
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104547,
+    "fields": {
+      "nombre": "Mora Micuna",
+      "municipio": 2062
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104548,
+    "fields": {
+      "nombre": "Puente Cangregillo",
+      "municipio": 2062
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104549,
+    "fields": {
+      "nombre": "Ciudacita",
+      "municipio": 2063
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104550,
+    "fields": {
+      "nombre": "Las Juntas (comuna Ciudacita)",
+      "municipio": 2063
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104551,
+    "fields": {
+      "nombre": "Loma de Ciudacita",
+      "municipio": 2063
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104552,
+    "fields": {
+      "nombre": "Sueldos",
+      "municipio": 2063
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104553,
+    "fields": {
+      "nombre": "El Polear",
+      "municipio": 2064
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104554,
+    "fields": {
+      "nombre": "La Rinconada",
+      "municipio": 2064
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104555,
+    "fields": {
+      "nombre": "Rinconada Chica",
+      "municipio": 2064
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104556,
+    "fields": {
+      "nombre": "Arroyo Atahona",
+      "municipio": 2065
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104557,
+    "fields": {
+      "nombre": "Las Juntas (comuna Monteagudo)",
+      "municipio": 2065
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104558,
+    "fields": {
+      "nombre": "Lazarte",
+      "municipio": 2065
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104559,
+    "fields": {
+      "nombre": "Los Gómez",
+      "municipio": 2065
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104560,
+    "fields": {
+      "nombre": "Los Pérez",
+      "municipio": 2065
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104561,
+    "fields": {
+      "nombre": "Los Trejos",
+      "municipio": 2065
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104562,
+    "fields": {
+      "nombre": "Melcho",
+      "municipio": 2065
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104563,
+    "fields": {
+      "nombre": "Palominos",
+      "municipio": 2065
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104564,
+    "fields": {
+      "nombre": "Sud de Sandoval",
+      "municipio": 2065
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104565,
+    "fields": {
+      "nombre": "Sur Yaco",
+      "municipio": 2065
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104566,
+    "fields": {
+      "nombre": "Alderete",
+      "municipio": 2066
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104567,
+    "fields": {
+      "nombre": "Güemes de Arco",
+      "municipio": 2066
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104568,
+    "fields": {
+      "nombre": "Las Cejas",
+      "municipio": 2066
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104569,
+    "fields": {
+      "nombre": "Los Güemes",
+      "municipio": 2066
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104570,
+    "fields": {
+      "nombre": "Pampa Mayo",
+      "municipio": 2066
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104571,
+    "fields": {
+      "nombre": "San Antonio de Padua",
+      "municipio": 2066
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104572,
+    "fields": {
+      "nombre": "Alto Las Flores",
+      "municipio": 2067
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104573,
+    "fields": {
+      "nombre": "El Durazno",
+      "municipio": 2067
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104574,
+    "fields": {
+      "nombre": "El Pacará",
+      "municipio": 2067
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104575,
+    "fields": {
+      "nombre": "El Rodeo",
+      "municipio": 2067
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104576,
+    "fields": {
+      "nombre": "El Talar",
+      "municipio": 2067
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104577,
+    "fields": {
+      "nombre": "Esquina",
+      "municipio": 2067
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104578,
+    "fields": {
+      "nombre": "Los Agudos",
+      "municipio": 2067
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104579,
+    "fields": {
+      "nombre": "Los Arrieta",
+      "municipio": 2067
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104580,
+    "fields": {
+      "nombre": "Los Ceibos",
+      "municipio": 2067
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104581,
+    "fields": {
+      "nombre": "Los Soria",
+      "municipio": 2067
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104582,
+    "fields": {
+      "nombre": "Niogasta",
+      "municipio": 2067
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104583,
+    "fields": {
+      "nombre": "Santa Rosa",
+      "municipio": 2067
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104584,
+    "fields": {
+      "nombre": "Sud de Lazarte",
+      "municipio": 2067
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104585,
+    "fields": {
+      "nombre": "Sud de Trejos",
+      "municipio": 2067
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104586,
+    "fields": {
+      "nombre": "El Mollar",
+      "municipio": 2068
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104587,
+    "fields": {
+      "nombre": "El Puesto",
+      "municipio": 2068
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104588,
+    "fields": {
+      "nombre": "La Ensenada",
+      "municipio": 2068
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104589,
+    "fields": {
+      "nombre": "La Loma",
+      "municipio": 2069
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104590,
+    "fields": {
+      "nombre": "La Tuna",
+      "municipio": 2069
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104591,
+    "fields": {
+      "nombre": "El Vizcacheral",
+      "municipio": 2070
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104592,
+    "fields": {
+      "nombre": "La Bolsa",
+      "municipio": 2070
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104593,
+    "fields": {
+      "nombre": "La Florida",
+      "municipio": 2070
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104594,
+    "fields": {
+      "nombre": "Las Talitas",
+      "municipio": 2070
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104595,
+    "fields": {
+      "nombre": "Los Mendoza",
+      "municipio": 2070
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104596,
+    "fields": {
+      "nombre": "Rodeo Grande",
+      "municipio": 2070
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104597,
+    "fields": {
+      "nombre": "Calimonte",
+      "municipio": 2071
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104598,
+    "fields": {
+      "nombre": "Chañar Pozo",
+      "municipio": 2071
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104599,
+    "fields": {
+      "nombre": "El Antigal",
+      "municipio": 2071
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104600,
+    "fields": {
+      "nombre": "El Paraíso",
+      "municipio": 2071
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104601,
+    "fields": {
+      "nombre": "El Remate",
+      "municipio": 2071
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104602,
+    "fields": {
+      "nombre": "El Tío",
+      "municipio": 2071
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104603,
+    "fields": {
+      "nombre": "Encalilla",
+      "municipio": 2071
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104604,
+    "fields": {
+      "nombre": "La Fronterita",
+      "municipio": 2071
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104605,
+    "fields": {
+      "nombre": "Lara",
+      "municipio": 2071
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104606,
+    "fields": {
+      "nombre": "Los Cardones",
+      "municipio": 2071
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104607,
+    "fields": {
+      "nombre": "Los Corpitos",
+      "municipio": 2071
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104608,
+    "fields": {
+      "nombre": "Los Sauzales",
+      "municipio": 2071
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104609,
+    "fields": {
+      "nombre": "Molle Yaco",
+      "municipio": 2071
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104610,
+    "fields": {
+      "nombre": "Puerta de Julipao",
+      "municipio": 2071
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104611,
+    "fields": {
+      "nombre": "Salamanca",
+      "municipio": 2071
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104612,
+    "fields": {
+      "nombre": "Salas",
+      "municipio": 2071
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104613,
+    "fields": {
+      "nombre": "Tío Punco Chico",
+      "municipio": 2071
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104614,
+    "fields": {
+      "nombre": "Tío Punco Grande",
+      "municipio": 2071
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104615,
+    "fields": {
+      "nombre": "Yasyamayo",
+      "municipio": 2071
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104616,
+    "fields": {
+      "nombre": "Anchillos",
+      "municipio": 2072
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104617,
+    "fields": {
+      "nombre": "Anjuana",
+      "municipio": 2072
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104618,
+    "fields": {
+      "nombre": "Casa de Campo",
+      "municipio": 2072
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104619,
+    "fields": {
+      "nombre": "Chañar Solo",
+      "municipio": 2072
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104620,
+    "fields": {
+      "nombre": "Chorrillos",
+      "municipio": 2072
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104621,
+    "fields": {
+      "nombre": "El Arbolar",
+      "municipio": 2072
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104622,
+    "fields": {
+      "nombre": "El Bañado",
+      "municipio": 2072
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104623,
+    "fields": {
+      "nombre": "El Carmen",
+      "municipio": 2072
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104624,
+    "fields": {
+      "nombre": "El Molino",
+      "municipio": 2072
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104625,
+    "fields": {
+      "nombre": "El Paso",
+      "municipio": 2072
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104626,
+    "fields": {
+      "nombre": "Huasa Mayo",
+      "municipio": 2072
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104627,
+    "fields": {
+      "nombre": "Las Cañas",
+      "municipio": 2072
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104628,
+    "fields": {
+      "nombre": "Los Chañares",
+      "municipio": 2072
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104629,
+    "fields": {
+      "nombre": "Pichao",
+      "municipio": 2072
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104630,
+    "fields": {
+      "nombre": "Quilmes",
+      "municipio": 2072
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104631,
+    "fields": {
+      "nombre": "Quilmes Bajo",
+      "municipio": 2072
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104632,
+    "fields": {
+      "nombre": "Quilmes Centro",
+      "municipio": 2072
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104633,
+    "fields": {
+      "nombre": "Rincón de Quilmes",
+      "municipio": 2072
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104634,
+    "fields": {
+      "nombre": "Ruinas de Quilmes",
+      "municipio": 2072
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104635,
+    "fields": {
+      "nombre": "Talapazo",
+      "municipio": 2072
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104636,
+    "fields": {
+      "nombre": "El Mirador del Cóndor",
+      "municipio": 2073
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104637,
+    "fields": {
+      "nombre": "El Rincón",
+      "municipio": 2073
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104638,
+    "fields": {
+      "nombre": "Flores Amarillas",
+      "municipio": 2073
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104639,
+    "fields": {
+      "nombre": "La Angostura",
+      "municipio": 2073
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104640,
+    "fields": {
+      "nombre": "La Junta",
+      "municipio": 2073
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104641,
+    "fields": {
+      "nombre": "Los Alisos",
+      "municipio": 2073
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104642,
+    "fields": {
+      "nombre": "Ojo de Agua",
+      "municipio": 2073
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104643,
+    "fields": {
+      "nombre": "Potrerillo",
+      "municipio": 2073
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104644,
+    "fields": {
+      "nombre": "Quebrada del Portugués",
+      "municipio": 2073
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104645,
+    "fields": {
+      "nombre": "Rodeo Grande",
+      "municipio": 2073
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104646,
+    "fields": {
+      "nombre": "Santa Cruz",
+      "municipio": 2073
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104647,
+    "fields": {
+      "nombre": "Anfama",
+      "municipio": 2074
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104648,
+    "fields": {
+      "nombre": "Cruz Yampa",
+      "municipio": 2074
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104649,
+    "fields": {
+      "nombre": "El Abra",
+      "municipio": 2074
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104650,
+    "fields": {
+      "nombre": "Garabatal",
+      "municipio": 2074
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104651,
+    "fields": {
+      "nombre": "La Hoyada",
+      "municipio": 2074
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104652,
+    "fields": {
+      "nombre": "La Junta",
+      "municipio": 2074
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104653,
+    "fields": {
+      "nombre": "La Toma",
+      "municipio": 2074
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104654,
+    "fields": {
+      "nombre": "Las Tapias",
+      "municipio": 2074
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104655,
+    "fields": {
+      "nombre": "Los Planchones",
+      "municipio": 2074
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104656,
+    "fields": {
+      "nombre": "Parque Sierra de San Javier",
+      "municipio": 2074
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104657,
+    "fields": {
+      "nombre": "Sauce Yaco",
+      "municipio": 2074
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104658,
+    "fields": {
+      "nombre": "Aliso Morado",
+      "municipio": 2075
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104659,
+    "fields": {
+      "nombre": "Ancajuli",
+      "municipio": 2075
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104660,
+    "fields": {
+      "nombre": "Chasquivil",
+      "municipio": 2075
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104661,
+    "fields": {
+      "nombre": "Las Arquitas",
+      "municipio": 2075
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104662,
+    "fields": {
+      "nombre": "Peñas Azules",
+      "municipio": 2075
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104663,
+    "fields": {
+      "nombre": "San José de Chasquivil",
+      "municipio": 2075
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104664,
+    "fields": {
+      "nombre": "Vaca Huasi",
+      "municipio": 2075
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104665,
+    "fields": {
+      "nombre": "El Duraznito",
+      "municipio": 2077
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104666,
+    "fields": {
+      "nombre": "Las Cañitas",
+      "municipio": 2077
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104667,
+    "fields": {
+      "nombre": "Aragón",
+      "municipio": 2078
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104668,
+    "fields": {
+      "nombre": "Bobayaco",
+      "municipio": 2078
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104669,
+    "fields": {
+      "nombre": "Chuschagasta",
+      "municipio": 2078
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104670,
+    "fields": {
+      "nombre": "Colonia Choromoro",
+      "municipio": 2078
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104671,
+    "fields": {
+      "nombre": "El Chorro",
+      "municipio": 2078
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104672,
+    "fields": {
+      "nombre": "El Corral",
+      "municipio": 2078
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104673,
+    "fields": {
+      "nombre": "El ñorco",
+      "municipio": 2078
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104674,
+    "fields": {
+      "nombre": "Gonzalo",
+      "municipio": 2078
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104675,
+    "fields": {
+      "nombre": "Huasamayo",
+      "municipio": 2078
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104676,
+    "fields": {
+      "nombre": "La Higuera",
+      "municipio": 2078
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104677,
+    "fields": {
+      "nombre": "Las Juntas",
+      "municipio": 2078
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104678,
+    "fields": {
+      "nombre": "Potrero Grande",
+      "municipio": 2078
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104679,
+    "fields": {
+      "nombre": "Rodeo Grande",
+      "municipio": 2078
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104680,
+    "fields": {
+      "nombre": "San Vicente",
+      "municipio": 2078
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104681,
+    "fields": {
+      "nombre": "Vipos de Arriba",
+      "municipio": 2078
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104682,
+    "fields": {
+      "nombre": "Chulca",
+      "municipio": 2079
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104683,
+    "fields": {
+      "nombre": "El Quebrachal",
+      "municipio": 2079
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104684,
+    "fields": {
+      "nombre": "El Simbolar",
+      "municipio": 2079
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104685,
+    "fields": {
+      "nombre": "Hualinchay",
+      "municipio": 2079
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104686,
+    "fields": {
+      "nombre": "Piedra Pintada",
+      "municipio": 2079
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104687,
+    "fields": {
+      "nombre": "Rearte Sur",
+      "municipio": 2079
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104688,
+    "fields": {
+      "nombre": "San Fernando",
+      "municipio": 2079
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104689,
+    "fields": {
+      "nombre": "Tacanas Chicas",
+      "municipio": 2079
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104690,
+    "fields": {
+      "nombre": "Tacanas Grandes",
+      "municipio": 2079
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104691,
+    "fields": {
+      "nombre": "Tres Quebrachos",
+      "municipio": 2079
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104692,
+    "fields": {
+      "nombre": "Zárate Norte",
+      "municipio": 2079
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104693,
+    "fields": {
+      "nombre": "Zárate Sur",
+      "municipio": 2079
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104694,
+    "fields": {
+      "nombre": "Los Planchones",
+      "municipio": 2080
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104695,
+    "fields": {
+      "nombre": "Ticucho",
+      "municipio": 2080
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104696,
+    "fields": {
+      "nombre": "Toma del Río Vipos",
+      "municipio": 2080
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104697,
+    "fields": {
+      "nombre": "Bajo de la Baya",
+      "municipio": 2082
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104698,
+    "fields": {
+      "nombre": "Cortaderas",
+      "municipio": 2082
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104699,
+    "fields": {
+      "nombre": "Curacó",
+      "municipio": 2082
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104700,
+    "fields": {
+      "nombre": "El Trapial",
+      "municipio": 2082
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104701,
+    "fields": {
+      "nombre": "Paso de las Bardas",
+      "municipio": 2082
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104702,
+    "fields": {
+      "nombre": "San Eduardo",
+      "municipio": 2082
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104703,
+    "fields": {
+      "nombre": "Señal Cerro Bayo",
+      "municipio": 2082
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104704,
+    "fields": {
+      "nombre": "Sierra de Huantraico",
+      "municipio": 2082
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104705,
+    "fields": {
+      "nombre": "Bahía Fox Oeste",
+      "municipio": 2083
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104706,
+    "fields": {
+      "nombre": "Base Corbeta Uruguay",
+      "municipio": 2083
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104707,
+    "fields": {
+      "nombre": "Brazo Norte",
+      "municipio": 2083
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104708,
+    "fields": {
+      "nombre": "Puerto Agradable",
+      "municipio": 2083
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104709,
+    "fields": {
+      "nombre": "Puerto Argentino",
+      "municipio": 2083
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104710,
+    "fields": {
+      "nombre": "Puerto Darwin",
+      "municipio": 2083
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104711,
+    "fields": {
+      "nombre": "Puerto Leith",
+      "municipio": 2083
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104712,
+    "fields": {
+      "nombre": "Puerto Mitre",
+      "municipio": 2083
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104713,
+    "fields": {
+      "nombre": "Puerto San Carlos",
+      "municipio": 2083
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104714,
+    "fields": {
+      "nombre": "Puerto Soledad",
+      "municipio": 2083
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104715,
+    "fields": {
+      "nombre": "Árbol Blanco",
+      "municipio": 2084
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104716,
+    "fields": {
+      "nombre": "El Molino",
+      "municipio": 2084
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104717,
+    "fields": {
+      "nombre": "Ischilín",
+      "municipio": 2084
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104718,
+    "fields": {
+      "nombre": "Ischilín Viejo",
+      "municipio": 2084
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104719,
+    "fields": {
+      "nombre": "La Barranca",
+      "municipio": 2084
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104720,
+    "fields": {
+      "nombre": "La Botija",
+      "municipio": 2084
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104721,
+    "fields": {
+      "nombre": "La Cantera",
+      "municipio": 2084
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104722,
+    "fields": {
+      "nombre": "La Cienaguita",
+      "municipio": 2084
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104723,
+    "fields": {
+      "nombre": "La Higuerita",
+      "municipio": 2084
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104724,
+    "fields": {
+      "nombre": "Las Tuscas",
+      "municipio": 2084
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104725,
+    "fields": {
+      "nombre": "Los Talas",
+      "municipio": 2084
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104726,
+    "fields": {
+      "nombre": "Los Tártagos",
+      "municipio": 2084
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104727,
+    "fields": {
+      "nombre": "Masa",
+      "municipio": 2084
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104728,
+    "fields": {
+      "nombre": "Ongamira",
+      "municipio": 2084
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104729,
+    "fields": {
+      "nombre": "Palo Cortado",
+      "municipio": 2084
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104730,
+    "fields": {
+      "nombre": "Puerta Colorada",
+      "municipio": 2084
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104731,
+    "fields": {
+      "nombre": "Puesto de los Rodríguez",
+      "municipio": 2084
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104732,
+    "fields": {
+      "nombre": "Saguion",
+      "municipio": 2084
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104733,
+    "fields": {
+      "nombre": "San Bernardo",
+      "municipio": 2084
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104734,
+    "fields": {
+      "nombre": "San Pedro de Toyos",
+      "municipio": 2084
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104735,
+    "fields": {
+      "nombre": "Todos los Santos",
+      "municipio": 2084
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104736,
+    "fields": {
+      "nombre": "Bajo Alegre",
+      "municipio": 2085
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104737,
+    "fields": {
+      "nombre": "Bajo Hondo",
+      "municipio": 2085
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104738,
+    "fields": {
+      "nombre": "Buen Lugar",
+      "municipio": 2085
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104739,
+    "fields": {
+      "nombre": "Caschico",
+      "municipio": 2085
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104740,
+    "fields": {
+      "nombre": "Ceja Pozo",
+      "municipio": 2085
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104741,
+    "fields": {
+      "nombre": "El Arenal",
+      "municipio": 2085
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104742,
+    "fields": {
+      "nombre": "El Bagual",
+      "municipio": 2085
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104743,
+    "fields": {
+      "nombre": "El Bobadal",
+      "municipio": 2085
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104744,
+    "fields": {
+      "nombre": "El Cambiado",
+      "municipio": 2085
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104745,
+    "fields": {
+      "nombre": "El Charco",
+      "municipio": 2085
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104746,
+    "fields": {
+      "nombre": "El Churqui",
+      "municipio": 2085
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104747,
+    "fields": {
+      "nombre": "El Fisco de Fátima",
+      "municipio": 2085
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104748,
+    "fields": {
+      "nombre": "El Palomar",
+      "municipio": 2085
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104749,
+    "fields": {
+      "nombre": "El Rincón",
+      "municipio": 2085
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104750,
+    "fields": {
+      "nombre": "Gramilla",
+      "municipio": 2085
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104751,
+    "fields": {
+      "nombre": "Isca Yacu",
+      "municipio": 2085
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104752,
+    "fields": {
+      "nombre": "Isca Yacu Semaul",
+      "municipio": 2085
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104753,
+    "fields": {
+      "nombre": "La Costosa",
+      "municipio": 2085
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104754,
+    "fields": {
+      "nombre": "La Fortuna",
+      "municipio": 2085
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104755,
+    "fields": {
+      "nombre": "La Fortuna Este",
+      "municipio": 2085
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104756,
+    "fields": {
+      "nombre": "La Guanaca",
+      "municipio": 2085
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104757,
+    "fields": {
+      "nombre": "La Mesada",
+      "municipio": 2085
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104758,
+    "fields": {
+      "nombre": "La Verde",
+      "municipio": 2085
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104759,
+    "fields": {
+      "nombre": "Las Lomitas",
+      "municipio": 2085
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104760,
+    "fields": {
+      "nombre": "Las Puertas",
+      "municipio": 2085
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104761,
+    "fields": {
+      "nombre": "Los Ralos",
+      "municipio": 2085
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104762,
+    "fields": {
+      "nombre": "Los Santillán",
+      "municipio": 2085
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104763,
+    "fields": {
+      "nombre": "Mistol Puesto",
+      "municipio": 2085
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104764,
+    "fields": {
+      "nombre": "Monte Bello",
+      "municipio": 2085
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104765,
+    "fields": {
+      "nombre": "Monte Flor",
+      "municipio": 2085
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104766,
+    "fields": {
+      "nombre": "Nueva Luján",
+      "municipio": 2085
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104767,
+    "fields": {
+      "nombre": "Pacará",
+      "municipio": 2085
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104768,
+    "fields": {
+      "nombre": "Palos Quemados",
+      "municipio": 2085
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104769,
+    "fields": {
+      "nombre": "Pozo Hondo",
+      "municipio": 2085
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104770,
+    "fields": {
+      "nombre": "Puerto Grande",
+      "municipio": 2085
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104771,
+    "fields": {
+      "nombre": "Puesto Libertad",
+      "municipio": 2085
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104772,
+    "fields": {
+      "nombre": "San Andrés del Sur",
+      "municipio": 2085
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104773,
+    "fields": {
+      "nombre": "San Cristóbal",
+      "municipio": 2085
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104774,
+    "fields": {
+      "nombre": "San Félix",
+      "municipio": 2085
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104775,
+    "fields": {
+      "nombre": "San Gregorio",
+      "municipio": 2085
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104776,
+    "fields": {
+      "nombre": "San Javier",
+      "municipio": 2085
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104777,
+    "fields": {
+      "nombre": "San José",
+      "municipio": 2085
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104778,
+    "fields": {
+      "nombre": "San Pedro",
+      "municipio": 2085
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104779,
+    "fields": {
+      "nombre": "San Roque",
+      "municipio": 2085
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104780,
+    "fields": {
+      "nombre": "Santa Bárbara",
+      "municipio": 2085
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104781,
+    "fields": {
+      "nombre": "Santa Rosa",
+      "municipio": 2085
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104782,
+    "fields": {
+      "nombre": "Suri Pozo",
+      "municipio": 2085
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104783,
+    "fields": {
+      "nombre": "Toro Pozo",
+      "municipio": 2085
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104784,
+    "fields": {
+      "nombre": "Tres Cruces",
+      "municipio": 2085
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104785,
+    "fields": {
+      "nombre": "Tusca Pozo",
+      "municipio": 2085
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104786,
+    "fields": {
+      "nombre": "Vitiaca",
+      "municipio": 2085
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104787,
+    "fields": {
+      "nombre": "Barrio Sud América",
+      "municipio": 2089
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104788,
+    "fields": {
+      "nombre": "Buey Muerto",
+      "municipio": 2089
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104789,
+    "fields": {
+      "nombre": "Ceibo Trece",
+      "municipio": 2089
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104790,
+    "fields": {
+      "nombre": "Colonia La Primavera",
+      "municipio": 2089
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104791,
+    "fields": {
+      "nombre": "Colonia Los Santafesinos",
+      "municipio": 2089
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104792,
+    "fields": {
+      "nombre": "Colonia San Juan",
+      "municipio": 2089
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104793,
+    "fields": {
+      "nombre": "Colonia Sarmiento",
+      "municipio": 2089
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104794,
+    "fields": {
+      "nombre": "El Paraíso",
+      "municipio": 2089
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104795,
+    "fields": {
+      "nombre": "El Recodo",
+      "municipio": 2089
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104796,
+    "fields": {
+      "nombre": "Esperanza",
+      "municipio": 2089
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104797,
+    "fields": {
+      "nombre": "Frontera",
+      "municipio": 2089
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104798,
+    "fields": {
+      "nombre": "Isla Puén",
+      "municipio": 2089
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104799,
+    "fields": {
+      "nombre": "Isla Yabol Guazú",
+      "municipio": 2089
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104800,
+    "fields": {
+      "nombre": "José María Paz",
+      "municipio": 2089
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104801,
+    "fields": {
+      "nombre": "La Primavera",
+      "municipio": 2089
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104802,
+    "fields": {
+      "nombre": "Loma Hermosa",
+      "municipio": 2089
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104803,
+    "fields": {
+      "nombre": "Loma Tuyutu",
+      "municipio": 2089
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104804,
+    "fields": {
+      "nombre": "Lucero Cué",
+      "municipio": 2089
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104805,
+    "fields": {
+      "nombre": "Marcam",
+      "municipio": 2089
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104806,
+    "fields": {
+      "nombre": "Martín Fierro",
+      "municipio": 2089
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104807,
+    "fields": {
+      "nombre": "Palma Sola",
+      "municipio": 2089
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104808,
+    "fields": {
+      "nombre": "Paso Angelito",
+      "municipio": 2089
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104809,
+    "fields": {
+      "nombre": "Presidente Avellaneda",
+      "municipio": 2089
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104810,
+    "fields": {
+      "nombre": "Punta Guía",
+      "municipio": 2089
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104811,
+    "fields": {
+      "nombre": "Sol de Mayo",
+      "municipio": 2089
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104812,
+    "fields": {
+      "nombre": "Toro Paso",
+      "municipio": 2089
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104813,
+    "fields": {
+      "nombre": "Virasol",
+      "municipio": 2089
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104814,
+    "fields": {
+      "nombre": "Confluencia",
+      "municipio": 2090
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104815,
+    "fields": {
+      "nombre": "Cuyín Manzano",
+      "municipio": 2090
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104816,
+    "fields": {
+      "nombre": "El Portezuelo",
+      "municipio": 2090
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104817,
+    "fields": {
+      "nombre": "El Rincón",
+      "municipio": 2090
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104818,
+    "fields": {
+      "nombre": "Huemul",
+      "municipio": 2090
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104819,
+    "fields": {
+      "nombre": "La Lipela",
+      "municipio": 2090
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104820,
+    "fields": {
+      "nombre": "Lago Espejo",
+      "municipio": 2090
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104821,
+    "fields": {
+      "nombre": "Lago Espejo Chico",
+      "municipio": 2090
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104822,
+    "fields": {
+      "nombre": "Laguna Bailey Willis",
+      "municipio": 2090
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104823,
+    "fields": {
+      "nombre": "Los Cántaros",
+      "municipio": 2090
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104824,
+    "fields": {
+      "nombre": "Malal Huaca",
+      "municipio": 2090
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104825,
+    "fields": {
+      "nombre": "Nahuel Huapi",
+      "municipio": 2090
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104826,
+    "fields": {
+      "nombre": "Paso Cardenal Samoré",
+      "municipio": 2090
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104827,
+    "fields": {
+      "nombre": "Pichi Traful",
+      "municipio": 2090
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104828,
+    "fields": {
+      "nombre": "Puerto Anchorena",
+      "municipio": 2090
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104829,
+    "fields": {
+      "nombre": "Puerto Arrayán",
+      "municipio": 2090
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104830,
+    "fields": {
+      "nombre": "Puerto Chucao",
+      "municipio": 2090
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104831,
+    "fields": {
+      "nombre": "Puerto Huemul",
+      "municipio": 2090
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104832,
+    "fields": {
+      "nombre": "Puerto Llavallol",
+      "municipio": 2090
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104833,
+    "fields": {
+      "nombre": "Puerto Piedras Blancas",
+      "municipio": 2090
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104834,
+    "fields": {
+      "nombre": "Puerto Radal",
+      "municipio": 2090
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104835,
+    "fields": {
+      "nombre": "Quintupuray",
+      "municipio": 2090
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104836,
+    "fields": {
+      "nombre": "Rincón Chico",
+      "municipio": 2090
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104837,
+    "fields": {
+      "nombre": "Rincón de Creide",
+      "municipio": 2090
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104838,
+    "fields": {
+      "nombre": "Rincón Grande",
+      "municipio": 2090
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104839,
+    "fields": {
+      "nombre": "Ruca Malen",
+      "municipio": 2090
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104840,
+    "fields": {
+      "nombre": "Valle Encantado",
+      "municipio": 2090
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104841,
+    "fields": {
+      "nombre": "Alto Chapanay",
+      "municipio": 2091
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104842,
+    "fields": {
+      "nombre": "Alto Salvador",
+      "municipio": 2091
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104843,
+    "fields": {
+      "nombre": "Barrio Chivilcoy",
+      "municipio": 2091
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104844,
+    "fields": {
+      "nombre": "Barrio Emanuel",
+      "municipio": 2091
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104845,
+    "fields": {
+      "nombre": "Barrio Los Charabones",
+      "municipio": 2091
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104846,
+    "fields": {
+      "nombre": "Barrio Ntra. Sra. De Fátima",
+      "municipio": 2091
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104847,
+    "fields": {
+      "nombre": "Barrio Santa Cecilia",
+      "municipio": 2091
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104848,
+    "fields": {
+      "nombre": "Buen Orden",
+      "municipio": 2091
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104849,
+    "fields": {
+      "nombre": "Chapanay",
+      "municipio": 2091
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104850,
+    "fields": {
+      "nombre": "Chivilcoy",
+      "municipio": 2091
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104851,
+    "fields": {
+      "nombre": "Colonia Lambaré",
+      "municipio": 2091
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104852,
+    "fields": {
+      "nombre": "Colonia Montecaseros",
+      "municipio": 2091
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104853,
+    "fields": {
+      "nombre": "El Central",
+      "municipio": 2091
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104854,
+    "fields": {
+      "nombre": "El Divisadero",
+      "municipio": 2091
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104855,
+    "fields": {
+      "nombre": "El Ramblón",
+      "municipio": 2091
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104856,
+    "fields": {
+      "nombre": "La Colonia",
+      "municipio": 2091
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104857,
+    "fields": {
+      "nombre": "La Sultana",
+      "municipio": 2091
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104858,
+    "fields": {
+      "nombre": "Las Chimbas",
+      "municipio": 2091
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104859,
+    "fields": {
+      "nombre": "Moluches",
+      "municipio": 2091
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104860,
+    "fields": {
+      "nombre": "Montecaseros",
+      "municipio": 2091
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104861,
+    "fields": {
+      "nombre": "Nueva California",
+      "municipio": 2091
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104862,
+    "fields": {
+      "nombre": "Nueva California Sur",
+      "municipio": 2091
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104863,
+    "fields": {
+      "nombre": "Palmira",
+      "municipio": 2091
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104864,
+    "fields": {
+      "nombre": "San Martín",
+      "municipio": 2091
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104865,
+    "fields": {
+      "nombre": "Tres Esquinas",
+      "municipio": 2091
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104866,
+    "fields": {
+      "nombre": "Tres Porteñas",
+      "municipio": 2091
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104867,
+    "fields": {
+      "nombre": "El Eje",
+      "municipio": 2092
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104868,
+    "fields": {
+      "nombre": "San Fernando Norte",
+      "municipio": 2092
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104869,
+    "fields": {
+      "nombre": "Baños Lunlunta",
+      "municipio": 2093
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104870,
+    "fields": {
+      "nombre": "Barrancas",
+      "municipio": 2093
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104871,
+    "fields": {
+      "nombre": "Barrio Jesús de Nazaret",
+      "municipio": 2093
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104872,
+    "fields": {
+      "nombre": "Ciudad de Maipú",
+      "municipio": 2093
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104873,
+    "fields": {
+      "nombre": "Colonia Yrigoyen",
+      "municipio": 2093
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104874,
+    "fields": {
+      "nombre": "Coquimbito",
+      "municipio": 2093
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104875,
+    "fields": {
+      "nombre": "Cruz de Piedra",
+      "municipio": 2093
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104876,
+    "fields": {
+      "nombre": "El Paraíso",
+      "municipio": 2093
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104877,
+    "fields": {
+      "nombre": "El Pedregal",
+      "municipio": 2093
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104878,
+    "fields": {
+      "nombre": "Fray Luis Beltrán",
+      "municipio": 2093
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104879,
+    "fields": {
+      "nombre": "General Gutiérrez",
+      "municipio": 2093
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104880,
+    "fields": {
+      "nombre": "Los Álamos",
+      "municipio": 2093
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104881,
+    "fields": {
+      "nombre": "Los Olivos",
+      "municipio": 2093
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104882,
+    "fields": {
+      "nombre": "Luzuriaga",
+      "municipio": 2093
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104883,
+    "fields": {
+      "nombre": "Parque Chachingo",
+      "municipio": 2093
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104884,
+    "fields": {
+      "nombre": "Russell",
+      "municipio": 2093
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104885,
+    "fields": {
+      "nombre": "Titarelli",
+      "municipio": 2093
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104886,
+    "fields": {
+      "nombre": "Tres Banderas",
+      "municipio": 2093
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104887,
+    "fields": {
+      "nombre": "Villa Teresa",
+      "municipio": 2093
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104888,
+    "fields": {
+      "nombre": "Alto de Sierra",
+      "municipio": 2094
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104889,
+    "fields": {
+      "nombre": "Colonia Fiorito",
+      "municipio": 2094
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104890,
+    "fields": {
+      "nombre": "La Majadita",
+      "municipio": 2094
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104891,
+    "fields": {
+      "nombre": "Las Chacritas",
+      "municipio": 2094
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104892,
+    "fields": {
+      "nombre": "Libella",
+      "municipio": 2094
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104893,
+    "fields": {
+      "nombre": "Rincón Cercado",
+      "municipio": 2094
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104894,
+    "fields": {
+      "nombre": "Algarrobo Grande",
+      "municipio": 2095
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104895,
+    "fields": {
+      "nombre": "Alto Verde",
+      "municipio": 2095
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104896,
+    "fields": {
+      "nombre": "Barrio La Estación",
+      "municipio": 2095
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104897,
+    "fields": {
+      "nombre": "Ingeniero Giagnoni",
+      "municipio": 2095
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104898,
+    "fields": {
+      "nombre": "Medrano",
+      "municipio": 2095
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104899,
+    "fields": {
+      "nombre": "Mundo Nuevo",
+      "municipio": 2095
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104900,
+    "fields": {
+      "nombre": "Phillips",
+      "municipio": 2095
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104901,
+    "fields": {
+      "nombre": "Rodríguez Peña",
+      "municipio": 2095
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104902,
+    "fields": {
+      "nombre": "Tres Esquinas",
+      "municipio": 2095
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104903,
+    "fields": {
+      "nombre": "Algarrobo Verde",
+      "municipio": 2096
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104904,
+    "fields": {
+      "nombre": "Camarico",
+      "municipio": 2096
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104905,
+    "fields": {
+      "nombre": "Cristo Peregrino",
+      "municipio": 2096
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104906,
+    "fields": {
+      "nombre": "Cruz de San Pedro",
+      "municipio": 2096
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104907,
+    "fields": {
+      "nombre": "Cuatro Esquinas",
+      "municipio": 2096
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104908,
+    "fields": {
+      "nombre": "El Encón",
+      "municipio": 2096
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104909,
+    "fields": {
+      "nombre": "La Chimbera",
+      "municipio": 2096
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104910,
+    "fields": {
+      "nombre": "La Tranca",
+      "municipio": 2096
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104911,
+    "fields": {
+      "nombre": "Las Casuarinas",
+      "municipio": 2096
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104912,
+    "fields": {
+      "nombre": "Pozo del Salado",
+      "municipio": 2096
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104913,
+    "fields": {
+      "nombre": "Punta del Agua",
+      "municipio": 2096
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104914,
+    "fields": {
+      "nombre": "Punta del Médano",
+      "municipio": 2096
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104915,
+    "fields": {
+      "nombre": "Villa Borjas",
+      "municipio": 2096
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104916,
+    "fields": {
+      "nombre": "Villa Borjas - La Chimbera",
+      "municipio": 2096
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104917,
+    "fields": {
+      "nombre": "Villa El Tango",
+      "municipio": 2096
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104918,
+    "fields": {
+      "nombre": "Villa Santa Rosa",
+      "municipio": 2096
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104919,
+    "fields": {
+      "nombre": "Andrade",
+      "municipio": 2097
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104920,
+    "fields": {
+      "nombre": "Barrio Cooperativa Los Campamentos",
+      "municipio": 2097
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104921,
+    "fields": {
+      "nombre": "Barrio Rivadavia",
+      "municipio": 2097
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104922,
+    "fields": {
+      "nombre": "Costa Anzorena",
+      "municipio": 2097
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104923,
+    "fields": {
+      "nombre": "Cuadro Ortega",
+      "municipio": 2097
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104924,
+    "fields": {
+      "nombre": "Dique El Carrizal",
+      "municipio": 2097
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104925,
+    "fields": {
+      "nombre": "El Mirador",
+      "municipio": 2097
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104926,
+    "fields": {
+      "nombre": "La Central",
+      "municipio": 2097
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104927,
+    "fields": {
+      "nombre": "La Esperanza",
+      "municipio": 2097
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104928,
+    "fields": {
+      "nombre": "La Florida",
+      "municipio": 2097
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104929,
+    "fields": {
+      "nombre": "La Libertad",
+      "municipio": 2097
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104930,
+    "fields": {
+      "nombre": "Los Árboles",
+      "municipio": 2097
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104931,
+    "fields": {
+      "nombre": "Los Campamentos",
+      "municipio": 2097
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104932,
+    "fields": {
+      "nombre": "Los Huarpes",
+      "municipio": 2097
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104933,
+    "fields": {
+      "nombre": "Medrano",
+      "municipio": 2097
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104934,
+    "fields": {
+      "nombre": "Reducción de Abajo",
+      "municipio": 2097
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104935,
+    "fields": {
+      "nombre": "San Isidro",
+      "municipio": 2097
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104936,
+    "fields": {
+      "nombre": "Santa María de Oro",
+      "municipio": 2097
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104937,
+    "fields": {
+      "nombre": "Yacimiento Vizcacheras",
+      "municipio": 2097
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104938,
+    "fields": {
+      "nombre": "Abra Grande",
+      "municipio": 2098
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104939,
+    "fields": {
+      "nombre": "Antilo",
+      "municipio": 2098
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104940,
+    "fields": {
+      "nombre": "Churqui",
+      "municipio": 2098
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104941,
+    "fields": {
+      "nombre": "El Barrial",
+      "municipio": 2098
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104942,
+    "fields": {
+      "nombre": "El Deán",
+      "municipio": 2098
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104943,
+    "fields": {
+      "nombre": "El Mojón",
+      "municipio": 2098
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104944,
+    "fields": {
+      "nombre": "El Puestito",
+      "municipio": 2098
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104945,
+    "fields": {
+      "nombre": "El Zanjón",
+      "municipio": 2098
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104946,
+    "fields": {
+      "nombre": "Huaico Redondo",
+      "municipio": 2098
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104947,
+    "fields": {
+      "nombre": "Ingeniero Ezcurra",
+      "municipio": 2098
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104948,
+    "fields": {
+      "nombre": "La Candelaria",
+      "municipio": 2098
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104949,
+    "fields": {
+      "nombre": "La Estancita",
+      "municipio": 2098
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104950,
+    "fields": {
+      "nombre": "Las Palmeras",
+      "municipio": 2098
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104951,
+    "fields": {
+      "nombre": "Loma Grande",
+      "municipio": 2098
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104952,
+    "fields": {
+      "nombre": "Lomas de Zamora",
+      "municipio": 2098
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104953,
+    "fields": {
+      "nombre": "Los Cardozos",
+      "municipio": 2098
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104954,
+    "fields": {
+      "nombre": "Los Pocitos",
+      "municipio": 2098
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104955,
+    "fields": {
+      "nombre": "Maco",
+      "municipio": 2098
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104956,
+    "fields": {
+      "nombre": "Maquito",
+      "municipio": 2098
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104957,
+    "fields": {
+      "nombre": "Morales",
+      "municipio": 2098
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104958,
+    "fields": {
+      "nombre": "Palma Pozo",
+      "municipio": 2098
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104959,
+    "fields": {
+      "nombre": "Pampa Muyoj",
+      "municipio": 2098
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104960,
+    "fields": {
+      "nombre": "Pozo Cavado",
+      "municipio": 2098
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104961,
+    "fields": {
+      "nombre": "Puesto de San Antonio",
+      "municipio": 2098
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104962,
+    "fields": {
+      "nombre": "Puesto del Medio",
+      "municipio": 2098
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104963,
+    "fields": {
+      "nombre": "Remes",
+      "municipio": 2098
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104964,
+    "fields": {
+      "nombre": "Rodeo de Soria",
+      "municipio": 2098
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104965,
+    "fields": {
+      "nombre": "San Antonio de los Cáceres",
+      "municipio": 2098
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104966,
+    "fields": {
+      "nombre": "San Benito",
+      "municipio": 2098
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104967,
+    "fields": {
+      "nombre": "San José",
+      "municipio": 2098
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104968,
+    "fields": {
+      "nombre": "San Lorenzo",
+      "municipio": 2098
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104969,
+    "fields": {
+      "nombre": "San Lorenzo de los Sayagos",
+      "municipio": 2098
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104970,
+    "fields": {
+      "nombre": "San Pedro",
+      "municipio": 2098
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104971,
+    "fields": {
+      "nombre": "Santa María",
+      "municipio": 2098
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104972,
+    "fields": {
+      "nombre": "Santa Rosa",
+      "municipio": 2098
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104973,
+    "fields": {
+      "nombre": "Santo Domingo",
+      "municipio": 2098
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104974,
+    "fields": {
+      "nombre": "Sol de Mayo",
+      "municipio": 2098
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104975,
+    "fields": {
+      "nombre": "Tipiro",
+      "municipio": 2098
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104976,
+    "fields": {
+      "nombre": "Upianita",
+      "municipio": 2098
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104977,
+    "fields": {
+      "nombre": "Vuelta de la Barranca",
+      "municipio": 2098
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104978,
+    "fields": {
+      "nombre": "Yanda",
+      "municipio": 2098
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104979,
+    "fields": {
+      "nombre": "Astilleros",
+      "municipio": 2099
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104980,
+    "fields": {
+      "nombre": "Atocha",
+      "municipio": 2099
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104981,
+    "fields": {
+      "nombre": "Barrio San Rafael",
+      "municipio": 2099
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104982,
+    "fields": {
+      "nombre": "Castellanos",
+      "municipio": 2099
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104983,
+    "fields": {
+      "nombre": "La Ciénaga",
+      "municipio": 2099
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104984,
+    "fields": {
+      "nombre": "La Ciénaga - Barrio San Rafael",
+      "municipio": 2099
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104985,
+    "fields": {
+      "nombre": "La Toma",
+      "municipio": 2099
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104986,
+    "fields": {
+      "nombre": "Las Costas",
+      "municipio": 2099
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104987,
+    "fields": {
+      "nombre": "Villa San Lorenzo",
+      "municipio": 2099
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104988,
+    "fields": {
+      "nombre": "Azul Pampa",
+      "municipio": 2100
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104989,
+    "fields": {
+      "nombre": "Candelaria",
+      "municipio": 2100
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104990,
+    "fields": {
+      "nombre": "Casillas",
+      "municipio": 2100
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104991,
+    "fields": {
+      "nombre": "Chaupi Rodeo",
+      "municipio": 2100
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104992,
+    "fields": {
+      "nombre": "Cóndor",
+      "municipio": 2100
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104993,
+    "fields": {
+      "nombre": "Inti Cueva",
+      "municipio": 2100
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104994,
+    "fields": {
+      "nombre": "Juire",
+      "municipio": 2100
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104995,
+    "fields": {
+      "nombre": "La Cueva",
+      "municipio": 2100
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104996,
+    "fields": {
+      "nombre": "Muyayoc",
+      "municipio": 2100
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104997,
+    "fields": {
+      "nombre": "Negra Muerta",
+      "municipio": 2100
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104998,
+    "fields": {
+      "nombre": "Pueblo Viejo",
+      "municipio": 2100
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 104999,
+    "fields": {
+      "nombre": "Colonia Lagos",
+      "municipio": 2101
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105000,
+    "fields": {
+      "nombre": "Helvecia",
+      "municipio": 2102
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105001,
+    "fields": {
+      "nombre": "Barrio Canale",
+      "municipio": 2103
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105002,
+    "fields": {
+      "nombre": "Barrio Chacra Monte",
+      "municipio": 2103
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105003,
+    "fields": {
+      "nombre": "Barrio Destacamento",
+      "municipio": 2103
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105004,
+    "fields": {
+      "nombre": "Barrio El Petróleo",
+      "municipio": 2103
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105005,
+    "fields": {
+      "nombre": "Barrio La Costa",
+      "municipio": 2103
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105006,
+    "fields": {
+      "nombre": "Barrio La Ribera - Barrio APYCAR",
+      "municipio": 2103
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105007,
+    "fields": {
+      "nombre": "Barrio Mar del Plata",
+      "municipio": 2103
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105008,
+    "fields": {
+      "nombre": "Barrio Mosconi",
+      "municipio": 2103
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105009,
+    "fields": {
+      "nombre": "Barrio Pinar",
+      "municipio": 2103
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105010,
+    "fields": {
+      "nombre": "Barrio Pino Azul",
+      "municipio": 2103
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105011,
+    "fields": {
+      "nombre": "Catriel Oeste",
+      "municipio": 2103
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105012,
+    "fields": {
+      "nombre": "El Medanito",
+      "municipio": 2103
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105013,
+    "fields": {
+      "nombre": "Entre Lomas",
+      "municipio": 2103
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105014,
+    "fields": {
+      "nombre": "Ingeniero Julián Romero",
+      "municipio": 2103
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105015,
+    "fields": {
+      "nombre": "Kilómetro 1071",
+      "municipio": 2103
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105016,
+    "fields": {
+      "nombre": "Paraje Arroyón (Bajo San Cayetano)",
+      "municipio": 2103
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105017,
+    "fields": {
+      "nombre": "Paso Córdova",
+      "municipio": 2103
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105018,
+    "fields": {
+      "nombre": "Península Ruca Co",
+      "municipio": 2103
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105019,
+    "fields": {
+      "nombre": "Señal Picada",
+      "municipio": 2103
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105020,
+    "fields": {
+      "nombre": "Valle Verde",
+      "municipio": 2103
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105021,
+    "fields": {
+      "nombre": "Bajo de los Huesos",
+      "municipio": 2104
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105022,
+    "fields": {
+      "nombre": "Durazno Chico",
+      "municipio": 2104
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105023,
+    "fields": {
+      "nombre": "Loma Blanca",
+      "municipio": 2104
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105024,
+    "fields": {
+      "nombre": "Playa Isla Escondida",
+      "municipio": 2104
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105025,
+    "fields": {
+      "nombre": "Playa Magagna",
+      "municipio": 2104
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105026,
+    "fields": {
+      "nombre": "Playa Santa Isabel",
+      "municipio": 2104
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105027,
+    "fields": {
+      "nombre": "Playa Unión",
+      "municipio": 2104
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105028,
+    "fields": {
+      "nombre": "Punta Conscriptos",
+      "municipio": 2104
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105029,
+    "fields": {
+      "nombre": "Punta León",
+      "municipio": 2104
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105030,
+    "fields": {
+      "nombre": "Punta Ninfas",
+      "municipio": 2104
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105031,
+    "fields": {
+      "nombre": "4 Esquinas",
+      "municipio": 2105
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105032,
+    "fields": {
+      "nombre": "Aguayo",
+      "municipio": 2105
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105033,
+    "fields": {
+      "nombre": "Alto Corral de Isaac",
+      "municipio": 2105
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105034,
+    "fields": {
+      "nombre": "Bajo Corral de Isaac",
+      "municipio": 2105
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105035,
+    "fields": {
+      "nombre": "Bajo Hondo",
+      "municipio": 2105
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105036,
+    "fields": {
+      "nombre": "Balde de la Viuda",
+      "municipio": 2105
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105037,
+    "fields": {
+      "nombre": "Baldecito",
+      "municipio": 2105
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105038,
+    "fields": {
+      "nombre": "El 14",
+      "municipio": 2105
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105039,
+    "fields": {
+      "nombre": "El Abra",
+      "municipio": 2105
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105040,
+    "fields": {
+      "nombre": "El Buen Retiro",
+      "municipio": 2105
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105041,
+    "fields": {
+      "nombre": "El Cadillo",
+      "municipio": 2105
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105042,
+    "fields": {
+      "nombre": "El Combado",
+      "municipio": 2105
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105043,
+    "fields": {
+      "nombre": "Entre Ríos",
+      "municipio": 2105
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105044,
+    "fields": {
+      "nombre": "Isla del Tigre",
+      "municipio": 2105
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105045,
+    "fields": {
+      "nombre": "La Banderita",
+      "municipio": 2105
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105046,
+    "fields": {
+      "nombre": "La Industria",
+      "municipio": 2105
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105047,
+    "fields": {
+      "nombre": "La Lilia",
+      "municipio": 2105
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105048,
+    "fields": {
+      "nombre": "La Lomita",
+      "municipio": 2105
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105049,
+    "fields": {
+      "nombre": "La Represa",
+      "municipio": 2105
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105050,
+    "fields": {
+      "nombre": "La Represita",
+      "municipio": 2105
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105051,
+    "fields": {
+      "nombre": "La Suspensión",
+      "municipio": 2105
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105052,
+    "fields": {
+      "nombre": "Las Ventanitas",
+      "municipio": 2105
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105053,
+    "fields": {
+      "nombre": "Nueva Esperanza",
+      "municipio": 2105
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105054,
+    "fields": {
+      "nombre": "Pozo de la Pampa",
+      "municipio": 2105
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105055,
+    "fields": {
+      "nombre": "Puesto de los Conejos",
+      "municipio": 2105
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105056,
+    "fields": {
+      "nombre": "Puesto Dichoso",
+      "municipio": 2105
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105057,
+    "fields": {
+      "nombre": "San José",
+      "municipio": 2105
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105058,
+    "fields": {
+      "nombre": "San Rafael",
+      "municipio": 2105
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105059,
+    "fields": {
+      "nombre": "San Solano",
+      "municipio": 2105
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105060,
+    "fields": {
+      "nombre": "Siempre Verde",
+      "municipio": 2105
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105061,
+    "fields": {
+      "nombre": "Tres de Mayo",
+      "municipio": 2105
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105062,
+    "fields": {
+      "nombre": "Villa Clotilde",
+      "municipio": 2105
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105063,
+    "fields": {
+      "nombre": "Villa Luisa",
+      "municipio": 2105
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105064,
+    "fields": {
+      "nombre": "Villa Nidia",
+      "municipio": 2105
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105065,
+    "fields": {
+      "nombre": "Virgen del Valle",
+      "municipio": 2105
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105066,
+    "fields": {
+      "nombre": "Bañado de Paja",
+      "municipio": 2106
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105067,
+    "fields": {
+      "nombre": "El Bordo",
+      "municipio": 2106
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105068,
+    "fields": {
+      "nombre": "La Cortadera",
+      "municipio": 2106
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105069,
+    "fields": {
+      "nombre": "Cruce Río Colorado",
+      "municipio": 2107
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105070,
+    "fields": {
+      "nombre": "Entre Ríos",
+      "municipio": 2107
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105071,
+    "fields": {
+      "nombre": "Manchalá",
+      "municipio": 2107
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105072,
+    "fields": {
+      "nombre": "San José de Buena Vista",
+      "municipio": 2107
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105073,
+    "fields": {
+      "nombre": "Santa Rita",
+      "municipio": 2107
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105074,
+    "fields": {
+      "nombre": "Iltico",
+      "municipio": 2108
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105075,
+    "fields": {
+      "nombre": "Los Vallejos",
+      "municipio": 2108
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105076,
+    "fields": {
+      "nombre": "Chacras de Sarmiento",
+      "municipio": 2109
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105077,
+    "fields": {
+      "nombre": "Colhué Huapi",
+      "municipio": 2109
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105078,
+    "fields": {
+      "nombre": "El Salitral",
+      "municipio": 2109
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105079,
+    "fields": {
+      "nombre": "Hermitte",
+      "municipio": 2109
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105080,
+    "fields": {
+      "nombre": "La Esperanza",
+      "municipio": 2109
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105081,
+    "fields": {
+      "nombre": "La Helvética",
+      "municipio": 2109
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105082,
+    "fields": {
+      "nombre": "Lago Musters",
+      "municipio": 2109
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105083,
+    "fields": {
+      "nombre": "Los Manantiales",
+      "municipio": 2109
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105084,
+    "fields": {
+      "nombre": "Pampa de los Guanacos",
+      "municipio": 2109
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105085,
+    "fields": {
+      "nombre": "Pío Pío",
+      "municipio": 2109
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105086,
+    "fields": {
+      "nombre": "Valle Hermoso",
+      "municipio": 2109
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105087,
+    "fields": {
+      "nombre": "El Duraznito",
+      "municipio": 2110
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105088,
+    "fields": {
+      "nombre": "Costa Alegre",
+      "municipio": 2111
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105089,
+    "fields": {
+      "nombre": "Rodeo Tapití",
+      "municipio": 2111
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105090,
+    "fields": {
+      "nombre": "Bowen",
+      "municipio": 2112
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105091,
+    "fields": {
+      "nombre": "Campo Grariel",
+      "municipio": 2112
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105092,
+    "fields": {
+      "nombre": "Canalejas",
+      "municipio": 2112
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105093,
+    "fields": {
+      "nombre": "Carmensa",
+      "municipio": 2112
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105094,
+    "fields": {
+      "nombre": "Cochicó",
+      "municipio": 2112
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105095,
+    "fields": {
+      "nombre": "Colonia Rusa",
+      "municipio": 2112
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105096,
+    "fields": {
+      "nombre": "Colonia San Pedro del Atuel",
+      "municipio": 2112
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105097,
+    "fields": {
+      "nombre": "Corral de Lorca",
+      "municipio": 2112
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105098,
+    "fields": {
+      "nombre": "Don Carlos",
+      "municipio": 2112
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105099,
+    "fields": {
+      "nombre": "El Algarrobal",
+      "municipio": 2112
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105100,
+    "fields": {
+      "nombre": "El Ceibo",
+      "municipio": 2112
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105101,
+    "fields": {
+      "nombre": "Estación Canalejas",
+      "municipio": 2112
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105102,
+    "fields": {
+      "nombre": "Gaspar Campos",
+      "municipio": 2112
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105103,
+    "fields": {
+      "nombre": "Goico",
+      "municipio": 2112
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105104,
+    "fields": {
+      "nombre": "La Betania",
+      "municipio": 2112
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105105,
+    "fields": {
+      "nombre": "La California",
+      "municipio": 2112
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105106,
+    "fields": {
+      "nombre": "La Cortadera Grande",
+      "municipio": 2112
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105107,
+    "fields": {
+      "nombre": "La Escandinava",
+      "municipio": 2112
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105108,
+    "fields": {
+      "nombre": "La Escandinava Sur",
+      "municipio": 2112
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105109,
+    "fields": {
+      "nombre": "La Marsolina",
+      "municipio": 2112
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105110,
+    "fields": {
+      "nombre": "La Montilla",
+      "municipio": 2112
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105111,
+    "fields": {
+      "nombre": "La Mora",
+      "municipio": 2112
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105112,
+    "fields": {
+      "nombre": "Los Campamentos",
+      "municipio": 2112
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105113,
+    "fields": {
+      "nombre": "Los Compartos",
+      "municipio": 2112
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105114,
+    "fields": {
+      "nombre": "Los Huarpes",
+      "municipio": 2112
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105115,
+    "fields": {
+      "nombre": "Media Luna",
+      "municipio": 2112
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105116,
+    "fields": {
+      "nombre": "Ovejería",
+      "municipio": 2112
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105117,
+    "fields": {
+      "nombre": "Pampa del Tigre",
+      "municipio": 2112
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105118,
+    "fields": {
+      "nombre": "Poste de Fierro",
+      "municipio": 2112
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105119,
+    "fields": {
+      "nombre": "Alvarado",
+      "municipio": 2113
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105120,
+    "fields": {
+      "nombre": "Barrio Carrasco",
+      "municipio": 2113
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105121,
+    "fields": {
+      "nombre": "Barrio El Cepillo",
+      "municipio": 2113
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105122,
+    "fields": {
+      "nombre": "Casas Viejas",
+      "municipio": 2113
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105123,
+    "fields": {
+      "nombre": "Chilecito",
+      "municipio": 2113
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105124,
+    "fields": {
+      "nombre": "Cruz de Piedra",
+      "municipio": 2113
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105125,
+    "fields": {
+      "nombre": "El Capacho",
+      "municipio": 2113
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105126,
+    "fields": {
+      "nombre": "El Cilindro",
+      "municipio": 2113
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105127,
+    "fields": {
+      "nombre": "El Manantial de Capiz",
+      "municipio": 2113
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105128,
+    "fields": {
+      "nombre": "El Rincón",
+      "municipio": 2113
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105129,
+    "fields": {
+      "nombre": "Eugenio Bustos",
+      "municipio": 2113
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105130,
+    "fields": {
+      "nombre": "La Jaula",
+      "municipio": 2113
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105131,
+    "fields": {
+      "nombre": "Laguna Diamante",
+      "municipio": 2113
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105132,
+    "fields": {
+      "nombre": "Los Alamitos",
+      "municipio": 2113
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105133,
+    "fields": {
+      "nombre": "Los Paramillos",
+      "municipio": 2113
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105134,
+    "fields": {
+      "nombre": "Ojo de Agua",
+      "municipio": 2113
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105135,
+    "fields": {
+      "nombre": "Pampa de los Avestruces",
+      "municipio": 2113
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105136,
+    "fields": {
+      "nombre": "Papagayos",
+      "municipio": 2113
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105137,
+    "fields": {
+      "nombre": "Pareditas",
+      "municipio": 2113
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105138,
+    "fields": {
+      "nombre": "Paso de las Carretas",
+      "municipio": 2113
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105139,
+    "fields": {
+      "nombre": "Paso de Maipo",
+      "municipio": 2113
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105140,
+    "fields": {
+      "nombre": "Piedras Blancas",
+      "municipio": 2113
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105141,
+    "fields": {
+      "nombre": "Tres Esquinas",
+      "municipio": 2113
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105142,
+    "fields": {
+      "nombre": "Villa El Chacón",
+      "municipio": 2113
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105143,
+    "fields": {
+      "nombre": "Viluco",
+      "municipio": 2113
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105144,
+    "fields": {
+      "nombre": "Yacimiento Vizcacheras",
+      "municipio": 2113
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105145,
+    "fields": {
+      "nombre": "Ayuncha",
+      "municipio": 2114
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105146,
+    "fields": {
+      "nombre": "Beltrán",
+      "municipio": 2114
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105147,
+    "fields": {
+      "nombre": "Campo Amor",
+      "municipio": 2114
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105148,
+    "fields": {
+      "nombre": "Crucesitas",
+      "municipio": 2114
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105149,
+    "fields": {
+      "nombre": "Diente del Arado",
+      "municipio": 2114
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105150,
+    "fields": {
+      "nombre": "El Mistol",
+      "municipio": 2114
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105151,
+    "fields": {
+      "nombre": "Jumi Pozo",
+      "municipio": 2114
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105152,
+    "fields": {
+      "nombre": "Kilómetro 83",
+      "municipio": 2114
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105153,
+    "fields": {
+      "nombre": "Kilómetro 90",
+      "municipio": 2114
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105154,
+    "fields": {
+      "nombre": "La Dormida",
+      "municipio": 2114
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105155,
+    "fields": {
+      "nombre": "La Meleada",
+      "municipio": 2114
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105156,
+    "fields": {
+      "nombre": "La Resbalosa",
+      "municipio": 2114
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105157,
+    "fields": {
+      "nombre": "La Revancha",
+      "municipio": 2114
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105158,
+    "fields": {
+      "nombre": "Lomitas",
+      "municipio": 2114
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105159,
+    "fields": {
+      "nombre": "Monte Redondo",
+      "municipio": 2114
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105160,
+    "fields": {
+      "nombre": "Morampa",
+      "municipio": 2114
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105161,
+    "fields": {
+      "nombre": "Pozo Ciego",
+      "municipio": 2114
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105162,
+    "fields": {
+      "nombre": "Pozo Verde",
+      "municipio": 2114
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105163,
+    "fields": {
+      "nombre": "Puesto de Juanes",
+      "municipio": 2114
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105164,
+    "fields": {
+      "nombre": "Punua",
+      "municipio": 2114
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105165,
+    "fields": {
+      "nombre": "Río Pinto",
+      "municipio": 2114
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105166,
+    "fields": {
+      "nombre": "San Juan",
+      "municipio": 2114
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105167,
+    "fields": {
+      "nombre": "San Vicente",
+      "municipio": 2114
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105168,
+    "fields": {
+      "nombre": "Santa Bárbara",
+      "municipio": 2114
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105169,
+    "fields": {
+      "nombre": "Santa Rosa",
+      "municipio": 2114
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105170,
+    "fields": {
+      "nombre": "Sauce Solo",
+      "municipio": 2114
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105171,
+    "fields": {
+      "nombre": "Tacanas",
+      "municipio": 2114
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105172,
+    "fields": {
+      "nombre": "Tío Pozo",
+      "municipio": 2114
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105173,
+    "fields": {
+      "nombre": "Totora Pampa",
+      "municipio": 2114
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105174,
+    "fields": {
+      "nombre": "Villa San Martín (Est. Loreto)",
+      "municipio": 2114
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105175,
+    "fields": {
+      "nombre": "Villa Vieja",
+      "municipio": 2114
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105176,
+    "fields": {
+      "nombre": "Aldea Guapoy",
+      "municipio": 2115
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105177,
+    "fields": {
+      "nombre": "Puerto Bossetti",
+      "municipio": 2115
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105178,
+    "fields": {
+      "nombre": "Tirica",
+      "municipio": 2115
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105179,
+    "fields": {
+      "nombre": "Villa Cooperativa",
+      "municipio": 2115
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105180,
+    "fields": {
+      "nombre": "Alegría",
+      "municipio": 2116
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105181,
+    "fields": {
+      "nombre": "Aster",
+      "municipio": 2116
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105182,
+    "fields": {
+      "nombre": "Bello Horizonte",
+      "municipio": 2116
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105183,
+    "fields": {
+      "nombre": "Colonia Fortaleza",
+      "municipio": 2116
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105184,
+    "fields": {
+      "nombre": "Colonia Primavera",
+      "municipio": 2116
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105185,
+    "fields": {
+      "nombre": "Cruce Caballero",
+      "municipio": 2116
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105186,
+    "fields": {
+      "nombre": "El 48",
+      "municipio": 2116
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105187,
+    "fields": {
+      "nombre": "Gentile",
+      "municipio": 2116
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105188,
+    "fields": {
+      "nombre": "Las Minas",
+      "municipio": 2116
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105189,
+    "fields": {
+      "nombre": "Luján",
+      "municipio": 2116
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105190,
+    "fields": {
+      "nombre": "Macaca",
+      "municipio": 2116
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105191,
+    "fields": {
+      "nombre": "Nueva Esperanza",
+      "municipio": 2116
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105192,
+    "fields": {
+      "nombre": "Paduán",
+      "municipio": 2116
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105193,
+    "fields": {
+      "nombre": "Palmera Boca",
+      "municipio": 2116
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105194,
+    "fields": {
+      "nombre": "Paso Rosales",
+      "municipio": 2116
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105195,
+    "fields": {
+      "nombre": "Picada María Auxiiadora",
+      "municipio": 2116
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105196,
+    "fields": {
+      "nombre": "Piñalito Sur",
+      "municipio": 2116
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105197,
+    "fields": {
+      "nombre": "Saltos del Moconá",
+      "municipio": 2116
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105198,
+    "fields": {
+      "nombre": "Santa Rosa",
+      "municipio": 2116
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105199,
+    "fields": {
+      "nombre": "Siete Estrellas",
+      "municipio": 2116
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105200,
+    "fields": {
+      "nombre": "Villa Don Bosco",
+      "municipio": 2116
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105201,
+    "fields": {
+      "nombre": "Yabotí",
+      "municipio": 2116
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105202,
+    "fields": {
+      "nombre": "Alegría",
+      "municipio": 2117
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105203,
+    "fields": {
+      "nombre": "Azopardo",
+      "municipio": 2117
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105204,
+    "fields": {
+      "nombre": "Barbacuá",
+      "municipio": 2117
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105205,
+    "fields": {
+      "nombre": "Capitán Pedro Giachino",
+      "municipio": 2117
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105206,
+    "fields": {
+      "nombre": "El Central",
+      "municipio": 2117
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105207,
+    "fields": {
+      "nombre": "El Pesado",
+      "municipio": 2117
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105208,
+    "fields": {
+      "nombre": "Kilómetro 130",
+      "municipio": 2117
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105209,
+    "fields": {
+      "nombre": "Piñalito Norte",
+      "municipio": 2117
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105210,
+    "fields": {
+      "nombre": "Puente Uruzú",
+      "municipio": 2117
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105211,
+    "fields": {
+      "nombre": "Saracura",
+      "municipio": 2117
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105212,
+    "fields": {
+      "nombre": "Villa Unión",
+      "municipio": 2117
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105213,
+    "fields": {
+      "nombre": "Campo Gentilini",
+      "municipio": 2118
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105214,
+    "fields": {
+      "nombre": "La Sierrita",
+      "municipio": 2118
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105215,
+    "fields": {
+      "nombre": "Parque Sierra Crovetto",
+      "municipio": 2118
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105216,
+    "fields": {
+      "nombre": "Pindapoy",
+      "municipio": 2118
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105217,
+    "fields": {
+      "nombre": "Sierrita San José",
+      "municipio": 2118
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105218,
+    "fields": {
+      "nombre": "Cruz Quemada",
+      "municipio": 2119
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105219,
+    "fields": {
+      "nombre": "Cuchiuman",
+      "municipio": 2119
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105220,
+    "fields": {
+      "nombre": "El Algarrobal",
+      "municipio": 2119
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105221,
+    "fields": {
+      "nombre": "El Estanque",
+      "municipio": 2119
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105222,
+    "fields": {
+      "nombre": "El Saladillo",
+      "municipio": 2119
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105223,
+    "fields": {
+      "nombre": "El Salto",
+      "municipio": 2119
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105224,
+    "fields": {
+      "nombre": "El Zapallar",
+      "municipio": 2119
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105225,
+    "fields": {
+      "nombre": "Esquina de Quisto",
+      "municipio": 2119
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105226,
+    "fields": {
+      "nombre": "Juramento",
+      "municipio": 2119
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105227,
+    "fields": {
+      "nombre": "La Trampa",
+      "municipio": 2119
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105228,
+    "fields": {
+      "nombre": "Madre Vieja",
+      "municipio": 2119
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105229,
+    "fields": {
+      "nombre": "Palomitas",
+      "municipio": 2119
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105230,
+    "fields": {
+      "nombre": "Santa Rita",
+      "municipio": 2119
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105231,
+    "fields": {
+      "nombre": "Virgilio Tedín",
+      "municipio": 2119
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105232,
+    "fields": {
+      "nombre": "Yaquiasmé",
+      "municipio": 2119
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105233,
+    "fields": {
+      "nombre": "Alta Unión",
+      "municipio": 2120
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105234,
+    "fields": {
+      "nombre": "Colonia Florida",
+      "municipio": 2120
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105235,
+    "fields": {
+      "nombre": "Colonia Manuel Belgrano",
+      "municipio": 2120
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105236,
+    "fields": {
+      "nombre": "Cruce Londero",
+      "municipio": 2120
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105237,
+    "fields": {
+      "nombre": "El Lucero",
+      "municipio": 2120
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105238,
+    "fields": {
+      "nombre": "El Pacífico",
+      "municipio": 2120
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105239,
+    "fields": {
+      "nombre": "El Socorro",
+      "municipio": 2120
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105240,
+    "fields": {
+      "nombre": "Fracrán",
+      "municipio": 2120
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105241,
+    "fields": {
+      "nombre": "Guiray",
+      "municipio": 2120
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105242,
+    "fields": {
+      "nombre": "Kilómetro 44",
+      "municipio": 2120
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105243,
+    "fields": {
+      "nombre": "Kilómetro 68",
+      "municipio": 2120
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105244,
+    "fields": {
+      "nombre": "Kilómetro 74 Picada Progreso",
+      "municipio": 2120
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105245,
+    "fields": {
+      "nombre": "Kilómetro 90",
+      "municipio": 2120
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105246,
+    "fields": {
+      "nombre": "Las Mercedes",
+      "municipio": 2120
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105247,
+    "fields": {
+      "nombre": "Picada 37",
+      "municipio": 2120
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105248,
+    "fields": {
+      "nombre": "Picada El Molino",
+      "municipio": 2120
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105249,
+    "fields": {
+      "nombre": "Picada Flor",
+      "municipio": 2120
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105250,
+    "fields": {
+      "nombre": "Picada Mojón Grande",
+      "municipio": 2120
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105251,
+    "fields": {
+      "nombre": "Picada Sulma",
+      "municipio": 2120
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105252,
+    "fields": {
+      "nombre": "Puerto Argentino",
+      "municipio": 2120
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105253,
+    "fields": {
+      "nombre": "San Carlos",
+      "municipio": 2120
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105254,
+    "fields": {
+      "nombre": "San Isidro",
+      "municipio": 2120
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105255,
+    "fields": {
+      "nombre": "San José",
+      "municipio": 2120
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105256,
+    "fields": {
+      "nombre": "Virgen de la Candelaria",
+      "municipio": 2120
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105257,
+    "fields": {
+      "nombre": "Domingo Savio",
+      "municipio": 2121
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105258,
+    "fields": {
+      "nombre": "Invernada",
+      "municipio": 2121
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105259,
+    "fields": {
+      "nombre": "Pastoreo",
+      "municipio": 2121
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105260,
+    "fields": {
+      "nombre": "San Rafael",
+      "municipio": 2121
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105261,
+    "fields": {
+      "nombre": "Teyú Cuaré",
+      "municipio": 2121
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105262,
+    "fields": {
+      "nombre": "Villa Emma",
+      "municipio": 2121
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105263,
+    "fields": {
+      "nombre": "Alto de las Lechuzas",
+      "municipio": 2122
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105264,
+    "fields": {
+      "nombre": "Ampata",
+      "municipio": 2122
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105265,
+    "fields": {
+      "nombre": "Los Sandovales",
+      "municipio": 2122
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105266,
+    "fields": {
+      "nombre": "Los Valenzuelas",
+      "municipio": 2122
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105267,
+    "fields": {
+      "nombre": "Yacuchiri",
+      "municipio": 2122
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105268,
+    "fields": {
+      "nombre": "La Cruz",
+      "municipio": 2123
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105269,
+    "fields": {
+      "nombre": "La Fortaleza",
+      "municipio": 2123
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105270,
+    "fields": {
+      "nombre": "Santa Ana",
+      "municipio": 2123
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105271,
+    "fields": {
+      "nombre": "La Higuerita",
+      "municipio": 2124
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105272,
+    "fields": {
+      "nombre": "Mesada de las Colmenas",
+      "municipio": 2124
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105273,
+    "fields": {
+      "nombre": "Palos Blancos",
+      "municipio": 2124
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105274,
+    "fields": {
+      "nombre": "Paulina",
+      "municipio": 2124
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105275,
+    "fields": {
+      "nombre": "Pueblo Ledesma",
+      "municipio": 2124
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105276,
+    "fields": {
+      "nombre": "Buena Vista",
+      "municipio": 2125
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105277,
+    "fields": {
+      "nombre": "Caá Caraí",
+      "municipio": 2125
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105278,
+    "fields": {
+      "nombre": "Isla Apipé Chico",
+      "municipio": 2125
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105279,
+    "fields": {
+      "nombre": "Paraje Libertad",
+      "municipio": 2125
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105280,
+    "fields": {
+      "nombre": "Paso Caá Caraí",
+      "municipio": 2125
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105281,
+    "fields": {
+      "nombre": "Paso Moreno",
+      "municipio": 2125
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105282,
+    "fields": {
+      "nombre": "Puerto Valle",
+      "municipio": 2125
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105283,
+    "fields": {
+      "nombre": "Represa Yaciretá",
+      "municipio": 2125
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105284,
+    "fields": {
+      "nombre": "Rincón Ombú Chico",
+      "municipio": 2125
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105285,
+    "fields": {
+      "nombre": "Alem Cué",
+      "municipio": 2126
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105286,
+    "fields": {
+      "nombre": "Costa Guaviraví",
+      "municipio": 2126
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105287,
+    "fields": {
+      "nombre": "El Orejano",
+      "municipio": 2126
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105288,
+    "fields": {
+      "nombre": "Horqueta de Guaviraví",
+      "municipio": 2126
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105289,
+    "fields": {
+      "nombre": "Isoqui",
+      "municipio": 2126
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105290,
+    "fields": {
+      "nombre": "Loma Alta",
+      "municipio": 2126
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105291,
+    "fields": {
+      "nombre": "Paso La Sirena",
+      "municipio": 2126
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105292,
+    "fields": {
+      "nombre": "Paso San Joaquín",
+      "municipio": 2126
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105293,
+    "fields": {
+      "nombre": "San Carlos",
+      "municipio": 2126
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105294,
+    "fields": {
+      "nombre": "San Gabriel",
+      "municipio": 2126
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105295,
+    "fields": {
+      "nombre": "Tres Cerros",
+      "municipio": 2126
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105296,
+    "fields": {
+      "nombre": "Yacaré",
+      "municipio": 2126
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105297,
+    "fields": {
+      "nombre": "Yuru Cuá",
+      "municipio": 2126
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105298,
+    "fields": {
+      "nombre": "Alfonso Loma",
+      "municipio": 2127
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105299,
+    "fields": {
+      "nombre": "Arroyo Grande",
+      "municipio": 2127
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105300,
+    "fields": {
+      "nombre": "Arroyo Yuquerí",
+      "municipio": 2127
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105301,
+    "fields": {
+      "nombre": "Boquerón",
+      "municipio": 2127
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105302,
+    "fields": {
+      "nombre": "Capi Vari",
+      "municipio": 2127
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105303,
+    "fields": {
+      "nombre": "Itá Caabo",
+      "municipio": 2127
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105304,
+    "fields": {
+      "nombre": "Itá Corá",
+      "municipio": 2127
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105305,
+    "fields": {
+      "nombre": "Itá Jhasé",
+      "municipio": 2127
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105306,
+    "fields": {
+      "nombre": "Itá Pucá",
+      "municipio": 2127
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105307,
+    "fields": {
+      "nombre": "Naranjito",
+      "municipio": 2127
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105308,
+    "fields": {
+      "nombre": "Paso Mesa",
+      "municipio": 2127
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105309,
+    "fields": {
+      "nombre": "Paso Pucheta",
+      "municipio": 2127
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105310,
+    "fields": {
+      "nombre": "Pay Ubre Chico",
+      "municipio": 2127
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105311,
+    "fields": {
+      "nombre": "Puesto Ciro",
+      "municipio": 2127
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105312,
+    "fields": {
+      "nombre": "Rincón de Yaguary",
+      "municipio": 2127
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105313,
+    "fields": {
+      "nombre": "Rincón del Diablo",
+      "municipio": 2127
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105314,
+    "fields": {
+      "nombre": "Rincón del Ombú",
+      "municipio": 2127
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105315,
+    "fields": {
+      "nombre": "Rincón Tranquera General",
+      "municipio": 2127
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105316,
+    "fields": {
+      "nombre": "Santa Clara",
+      "municipio": 2127
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105317,
+    "fields": {
+      "nombre": "Santa Juana",
+      "municipio": 2127
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105318,
+    "fields": {
+      "nombre": "Tacuaral",
+      "municipio": 2127
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105319,
+    "fields": {
+      "nombre": "Timbocito",
+      "municipio": 2127
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105320,
+    "fields": {
+      "nombre": "Toro Ratay",
+      "municipio": 2127
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105321,
+    "fields": {
+      "nombre": "Uguay",
+      "municipio": 2127
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105322,
+    "fields": {
+      "nombre": "Yuquerí",
+      "municipio": 2127
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105323,
+    "fields": {
+      "nombre": "El Tabacal",
+      "municipio": 2128
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105324,
+    "fields": {
+      "nombre": "Picada Sud",
+      "municipio": 2129
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105325,
+    "fields": {
+      "nombre": "Cabra Corral",
+      "municipio": 2131
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105326,
+    "fields": {
+      "nombre": "Dique Puerta de Díaz",
+      "municipio": 2131
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105327,
+    "fields": {
+      "nombre": "La Bodega",
+      "municipio": 2131
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105328,
+    "fields": {
+      "nombre": "Osma",
+      "municipio": 2131
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105329,
+    "fields": {
+      "nombre": "Peñas Blancas",
+      "municipio": 2131
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105330,
+    "fields": {
+      "nombre": "Punta Diamante",
+      "municipio": 2131
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105331,
+    "fields": {
+      "nombre": "La Misión",
+      "municipio": 2132
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105332,
+    "fields": {
+      "nombre": "Saucelito",
+      "municipio": 2132
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105333,
+    "fields": {
+      "nombre": "Amblayo",
+      "municipio": 2133
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105334,
+    "fields": {
+      "nombre": "El Barrial",
+      "municipio": 2133
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105335,
+    "fields": {
+      "nombre": "Isonza",
+      "municipio": 2133
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105336,
+    "fields": {
+      "nombre": "La Merced",
+      "municipio": 2133
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105337,
+    "fields": {
+      "nombre": "Las Barrancas",
+      "municipio": 2133
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105338,
+    "fields": {
+      "nombre": "Las Cortaderas",
+      "municipio": 2133
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105339,
+    "fields": {
+      "nombre": "Los Sauces",
+      "municipio": 2133
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105340,
+    "fields": {
+      "nombre": "Mina Don Otto",
+      "municipio": 2133
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105341,
+    "fields": {
+      "nombre": "Ovejería",
+      "municipio": 2133
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105342,
+    "fields": {
+      "nombre": "Palo Pintado",
+      "municipio": 2133
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105343,
+    "fields": {
+      "nombre": "Payogastilla",
+      "municipio": 2133
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105344,
+    "fields": {
+      "nombre": "Río Salado",
+      "municipio": 2133
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105345,
+    "fields": {
+      "nombre": "San Lucas",
+      "municipio": 2133
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105346,
+    "fields": {
+      "nombre": "San Rafael",
+      "municipio": 2133
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105347,
+    "fields": {
+      "nombre": "Chico Alférez",
+      "municipio": 2134
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105348,
+    "fields": {
+      "nombre": "Florentino Ameghino",
+      "municipio": 2134
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105349,
+    "fields": {
+      "nombre": "Puerto Rosario",
+      "municipio": 2134
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105350,
+    "fields": {
+      "nombre": "Boroloré",
+      "municipio": 2136
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105351,
+    "fields": {
+      "nombre": "Los Galpones",
+      "municipio": 2136
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105352,
+    "fields": {
+      "nombre": "Picada San Javier",
+      "municipio": 2136
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105353,
+    "fields": {
+      "nombre": "Rincón del Guerrero",
+      "municipio": 2136
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105354,
+    "fields": {
+      "nombre": "Santa Irene",
+      "municipio": 2136
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105355,
+    "fields": {
+      "nombre": "Alborada",
+      "municipio": 2137
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105356,
+    "fields": {
+      "nombre": "Aristóbulo Chico",
+      "municipio": 2137
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105357,
+    "fields": {
+      "nombre": "El Saltito",
+      "municipio": 2137
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105358,
+    "fields": {
+      "nombre": "La Yerba",
+      "municipio": 2137
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105359,
+    "fields": {
+      "nombre": "Mai Bao",
+      "municipio": 2137
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105360,
+    "fields": {
+      "nombre": "Picada Malvinas",
+      "municipio": 2137
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105361,
+    "fields": {
+      "nombre": "Picada Río Uruguay",
+      "municipio": 2137
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105362,
+    "fields": {
+      "nombre": "Primavera",
+      "municipio": 2137
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105363,
+    "fields": {
+      "nombre": "Torta Quemada",
+      "municipio": 2137
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105364,
+    "fields": {
+      "nombre": "Villa Vilma",
+      "municipio": 2137
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105365,
+    "fields": {
+      "nombre": "Abra Guazú",
+      "municipio": 2139
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105366,
+    "fields": {
+      "nombre": "Arroyo Soro",
+      "municipio": 2139
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105367,
+    "fields": {
+      "nombre": "Bella Vista",
+      "municipio": 2139
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105368,
+    "fields": {
+      "nombre": "Campo La Emilia",
+      "municipio": 2139
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105369,
+    "fields": {
+      "nombre": "Campo Pernizza",
+      "municipio": 2139
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105370,
+    "fields": {
+      "nombre": "Campo Romero",
+      "municipio": 2139
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105371,
+    "fields": {
+      "nombre": "Chacras Norte",
+      "municipio": 2139
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105372,
+    "fields": {
+      "nombre": "El Carmen",
+      "municipio": 2139
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105373,
+    "fields": {
+      "nombre": "Inga",
+      "municipio": 2139
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105374,
+    "fields": {
+      "nombre": "La Concepción",
+      "municipio": 2139
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105375,
+    "fields": {
+      "nombre": "La Dorita",
+      "municipio": 2139
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105376,
+    "fields": {
+      "nombre": "La Floresta",
+      "municipio": 2139
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105377,
+    "fields": {
+      "nombre": "Laguna Limpia",
+      "municipio": 2139
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105378,
+    "fields": {
+      "nombre": "Los Flotadores",
+      "municipio": 2139
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105379,
+    "fields": {
+      "nombre": "Los Flotadores Norte",
+      "municipio": 2139
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105380,
+    "fields": {
+      "nombre": "Malvinas Centro",
+      "municipio": 2139
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105381,
+    "fields": {
+      "nombre": "Malvinas Norte",
+      "municipio": 2139
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105382,
+    "fields": {
+      "nombre": "Malvinas Sur",
+      "municipio": 2139
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105383,
+    "fields": {
+      "nombre": "Paso Hu",
+      "municipio": 2139
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105384,
+    "fields": {
+      "nombre": "Picada Amara",
+      "municipio": 2139
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105385,
+    "fields": {
+      "nombre": "Rincón de Guayquiraró",
+      "municipio": 2139
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105386,
+    "fields": {
+      "nombre": "Rincón del Sarandí",
+      "municipio": 2139
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105387,
+    "fields": {
+      "nombre": "San Antonio",
+      "municipio": 2139
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105388,
+    "fields": {
+      "nombre": "Santa Catalina",
+      "municipio": 2139
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105389,
+    "fields": {
+      "nombre": "Santa Librada",
+      "municipio": 2139
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105390,
+    "fields": {
+      "nombre": "Santo Domingo",
+      "municipio": 2139
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105391,
+    "fields": {
+      "nombre": "Sarandí",
+      "municipio": 2139
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105392,
+    "fields": {
+      "nombre": "Tranquera Cadena",
+      "municipio": 2139
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105393,
+    "fields": {
+      "nombre": "Tres Mojones",
+      "municipio": 2139
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105394,
+    "fields": {
+      "nombre": "Villa Rosa",
+      "municipio": 2139
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105395,
+    "fields": {
+      "nombre": "Colonia Gutiérrez",
+      "municipio": 2140
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105396,
+    "fields": {
+      "nombre": "Alto Verde",
+      "municipio": 2141
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105397,
+    "fields": {
+      "nombre": "Cañada Honda",
+      "municipio": 2141
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105398,
+    "fields": {
+      "nombre": "Cienaguita",
+      "municipio": 2141
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105399,
+    "fields": {
+      "nombre": "Cochagual",
+      "municipio": 2141
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105400,
+    "fields": {
+      "nombre": "Colonia Fiscal",
+      "municipio": 2141
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105401,
+    "fields": {
+      "nombre": "Colonia San Antonio",
+      "municipio": 2141
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105402,
+    "fields": {
+      "nombre": "Divisadero",
+      "municipio": 2141
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105403,
+    "fields": {
+      "nombre": "El Acequión",
+      "municipio": 2141
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105404,
+    "fields": {
+      "nombre": "Guanacache",
+      "municipio": 2141
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105405,
+    "fields": {
+      "nombre": "Las Lagunas",
+      "municipio": 2141
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105406,
+    "fields": {
+      "nombre": "Los Nogales",
+      "municipio": 2141
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105407,
+    "fields": {
+      "nombre": "Pedernal",
+      "municipio": 2141
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105408,
+    "fields": {
+      "nombre": "Punta del Médano",
+      "municipio": 2141
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105409,
+    "fields": {
+      "nombre": "Ramblón",
+      "municipio": 2141
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105410,
+    "fields": {
+      "nombre": "Retamito",
+      "municipio": 2141
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105411,
+    "fields": {
+      "nombre": "San Carlos",
+      "municipio": 2141
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105412,
+    "fields": {
+      "nombre": "Tres Esquinas",
+      "municipio": 2141
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105413,
+    "fields": {
+      "nombre": "Villa Media Agua",
+      "municipio": 2141
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105414,
+    "fields": {
+      "nombre": "Buena Vista",
+      "municipio": 2238
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105415,
+    "fields": {
+      "nombre": "Campo Araoz",
+      "municipio": 2238
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105416,
+    "fields": {
+      "nombre": "Campo Blanco",
+      "municipio": 2238
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105417,
+    "fields": {
+      "nombre": "Campo Pitteri",
+      "municipio": 2238
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105418,
+    "fields": {
+      "nombre": "Campo Roffo",
+      "municipio": 2238
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105419,
+    "fields": {
+      "nombre": "Colonia La Aurora",
+      "municipio": 2238
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105420,
+    "fields": {
+      "nombre": "Colonia Oeste",
+      "municipio": 2238
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105421,
+    "fields": {
+      "nombre": "Colonia Winter",
+      "municipio": 2238
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105422,
+    "fields": {
+      "nombre": "Costa Guaycurú",
+      "municipio": 2238
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105423,
+    "fields": {
+      "nombre": "El Correntoso",
+      "municipio": 2238
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105424,
+    "fields": {
+      "nombre": "El Fiscalito",
+      "municipio": 2238
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105425,
+    "fields": {
+      "nombre": "El Lunar",
+      "municipio": 2238
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105426,
+    "fields": {
+      "nombre": "La Palmira",
+      "municipio": 2238
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105427,
+    "fields": {
+      "nombre": "Laguna Lobo",
+      "municipio": 2238
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105428,
+    "fields": {
+      "nombre": "Legua 131",
+      "municipio": 2238
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105429,
+    "fields": {
+      "nombre": "Lote 92",
+      "municipio": 2238
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105430,
+    "fields": {
+      "nombre": "Paraje San Antonio",
+      "municipio": 2238
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105431,
+    "fields": {
+      "nombre": "Puerto El Zapallar",
+      "municipio": 2238
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105432,
+    "fields": {
+      "nombre": "Puesto Expedición",
+      "municipio": 2238
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105433,
+    "fields": {
+      "nombre": "Siete Árboles",
+      "municipio": 2238
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105434,
+    "fields": {
+      "nombre": "Tres Banderas",
+      "municipio": 2238
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105435,
+    "fields": {
+      "nombre": "Zapallar Norte",
+      "municipio": 2238
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105436,
+    "fields": {
+      "nombre": "Campo Aiassa",
+      "municipio": 2239
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105437,
+    "fields": {
+      "nombre": "Colonia Santa Irene",
+      "municipio": 2239
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105438,
+    "fields": {
+      "nombre": "Puerto Aragón",
+      "municipio": 2247
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105439,
+    "fields": {
+      "nombre": "Colonia California",
+      "municipio": 2248
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105440,
+    "fields": {
+      "nombre": "Colonia Criolla",
+      "municipio": 2248
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105441,
+    "fields": {
+      "nombre": "Colonia Francesa",
+      "municipio": 2248
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105442,
+    "fields": {
+      "nombre": "Colonia San Ignacio",
+      "municipio": 2248
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105443,
+    "fields": {
+      "nombre": "Colonia San José",
+      "municipio": 2248
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105444,
+    "fields": {
+      "nombre": "Colonia Teresa",
+      "municipio": 2248
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105445,
+    "fields": {
+      "nombre": "Colonia Yatay",
+      "municipio": 2248
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105446,
+    "fields": {
+      "nombre": "9 de Julio",
+      "municipio": 2249
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105447,
+    "fields": {
+      "nombre": "Aerolito",
+      "municipio": 2249
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105448,
+    "fields": {
+      "nombre": "Alhuampa",
+      "municipio": 2249
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105449,
+    "fields": {
+      "nombre": "Amamá",
+      "municipio": 2249
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105450,
+    "fields": {
+      "nombre": "Anchilo",
+      "municipio": 2249
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105451,
+    "fields": {
+      "nombre": "Árbol Blanco",
+      "municipio": 2249
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105452,
+    "fields": {
+      "nombre": "Campo del Infierno",
+      "municipio": 2249
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105453,
+    "fields": {
+      "nombre": "Catamarca",
+      "municipio": 2249
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105454,
+    "fields": {
+      "nombre": "Cejolao",
+      "municipio": 2249
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105455,
+    "fields": {
+      "nombre": "Colonia España",
+      "municipio": 2249
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105456,
+    "fields": {
+      "nombre": "Concepción",
+      "municipio": 2249
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105457,
+    "fields": {
+      "nombre": "El 90",
+      "municipio": 2249
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105458,
+    "fields": {
+      "nombre": "El Arbolito",
+      "municipio": 2249
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105459,
+    "fields": {
+      "nombre": "El Carmen",
+      "municipio": 2249
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105460,
+    "fields": {
+      "nombre": "El Fisco",
+      "municipio": 2249
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105461,
+    "fields": {
+      "nombre": "El Hoyo",
+      "municipio": 2249
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105462,
+    "fields": {
+      "nombre": "El Ochenta y Cinco",
+      "municipio": 2249
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105463,
+    "fields": {
+      "nombre": "El Ochenta y Seis",
+      "municipio": 2249
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105464,
+    "fields": {
+      "nombre": "El Pértigo",
+      "municipio": 2249
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105465,
+    "fields": {
+      "nombre": "El Prado",
+      "municipio": 2249
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105466,
+    "fields": {
+      "nombre": "El Rosario",
+      "municipio": 2249
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105467,
+    "fields": {
+      "nombre": "El Simbolar",
+      "municipio": 2249
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105468,
+    "fields": {
+      "nombre": "Fortuna",
+      "municipio": 2249
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105469,
+    "fields": {
+      "nombre": "Girardet",
+      "municipio": 2249
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105470,
+    "fields": {
+      "nombre": "Granadero Gatica",
+      "municipio": 2249
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105471,
+    "fields": {
+      "nombre": "Hasse",
+      "municipio": 2249
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105472,
+    "fields": {
+      "nombre": "Hernán Mejía Miraval",
+      "municipio": 2249
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105473,
+    "fields": {
+      "nombre": "Huasi Bamba",
+      "municipio": 2249
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105474,
+    "fields": {
+      "nombre": "Huchu Payana",
+      "municipio": 2249
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105475,
+    "fields": {
+      "nombre": "La Esperanza",
+      "municipio": 2249
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105476,
+    "fields": {
+      "nombre": "La Magdalena",
+      "municipio": 2249
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105477,
+    "fields": {
+      "nombre": "La Nombrada",
+      "municipio": 2249
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105478,
+    "fields": {
+      "nombre": "La Paloma",
+      "municipio": 2249
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105479,
+    "fields": {
+      "nombre": "Las Dos A",
+      "municipio": 2249
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105480,
+    "fields": {
+      "nombre": "Las Randas",
+      "municipio": 2249
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105481,
+    "fields": {
+      "nombre": "Las Tinajas",
+      "municipio": 2249
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105482,
+    "fields": {
+      "nombre": "Las Tres Lomas",
+      "municipio": 2249
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105483,
+    "fields": {
+      "nombre": "Ledesma",
+      "municipio": 2249
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105484,
+    "fields": {
+      "nombre": "Libertad",
+      "municipio": 2249
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105485,
+    "fields": {
+      "nombre": "Lilo Viejo",
+      "municipio": 2249
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105486,
+    "fields": {
+      "nombre": "Lincho",
+      "municipio": 2249
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105487,
+    "fields": {
+      "nombre": "Los Milagros",
+      "municipio": 2249
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105488,
+    "fields": {
+      "nombre": "Lote 110",
+      "municipio": 2249
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105489,
+    "fields": {
+      "nombre": "Lote 115",
+      "municipio": 2249
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105490,
+    "fields": {
+      "nombre": "Lote 28",
+      "municipio": 2249
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105491,
+    "fields": {
+      "nombre": "Lote 3",
+      "municipio": 2249
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105492,
+    "fields": {
+      "nombre": "Lote 31",
+      "municipio": 2249
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105493,
+    "fields": {
+      "nombre": "Lote 48",
+      "municipio": 2249
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105494,
+    "fields": {
+      "nombre": "Luján",
+      "municipio": 2249
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105495,
+    "fields": {
+      "nombre": "Mercedes",
+      "municipio": 2249
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105496,
+    "fields": {
+      "nombre": "Mistol Pampa",
+      "municipio": 2249
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105497,
+    "fields": {
+      "nombre": "Monte Alto",
+      "municipio": 2249
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105498,
+    "fields": {
+      "nombre": "Monte Redondo",
+      "municipio": 2249
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105499,
+    "fields": {
+      "nombre": "Muyusca",
+      "municipio": 2249
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105500,
+    "fields": {
+      "nombre": "Obraje María Angélica",
+      "municipio": 2249
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105501,
+    "fields": {
+      "nombre": "Ottavia",
+      "municipio": 2249
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105502,
+    "fields": {
+      "nombre": "Palermo",
+      "municipio": 2249
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105503,
+    "fields": {
+      "nombre": "Pampa Charquina",
+      "municipio": 2249
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105504,
+    "fields": {
+      "nombre": "Pampa Pozo",
+      "municipio": 2249
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105505,
+    "fields": {
+      "nombre": "Paraje El Simbolar",
+      "municipio": 2249
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105506,
+    "fields": {
+      "nombre": "Patay",
+      "municipio": 2249
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105507,
+    "fields": {
+      "nombre": "Pueblo Pablo Torelo",
+      "municipio": 2249
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105508,
+    "fields": {
+      "nombre": "Quilumpa",
+      "municipio": 2249
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105509,
+    "fields": {
+      "nombre": "Roversi",
+      "municipio": 2249
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105510,
+    "fields": {
+      "nombre": "Saldívar",
+      "municipio": 2249
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105511,
+    "fields": {
+      "nombre": "San Antonio",
+      "municipio": 2249
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105512,
+    "fields": {
+      "nombre": "San Carlos",
+      "municipio": 2249
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105513,
+    "fields": {
+      "nombre": "San Felipe",
+      "municipio": 2249
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105514,
+    "fields": {
+      "nombre": "San Francisco",
+      "municipio": 2249
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105515,
+    "fields": {
+      "nombre": "San Martín",
+      "municipio": 2249
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105516,
+    "fields": {
+      "nombre": "Santa Lucía",
+      "municipio": 2249
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105517,
+    "fields": {
+      "nombre": "Santa María",
+      "municipio": 2249
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105518,
+    "fields": {
+      "nombre": "Santa Rita",
+      "municipio": 2249
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105519,
+    "fields": {
+      "nombre": "Santa Rosa",
+      "municipio": 2249
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105520,
+    "fields": {
+      "nombre": "Santa Teresita",
+      "municipio": 2249
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105521,
+    "fields": {
+      "nombre": "Santo Domingo",
+      "municipio": 2249
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105522,
+    "fields": {
+      "nombre": "Santo Domingo de Cisneros",
+      "municipio": 2249
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105523,
+    "fields": {
+      "nombre": "Stayle",
+      "municipio": 2249
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105524,
+    "fields": {
+      "nombre": "Suri Pozo",
+      "municipio": 2249
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105525,
+    "fields": {
+      "nombre": "Tabianita",
+      "municipio": 2249
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105526,
+    "fields": {
+      "nombre": "Tierra del Este",
+      "municipio": 2249
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105527,
+    "fields": {
+      "nombre": "Tinajerayoj",
+      "municipio": 2249
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105528,
+    "fields": {
+      "nombre": "Tintina",
+      "municipio": 2249
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105529,
+    "fields": {
+      "nombre": "Tres Mojones",
+      "municipio": 2249
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105530,
+    "fields": {
+      "nombre": "Villa Brana",
+      "municipio": 2249
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105531,
+    "fields": {
+      "nombre": "Villa Petocha",
+      "municipio": 2249
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105532,
+    "fields": {
+      "nombre": "Weisburd",
+      "municipio": 2249
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105533,
+    "fields": {
+      "nombre": "Dique La Huertita",
+      "municipio": 2253
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105534,
+    "fields": {
+      "nombre": "La Huertita",
+      "municipio": 2253
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105535,
+    "fields": {
+      "nombre": "Colonia Caimán",
+      "municipio": 2260
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105536,
+    "fields": {
+      "nombre": "Curuzú Laurel",
+      "municipio": 2260
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105537,
+    "fields": {
+      "nombre": "San Antonio",
+      "municipio": 2260
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105538,
+    "fields": {
+      "nombre": "Santa Bárbara",
+      "municipio": 2260
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105539,
+    "fields": {
+      "nombre": "Silvero Cué",
+      "municipio": 2260
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105540,
+    "fields": {
+      "nombre": "Yataity Poi",
+      "municipio": 2260
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105541,
+    "fields": {
+      "nombre": "Aldea San Gregorio",
+      "municipio": 2263
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105542,
+    "fields": {
+      "nombre": "Berduc",
+      "municipio": 2263
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105543,
+    "fields": {
+      "nombre": "Colonia Hugues",
+      "municipio": 2263
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105544,
+    "fields": {
+      "nombre": "Colonia Palmar Yatay",
+      "municipio": 2263
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105545,
+    "fields": {
+      "nombre": "Colonia Paso Paysandú",
+      "municipio": 2263
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105546,
+    "fields": {
+      "nombre": "El Palmar",
+      "municipio": 2263
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105547,
+    "fields": {
+      "nombre": "Santa Inés",
+      "municipio": 2263
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105548,
+    "fields": {
+      "nombre": "Sumaca",
+      "municipio": 2263
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105549,
+    "fields": {
+      "nombre": "Arbilla",
+      "municipio": 2264
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105550,
+    "fields": {
+      "nombre": "Kilómetro 101",
+      "municipio": 2264
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105551,
+    "fields": {
+      "nombre": "Monte Flores",
+      "municipio": 2264
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105552,
+    "fields": {
+      "nombre": "Rastreador Fournier",
+      "municipio": 2266
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105553,
+    "fields": {
+      "nombre": "Runciman",
+      "municipio": 2266
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105554,
+    "fields": {
+      "nombre": "Villa Sol de Mayo",
+      "municipio": 2266
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105555,
+    "fields": {
+      "nombre": "Colonia Ensanche Sauce",
+      "municipio": 2267
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105556,
+    "fields": {
+      "nombre": "Colonia Santa Eloísa",
+      "municipio": 2267
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105557,
+    "fields": {
+      "nombre": "Abra del Manzano",
+      "municipio": 2268
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105558,
+    "fields": {
+      "nombre": "Arroyo de Álvarez Centro",
+      "municipio": 2268
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105559,
+    "fields": {
+      "nombre": "Arroyo de Álvarez Norte",
+      "municipio": 2268
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105560,
+    "fields": {
+      "nombre": "Arroyo de los Leones",
+      "municipio": 2268
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105561,
+    "fields": {
+      "nombre": "Cabituyo",
+      "municipio": 2268
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105562,
+    "fields": {
+      "nombre": "Campo 25 de Mayo",
+      "municipio": 2268
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105563,
+    "fields": {
+      "nombre": "Campo Callerio",
+      "municipio": 2268
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105564,
+    "fields": {
+      "nombre": "Campo La Salada",
+      "municipio": 2268
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105565,
+    "fields": {
+      "nombre": "Campo La Soledad",
+      "municipio": 2268
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105566,
+    "fields": {
+      "nombre": "Campo Las Víboras",
+      "municipio": 2268
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105567,
+    "fields": {
+      "nombre": "Campo Lavalle",
+      "municipio": 2268
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105568,
+    "fields": {
+      "nombre": "Campo López",
+      "municipio": 2268
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105569,
+    "fields": {
+      "nombre": "Campo Los Porteños",
+      "municipio": 2268
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105570,
+    "fields": {
+      "nombre": "Campo Los Terceranos",
+      "municipio": 2268
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105571,
+    "fields": {
+      "nombre": "Campo Los Zorros",
+      "municipio": 2268
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105572,
+    "fields": {
+      "nombre": "Capilla San Antonio",
+      "municipio": 2268
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105573,
+    "fields": {
+      "nombre": "Colonia 10 de Julio",
+      "municipio": 2268
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105574,
+    "fields": {
+      "nombre": "Colonia Amalia",
+      "municipio": 2268
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105575,
+    "fields": {
+      "nombre": "Colonia Beiró",
+      "municipio": 2268
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105576,
+    "fields": {
+      "nombre": "Colonia Beiró Este",
+      "municipio": 2268
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105577,
+    "fields": {
+      "nombre": "Colonia Beiró Norte",
+      "municipio": 2268
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105578,
+    "fields": {
+      "nombre": "Colonia Ceferina",
+      "municipio": 2268
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105579,
+    "fields": {
+      "nombre": "Colonia Coyunda",
+      "municipio": 2268
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105580,
+    "fields": {
+      "nombre": "Colonia Dos Hermanos Norte",
+      "municipio": 2268
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105581,
+    "fields": {
+      "nombre": "Colonia Dos Herrmanos",
+      "municipio": 2268
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105582,
+    "fields": {
+      "nombre": "Colonia El Fortín",
+      "municipio": 2268
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105583,
+    "fields": {
+      "nombre": "Colonia El Milagro Este",
+      "municipio": 2268
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105584,
+    "fields": {
+      "nombre": "Colonia El Milagro Oeste",
+      "municipio": 2268
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105585,
+    "fields": {
+      "nombre": "Colonia El Porvenir",
+      "municipio": 2268
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105586,
+    "fields": {
+      "nombre": "Colonia El Sauce",
+      "municipio": 2268
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105587,
+    "fields": {
+      "nombre": "Colonia El Trabajo",
+      "municipio": 2268
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105588,
+    "fields": {
+      "nombre": "Colonia Eugenia",
+      "municipio": 2268
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105589,
+    "fields": {
+      "nombre": "Colonia Freyre Noreste",
+      "municipio": 2268
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105590,
+    "fields": {
+      "nombre": "Colonia Freyre Noroeste",
+      "municipio": 2268
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105591,
+    "fields": {
+      "nombre": "Colonia Frontera Norte",
+      "municipio": 2268
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105592,
+    "fields": {
+      "nombre": "Colonia Frontera Sur",
+      "municipio": 2268
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105593,
+    "fields": {
+      "nombre": "Colonia General Deheza",
+      "municipio": 2268
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105594,
+    "fields": {
+      "nombre": "Colonia La Taperita",
+      "municipio": 2268
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105595,
+    "fields": {
+      "nombre": "Colonia La Trinchera",
+      "municipio": 2268
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105596,
+    "fields": {
+      "nombre": "Colonia Las Lomas",
+      "municipio": 2268
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105597,
+    "fields": {
+      "nombre": "Colonia Las Palmeras",
+      "municipio": 2268
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105598,
+    "fields": {
+      "nombre": "Colonia Madreselva",
+      "municipio": 2268
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105599,
+    "fields": {
+      "nombre": "Colonia Malbertina",
+      "municipio": 2268
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105600,
+    "fields": {
+      "nombre": "Colonia Maunier Centro",
+      "municipio": 2268
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105601,
+    "fields": {
+      "nombre": "Colonia Maunier Norte",
+      "municipio": 2268
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105602,
+    "fields": {
+      "nombre": "Colonia Maunier Sur",
+      "municipio": 2268
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105603,
+    "fields": {
+      "nombre": "Colonia Milessi",
+      "municipio": 2268
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105604,
+    "fields": {
+      "nombre": "Colonia Miramar",
+      "municipio": 2268
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105605,
+    "fields": {
+      "nombre": "Colonia Monte Grande",
+      "municipio": 2268
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105606,
+    "fields": {
+      "nombre": "Colonia Monte Tala",
+      "municipio": 2268
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105607,
+    "fields": {
+      "nombre": "Colonia Nueva Francia",
+      "municipio": 2268
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105608,
+    "fields": {
+      "nombre": "Colonia Nueva Údine",
+      "municipio": 2268
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105609,
+    "fields": {
+      "nombre": "Colonia Palo Labrado",
+      "municipio": 2268
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105610,
+    "fields": {
+      "nombre": "Colonia San Rafael",
+      "municipio": 2268
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105611,
+    "fields": {
+      "nombre": "Colonia Severina",
+      "municipio": 2268
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105612,
+    "fields": {
+      "nombre": "Colonia Unidad",
+      "municipio": 2268
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105613,
+    "fields": {
+      "nombre": "El Descanso",
+      "municipio": 2268
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105614,
+    "fields": {
+      "nombre": "El Desquite",
+      "municipio": 2268
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105615,
+    "fields": {
+      "nombre": "El Jumeal",
+      "municipio": 2268
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105616,
+    "fields": {
+      "nombre": "El Pino",
+      "municipio": 2268
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105617,
+    "fields": {
+      "nombre": "Jeanmarie",
+      "municipio": 2268
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105618,
+    "fields": {
+      "nombre": "Jerónimo Cortés",
+      "municipio": 2268
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105619,
+    "fields": {
+      "nombre": "Kilómetro 581",
+      "municipio": 2268
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105620,
+    "fields": {
+      "nombre": "La Cortadera",
+      "municipio": 2268
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105621,
+    "fields": {
+      "nombre": "La Quemada",
+      "municipio": 2268
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105622,
+    "fields": {
+      "nombre": "La Toscanita",
+      "municipio": 2268
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105623,
+    "fields": {
+      "nombre": "La Victoria",
+      "municipio": 2268
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105624,
+    "fields": {
+      "nombre": "Las Delicias",
+      "municipio": 2268
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105625,
+    "fields": {
+      "nombre": "Las Dos Provincias",
+      "municipio": 2268
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105626,
+    "fields": {
+      "nombre": "Loma de los Indios",
+      "municipio": 2268
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105627,
+    "fields": {
+      "nombre": "Monte Redondo",
+      "municipio": 2268
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105628,
+    "fields": {
+      "nombre": "Pampa del Mercado",
+      "municipio": 2268
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105629,
+    "fields": {
+      "nombre": "Pista Rosalinda",
+      "municipio": 2268
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105630,
+    "fields": {
+      "nombre": "Playa Grande",
+      "municipio": 2268
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105631,
+    "fields": {
+      "nombre": "Plaza Bruno",
+      "municipio": 2268
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105632,
+    "fields": {
+      "nombre": "Pozo del Mortero",
+      "municipio": 2268
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105633,
+    "fields": {
+      "nombre": "Pozo El Chaya",
+      "municipio": 2268
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105634,
+    "fields": {
+      "nombre": "Pozo Salado",
+      "municipio": 2268
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105635,
+    "fields": {
+      "nombre": "Puerta Los Montes",
+      "municipio": 2268
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105636,
+    "fields": {
+      "nombre": "Trinchera",
+      "municipio": 2268
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105637,
+    "fields": {
+      "nombre": "Colonia Vásquez",
+      "municipio": 2272
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105638,
+    "fields": {
+      "nombre": "Las Palmitas",
+      "municipio": 100000
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105639,
+    "fields": {
+      "nombre": "Avellaneda",
+      "municipio": 100001
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105640,
+    "fields": {
+      "nombre": "El Estanque",
+      "municipio": 100001
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105641,
+    "fields": {
+      "nombre": "Juan García",
+      "municipio": 100001
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105642,
+    "fields": {
+      "nombre": "Tiu Mayu",
+      "municipio": 100002
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105643,
+    "fields": {
+      "nombre": "El Rodeo",
+      "municipio": 100003
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105644,
+    "fields": {
+      "nombre": "La Maza",
+      "municipio": 100003
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105645,
+    "fields": {
+      "nombre": "Campo El Chato",
+      "municipio": 100004
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105646,
+    "fields": {
+      "nombre": "Campo La Alejandra",
+      "municipio": 100004
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105647,
+    "fields": {
+      "nombre": "Campo Los Prados",
+      "municipio": 100004
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105648,
+    "fields": {
+      "nombre": "Cayuqueo",
+      "municipio": 100004
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105649,
+    "fields": {
+      "nombre": "Chacras de Tío Pujio",
+      "municipio": 100004
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105650,
+    "fields": {
+      "nombre": "Isleta Cabral",
+      "municipio": 100004
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105651,
+    "fields": {
+      "nombre": "Las Mojarras",
+      "municipio": 100004
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105652,
+    "fields": {
+      "nombre": "Pedanía Yucat",
+      "municipio": 100004
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105653,
+    "fields": {
+      "nombre": "Santa Victoria",
+      "municipio": 100004
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105654,
+    "fields": {
+      "nombre": "Cañada Grande",
+      "municipio": 100005
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105655,
+    "fields": {
+      "nombre": "Cañada La Negra",
+      "municipio": 100005
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105656,
+    "fields": {
+      "nombre": "Cruz Caña",
+      "municipio": 100005
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105657,
+    "fields": {
+      "nombre": "El Manantial",
+      "municipio": 100005
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105658,
+    "fields": {
+      "nombre": "La Guarida",
+      "municipio": 100005
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105659,
+    "fields": {
+      "nombre": "La Paz",
+      "municipio": 100005
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105660,
+    "fields": {
+      "nombre": "La Ramada",
+      "municipio": 100005
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105661,
+    "fields": {
+      "nombre": "Las Chacras",
+      "municipio": 100005
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105662,
+    "fields": {
+      "nombre": "Loma Bola",
+      "municipio": 100005
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105663,
+    "fields": {
+      "nombre": "Los Mates",
+      "municipio": 100005
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105664,
+    "fields": {
+      "nombre": "Quebracho Ladeado",
+      "municipio": 100005
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105665,
+    "fields": {
+      "nombre": "Tilquicho",
+      "municipio": 100005
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105666,
+    "fields": {
+      "nombre": "Malvinas Argentinas",
+      "municipio": 100006
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105667,
+    "fields": {
+      "nombre": "Tejeda",
+      "municipio": 100006
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105668,
+    "fields": {
+      "nombre": "Villa Corazón de María",
+      "municipio": 100006
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105669,
+    "fields": {
+      "nombre": "Pilar",
+      "municipio": 100007
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105670,
+    "fields": {
+      "nombre": "Saladillo",
+      "municipio": 100008
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105671,
+    "fields": {
+      "nombre": "San José",
+      "municipio": 100009
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105672,
+    "fields": {
+      "nombre": "Balde de la Mora",
+      "municipio": 100010
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105673,
+    "fields": {
+      "nombre": "La Reducción",
+      "municipio": 100010
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105674,
+    "fields": {
+      "nombre": "Las Toscas",
+      "municipio": 100010
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105675,
+    "fields": {
+      "nombre": "San Martín",
+      "municipio": 100010
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105676,
+    "fields": {
+      "nombre": "San Miguel",
+      "municipio": 100010
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105677,
+    "fields": {
+      "nombre": "San Rafael",
+      "municipio": 100010
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105678,
+    "fields": {
+      "nombre": "San Vicente",
+      "municipio": 100010
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105679,
+    "fields": {
+      "nombre": "Santa María",
+      "municipio": 100010
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105680,
+    "fields": {
+      "nombre": "Alto del Fierro",
+      "municipio": 100011
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105681,
+    "fields": {
+      "nombre": "Bajo Chico",
+      "municipio": 100011
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105682,
+    "fields": {
+      "nombre": "Bajo Grande",
+      "municipio": 100011
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105683,
+    "fields": {
+      "nombre": "Campo Buena Esperanza",
+      "municipio": 100011
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105684,
+    "fields": {
+      "nombre": "Colonia Cocha",
+      "municipio": 100011
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105685,
+    "fields": {
+      "nombre": "Kilómetro 15",
+      "municipio": 100011
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105686,
+    "fields": {
+      "nombre": "La Acequiecita",
+      "municipio": 100011
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105687,
+    "fields": {
+      "nombre": "La Carbonada",
+      "municipio": 100011
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105688,
+    "fields": {
+      "nombre": "Pampa de Achala",
+      "municipio": 100011
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105689,
+    "fields": {
+      "nombre": "Río del Medio",
+      "municipio": 100011
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105690,
+    "fields": {
+      "nombre": "San Antonio Norte",
+      "municipio": 100011
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105691,
+    "fields": {
+      "nombre": "Socavones",
+      "municipio": 100011
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105692,
+    "fields": {
+      "nombre": "Tres Pozos Sud",
+      "municipio": 100011
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105693,
+    "fields": {
+      "nombre": "9 de Julio",
+      "municipio": 100012
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105694,
+    "fields": {
+      "nombre": "Algarrobal",
+      "municipio": 100012
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105695,
+    "fields": {
+      "nombre": "Colonia Juan Ramón Vidal",
+      "municipio": 100012
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105696,
+    "fields": {
+      "nombre": "Costa Santa Lucía",
+      "municipio": 100012
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105697,
+    "fields": {
+      "nombre": "Kilómetro 387",
+      "municipio": 100012
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105698,
+    "fields": {
+      "nombre": "La Loma",
+      "municipio": 100013
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105699,
+    "fields": {
+      "nombre": "Lavalle",
+      "municipio": 100013
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105700,
+    "fields": {
+      "nombre": "Puerto Viejo",
+      "municipio": 100013
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105701,
+    "fields": {
+      "nombre": "Rincón de Santa Lucía",
+      "municipio": 100013
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105702,
+    "fields": {
+      "nombre": "Rincón de Soto",
+      "municipio": 100013
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105703,
+    "fields": {
+      "nombre": "Bañado de San Antonio",
+      "municipio": 100014
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105704,
+    "fields": {
+      "nombre": "Buena Esperanza",
+      "municipio": 100014
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105705,
+    "fields": {
+      "nombre": "Campo Morato",
+      "municipio": 100014
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105706,
+    "fields": {
+      "nombre": "El Duraznillo",
+      "municipio": 100014
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105707,
+    "fields": {
+      "nombre": "El Quebracho",
+      "municipio": 100014
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105708,
+    "fields": {
+      "nombre": "Invernada",
+      "municipio": 100014
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105709,
+    "fields": {
+      "nombre": "Isla Talar",
+      "municipio": 100014
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105710,
+    "fields": {
+      "nombre": "La Cucucha",
+      "municipio": 100014
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105711,
+    "fields": {
+      "nombre": "La Marta",
+      "municipio": 100014
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105712,
+    "fields": {
+      "nombre": "Paso Los Ángeles",
+      "municipio": 100014
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105713,
+    "fields": {
+      "nombre": "Paso San Juan",
+      "municipio": 100014
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105714,
+    "fields": {
+      "nombre": "Paso Santa Rosa",
+      "municipio": 100014
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105715,
+    "fields": {
+      "nombre": "Paso Trementina",
+      "municipio": 100014
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105716,
+    "fields": {
+      "nombre": "Rincón del Pago",
+      "municipio": 100014
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105717,
+    "fields": {
+      "nombre": "San Antonio",
+      "municipio": 100014
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105718,
+    "fields": {
+      "nombre": "San Gregorio",
+      "municipio": 100014
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105719,
+    "fields": {
+      "nombre": "San Isidro",
+      "municipio": 100014
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105720,
+    "fields": {
+      "nombre": "San Martín",
+      "municipio": 100014
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105721,
+    "fields": {
+      "nombre": "Santa Rita",
+      "municipio": 100014
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105722,
+    "fields": {
+      "nombre": "Stella Maris",
+      "municipio": 100014
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105723,
+    "fields": {
+      "nombre": "Tres Bocas",
+      "municipio": 100014
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105724,
+    "fields": {
+      "nombre": "Arroyo Ceibal",
+      "municipio": 100015
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105725,
+    "fields": {
+      "nombre": "El Ceibal",
+      "municipio": 100015
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105726,
+    "fields": {
+      "nombre": "Rincón de Ambrosio",
+      "municipio": 100015
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105727,
+    "fields": {
+      "nombre": "Rincón de San Lorenzo",
+      "municipio": 100015
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105728,
+    "fields": {
+      "nombre": "San Lorenzo",
+      "municipio": 100015
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105729,
+    "fields": {
+      "nombre": "Arroyo González",
+      "municipio": 100016
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105730,
+    "fields": {
+      "nombre": "Arroyo Paraíso",
+      "municipio": 100016
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105731,
+    "fields": {
+      "nombre": "Luján",
+      "municipio": 100016
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105732,
+    "fields": {
+      "nombre": "San Roque",
+      "municipio": 100016
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105733,
+    "fields": {
+      "nombre": "Santa Angélica",
+      "municipio": 100016
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105734,
+    "fields": {
+      "nombre": "Santo Domingo",
+      "municipio": 100016
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105735,
+    "fields": {
+      "nombre": "Cancha Larga",
+      "municipio": 100017
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105736,
+    "fields": {
+      "nombre": "El Palmar",
+      "municipio": 100017
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105737,
+    "fields": {
+      "nombre": "Las Palmas",
+      "municipio": 100017
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105738,
+    "fields": {
+      "nombre": "Limita",
+      "municipio": 100017
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105739,
+    "fields": {
+      "nombre": "Mongay",
+      "municipio": 100017
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105740,
+    "fields": {
+      "nombre": "Puerto Las Palmas",
+      "municipio": 100017
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105741,
+    "fields": {
+      "nombre": "Paralelo 28",
+      "municipio": 100018
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105742,
+    "fields": {
+      "nombre": "Cabo Dos Bahías",
+      "municipio": 100019
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105743,
+    "fields": {
+      "nombre": "Cabo Raso",
+      "municipio": 100019
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105744,
+    "fields": {
+      "nombre": "Caleta Hornos",
+      "municipio": 100019
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105745,
+    "fields": {
+      "nombre": "Caleta Sara",
+      "municipio": 100019
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105746,
+    "fields": {
+      "nombre": "Cruce Camarones",
+      "municipio": 100019
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105747,
+    "fields": {
+      "nombre": "Dos Pozos",
+      "municipio": 100019
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105748,
+    "fields": {
+      "nombre": "Florentino Ameghino",
+      "municipio": 100019
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105749,
+    "fields": {
+      "nombre": "Garayalde",
+      "municipio": 100019
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105750,
+    "fields": {
+      "nombre": "Malaspina",
+      "municipio": 100019
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105751,
+    "fields": {
+      "nombre": "Paso Chico",
+      "municipio": 100019
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105752,
+    "fields": {
+      "nombre": "Puerto Melo",
+      "municipio": 100019
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105753,
+    "fields": {
+      "nombre": "Punta Tombo",
+      "municipio": 100019
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105754,
+    "fields": {
+      "nombre": "Uzcudun",
+      "municipio": 100019
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105755,
+    "fields": {
+      "nombre": "Alto de las Plumas",
+      "municipio": 100020
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105756,
+    "fields": {
+      "nombre": "Bajada del Diablo",
+      "municipio": 100020
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105757,
+    "fields": {
+      "nombre": "El Mirasol",
+      "municipio": 100020
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105758,
+    "fields": {
+      "nombre": "La Rosada",
+      "municipio": 100020
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105759,
+    "fields": {
+      "nombre": "Laguna Grande",
+      "municipio": 100020
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105760,
+    "fields": {
+      "nombre": "Las Chapas",
+      "municipio": 100020
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105761,
+    "fields": {
+      "nombre": "Paso Malerba",
+      "municipio": 100020
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105762,
+    "fields": {
+      "nombre": "Sierra Negra",
+      "municipio": 100020
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105763,
+    "fields": {
+      "nombre": "Aldea Santa María",
+      "municipio": 100021
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105764,
+    "fields": {
+      "nombre": "Campo Furlan",
+      "municipio": 100021
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105765,
+    "fields": {
+      "nombre": "Aldea San Francisco",
+      "municipio": 100022
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105766,
+    "fields": {
+      "nombre": "General Alvear",
+      "municipio": 100022
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105767,
+    "fields": {
+      "nombre": "Colonia General Roca",
+      "municipio": 100023
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105768,
+    "fields": {
+      "nombre": "Alcaraz Primero",
+      "municipio": 100024
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105769,
+    "fields": {
+      "nombre": "Colonia El Chañar",
+      "municipio": 100024
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105770,
+    "fields": {
+      "nombre": "Colonia Máximo Castro",
+      "municipio": 100024
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105771,
+    "fields": {
+      "nombre": "Colonia San Luis",
+      "municipio": 100024
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105772,
+    "fields": {
+      "nombre": "Colonia San Pedro",
+      "municipio": 100024
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105773,
+    "fields": {
+      "nombre": "El Salado",
+      "municipio": 100024
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105774,
+    "fields": {
+      "nombre": "El Tigre",
+      "municipio": 100024
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105775,
+    "fields": {
+      "nombre": "La Armonía",
+      "municipio": 100024
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105776,
+    "fields": {
+      "nombre": "La Paz",
+      "municipio": 100024
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105777,
+    "fields": {
+      "nombre": "Los Talas",
+      "municipio": 100024
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105778,
+    "fields": {
+      "nombre": "Montiel",
+      "municipio": 100024
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105779,
+    "fields": {
+      "nombre": "Paso Telégrafo",
+      "municipio": 100024
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105780,
+    "fields": {
+      "nombre": "Primer Congreso",
+      "municipio": 100024
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105781,
+    "fields": {
+      "nombre": "Puerto La Esmeralda",
+      "municipio": 100024
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105782,
+    "fields": {
+      "nombre": "Santa Inés",
+      "municipio": 100024
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105783,
+    "fields": {
+      "nombre": "El Brillante",
+      "municipio": 100025
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105784,
+    "fields": {
+      "nombre": "El Colorado",
+      "municipio": 100025
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105785,
+    "fields": {
+      "nombre": "San José",
+      "municipio": 100025
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105786,
+    "fields": {
+      "nombre": "Ishtilart",
+      "municipio": 100026
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105787,
+    "fields": {
+      "nombre": "Rincón Santa María",
+      "municipio": 100026
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105788,
+    "fields": {
+      "nombre": "San Justo",
+      "municipio": 100026
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105789,
+    "fields": {
+      "nombre": "Villa San Justo",
+      "municipio": 100026
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105790,
+    "fields": {
+      "nombre": "Colonia Las Pepas",
+      "municipio": 100027
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105791,
+    "fields": {
+      "nombre": "Colonia Nueva San Miguel",
+      "municipio": 100027
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105792,
+    "fields": {
+      "nombre": "Colonia Puente del Gualeguaychú",
+      "municipio": 100027
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105793,
+    "fields": {
+      "nombre": "Paraje Santa Rosa",
+      "municipio": 100027
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105794,
+    "fields": {
+      "nombre": "Colonia Cadel",
+      "municipio": 100028
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105795,
+    "fields": {
+      "nombre": "San Pedro",
+      "municipio": 100028
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105796,
+    "fields": {
+      "nombre": "Colonia Aymán",
+      "municipio": 100029
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105797,
+    "fields": {
+      "nombre": "San Roque",
+      "municipio": 100029
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105798,
+    "fields": {
+      "nombre": "Colonia Oficial Nº 22",
+      "municipio": 100030
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105799,
+    "fields": {
+      "nombre": "Santa Elena",
+      "municipio": 100030
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105800,
+    "fields": {
+      "nombre": "Villa Fontana",
+      "municipio": 100032
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105801,
+    "fields": {
+      "nombre": "Alto Alegre",
+      "municipio": 100033
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105802,
+    "fields": {
+      "nombre": "Bajo Hondo",
+      "municipio": 100033
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105803,
+    "fields": {
+      "nombre": "Colonia 8 de Abril",
+      "municipio": 100033
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105804,
+    "fields": {
+      "nombre": "El Aibal El Silencio",
+      "municipio": 100033
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105805,
+    "fields": {
+      "nombre": "El Azotado",
+      "municipio": 100033
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105806,
+    "fields": {
+      "nombre": "El Bajo",
+      "municipio": 100033
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105807,
+    "fields": {
+      "nombre": "El Cajón",
+      "municipio": 100033
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105808,
+    "fields": {
+      "nombre": "El Chañaral",
+      "municipio": 100033
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105809,
+    "fields": {
+      "nombre": "El Churcal",
+      "municipio": 100033
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105810,
+    "fields": {
+      "nombre": "El Churcalito",
+      "municipio": 100033
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105811,
+    "fields": {
+      "nombre": "El Coleto",
+      "municipio": 100033
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105812,
+    "fields": {
+      "nombre": "El Lindero",
+      "municipio": 100033
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105813,
+    "fields": {
+      "nombre": "El Quemado",
+      "municipio": 100033
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105814,
+    "fields": {
+      "nombre": "El Quimil",
+      "municipio": 100033
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105815,
+    "fields": {
+      "nombre": "El Remanso",
+      "municipio": 100033
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105816,
+    "fields": {
+      "nombre": "El Simbolar",
+      "municipio": 100033
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105817,
+    "fields": {
+      "nombre": "El Simbolar Norte",
+      "municipio": 100033
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105818,
+    "fields": {
+      "nombre": "El Solitario",
+      "municipio": 100033
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105819,
+    "fields": {
+      "nombre": "Fortín Nuevo Pilcomayo",
+      "municipio": 100033
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105820,
+    "fields": {
+      "nombre": "Fortín Pilcomayo",
+      "municipio": 100033
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105821,
+    "fields": {
+      "nombre": "Fortín Soledad",
+      "municipio": 100033
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105822,
+    "fields": {
+      "nombre": "Guadalcazar",
+      "municipio": 100033
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105823,
+    "fields": {
+      "nombre": "Ingeniero Enrique H. Faure",
+      "municipio": 100033
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105824,
+    "fields": {
+      "nombre": "La Esperanza",
+      "municipio": 100033
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105825,
+    "fields": {
+      "nombre": "La Laguna",
+      "municipio": 100033
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105826,
+    "fields": {
+      "nombre": "La Lagunita",
+      "municipio": 100033
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105827,
+    "fields": {
+      "nombre": "La Libertad",
+      "municipio": 100033
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105828,
+    "fields": {
+      "nombre": "La Línea",
+      "municipio": 100033
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105829,
+    "fields": {
+      "nombre": "La Madrugada",
+      "municipio": 100033
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105830,
+    "fields": {
+      "nombre": "La Mocha",
+      "municipio": 100033
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105831,
+    "fields": {
+      "nombre": "La Palizada",
+      "municipio": 100033
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105832,
+    "fields": {
+      "nombre": "La Represa",
+      "municipio": 100033
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105833,
+    "fields": {
+      "nombre": "La Rinconada",
+      "municipio": 100033
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105834,
+    "fields": {
+      "nombre": "La Zanja",
+      "municipio": 100033
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105835,
+    "fields": {
+      "nombre": "Lagunas Tres Paces",
+      "municipio": 100033
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105836,
+    "fields": {
+      "nombre": "Lagunita",
+      "municipio": 100033
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105837,
+    "fields": {
+      "nombre": "Lamadrid",
+      "municipio": 100033
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105838,
+    "fields": {
+      "nombre": "Las Avispas",
+      "municipio": 100033
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105839,
+    "fields": {
+      "nombre": "Las Banderitas",
+      "municipio": 100033
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105840,
+    "fields": {
+      "nombre": "Los Cieneguitos",
+      "municipio": 100033
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105841,
+    "fields": {
+      "nombre": "Los Pocitos",
+      "municipio": 100033
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105842,
+    "fields": {
+      "nombre": "Matías Gulacsi",
+      "municipio": 100033
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105843,
+    "fields": {
+      "nombre": "Media Luna",
+      "municipio": 100033
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105844,
+    "fields": {
+      "nombre": "Paso El Remanso",
+      "municipio": 100033
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105845,
+    "fields": {
+      "nombre": "Paso Lamadrid",
+      "municipio": 100033
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105846,
+    "fields": {
+      "nombre": "Pescado Negro",
+      "municipio": 100033
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105847,
+    "fields": {
+      "nombre": "Pozo de Maza",
+      "municipio": 100033
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105848,
+    "fields": {
+      "nombre": "Pozo de Molina",
+      "municipio": 100033
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105849,
+    "fields": {
+      "nombre": "Pozo del Mortero",
+      "municipio": 100033
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105850,
+    "fields": {
+      "nombre": "Pozo Ramón",
+      "municipio": 100033
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105851,
+    "fields": {
+      "nombre": "Pozo Sargento",
+      "municipio": 100033
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105852,
+    "fields": {
+      "nombre": "Puesto Cabo Irigoyen",
+      "municipio": 100033
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105853,
+    "fields": {
+      "nombre": "Río Muerto",
+      "municipio": 100033
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105854,
+    "fields": {
+      "nombre": "San Camilo",
+      "municipio": 100033
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105855,
+    "fields": {
+      "nombre": "San Cayetano",
+      "municipio": 100033
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105856,
+    "fields": {
+      "nombre": "Santa Isabel",
+      "municipio": 100033
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105857,
+    "fields": {
+      "nombre": "Sumayén",
+      "municipio": 100033
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105858,
+    "fields": {
+      "nombre": "Tres Yuchán",
+      "municipio": 100033
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105859,
+    "fields": {
+      "nombre": "Vaca Perdida",
+      "municipio": 100033
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105860,
+    "fields": {
+      "nombre": "Villa General Manuel Belgrano",
+      "municipio": 100034
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105861,
+    "fields": {
+      "nombre": "Alto Calilegua",
+      "municipio": 100035
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105862,
+    "fields": {
+      "nombre": "El Cedral",
+      "municipio": 100035
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105863,
+    "fields": {
+      "nombre": "El Saladillo",
+      "municipio": 100035
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105864,
+    "fields": {
+      "nombre": "San Francisco",
+      "municipio": 100035
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105865,
+    "fields": {
+      "nombre": "Santa Ana",
+      "municipio": 100036
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105866,
+    "fields": {
+      "nombre": "Valle Colorado",
+      "municipio": 100036
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105867,
+    "fields": {
+      "nombre": "Colonia San Juan",
+      "municipio": 100037
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105868,
+    "fields": {
+      "nombre": "General Manuel J. Campos",
+      "municipio": 100037
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105869,
+    "fields": {
+      "nombre": "La Natural",
+      "municipio": 100037
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105870,
+    "fields": {
+      "nombre": "General San Martín",
+      "municipio": 100038
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105871,
+    "fields": {
+      "nombre": "La Colorada Grande",
+      "municipio": 100038
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105872,
+    "fields": {
+      "nombre": "Bajo Hondo",
+      "municipio": 100039
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105873,
+    "fields": {
+      "nombre": "Balde de Pacheco",
+      "municipio": 100039
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105874,
+    "fields": {
+      "nombre": "Castro Barros",
+      "municipio": 100039
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105875,
+    "fields": {
+      "nombre": "Chañar",
+      "municipio": 100039
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105876,
+    "fields": {
+      "nombre": "Chañar Viejo",
+      "municipio": 100039
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105877,
+    "fields": {
+      "nombre": "Corral del Negro",
+      "municipio": 100039
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105878,
+    "fields": {
+      "nombre": "Cortaderas",
+      "municipio": 100039
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105879,
+    "fields": {
+      "nombre": "Dique de Olta",
+      "municipio": 100039
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105880,
+    "fields": {
+      "nombre": "El Recreo",
+      "municipio": 100039
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105881,
+    "fields": {
+      "nombre": "El Simbolar",
+      "municipio": 100039
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105882,
+    "fields": {
+      "nombre": "El Virque",
+      "municipio": 100039
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105883,
+    "fields": {
+      "nombre": "Esquina del Sud",
+      "municipio": 100039
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105884,
+    "fields": {
+      "nombre": "La Aguada",
+      "municipio": 100039
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105885,
+    "fields": {
+      "nombre": "La Esmeralda",
+      "municipio": 100039
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105886,
+    "fields": {
+      "nombre": "La Esperanza",
+      "municipio": 100039
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105887,
+    "fields": {
+      "nombre": "La Florida",
+      "municipio": 100039
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105888,
+    "fields": {
+      "nombre": "La Huerta",
+      "municipio": 100039
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105889,
+    "fields": {
+      "nombre": "Loma Blanca",
+      "municipio": 100039
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105890,
+    "fields": {
+      "nombre": "Monte Grande",
+      "municipio": 100039
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105891,
+    "fields": {
+      "nombre": "Monte Negro",
+      "municipio": 100039
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105892,
+    "fields": {
+      "nombre": "Nepes",
+      "municipio": 100039
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105893,
+    "fields": {
+      "nombre": "Olta",
+      "municipio": 100039
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105894,
+    "fields": {
+      "nombre": "Pozo de la Vaca",
+      "municipio": 100039
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105895,
+    "fields": {
+      "nombre": "San Pedro",
+      "municipio": 100039
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105896,
+    "fields": {
+      "nombre": "Santa Cruz",
+      "municipio": 100039
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105897,
+    "fields": {
+      "nombre": "Sierra de las Higueras",
+      "municipio": 100039
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105898,
+    "fields": {
+      "nombre": "Sierra de los Quinteros",
+      "municipio": 100039
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105899,
+    "fields": {
+      "nombre": "Tala Verde",
+      "municipio": 100039
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105900,
+    "fields": {
+      "nombre": "Talva",
+      "municipio": 100039
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105901,
+    "fields": {
+      "nombre": "Balde de Piedra",
+      "municipio": 100040
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105902,
+    "fields": {
+      "nombre": "Barrio 12 de Octubre",
+      "municipio": 100040
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105903,
+    "fields": {
+      "nombre": "Barrio María Auxiliadora",
+      "municipio": 100040
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105904,
+    "fields": {
+      "nombre": "Barrio Molina Cabrera",
+      "municipio": 100040
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105905,
+    "fields": {
+      "nombre": "Catitas Vieja",
+      "municipio": 100040
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105906,
+    "fields": {
+      "nombre": "Colonia San Jorge",
+      "municipio": 100040
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105907,
+    "fields": {
+      "nombre": "Comandante Salas",
+      "municipio": 100040
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105908,
+    "fields": {
+      "nombre": "El Marcado",
+      "municipio": 100040
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105909,
+    "fields": {
+      "nombre": "Gobernador Civit",
+      "municipio": 100040
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105910,
+    "fields": {
+      "nombre": "Kilómetro 947",
+      "municipio": 100040
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105911,
+    "fields": {
+      "nombre": "La Cienaguita",
+      "municipio": 100040
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105912,
+    "fields": {
+      "nombre": "La Dormida",
+      "municipio": 100040
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105913,
+    "fields": {
+      "nombre": "La Menta",
+      "municipio": 100040
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105914,
+    "fields": {
+      "nombre": "Las Catitas",
+      "municipio": 100040
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105915,
+    "fields": {
+      "nombre": "Los Lotes",
+      "municipio": 100040
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105916,
+    "fields": {
+      "nombre": "Los Yoles",
+      "municipio": 100040
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105917,
+    "fields": {
+      "nombre": "ñacuñan",
+      "municipio": 100040
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105918,
+    "fields": {
+      "nombre": "Parrales Mendocinos",
+      "municipio": 100040
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105919,
+    "fields": {
+      "nombre": "Pichi Ciego",
+      "municipio": 100040
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105920,
+    "fields": {
+      "nombre": "Santa Rosa",
+      "municipio": 100040
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105921,
+    "fields": {
+      "nombre": "9 de Julio Kilómetro 20",
+      "municipio": 100041
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105922,
+    "fields": {
+      "nombre": "9 de Julio Kilómetro 28",
+      "municipio": 100041
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105923,
+    "fields": {
+      "nombre": "Mariano Moreno",
+      "municipio": 100041
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105924,
+    "fields": {
+      "nombre": "Valle Hermoso",
+      "municipio": 100041
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105925,
+    "fields": {
+      "nombre": "Almafuerte",
+      "municipio": 100042
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105926,
+    "fields": {
+      "nombre": "Picada Yacutingá",
+      "municipio": 100042
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105927,
+    "fields": {
+      "nombre": "Santa María Magdalena",
+      "municipio": 100042
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105928,
+    "fields": {
+      "nombre": "Arroyo del Medio",
+      "municipio": 100043
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105929,
+    "fields": {
+      "nombre": "Bonpland",
+      "municipio": 100044
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105930,
+    "fields": {
+      "nombre": "Ojo de Agua",
+      "municipio": 100044
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105931,
+    "fields": {
+      "nombre": "General Alvear",
+      "municipio": 100045
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105932,
+    "fields": {
+      "nombre": "Los Indios",
+      "municipio": 100045
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105933,
+    "fields": {
+      "nombre": "Picada Vasca",
+      "municipio": 100045
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105934,
+    "fields": {
+      "nombre": "Loreto",
+      "municipio": 100046
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105935,
+    "fields": {
+      "nombre": "Colonia Finlandesa",
+      "municipio": 100047
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105936,
+    "fields": {
+      "nombre": "Picada Finlandesa",
+      "municipio": 100047
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105937,
+    "fields": {
+      "nombre": "San Martín",
+      "municipio": 100047
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105938,
+    "fields": {
+      "nombre": "Arroyo Santa María",
+      "municipio": 100048
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105939,
+    "fields": {
+      "nombre": "Caá Guazú",
+      "municipio": 100048
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105940,
+    "fields": {
+      "nombre": "Cascabel",
+      "municipio": 100048
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105941,
+    "fields": {
+      "nombre": "Cerro Mártires",
+      "municipio": 100048
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105942,
+    "fields": {
+      "nombre": "La Corita",
+      "municipio": 100048
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105943,
+    "fields": {
+      "nombre": "San Juan de la Sierra",
+      "municipio": 100048
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105944,
+    "fields": {
+      "nombre": "Santa María",
+      "municipio": 100048
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105945,
+    "fields": {
+      "nombre": "Laguna Varvarco Campos",
+      "municipio": 100049
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105946,
+    "fields": {
+      "nombre": "Los Cerrillos",
+      "municipio": 100049
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105947,
+    "fields": {
+      "nombre": "Aguada de Guerra",
+      "municipio": 100050
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105948,
+    "fields": {
+      "nombre": "Atraicó",
+      "municipio": 100050
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105949,
+    "fields": {
+      "nombre": "Barril Niyeu",
+      "municipio": 100050
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105950,
+    "fields": {
+      "nombre": "Cari Laufquen",
+      "municipio": 100050
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105951,
+    "fields": {
+      "nombre": "Carrilaufquen",
+      "municipio": 100050
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105952,
+    "fields": {
+      "nombre": "Clemente Onelli",
+      "municipio": 100050
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105953,
+    "fields": {
+      "nombre": "Colan Conhue",
+      "municipio": 100050
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105954,
+    "fields": {
+      "nombre": "El Caín",
+      "municipio": 100050
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105955,
+    "fields": {
+      "nombre": "El Chaiful",
+      "municipio": 100050
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105956,
+    "fields": {
+      "nombre": "El Moligüe",
+      "municipio": 100050
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105957,
+    "fields": {
+      "nombre": "El Tropezón",
+      "municipio": 100050
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105958,
+    "fields": {
+      "nombre": "Kilómetro 648",
+      "municipio": 100050
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105959,
+    "fields": {
+      "nombre": "La Esperanza",
+      "municipio": 100050
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105960,
+    "fields": {
+      "nombre": "Laguna Blanca Chica",
+      "municipio": 100050
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105961,
+    "fields": {
+      "nombre": "Lifi Mahuida",
+      "municipio": 100050
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105962,
+    "fields": {
+      "nombre": "Llama Niyeo",
+      "municipio": 100050
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105963,
+    "fields": {
+      "nombre": "Los Molles",
+      "municipio": 100050
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105964,
+    "fields": {
+      "nombre": "Mina María Isabel",
+      "municipio": 100050
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105965,
+    "fields": {
+      "nombre": "Mina Santa Teresita",
+      "municipio": 100050
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105966,
+    "fields": {
+      "nombre": "Ne Luan",
+      "municipio": 100050
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105967,
+    "fields": {
+      "nombre": "Pilquiniyeu",
+      "municipio": 100050
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105968,
+    "fields": {
+      "nombre": "Quetrequil",
+      "municipio": 100050
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105969,
+    "fields": {
+      "nombre": "Queupuniyeu",
+      "municipio": 100050
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105970,
+    "fields": {
+      "nombre": "Ruca Luan",
+      "municipio": 100050
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105971,
+    "fields": {
+      "nombre": "Vaca Laufquen",
+      "municipio": 100050
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105972,
+    "fields": {
+      "nombre": "Chajaijo",
+      "municipio": 100051
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105973,
+    "fields": {
+      "nombre": "Choique Mahuida",
+      "municipio": 100051
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105974,
+    "fields": {
+      "nombre": "Comicó",
+      "municipio": 100051
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105975,
+    "fields": {
+      "nombre": "Cona Niyeu",
+      "municipio": 100051
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105976,
+    "fields": {
+      "nombre": "Cullún Leufú",
+      "municipio": 100051
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105977,
+    "fields": {
+      "nombre": "El Abra",
+      "municipio": 100051
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105978,
+    "fields": {
+      "nombre": "Falckner",
+      "municipio": 100051
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105979,
+    "fields": {
+      "nombre": "Las Golondrinas",
+      "municipio": 100051
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105980,
+    "fields": {
+      "nombre": "Lauriente",
+      "municipio": 100051
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105981,
+    "fields": {
+      "nombre": "Painaluf",
+      "municipio": 100051
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105982,
+    "fields": {
+      "nombre": "Prahuaniyeu",
+      "municipio": 100051
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105983,
+    "fields": {
+      "nombre": "San Nicolás",
+      "municipio": 100051
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105984,
+    "fields": {
+      "nombre": "Talcahuala",
+      "municipio": 100051
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105985,
+    "fields": {
+      "nombre": "Tambelén",
+      "municipio": 100051
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105986,
+    "fields": {
+      "nombre": "Treneta",
+      "municipio": 100051
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105987,
+    "fields": {
+      "nombre": "Yaminué",
+      "municipio": 100051
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105988,
+    "fields": {
+      "nombre": "Caleta de los Loros",
+      "municipio": 100052
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105989,
+    "fields": {
+      "nombre": "Cubanea",
+      "municipio": 100052
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105990,
+    "fields": {
+      "nombre": "El Pozo Salado",
+      "municipio": 100052
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105991,
+    "fields": {
+      "nombre": "General Liborio Bernal",
+      "municipio": 100052
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105992,
+    "fields": {
+      "nombre": "General Lorenzo Vintter",
+      "municipio": 100052
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105993,
+    "fields": {
+      "nombre": "General Nicolás H. Palacios",
+      "municipio": 100052
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105994,
+    "fields": {
+      "nombre": "La Matilde",
+      "municipio": 100052
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105995,
+    "fields": {
+      "nombre": "Monte Bagual",
+      "municipio": 100052
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105996,
+    "fields": {
+      "nombre": "Nuevo León",
+      "municipio": 100052
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105997,
+    "fields": {
+      "nombre": "Pozo Salado",
+      "municipio": 100052
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105998,
+    "fields": {
+      "nombre": "San Javier",
+      "municipio": 100052
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 105999,
+    "fields": {
+      "nombre": "Sauce Chico",
+      "municipio": 100052
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 106000,
+    "fields": {
+      "nombre": "Vicealmirante Eduardo O' Connor",
+      "municipio": 100052
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 106001,
+    "fields": {
+      "nombre": "Zanjón de Oyuela",
+      "municipio": 100052
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 106002,
+    "fields": {
+      "nombre": "Bajo de los Menucos",
+      "municipio": 100053
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 106003,
+    "fields": {
+      "nombre": "Bajo de Santa Rosa",
+      "municipio": 100053
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 106004,
+    "fields": {
+      "nombre": "Benjamín Zorrilla",
+      "municipio": 100053
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 106005,
+    "fields": {
+      "nombre": "Caitacó",
+      "municipio": 100053
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 106006,
+    "fields": {
+      "nombre": "Chelforó",
+      "municipio": 100053
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 106007,
+    "fields": {
+      "nombre": "Colonia Josefa",
+      "municipio": 100053
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 106008,
+    "fields": {
+      "nombre": "Colonia La Esperanza",
+      "municipio": 100053
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 106009,
+    "fields": {
+      "nombre": "Fortín Uno",
+      "municipio": 100053
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 106010,
+    "fields": {
+      "nombre": "Kilómetro 935",
+      "municipio": 100053
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 106011,
+    "fields": {
+      "nombre": "Kilómetro 967",
+      "municipio": 100053
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 106012,
+    "fields": {
+      "nombre": "La Japonesa",
+      "municipio": 100053
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 106013,
+    "fields": {
+      "nombre": "La Julia",
+      "municipio": 100053
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 106014,
+    "fields": {
+      "nombre": "Negro Muerto",
+      "municipio": 100053
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 106015,
+    "fields": {
+      "nombre": "Parador Kilómetro 46",
+      "municipio": 100053
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 106016,
+    "fields": {
+      "nombre": "Barrio El Labrador",
+      "municipio": 100054
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 106017,
+    "fields": {
+      "nombre": "Sargento Vidal",
+      "municipio": 100054
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 106018,
+    "fields": {
+      "nombre": "Villa Manzano",
+      "municipio": 100054
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 106019,
+    "fields": {
+      "nombre": "Villa San Isidro",
+      "municipio": 100054
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 106020,
+    "fields": {
+      "nombre": "El Solito",
+      "municipio": 100055
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 106021,
+    "fields": {
+      "nombre": "Baños de la Salud",
+      "municipio": 100056
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 106022,
+    "fields": {
+      "nombre": "Jardín de los Poetas",
+      "municipio": 100056
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 106023,
+    "fields": {
+      "nombre": "Rivadavia",
+      "municipio": 100056
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 106024,
+    "fields": {
+      "nombre": "Barrio Sadop - Bella Vista",
+      "municipio": 100057
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 106025,
+    "fields": {
+      "nombre": "Coll",
+      "municipio": 100057
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 106026,
+    "fields": {
+      "nombre": "Dos Acequias",
+      "municipio": 100057
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 106027,
+    "fields": {
+      "nombre": "Los Compartos",
+      "municipio": 100057
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 106028,
+    "fields": {
+      "nombre": "San Isidro",
+      "municipio": 100057
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 106029,
+    "fields": {
+      "nombre": "Villa del Salvador",
+      "municipio": 100057
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 106030,
+    "fields": {
+      "nombre": "Villa Dominguito",
+      "municipio": 100057
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 106031,
+    "fields": {
+      "nombre": "Villa Don Bosco",
+      "municipio": 100057
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 106032,
+    "fields": {
+      "nombre": "Villa Lugano",
+      "municipio": 100057
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 106033,
+    "fields": {
+      "nombre": "Villa San Martín",
+      "municipio": 100057
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 106034,
+    "fields": {
+      "nombre": "Alto Tavira",
+      "municipio": 100058
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 106035,
+    "fields": {
+      "nombre": "Balde de Azcurra",
+      "municipio": 100058
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 106036,
+    "fields": {
+      "nombre": "Balde de los Torres",
+      "municipio": 100058
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 106037,
+    "fields": {
+      "nombre": "Balde de Puertas",
+      "municipio": 100058
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 106038,
+    "fields": {
+      "nombre": "Balde de Quines",
+      "municipio": 100058
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 106039,
+    "fields": {
+      "nombre": "Balde del Carmen",
+      "municipio": 100058
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 106040,
+    "fields": {
+      "nombre": "Balde Retamo",
+      "municipio": 100058
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 106041,
+    "fields": {
+      "nombre": "Baldecito",
+      "municipio": 100058
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 106042,
+    "fields": {
+      "nombre": "Balzora",
+      "municipio": 100058
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 106043,
+    "fields": {
+      "nombre": "Bella Vista",
+      "municipio": 100058
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 106044,
+    "fields": {
+      "nombre": "Cerro Bayo",
+      "municipio": 100058
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 106045,
+    "fields": {
+      "nombre": "Cruz del Eje",
+      "municipio": 100058
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 106046,
+    "fields": {
+      "nombre": "El Bañado",
+      "municipio": 100058
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 106047,
+    "fields": {
+      "nombre": "El Caldén",
+      "municipio": 100058
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 106048,
+    "fields": {
+      "nombre": "El Chañar",
+      "municipio": 100058
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 106049,
+    "fields": {
+      "nombre": "El Rincón",
+      "municipio": 100058
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 106050,
+    "fields": {
+      "nombre": "El Señuelo",
+      "municipio": 100058
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 106051,
+    "fields": {
+      "nombre": "El Vinagrillo",
+      "municipio": 100058
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 106052,
+    "fields": {
+      "nombre": "El Zampal",
+      "municipio": 100058
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 106053,
+    "fields": {
+      "nombre": "La Avenencia",
+      "municipio": 100058
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 106054,
+    "fields": {
+      "nombre": "La Botija",
+      "municipio": 100058
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 106055,
+    "fields": {
+      "nombre": "La Chañarienta",
+      "municipio": 100058
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 106056,
+    "fields": {
+      "nombre": "La Esquina",
+      "municipio": 100058
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 106057,
+    "fields": {
+      "nombre": "La Leona",
+      "municipio": 100058
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 106058,
+    "fields": {
+      "nombre": "La Salvadora",
+      "municipio": 100058
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 106059,
+    "fields": {
+      "nombre": "La Selva",
+      "municipio": 100058
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 106060,
+    "fields": {
+      "nombre": "La Sirena",
+      "municipio": 100058
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 106061,
+    "fields": {
+      "nombre": "La Tranca",
+      "municipio": 100058
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 106062,
+    "fields": {
+      "nombre": "Las Chimbas",
+      "municipio": 100058
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 106063,
+    "fields": {
+      "nombre": "Las Lagunitas",
+      "municipio": 100058
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 106064,
+    "fields": {
+      "nombre": "Lomas Blancas",
+      "municipio": 100058
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 106065,
+    "fields": {
+      "nombre": "Los Dos Buhos",
+      "municipio": 100058
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 106066,
+    "fields": {
+      "nombre": "Los Quemados",
+      "municipio": 100058
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 106067,
+    "fields": {
+      "nombre": "Pampa Grande",
+      "municipio": 100058
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 106068,
+    "fields": {
+      "nombre": "Puerta de la Quebrada",
+      "municipio": 100058
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 106069,
+    "fields": {
+      "nombre": "Puerta Negra",
+      "municipio": 100058
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 106070,
+    "fields": {
+      "nombre": "Rodeo de Cadenas",
+      "municipio": 100058
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 106071,
+    "fields": {
+      "nombre": "San Ignacio",
+      "municipio": 100058
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 106072,
+    "fields": {
+      "nombre": "San Miguel",
+      "municipio": 100058
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 106073,
+    "fields": {
+      "nombre": "San Vicente",
+      "municipio": 100058
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 106074,
+    "fields": {
+      "nombre": "Santa Ana",
+      "municipio": 100058
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 106075,
+    "fields": {
+      "nombre": "Santa Rosa de Catantal",
+      "municipio": 100058
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 106076,
+    "fields": {
+      "nombre": "Santa Teresa",
+      "municipio": 100058
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 106077,
+    "fields": {
+      "nombre": "Boca del Río",
+      "municipio": 100059
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 106078,
+    "fields": {
+      "nombre": "Cuatro Esquinas",
+      "municipio": 100059
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 106079,
+    "fields": {
+      "nombre": "El Tala",
+      "municipio": 100059
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 106080,
+    "fields": {
+      "nombre": "La Celestina",
+      "municipio": 100059
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 106081,
+    "fields": {
+      "nombre": "La Cocha",
+      "municipio": 100059
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 106082,
+    "fields": {
+      "nombre": "Pozo Cavado",
+      "municipio": 100059
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 106083,
+    "fields": {
+      "nombre": "Puerta Colorada",
+      "municipio": 100059
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 106084,
+    "fields": {
+      "nombre": "Punta de la Loma",
+      "municipio": 100059
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 106085,
+    "fields": {
+      "nombre": "Punta de Monte",
+      "municipio": 100059
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 106086,
+    "fields": {
+      "nombre": "San Felipe",
+      "municipio": 100059
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 106087,
+    "fields": {
+      "nombre": "Santa Martina",
+      "municipio": 100059
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 106088,
+    "fields": {
+      "nombre": "Baldecitos",
+      "municipio": 100060
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 106089,
+    "fields": {
+      "nombre": "Ciénaga de Intihuasi",
+      "municipio": 100060
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 106090,
+    "fields": {
+      "nombre": "Comandante Granville",
+      "municipio": 100060
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 106091,
+    "fields": {
+      "nombre": "Cuatro Esquinas",
+      "municipio": 100060
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 106092,
+    "fields": {
+      "nombre": "Eleodoro Lobos",
+      "municipio": 100060
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 106093,
+    "fields": {
+      "nombre": "La Cumbre",
+      "municipio": 100060
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 106094,
+    "fields": {
+      "nombre": "La Petra",
+      "municipio": 100060
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 106095,
+    "fields": {
+      "nombre": "La Puerta",
+      "municipio": 100060
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 106096,
+    "fields": {
+      "nombre": "La Totora",
+      "municipio": 100060
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 106097,
+    "fields": {
+      "nombre": "Loma Alta",
+      "municipio": 100060
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 106098,
+    "fields": {
+      "nombre": "Los Membrillos",
+      "municipio": 100060
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 106099,
+    "fields": {
+      "nombre": "Mármol Verde",
+      "municipio": 100060
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 106100,
+    "fields": {
+      "nombre": "Paso de las Carretas",
+      "municipio": 100060
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 106101,
+    "fields": {
+      "nombre": "San Ignacio",
+      "municipio": 100060
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 106102,
+    "fields": {
+      "nombre": "Valle de Pancanta",
+      "municipio": 100060
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 106103,
+    "fields": {
+      "nombre": "El Durazno",
+      "municipio": 100061
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 106104,
+    "fields": {
+      "nombre": "El Manantial",
+      "municipio": 100061
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 106105,
+    "fields": {
+      "nombre": "Estancia Grande",
+      "municipio": 100061
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 106106,
+    "fields": {
+      "nombre": "Las Barranquitas",
+      "municipio": 100061
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 106107,
+    "fields": {
+      "nombre": "Virorco",
+      "municipio": 100061
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 106108,
+    "fields": {
+      "nombre": "Bajo de Véliz",
+      "municipio": 100062
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 106109,
+    "fields": {
+      "nombre": "Balde de Escudero",
+      "municipio": 100062
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 106110,
+    "fields": {
+      "nombre": "Bañado de Cautana",
+      "municipio": 100062
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 106111,
+    "fields": {
+      "nombre": "Barro Blanco",
+      "municipio": 100062
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 106112,
+    "fields": {
+      "nombre": "Cabeza de Novillo",
+      "municipio": 100062
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 106113,
+    "fields": {
+      "nombre": "Cerrito Blanco",
+      "municipio": 100062
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 106114,
+    "fields": {
+      "nombre": "El Injerto",
+      "municipio": 100062
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 106115,
+    "fields": {
+      "nombre": "La Lomita",
+      "municipio": 100062
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 106116,
+    "fields": {
+      "nombre": "La Quebrada",
+      "municipio": 100062
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 106117,
+    "fields": {
+      "nombre": "La Represita",
+      "municipio": 100062
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 106118,
+    "fields": {
+      "nombre": "La Unión",
+      "municipio": 100062
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 106119,
+    "fields": {
+      "nombre": "Lafinur",
+      "municipio": 100062
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 106120,
+    "fields": {
+      "nombre": "Las Chilcas",
+      "municipio": 100062
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 106121,
+    "fields": {
+      "nombre": "Las Islitas",
+      "municipio": 100062
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 106122,
+    "fields": {
+      "nombre": "Las Palomas",
+      "municipio": 100062
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 106123,
+    "fields": {
+      "nombre": "Los Cajones",
+      "municipio": 100062
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 106124,
+    "fields": {
+      "nombre": "Los Chañares",
+      "municipio": 100062
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 106125,
+    "fields": {
+      "nombre": "Los Lobos",
+      "municipio": 100062
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 106126,
+    "fields": {
+      "nombre": "Ojo del Río",
+      "municipio": 100062
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 106127,
+    "fields": {
+      "nombre": "Punta del Agua",
+      "municipio": 100062
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 106128,
+    "fields": {
+      "nombre": "Santa Ana",
+      "municipio": 100062
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 106129,
+    "fields": {
+      "nombre": "La Calera",
+      "municipio": 100063
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 106130,
+    "fields": {
+      "nombre": "La Majada",
+      "municipio": 100064
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 106131,
+    "fields": {
+      "nombre": "Leandro N. Alem",
+      "municipio": 100064
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 106132,
+    "fields": {
+      "nombre": "Barranca Alta",
+      "municipio": 100065
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 106133,
+    "fields": {
+      "nombre": "Bella Vista",
+      "municipio": 100065
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 106134,
+    "fields": {
+      "nombre": "Casa de los Tigres",
+      "municipio": 100065
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 106135,
+    "fields": {
+      "nombre": "Cerros Largos",
+      "municipio": 100065
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 106136,
+    "fields": {
+      "nombre": "Conlara",
+      "municipio": 100065
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 106137,
+    "fields": {
+      "nombre": "El Algarrobal",
+      "municipio": 100065
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 106138,
+    "fields": {
+      "nombre": "El Arenal",
+      "municipio": 100065
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 106139,
+    "fields": {
+      "nombre": "El Hornito",
+      "municipio": 100065
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 106140,
+    "fields": {
+      "nombre": "El Paraguay",
+      "municipio": 100065
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 106141,
+    "fields": {
+      "nombre": "Intihuasi",
+      "municipio": 100065
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 106142,
+    "fields": {
+      "nombre": "La Esperanza",
+      "municipio": 100065
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 106143,
+    "fields": {
+      "nombre": "La Ramada",
+      "municipio": 100065
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 106144,
+    "fields": {
+      "nombre": "La Totora",
+      "municipio": 100065
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 106145,
+    "fields": {
+      "nombre": "Las Lomas",
+      "municipio": 100065
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 106146,
+    "fields": {
+      "nombre": "Los Comedores",
+      "municipio": 100065
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 106147,
+    "fields": {
+      "nombre": "Mesilla del Cura",
+      "municipio": 100065
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 106148,
+    "fields": {
+      "nombre": "Paso de Piedras Anchas",
+      "municipio": 100065
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 106149,
+    "fields": {
+      "nombre": "Planta de Sandía",
+      "municipio": 100065
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 106150,
+    "fields": {
+      "nombre": "Potrerillo",
+      "municipio": 100065
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 106151,
+    "fields": {
+      "nombre": "Rincón del Carmen",
+      "municipio": 100065
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 106152,
+    "fields": {
+      "nombre": "San Fernando",
+      "municipio": 100065
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 106153,
+    "fields": {
+      "nombre": "San Isidro",
+      "municipio": 100065
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 106154,
+    "fields": {
+      "nombre": "San Rafael",
+      "municipio": 100065
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 106155,
+    "fields": {
+      "nombre": "San Vicente",
+      "municipio": 100065
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 106156,
+    "fields": {
+      "nombre": "Dique El Saladillo",
+      "municipio": 100066
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 106157,
+    "fields": {
+      "nombre": "Río Quinto",
+      "municipio": 100066
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 106158,
+    "fields": {
+      "nombre": "Saladillo",
+      "municipio": 100066
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 106159,
+    "fields": {
+      "nombre": "Carpintería",
+      "municipio": 100067
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 106160,
+    "fields": {
+      "nombre": "Dique Las Palmeras",
+      "municipio": 100067
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 106161,
+    "fields": {
+      "nombre": "Las Chacras",
+      "municipio": 100067
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 106162,
+    "fields": {
+      "nombre": "Pozo del Molle",
+      "municipio": 100067
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 106163,
+    "fields": {
+      "nombre": "Río Juan Gómez",
+      "municipio": 100067
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 106164,
+    "fields": {
+      "nombre": "San Francisco del Monte de Oro",
+      "municipio": 100067
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 106165,
+    "fields": {
+      "nombre": "Unión",
+      "municipio": 100068
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 106166,
+    "fields": {
+      "nombre": "Avellaneda",
+      "municipio": 100069
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 106167,
+    "fields": {
+      "nombre": "Colmena",
+      "municipio": 100069
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 106168,
+    "fields": {
+      "nombre": "El Carmen",
+      "municipio": 100069
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 106169,
+    "fields": {
+      "nombre": "El Timbó",
+      "municipio": 100069
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 106170,
+    "fields": {
+      "nombre": "La Vertiente",
+      "municipio": 100069
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 106171,
+    "fields": {
+      "nombre": "Moussy",
+      "municipio": 100069
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 106172,
+    "fields": {
+      "nombre": "Santa Ana",
+      "municipio": 100069
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 106173,
+    "fields": {
+      "nombre": "Colonia Iturraspe",
+      "municipio": 100070
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 106174,
+    "fields": {
+      "nombre": "San Miguel",
+      "municipio": 100070
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 106175,
+    "fields": {
+      "nombre": "Ituzaingó",
+      "municipio": 100071
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 106176,
+    "fields": {
+      "nombre": "Asunción María",
+      "municipio": 100072
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 106177,
+    "fields": {
+      "nombre": "Colonia La Blanca",
+      "municipio": 100072
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 106178,
+    "fields": {
+      "nombre": "La Blanca",
+      "municipio": 100072
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 106179,
+    "fields": {
+      "nombre": "La Criolla",
+      "municipio": 100072
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 106180,
+    "fields": {
+      "nombre": "La Nevada",
+      "municipio": 100072
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 106181,
+    "fields": {
+      "nombre": "El Palmar",
+      "municipio": 100073
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 106182,
+    "fields": {
+      "nombre": "El Tapialito",
+      "municipio": 100073
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 106183,
+    "fields": {
+      "nombre": "Isla Guaycurú",
+      "municipio": 100073
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 106184,
+    "fields": {
+      "nombre": "Las Garcitas",
+      "municipio": 100073
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 106185,
+    "fields": {
+      "nombre": "Las Garzas",
+      "municipio": 100073
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 106186,
+    "fields": {
+      "nombre": "Campo Winkler",
+      "municipio": 100074
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 106187,
+    "fields": {
+      "nombre": "Colonia Yaguareté",
+      "municipio": 100074
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 106188,
+    "fields": {
+      "nombre": "Las Toscas",
+      "municipio": 100074
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 106189,
+    "fields": {
+      "nombre": "Campo Foressi",
+      "municipio": 100075
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 106190,
+    "fields": {
+      "nombre": "Los Molinos",
+      "municipio": 100075
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 106191,
+    "fields": {
+      "nombre": "El Bosque",
+      "municipio": 100076
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 106192,
+    "fields": {
+      "nombre": "María Luisa",
+      "municipio": 100076
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 106193,
+    "fields": {
+      "nombre": "Pilar",
+      "municipio": 100077
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 106194,
+    "fields": {
+      "nombre": "Colonia Rivadavia",
+      "municipio": 100078
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 106195,
+    "fields": {
+      "nombre": "Villa Paso de las Piedras",
+      "municipio": 100078
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 106196,
+    "fields": {
+      "nombre": "Bajo Las Tunas",
+      "municipio": 100079
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 106197,
+    "fields": {
+      "nombre": "Campo Periotti",
+      "municipio": 100079
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 106198,
+    "fields": {
+      "nombre": "Estación San Agustín",
+      "municipio": 100079
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 106199,
+    "fields": {
+      "nombre": "Los Tres Reyes",
+      "municipio": 100079
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 106200,
+    "fields": {
+      "nombre": "San Agustín",
+      "municipio": 100079
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 106201,
+    "fields": {
+      "nombre": "San Antonio",
+      "municipio": 100080
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 106202,
+    "fields": {
+      "nombre": "Campo Derotier",
+      "municipio": 100081
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 106203,
+    "fields": {
+      "nombre": "El Descanso",
+      "municipio": 100081
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 106204,
+    "fields": {
+      "nombre": "El Molle",
+      "municipio": 100081
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 106205,
+    "fields": {
+      "nombre": "La Cautiva",
+      "municipio": 100081
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 106206,
+    "fields": {
+      "nombre": "La Emma",
+      "municipio": 100081
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 106207,
+    "fields": {
+      "nombre": "Las Chañas",
+      "municipio": 100081
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 106208,
+    "fields": {
+      "nombre": "Las Chuñas",
+      "municipio": 100081
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 106209,
+    "fields": {
+      "nombre": "Los Bayos",
+      "municipio": 100081
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 106210,
+    "fields": {
+      "nombre": "San Bernardo",
+      "municipio": 100081
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 106211,
+    "fields": {
+      "nombre": "Colonia San José",
+      "municipio": 100082
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 106212,
+    "fields": {
+      "nombre": "San José",
+      "municipio": 100082
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 106213,
+    "fields": {
+      "nombre": "Los Sembrados",
+      "municipio": 100083
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 106214,
+    "fields": {
+      "nombre": "San Vicente",
+      "municipio": 100083
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 106215,
+    "fields": {
+      "nombre": "Ingeniero Boassi",
+      "municipio": 100084
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 106216,
+    "fields": {
+      "nombre": "La Ramada",
+      "municipio": 100084
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 106217,
+    "fields": {
+      "nombre": "Sarmiento",
+      "municipio": 100084
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 106218,
+    "fields": {
+      "nombre": "Campo Dean",
+      "municipio": 100085
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 106219,
+    "fields": {
+      "nombre": "La Josefina",
+      "municipio": 100085
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 106220,
+    "fields": {
+      "nombre": "Tartagal",
+      "municipio": 100085
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 106221,
+    "fields": {
+      "nombre": "Barrial Alto",
+      "municipio": 100086
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 106222,
+    "fields": {
+      "nombre": "Blanca Pozo",
+      "municipio": 100086
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 106223,
+    "fields": {
+      "nombre": "Breayoj",
+      "municipio": 100086
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 106224,
+    "fields": {
+      "nombre": "Caloj",
+      "municipio": 100086
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 106225,
+    "fields": {
+      "nombre": "Campo Alegre",
+      "municipio": 100086
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 106226,
+    "fields": {
+      "nombre": "Colonia Alcira",
+      "municipio": 100086
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 106227,
+    "fields": {
+      "nombre": "Colonia Dora",
+      "municipio": 100086
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 106228,
+    "fields": {
+      "nombre": "Colonia Isla",
+      "municipio": 100086
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 106229,
+    "fields": {
+      "nombre": "Colonia Libanesa",
+      "municipio": 100086
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 106230,
+    "fields": {
+      "nombre": "El Molle",
+      "municipio": 100086
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 106231,
+    "fields": {
+      "nombre": "Gramilla",
+      "municipio": 100086
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 106232,
+    "fields": {
+      "nombre": "Hurmanita",
+      "municipio": 100086
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 106233,
+    "fields": {
+      "nombre": "Icaño",
+      "municipio": 100086
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 106234,
+    "fields": {
+      "nombre": "La Costa",
+      "municipio": 100086
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 106235,
+    "fields": {
+      "nombre": "Lago Muyoj",
+      "municipio": 100086
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 106236,
+    "fields": {
+      "nombre": "Lugones",
+      "municipio": 100086
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 106237,
+    "fields": {
+      "nombre": "Luján",
+      "municipio": 100086
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 106238,
+    "fields": {
+      "nombre": "Mancapa",
+      "municipio": 100086
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 106239,
+    "fields": {
+      "nombre": "Navicha",
+      "municipio": 100086
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 106240,
+    "fields": {
+      "nombre": "Paso Grande",
+      "municipio": 100086
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 106241,
+    "fields": {
+      "nombre": "Percas",
+      "municipio": 100086
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 106242,
+    "fields": {
+      "nombre": "Pozo Mosoj",
+      "municipio": 100086
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 106243,
+    "fields": {
+      "nombre": "Puente Negro",
+      "municipio": 100086
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 106244,
+    "fields": {
+      "nombre": "Punta Corral",
+      "municipio": 100086
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 106245,
+    "fields": {
+      "nombre": "Punta Isla",
+      "municipio": 100086
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 106246,
+    "fields": {
+      "nombre": "Punta Pozo",
+      "municipio": 100086
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 106247,
+    "fields": {
+      "nombre": "Quimilioj",
+      "municipio": 100086
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 106248,
+    "fields": {
+      "nombre": "Real Sayana",
+      "municipio": 100086
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 106249,
+    "fields": {
+      "nombre": "San Antonio",
+      "municipio": 100086
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 106250,
+    "fields": {
+      "nombre": "San Antonio de Copo",
+      "municipio": 100086
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 106251,
+    "fields": {
+      "nombre": "San José",
+      "municipio": 100086
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 106252,
+    "fields": {
+      "nombre": "San José Norte",
+      "municipio": 100086
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 106253,
+    "fields": {
+      "nombre": "San Pedro",
+      "municipio": 100086
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 106254,
+    "fields": {
+      "nombre": "San Roque",
+      "municipio": 100086
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 106255,
+    "fields": {
+      "nombre": "Santa Rosa",
+      "municipio": 100086
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 106256,
+    "fields": {
+      "nombre": "Santo Domingo",
+      "municipio": 100086
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 106257,
+    "fields": {
+      "nombre": "Tala Atún",
+      "municipio": 100086
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 106258,
+    "fields": {
+      "nombre": "Tala Pozo",
+      "municipio": 100086
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 106259,
+    "fields": {
+      "nombre": "Taqueyoj",
+      "municipio": 100086
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 106260,
+    "fields": {
+      "nombre": "Villa Mailín",
+      "municipio": 100086
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 106261,
+    "fields": {
+      "nombre": "Yacanioj",
+      "municipio": 100086
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 106262,
+    "fields": {
+      "nombre": "Bandera",
+      "municipio": 100087
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 106263,
+    "fields": {
+      "nombre": "Cuatro Bocas",
+      "municipio": 100087
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 106264,
+    "fields": {
+      "nombre": "Doña Lorenza",
+      "municipio": 100087
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 106265,
+    "fields": {
+      "nombre": "Fortín Aspirante",
+      "municipio": 100087
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 106266,
+    "fields": {
+      "nombre": "Fortín Inca",
+      "municipio": 100087
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 106267,
+    "fields": {
+      "nombre": "Guardia Escolta",
+      "municipio": 100087
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 106268,
+    "fields": {
+      "nombre": "La Carolina",
+      "municipio": 100087
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 106269,
+    "fields": {
+      "nombre": "La Dolores",
+      "municipio": 100087
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 106270,
+    "fields": {
+      "nombre": "Los Tableros",
+      "municipio": 100087
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 106271,
+    "fields": {
+      "nombre": "Pozo Dulce",
+      "municipio": 100087
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 106272,
+    "fields": {
+      "nombre": "Santa Lucía",
+      "municipio": 100087
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 106273,
+    "fields": {
+      "nombre": "Tres Lagunas",
+      "municipio": 100087
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 106274,
+    "fields": {
+      "nombre": "Agua Amarga",
+      "municipio": 100088
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 106275,
+    "fields": {
+      "nombre": "Agua Azul",
+      "municipio": 100088
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 106276,
+    "fields": {
+      "nombre": "Ahí Veremos",
+      "municipio": 100088
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 106277,
+    "fields": {
+      "nombre": "Algarrobal Viejo",
+      "municipio": 100088
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 106278,
+    "fields": {
+      "nombre": "Ampato Pozo",
+      "municipio": 100088
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 106279,
+    "fields": {
+      "nombre": "Babilonia",
+      "municipio": 100088
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 106280,
+    "fields": {
+      "nombre": "Belgrano",
+      "municipio": 100088
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 106281,
+    "fields": {
+      "nombre": "Campo Grande",
+      "municipio": 100088
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 106282,
+    "fields": {
+      "nombre": "El Arenal",
+      "municipio": 100088
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 106283,
+    "fields": {
+      "nombre": "El Azul",
+      "municipio": 100088
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 106284,
+    "fields": {
+      "nombre": "El Balde",
+      "municipio": 100088
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 106285,
+    "fields": {
+      "nombre": "El Corralito",
+      "municipio": 100088
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 106286,
+    "fields": {
+      "nombre": "El Diablo",
+      "municipio": 100088
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 106287,
+    "fields": {
+      "nombre": "El Guapo",
+      "municipio": 100088
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 106288,
+    "fields": {
+      "nombre": "El Mojón",
+      "municipio": 100088
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 106289,
+    "fields": {
+      "nombre": "El Ojito",
+      "municipio": 100088
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 106290,
+    "fields": {
+      "nombre": "El Porvenir",
+      "municipio": 100088
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 106291,
+    "fields": {
+      "nombre": "El Quemado",
+      "municipio": 100088
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 106292,
+    "fields": {
+      "nombre": "El Remate",
+      "municipio": 100088
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 106293,
+    "fields": {
+      "nombre": "El Rosado",
+      "municipio": 100088
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 106294,
+    "fields": {
+      "nombre": "El Saladillo",
+      "municipio": 100088
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 106295,
+    "fields": {
+      "nombre": "El Sauce",
+      "municipio": 100088
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 106296,
+    "fields": {
+      "nombre": "El Socorro",
+      "municipio": 100088
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 106297,
+    "fields": {
+      "nombre": "La Bolsa",
+      "municipio": 100088
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 106298,
+    "fields": {
+      "nombre": "La Cañada",
+      "municipio": 100088
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 106299,
+    "fields": {
+      "nombre": "La Florida",
+      "municipio": 100088
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 106300,
+    "fields": {
+      "nombre": "La Fortuna Este",
+      "municipio": 100088
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 106301,
+    "fields": {
+      "nombre": "La Fragua",
+      "municipio": 100088
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 106302,
+    "fields": {
+      "nombre": "La Manga",
+      "municipio": 100088
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 106303,
+    "fields": {
+      "nombre": "La Ovejería",
+      "municipio": 100088
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 106304,
+    "fields": {
+      "nombre": "La Reacción",
+      "municipio": 100088
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 106305,
+    "fields": {
+      "nombre": "Las Delicias",
+      "municipio": 100088
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 106306,
+    "fields": {
+      "nombre": "Las Lajas",
+      "municipio": 100088
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 106307,
+    "fields": {
+      "nombre": "Las Lomas",
+      "municipio": 100088
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 106308,
+    "fields": {
+      "nombre": "Los Cercos",
+      "municipio": 100088
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 106309,
+    "fields": {
+      "nombre": "Los Cercos Arriba",
+      "municipio": 100088
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 106310,
+    "fields": {
+      "nombre": "Los Pumas",
+      "municipio": 100088
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 106311,
+    "fields": {
+      "nombre": "Monte Quemado",
+      "municipio": 100088
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 106312,
+    "fields": {
+      "nombre": "Nueva Esperanza",
+      "municipio": 100088
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 106313,
+    "fields": {
+      "nombre": "Nuevo Simbolar",
+      "municipio": 100088
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 106314,
+    "fields": {
+      "nombre": "Pampa Pozo",
+      "municipio": 100088
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 106315,
+    "fields": {
+      "nombre": "Pampa Suni",
+      "municipio": 100088
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 106316,
+    "fields": {
+      "nombre": "Pozo Betbeder",
+      "municipio": 100088
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 106317,
+    "fields": {
+      "nombre": "Pozo Nuevo",
+      "municipio": 100088
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 106318,
+    "fields": {
+      "nombre": "Puesto del Ángel",
+      "municipio": 100088
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 106319,
+    "fields": {
+      "nombre": "Puesto Nuevo",
+      "municipio": 100088
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 106320,
+    "fields": {
+      "nombre": "Quebracho Coto",
+      "municipio": 100088
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 106321,
+    "fields": {
+      "nombre": "Quebracho Esquina",
+      "municipio": 100088
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 106322,
+    "fields": {
+      "nombre": "Quimilioj",
+      "municipio": 100088
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 106323,
+    "fields": {
+      "nombre": "Quiscaloro",
+      "municipio": 100088
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 106324,
+    "fields": {
+      "nombre": "Rapelli",
+      "municipio": 100088
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 106325,
+    "fields": {
+      "nombre": "San Carlos",
+      "municipio": 100088
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 106326,
+    "fields": {
+      "nombre": "San Ramón",
+      "municipio": 100088
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 106327,
+    "fields": {
+      "nombre": "San Ramón Norte",
+      "municipio": 100088
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 106328,
+    "fields": {
+      "nombre": "San Serafín",
+      "municipio": 100088
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 106329,
+    "fields": {
+      "nombre": "Santa Felisa",
+      "municipio": 100088
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 106330,
+    "fields": {
+      "nombre": "Santa María de las Chacras",
+      "municipio": 100088
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 106331,
+    "fields": {
+      "nombre": "Santo Domingo",
+      "municipio": 100088
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 106332,
+    "fields": {
+      "nombre": "Tacko Yuraj",
+      "municipio": 100088
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 106333,
+    "fields": {
+      "nombre": "Taco Bajada",
+      "municipio": 100088
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 106334,
+    "fields": {
+      "nombre": "Taco Pozo",
+      "municipio": 100088
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 106335,
+    "fields": {
+      "nombre": "Taco Punco",
+      "municipio": 100088
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 106336,
+    "fields": {
+      "nombre": "Toro Human",
+      "municipio": 100088
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 106337,
+    "fields": {
+      "nombre": "Tres Quebrachos",
+      "municipio": 100088
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 106338,
+    "fields": {
+      "nombre": "Tusca Bajada",
+      "municipio": 100088
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 106339,
+    "fields": {
+      "nombre": "Villa Estela",
+      "municipio": 100088
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 106340,
+    "fields": {
+      "nombre": "Villa Mercedes",
+      "municipio": 100088
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 106341,
+    "fields": {
+      "nombre": "Villa Nueva",
+      "municipio": 100088
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 106342,
+    "fields": {
+      "nombre": "Vinal Pozo",
+      "municipio": 100088
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 106343,
+    "fields": {
+      "nombre": "Yuchán",
+      "municipio": 100088
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 106344,
+    "fields": {
+      "nombre": "Colonia Alpina",
+      "municipio": 100089
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 106345,
+    "fields": {
+      "nombre": "Colonia La Victoria",
+      "municipio": 100089
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 106346,
+    "fields": {
+      "nombre": "Colonia Mackinlay",
+      "municipio": 100089
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 106347,
+    "fields": {
+      "nombre": "Colonia Mackinlay Sur",
+      "municipio": 100089
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 106348,
+    "fields": {
+      "nombre": "Dos Provincias",
+      "municipio": 100089
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 106349,
+    "fields": {
+      "nombre": "La Federación",
+      "municipio": 100089
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 106350,
+    "fields": {
+      "nombre": "La Huanaca",
+      "municipio": 100089
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 106351,
+    "fields": {
+      "nombre": "La Unión",
+      "municipio": 100089
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 106352,
+    "fields": {
+      "nombre": "La Victoria",
+      "municipio": 100089
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 106353,
+    "fields": {
+      "nombre": "Los Encantos",
+      "municipio": 100089
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 106354,
+    "fields": {
+      "nombre": "Los Porongos",
+      "municipio": 100089
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 106355,
+    "fields": {
+      "nombre": "Nueva Ceres",
+      "municipio": 100089
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 106356,
+    "fields": {
+      "nombre": "Palo Negro",
+      "municipio": 100089
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 106357,
+    "fields": {
+      "nombre": "Selva",
+      "municipio": 100089
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 106358,
+    "fields": {
+      "nombre": "Aloj Pozo",
+      "municipio": 100090
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 106359,
+    "fields": {
+      "nombre": "Ashpa Sinchi",
+      "municipio": 100090
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 106360,
+    "fields": {
+      "nombre": "Barrancas Coloradas",
+      "municipio": 100090
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 106361,
+    "fields": {
+      "nombre": "Brea Pozo Viejo",
+      "municipio": 100090
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 106362,
+    "fields": {
+      "nombre": "Cheej",
+      "municipio": 100090
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 106363,
+    "fields": {
+      "nombre": "Colonia Pinto",
+      "municipio": 100090
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 106364,
+    "fields": {
+      "nombre": "Diaspa",
+      "municipio": 100090
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 106365,
+    "fields": {
+      "nombre": "El 25",
+      "municipio": 100090
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 106366,
+    "fields": {
+      "nombre": "Estación Robles",
+      "municipio": 100090
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 106367,
+    "fields": {
+      "nombre": "Estación Taboada",
+      "municipio": 100090
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 106368,
+    "fields": {
+      "nombre": "Garciano",
+      "municipio": 100090
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 106369,
+    "fields": {
+      "nombre": "La Blanca",
+      "municipio": 100090
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 106370,
+    "fields": {
+      "nombre": "La Higuera",
+      "municipio": 100090
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 106371,
+    "fields": {
+      "nombre": "La Verde",
+      "municipio": 100090
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 106372,
+    "fields": {
+      "nombre": "Los Gallegos",
+      "municipio": 100090
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 106373,
+    "fields": {
+      "nombre": "Majadas",
+      "municipio": 100090
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 106374,
+    "fields": {
+      "nombre": "Pampa Atún",
+      "municipio": 100090
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 106375,
+    "fields": {
+      "nombre": "Percas",
+      "municipio": 100090
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 106376,
+    "fields": {
+      "nombre": "Perchil Bajo",
+      "municipio": 100090
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 106377,
+    "fields": {
+      "nombre": "Pozo Mosoj",
+      "municipio": 100090
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 106378,
+    "fields": {
+      "nombre": "Puestito",
+      "municipio": 100090
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 106379,
+    "fields": {
+      "nombre": "Puesto Nuevo",
+      "municipio": 100090
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 106380,
+    "fields": {
+      "nombre": "San Juan",
+      "municipio": 100090
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 106381,
+    "fields": {
+      "nombre": "San Marcos",
+      "municipio": 100090
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 106382,
+    "fields": {
+      "nombre": "Suncho Pozo",
+      "municipio": 100090
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 106383,
+    "fields": {
+      "nombre": "Tacoyoj",
+      "municipio": 100090
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 106384,
+    "fields": {
+      "nombre": "Tío Pozo",
+      "municipio": 100090
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 106385,
+    "fields": {
+      "nombre": "Tres Jazmines",
+      "municipio": 100090
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 106386,
+    "fields": {
+      "nombre": "Villa Nueva",
+      "municipio": 100090
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 106387,
+    "fields": {
+      "nombre": "Ampa",
+      "municipio": 100091
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 106388,
+    "fields": {
+      "nombre": "Azogasta",
+      "municipio": 100091
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 106389,
+    "fields": {
+      "nombre": "Chilcan",
+      "municipio": 100091
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 106390,
+    "fields": {
+      "nombre": "Colonia Siegel",
+      "municipio": 100091
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 106391,
+    "fields": {
+      "nombre": "Concepción",
+      "municipio": 100091
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 106392,
+    "fields": {
+      "nombre": "Conchayoj",
+      "municipio": 100091
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 106393,
+    "fields": {
+      "nombre": "El Cachi",
+      "municipio": 100091
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 106394,
+    "fields": {
+      "nombre": "El Empachado",
+      "municipio": 100091
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 106395,
+    "fields": {
+      "nombre": "Garza",
+      "municipio": 100091
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 106396,
+    "fields": {
+      "nombre": "Guaipe Guaipe",
+      "municipio": 100091
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 106397,
+    "fields": {
+      "nombre": "La Falda",
+      "municipio": 100091
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 106398,
+    "fields": {
+      "nombre": "Oso Huanchina",
+      "municipio": 100091
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 106399,
+    "fields": {
+      "nombre": "Paaj Rodeo",
+      "municipio": 100091
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 106400,
+    "fields": {
+      "nombre": "Pampa Muyoj",
+      "municipio": 100091
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 106401,
+    "fields": {
+      "nombre": "Pozo Barrancayoj",
+      "municipio": 100091
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 106402,
+    "fields": {
+      "nombre": "San Pedro",
+      "municipio": 100091
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 106403,
+    "fields": {
+      "nombre": "Villa Matará",
+      "municipio": 100091
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 106404,
+    "fields": {
+      "nombre": "Amaicha del Llano",
+      "municipio": 100092
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 106405,
+    "fields": {
+      "nombre": "Bella Vista",
+      "municipio": 100092
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 106406,
+    "fields": {
+      "nombre": "Doce Cuarenta",
+      "municipio": 100092
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 106407,
+    "fields": {
+      "nombre": "El Sunchal (comuna Bella Vista)",
+      "municipio": 100092
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 106408,
+    "fields": {
+      "nombre": "San Ramón",
+      "municipio": 100092
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 106409,
+    "fields": {
+      "nombre": "Buena Vista",
+      "municipio": 100093
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 106410,
+    "fields": {
+      "nombre": "Buena Vista Oeste",
+      "municipio": 100093
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 106411,
+    "fields": {
+      "nombre": "Campo Volante",
+      "municipio": 100093
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 106412,
+    "fields": {
+      "nombre": "Estación El Cadillal",
+      "municipio": 100094
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 106413,
+    "fields": {
+      "nombre": "Nueva Esperanza",
+      "municipio": 100094
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 106414,
+    "fields": {
+      "nombre": "Taficillo",
+      "municipio": 100094
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 106415,
+    "fields": {
+      "nombre": "Monte Redondo",
+      "municipio": 100095
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 106416,
+    "fields": {
+      "nombre": "San Miguel",
+      "municipio": 100095
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 106417,
+    "fields": {
+      "nombre": "Río Seco",
+      "municipio": 100096
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 106418,
+    "fields": {
+      "nombre": "Los Pizarros",
+      "municipio": 100097
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 106419,
+    "fields": {
+      "nombre": "San Ignacio",
+      "municipio": 100097
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 106420,
+    "fields": {
+      "nombre": "La Cascada",
+      "municipio": 100098
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 106421,
+    "fields": {
+      "nombre": "Villa San Javier",
+      "municipio": 100098
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 106422,
+    "fields": {
+      "nombre": "Colonia 1",
+      "municipio": 100099
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 106423,
+    "fields": {
+      "nombre": "Colonia 10",
+      "municipio": 100099
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 106424,
+    "fields": {
+      "nombre": "Colonia 14",
+      "municipio": 100099
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 106425,
+    "fields": {
+      "nombre": "Colonia 16",
+      "municipio": 100099
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 106426,
+    "fields": {
+      "nombre": "Colonia 17",
+      "municipio": 100099
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 106427,
+    "fields": {
+      "nombre": "Colonia 5",
+      "municipio": 100099
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 106428,
+    "fields": {
+      "nombre": "Colonia 6",
+      "municipio": 100099
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 106429,
+    "fields": {
+      "nombre": "Los Luna",
+      "municipio": 100099
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 106430,
+    "fields": {
+      "nombre": "Rayo Huaso",
+      "municipio": 100099
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 106431,
+    "fields": {
+      "nombre": "Río Chico",
+      "municipio": 100099
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 106432,
+    "fields": {
+      "nombre": "San José",
+      "municipio": 100099
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 106433,
+    "fields": {
+      "nombre": "Santa Ana",
+      "municipio": 100099
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 106434,
+    "fields": {
+      "nombre": "Villa Clodomiro Hileret",
+      "municipio": 100099
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 106435,
+    "fields": {
+      "nombre": "Caspichango",
+      "municipio": 100100
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 106436,
+    "fields": {
+      "nombre": "Santa Lucía",
+      "municipio": 100100
+    }
+  },
+  {
+    "model": "core.localidad",
+    "pk": 106437,
+    "fields": {
+      "nombre": "Zavalía",
+      "municipio": 100100
+    }
   }
 ]

--- a/core/management/commands/load_fixtures.py
+++ b/core/management/commands/load_fixtures.py
@@ -6,6 +6,7 @@ from django.core import serializers
 from django.db import transaction
 
 from intervenciones.services_catalogo import sync_catalogo_intervenciones
+from core.services.territorio_sync import sync_territorio_desde_fixture
 
 
 class Command(BaseCommand):
@@ -58,6 +59,7 @@ class Command(BaseCommand):
         return any(self.model_is_empty(m) for m in models)
 
     def upsert_fixture(self, fixture_path):
+        # pylint: disable=too-many-locals
         """Deserializa y guarda: si PK existe actualiza, si no inserta.
 
         Este es el mecanismo oficial para "pisar" fixtures sin borrar datos:
@@ -155,4 +157,12 @@ class Command(BaseCommand):
             f"tipos={resumen['tipos_sincronizados']}, "
             f"subtipos={resumen['subtipos_sincronizados']}, "
             f"subtipos_vacios_eliminados={resumen['subtipos_vacios_eliminados']}"
+        )
+        territorio = sync_territorio_desde_fixture()
+        self.stdout.write(
+            "✅ Territorio sincronizado: "
+            f"provincias={territorio['provincias_creadas']}, "
+            f"municipios={territorio['municipios_creadas']}, "
+            f"localidades={territorio['localidades_creadas']}, "
+            f"saltadas_por_integridad={territorio['saltadas_por_integridad']}"
         )

--- a/core/services/territorio_sync.py
+++ b/core/services/territorio_sync.py
@@ -1,0 +1,182 @@
+"""Sincronización create-only del catálogo territorial desde su fixture."""
+
+import json
+import logging
+import unicodedata
+from pathlib import Path
+
+from django.db import IntegrityError, transaction
+
+from core.models import Localidad, Municipio, Provincia
+
+
+logger = logging.getLogger(__name__)
+FIXTURE_TERRITORIO_PATH = Path("core/fixtures/localidad_municipio_provincia.json")
+
+
+def normalizar_nombre(valor):
+    """Aproxima la comparación ai_ci de MySQL para las claves naturales."""
+    texto = unicodedata.normalize("NFKD", valor or "")
+    texto = "".join(char for char in texto if not unicodedata.combining(char))
+    return " ".join(texto.casefold().split())
+
+
+def _por_clave_natural(instancias, clave):
+    """Conserva el primer PK si existen filas orgánicas equivalentes."""
+    resultado = {}
+    for instancia in instancias:
+        resultado.setdefault(clave(instancia), instancia)
+    return resultado
+
+
+def _crear_si_falta(  # pylint: disable=too-many-arguments
+    modelo, campos, pk_fixture, pks_ocupados, por_clave, clave, resumen, resumen_key
+):
+    existente = por_clave.get(clave)
+    if existente is not None:
+        return existente
+
+    kwargs = dict(campos)
+    if pk_fixture not in pks_ocupados:
+        kwargs["pk"] = pk_fixture
+    try:
+        with transaction.atomic():
+            instancia = modelo.objects.create(**kwargs)
+    except IntegrityError as error:
+        # Otra instancia puede haber creado la misma clave entre el prefetch y
+        # este insert, o MySQL puede detectar una equivalencia más amplia.
+        logger.warning(
+            "Territorio no sincronizado para %s(pk_fixture=%s): %s",
+            modelo._meta.label,
+            pk_fixture,
+            error,
+        )
+        instancia = modelo.objects.filter(**campos).order_by("pk").first()
+        if instancia is None:
+            return None
+        pks_ocupados.add(instancia.pk)
+        por_clave[clave] = instancia
+        return instancia
+
+    pks_ocupados.add(instancia.pk)
+    por_clave[clave] = instancia
+    resumen[resumen_key] += 1
+    return instancia
+
+
+def sync_territorio_desde_fixture(path=FIXTURE_TERRITORIO_PATH):
+    # pylint: disable=too-many-locals,too-many-branches,too-many-statements
+    """Crea claves territoriales faltantes sin modificar ni eliminar filas.
+
+    Las tres consultas iniciales permiten que el caso habitual (catálogo ya
+    completo) sea solo una comparación en memoria.
+    """
+    fixture = json.loads(Path(path).read_text(encoding="utf-8"))
+    provincias = list(Provincia.objects.all().order_by("pk"))
+    municipios = list(Municipio.objects.all().order_by("pk"))
+    localidades = list(Localidad.objects.all().order_by("pk"))
+    resumen = {
+        "provincias_creadas": 0,
+        "municipios_creadas": 0,
+        "localidades_creadas": 0,
+        "saltadas_por_integridad": 0,
+    }
+
+    provincias_por_nombre = _por_clave_natural(
+        provincias, lambda provincia: normalizar_nombre(provincia.nombre)
+    )
+    municipios_por_clave = _por_clave_natural(
+        municipios,
+        lambda municipio: (normalizar_nombre(municipio.nombre), municipio.provincia_id),
+    )
+    localidades_por_clave = _por_clave_natural(
+        localidades,
+        lambda localidad: (normalizar_nombre(localidad.nombre), localidad.municipio_id),
+    )
+    pks_provincia = {provincia.pk for provincia in provincias}
+    pks_municipio = {municipio.pk for municipio in municipios}
+    pks_localidad = {localidad.pk for localidad in localidades}
+    provincias_fixture = {}
+    municipios_fixture = {}
+
+    for entrada in fixture:
+        if entrada.get("model") != "core.provincia":
+            continue
+        nombre = entrada.get("fields", {}).get("nombre") or ""
+        clave = normalizar_nombre(nombre)
+        provincia = _crear_si_falta(
+            Provincia,
+            {"nombre": nombre},
+            entrada["pk"],
+            pks_provincia,
+            provincias_por_nombre,
+            clave,
+            resumen,
+            "provincias_creadas",
+        )
+        if provincia is None:
+            resumen["saltadas_por_integridad"] += 1
+            provincia = provincias_por_nombre.get(clave)
+        if provincia is not None:
+            provincias_fixture[entrada["pk"]] = provincia
+
+    for entrada in fixture:
+        if entrada.get("model") != "core.municipio":
+            continue
+        fields = entrada.get("fields", {})
+        provincia_fixture_pk = fields.get("provincia")
+        provincia = provincias_fixture.get(provincia_fixture_pk)
+        if provincia_fixture_pk is not None and provincia is None:
+            logger.warning(
+                "Municipio omitido: provincia fixture %s no fue resuelta.",
+                provincia_fixture_pk,
+            )
+            resumen["saltadas_por_integridad"] += 1
+            continue
+        nombre = fields.get("nombre") or ""
+        clave = (normalizar_nombre(nombre), provincia.pk if provincia else None)
+        municipio = _crear_si_falta(
+            Municipio,
+            {"nombre": nombre, "provincia": provincia},
+            entrada["pk"],
+            pks_municipio,
+            municipios_por_clave,
+            clave,
+            resumen,
+            "municipios_creadas",
+        )
+        if municipio is None:
+            resumen["saltadas_por_integridad"] += 1
+            municipio = municipios_por_clave.get(clave)
+        if municipio is not None:
+            municipios_fixture[entrada["pk"]] = municipio
+
+    for entrada in fixture:
+        if entrada.get("model") != "core.localidad":
+            continue
+        fields = entrada.get("fields", {})
+        municipio_fixture_pk = fields.get("municipio")
+        municipio = municipios_fixture.get(municipio_fixture_pk)
+        if municipio_fixture_pk is not None and municipio is None:
+            logger.warning(
+                "Localidad omitida: municipio fixture %s no fue resuelto.",
+                municipio_fixture_pk,
+            )
+            resumen["saltadas_por_integridad"] += 1
+            continue
+        nombre = fields.get("nombre") or ""
+        clave = (normalizar_nombre(nombre), municipio.pk if municipio else None)
+        localidad = _crear_si_falta(
+            Localidad,
+            {"nombre": nombre, "municipio": municipio},
+            entrada["pk"],
+            pks_localidad,
+            localidades_por_clave,
+            clave,
+            resumen,
+            "localidades_creadas",
+        )
+        if localidad is None:
+            resumen["saltadas_por_integridad"] += 1
+
+    return resumen

--- a/docs/registro/cambios/2026-07-17-bajada-bahra-territorio.md
+++ b/docs/registro/cambios/2026-07-17-bajada-bahra-territorio.md
@@ -1,0 +1,64 @@
+# 2026-07-17 - Bajada BAHRA de municipios y localidades
+
+## Contexto
+
+- El fixture territorial de SISOC no contenía todas las instancias publicadas
+  por BAHRA a través de IGN/georef.
+- La fuente se descargó el 2026-07-17 desde
+  <https://apis.datos.gob.ar/georef/api/asentamientos.csv> y
+  <https://apis.datos.gob.ar/georef/api/municipios.csv>.
+
+## Cambios aplicados
+
+- Se agregó el generador standalone
+  `scripts/actualizar_territorio_desde_bahra.py`. Lee el fixture y ambos CSV,
+  normaliza nombres con NFKD sin diacríticos y añade entradas al final sin
+  reserializar las existentes.
+- Se incorporaron 75 municipios oficiales y 26 pseudo-municipios de
+  departamento; los nuevos PKs de municipios y localidades comienzan en
+  `100000`, de forma independiente.
+- Se incorporaron 6.438 localidades: 444 localidades simples, 23 componentes
+  de localidad compuesta, 47 entidades y 5.924 parajes. Se excluyeron 13 bases
+  antárticas, 8.102 localidades ya existentes, 109 anclajes conservadores que
+  ya existían en la provincia y 11 duplicados internos BAHRA.
+- `sync_territorio_desde_fixture()` se ejecuta al final de
+  `load_fixtures.sync_post_load_catalogs()`. Es create-only y resuelve las
+  claves naturales contra las filas existentes, para no depender de los PKs
+  del fixture en bases donde GESTIONAR creó datos orgánicamente.
+
+## Casos de frontera entre provincias
+
+- Nueve asentamientos traen un municipio de una provincia vecina como efecto
+  del join espacial de IGN: Arroyo Verde, San Pedro, Paralelo 28, Centinela,
+  Laguna Negra, Balde del Norte, Colonia Los Valencianos, La Tranca y Pampa
+  Pozo.
+- Para esos nueve casos, un municipio no resoluble en la provincia del
+  asentamiento se trata igual que un municipio vacío: se ancla al departamento
+  de esa provincia, reutilizando o creando el municipio homónimo necesario.
+- La integridad provincial declarada por el asentamiento prevalece sobre la
+  precisión poligonal del join de IGN. El generador deja el conteo auditable
+  `municipio_cross_provincia_anclado_a_depto=9`.
+
+## Reproducción
+
+```powershell
+python scripts/actualizar_territorio_desde_bahra.py `
+  --fixture core/fixtures/localidad_municipio_provincia.json `
+  --asentamientos <ruta-a-asentamientos.csv> `
+  --municipios <ruta-a-municipios.csv>
+```
+
+Usar `--dry-run` para calcular y revisar los conteos sin escribir. El script
+aborta si la serialización de las entradas preexistentes no reproduce el
+archivo byte a byte.
+
+## Riesgos y rollback
+
+- La comparación Python aproxima la collation `ai_ci` de MySQL, pero puede
+  diferir en casos Unicode poco frecuentes. Ante una colisión, el sync registra
+  un warning y omite esa creación sin modificar filas existentes.
+- Arranques simultáneos pueden competir por una misma clave natural; cada fila
+  se inserta en una transacción independiente y un `IntegrityError` no aborta
+  el resto de la sincronización.
+- El rollback consiste en revertir el fixture, el servicio y la llamada del
+  comando; el sync no actualiza ni elimina datos ya existentes.

--- a/scripts/actualizar_territorio_desde_bahra.py
+++ b/scripts/actualizar_territorio_desde_bahra.py
@@ -1,0 +1,310 @@
+#!/usr/bin/env python3
+"""Incorpora asentamientos BAHRA al fixture territorial sin tocar sus entradas.
+
+El script usa exclusivamente la biblioteca estándar para poder auditar y
+reproducir la bajada sin inicializar Django.
+"""
+
+import argparse
+import csv
+import json
+import unicodedata
+from collections import Counter
+from pathlib import Path
+
+
+MODELO_PROVINCIA = "core.provincia"
+MODELO_MUNICIPIO = "core.municipio"
+MODELO_LOCALIDAD = "core.localidad"
+PK_INICIAL = 100000
+PRIORIDAD_CATEGORIA = {
+    "Localidad simple": 0,
+    "Componente de localidad compuesta": 1,
+    "Entidad": 2,
+    "Paraje": 3,
+}
+
+
+def norm(valor):
+    """Normaliza texto de la misma forma que la comparación del sync."""
+    texto = unicodedata.normalize("NFKD", valor or "")
+    texto = "".join(char for char in texto if not unicodedata.combining(char))
+    return " ".join(texto.casefold().split())
+
+
+def _read_csv(path):
+    with Path(path).open("r", encoding="utf-8-sig", newline="") as archivo:
+        return list(csv.DictReader(archivo))
+
+
+def _entry(model, pk, **fields):
+    return {"model": model, "pk": pk, "fields": fields}
+
+
+def _candidate_sort_key(row):
+    return (
+        PRIORIDAD_CATEGORIA[row["categoria"]],
+        norm(row["nombre"]),
+        row.get("id") or "",
+        row["nombre"],
+    )
+
+
+def calcular_actualizacion(fixture_data, asentamientos, municipios):
+    # pylint: disable=too-many-locals,too-many-branches,too-many-statements
+    """Devuelve entradas para append y un resumen, sin escribir en disco."""
+    provincias = {
+        norm(row["fields"].get("nombre")): row["pk"]
+        for row in fixture_data
+        if row.get("model") == MODELO_PROVINCIA
+    }
+    if not provincias:
+        raise ValueError("El fixture no contiene provincias.")
+
+    municipios_por_clave = {}
+    municipio_provincia = {}
+    for row in fixture_data:
+        if row.get("model") != MODELO_MUNICIPIO:
+            continue
+        fields = row["fields"]
+        clave = (norm(fields.get("nombre")), fields.get("provincia"))
+        municipios_por_clave[clave] = row["pk"]
+        municipio_provincia[row["pk"]] = fields.get("provincia")
+
+    localidades_existentes = set()
+    localidades_por_provincia = set()
+    for row in fixture_data:
+        if row.get("model") != MODELO_LOCALIDAD:
+            continue
+        fields = row["fields"]
+        municipio_pk = fields.get("municipio")
+        nombre_normalizado = norm(fields.get("nombre"))
+        localidades_existentes.add((nombre_normalizado, municipio_pk))
+        provincia_pk = municipio_provincia.get(municipio_pk)
+        if provincia_pk is not None:
+            localidades_por_provincia.add((nombre_normalizado, provincia_pk))
+
+    municipios_planeados = {}
+
+    def provincia_de(row, campo="provincia_nombre"):
+        provincia_pk = provincias.get(norm(row.get(campo)))
+        if provincia_pk is None:
+            raise ValueError(
+                "Provincia sin resolver en BAHRA: "
+                f"{row.get(campo)!r} ({row.get('nombre')!r})"
+            )
+        return provincia_pk
+
+    # El CSV de municipios se evalúa completo antes de resolver asentamientos.
+    for row in municipios:
+        provincia_pk = provincia_de(row)
+        nombre = (row.get("nombre") or "").strip()
+        clave = (norm(nombre), provincia_pk)
+        if not nombre:
+            raise ValueError("Municipio BAHRA sin nombre.")
+        if clave not in municipios_por_clave:
+            anterior = municipios_planeados.get(clave)
+            if anterior is None or (norm(nombre), nombre) < (
+                norm(anterior["nombre"]),
+                anterior["nombre"],
+            ):
+                municipios_planeados[clave] = {
+                    "nombre": nombre,
+                    "provincia": provincia_pk,
+                    "origen": "oficial",
+                }
+
+    # Las localidades se dejan como candidatas hasta asignar los PKs de todos
+    # los municipios nuevos, incluidos los pseudo-municipios de departamento.
+    candidatas = []
+    asentamientos_validos = [
+        row
+        for row in asentamientos
+        if norm((row.get("categoria") or "").strip()) != norm("Base Antartica")
+    ]
+    for row in sorted(asentamientos_validos, key=_candidate_sort_key):
+        categoria = (row.get("categoria") or "").strip()
+        if categoria not in PRIORIDAD_CATEGORIA:
+            continue
+        provincia_pk = provincia_de(row)
+        nombre = (row.get("nombre") or "").strip()
+        if not nombre:
+            raise ValueError(f"Asentamiento BAHRA sin nombre: {row.get('id')!r}")
+
+        municipio_nombre = (row.get("municipio_nombre") or "").strip()
+        destino_clave_municipio = (norm(municipio_nombre), provincia_pk)
+        municipio_cross_provincia = bool(municipio_nombre) and (
+            destino_clave_municipio not in municipios_por_clave
+            and destino_clave_municipio not in municipios_planeados
+        )
+        anclada_a_departamento = not municipio_nombre or municipio_cross_provincia
+        destino_nombre = (
+            (row.get("departamento_nombre") or "").strip()
+            if anclada_a_departamento
+            else municipio_nombre
+        )
+        if not destino_nombre:
+            raise ValueError(
+                f"Asentamiento sin municipio ni departamento: {row.get('id')!r}"
+            )
+        destino_clave = (norm(destino_nombre), provincia_pk)
+
+        if (
+            destino_clave not in municipios_por_clave
+            and destino_clave not in municipios_planeados
+        ):
+            municipios_planeados[destino_clave] = {
+                "nombre": destino_nombre,
+                "provincia": provincia_pk,
+                "origen": "pseudo_departamento",
+            }
+
+        candidatas.append(
+            {
+                "id": row.get("id") or "",
+                "nombre": nombre,
+                "nombre_norm": norm(nombre),
+                "categoria": categoria,
+                "provincia": provincia_pk,
+                "destino_clave": destino_clave,
+                "anclada_a_departamento": anclada_a_departamento,
+                "municipio_cross_provincia": municipio_cross_provincia,
+            }
+        )
+
+    municipios_nuevos = []
+    for pk, (_, definition) in enumerate(
+        sorted(
+            municipios_planeados.items(),
+            key=lambda item: (
+                item[1]["provincia"],
+                norm(item[1]["nombre"]),
+                item[1]["nombre"],
+            ),
+        ),
+        start=PK_INICIAL,
+    ):
+        definition["pk"] = pk
+        municipios_por_clave[_] = pk
+        municipio_provincia[pk] = definition["provincia"]
+        municipios_nuevos.append(
+            _entry(
+                MODELO_MUNICIPIO,
+                pk,
+                nombre=definition["nombre"],
+                provincia=definition["provincia"],
+            )
+        )
+
+    resumen = Counter(
+        {
+            "asentamientos_fuente": len(asentamientos),
+            "bases_antarticas_excluidas": len(asentamientos)
+            - len(asentamientos_validos),
+            "municipios_oficiales_nuevos": sum(
+                item["origen"] == "oficial" for item in municipios_planeados.values()
+            ),
+            "pseudo_municipios_nuevos": sum(
+                item["origen"] == "pseudo_departamento"
+                for item in municipios_planeados.values()
+            ),
+            "municipio_cross_provincia_anclado_a_depto": sum(
+                item["municipio_cross_provincia"] for item in candidatas
+            ),
+        }
+    )
+
+    ganadoras = {}
+    for candidata in candidatas:
+        municipio_pk = municipios_por_clave[candidata["destino_clave"]]
+        clave = (candidata["nombre_norm"], municipio_pk)
+        if clave in localidades_existentes:
+            resumen["descartes_localidad_existente"] += 1
+            continue
+        if (
+            candidata["anclada_a_departamento"]
+            and (candidata["nombre_norm"], candidata["provincia"])
+            in localidades_por_provincia
+        ):
+            resumen["descartes_anclaje_anti_duplicado"] += 1
+            continue
+        if clave in ganadoras:
+            resumen["descartes_dedup_interno"] += 1
+            continue
+        ganadoras[clave] = candidata
+
+    localidades_nuevas = []
+    for pk, (_, candidata) in enumerate(
+        sorted(
+            ganadoras.items(),
+            key=lambda item: (
+                item[0][1],
+                item[1]["nombre_norm"],
+                item[1]["nombre"],
+                item[1]["id"],
+            ),
+        ),
+        start=PK_INICIAL,
+    ):
+        municipio_pk = municipios_por_clave[candidata["destino_clave"]]
+        localidades_nuevas.append(
+            _entry(
+                MODELO_LOCALIDAD,
+                pk,
+                nombre=candidata["nombre"],
+                municipio=municipio_pk,
+            )
+        )
+        resumen[f"localidades_{candidata['categoria']}"] += 1
+
+    resumen["municipios_nuevos"] = len(municipios_nuevos)
+    resumen["localidades_nuevas"] = len(localidades_nuevas)
+    return municipios_nuevos, localidades_nuevas, dict(sorted(resumen.items()))
+
+
+def actualizar_fixture(
+    fixture_path, asentamientos_path, municipios_path, dry_run=False
+):
+    fixture_path = Path(fixture_path)
+    original = fixture_path.read_text(encoding="utf-8")
+    fixture_data = json.loads(original)
+    serializado_existente = json.dumps(fixture_data, ensure_ascii=False, indent=2)
+    if serializado_existente != original:
+        raise AssertionError(
+            "La serialización de las entradas existentes no reproduce el fixture "
+            "byte a byte; se aborta para preservar append-only."
+        )
+
+    municipios_nuevos, localidades_nuevas, resumen = calcular_actualizacion(
+        fixture_data,
+        _read_csv(asentamientos_path),
+        _read_csv(municipios_path),
+    )
+    nuevas_entradas = municipios_nuevos + localidades_nuevas
+    if nuevas_entradas and not dry_run:
+        serializado_nuevo = json.dumps(nuevas_entradas, ensure_ascii=False, indent=2)
+        # Se conserva byte por byte el bloque original de entradas; solo se
+        # sustituye el cierre final del array para continuar agregando objetos.
+        fixture_path.write_text(
+            original[:-2] + ",\n" + serializado_nuevo[2:], encoding="utf-8"
+        )
+    return resumen
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--fixture", required=True)
+    parser.add_argument("--asentamientos", required=True)
+    parser.add_argument("--municipios", required=True)
+    parser.add_argument("--dry-run", action="store_true")
+    args = parser.parse_args()
+
+    resumen = actualizar_fixture(
+        args.fixture, args.asentamientos, args.municipios, dry_run=args.dry_run
+    )
+    for clave, valor in resumen.items():
+        print(f"{clave}={valor}")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_actualizar_territorio_desde_bahra.py
+++ b/tests/test_actualizar_territorio_desde_bahra.py
@@ -1,0 +1,133 @@
+"""Pruebas del generador standalone de BAHRA."""
+
+import csv
+import importlib.util
+import json
+from pathlib import Path
+
+
+SCRIPT_PATH = (
+    Path(__file__).resolve().parents[1]
+    / "scripts"
+    / ("actualizar_territorio_desde_bahra.py")
+)
+SPEC = importlib.util.spec_from_file_location(
+    "actualizar_territorio_bahra", SCRIPT_PATH
+)
+bahra = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(bahra)
+
+
+def _escribir_csv(path, columnas, filas):
+    with path.open("w", encoding="utf-8", newline="") as archivo:
+        writer = csv.DictWriter(archivo, fieldnames=columnas)
+        writer.writeheader()
+        writer.writerows(filas)
+
+
+def test_generador_deduplica_normaliza_ancla_y_agrega_sin_reescribir_prefijo(tmp_path):
+    fixture = [
+        {
+            "model": "core.provincia",
+            "pk": 1,
+            "fields": {"nombre": "Córdoba"},
+        },
+        {
+            "model": "core.municipio",
+            "pk": 2,
+            "fields": {"nombre": "Capital", "provincia": 1},
+        },
+        {
+            "model": "core.localidad",
+            "pk": 3,
+            "fields": {"nombre": "Existente", "municipio": 2},
+        },
+    ]
+    fixture_path = tmp_path / "territorio.json"
+    original = json.dumps(fixture, ensure_ascii=False, indent=2)
+    fixture_path.write_text(original, encoding="utf-8")
+
+    asentamientos_path = tmp_path / "asentamientos.csv"
+    _escribir_csv(
+        asentamientos_path,
+        [
+            "categoria",
+            "id",
+            "nombre",
+            "provincia_nombre",
+            "municipio_nombre",
+            "departamento_nombre",
+        ],
+        [
+            {
+                "categoria": "Paraje",
+                "id": "1",
+                "nombre": "Nueva",
+                "provincia_nombre": "CORDOBA",
+                "municipio_nombre": "capital",
+                "departamento_nombre": "Capital",
+            },
+            {
+                "categoria": "Entidad",
+                "id": "2",
+                "nombre": "NUEVA",
+                "provincia_nombre": "Córdoba",
+                "municipio_nombre": "Capital",
+                "departamento_nombre": "Capital",
+            },
+            {
+                "categoria": "Localidad simple",
+                "id": "3",
+                "nombre": "Anclada",
+                "provincia_nombre": "Córdoba",
+                "municipio_nombre": "",
+                "departamento_nombre": "Capital",
+            },
+            {
+                "categoria": "Paraje",
+                "id": "4",
+                "nombre": "Existente",
+                "provincia_nombre": "Córdoba",
+                "municipio_nombre": "",
+                "departamento_nombre": "Departamento Nuevo",
+            },
+            {
+                "categoria": "Localidad simple",
+                "id": "5",
+                "nombre": "Cruce",
+                "provincia_nombre": "Córdoba",
+                "municipio_nombre": "Municipio Vecino",
+                "departamento_nombre": "Capital",
+            },
+        ],
+    )
+    municipios_path = tmp_path / "municipios.csv"
+    _escribir_csv(
+        municipios_path,
+        ["nombre", "provincia_nombre"],
+        [{"nombre": "Oficial", "provincia_nombre": "Córdoba"}],
+    )
+
+    resumen = bahra.actualizar_fixture(
+        fixture_path, asentamientos_path, municipios_path
+    )
+    resultado = fixture_path.read_text(encoding="utf-8")
+    datos = json.loads(resultado)
+
+    assert resultado.startswith(original[:-2])
+    assert not resultado.endswith("\n")
+    assert resumen["municipios_oficiales_nuevos"] == 1
+    assert resumen["pseudo_municipios_nuevos"] == 1
+    assert resumen["municipio_cross_provincia_anclado_a_depto"] == 1
+    assert resumen["descartes_dedup_interno"] == 1
+    assert resumen["descartes_anclaje_anti_duplicado"] == 1
+    assert resumen["localidades_Entidad"] == 1
+    assert resumen["localidades_Localidad simple"] == 2
+    assert all(entry["pk"] >= 100000 for entry in datos[3:])
+    assert [entry["model"] for entry in datos[3:]] == [
+        "core.municipio",
+        "core.municipio",
+        "core.localidad",
+        "core.localidad",
+        "core.localidad",
+    ]

--- a/tests/test_load_fixtures_command.py
+++ b/tests/test_load_fixtures_command.py
@@ -60,11 +60,21 @@ def test_handle_sincroniza_catalogo_cdi_despues_de_cargar():
                 "subtipos_vacios_eliminados": 3,
             },
         ) as sync_mock,
+        patch(
+            "core.management.commands.load_fixtures.sync_territorio_desde_fixture",
+            return_value={
+                "provincias_creadas": 0,
+                "municipios_creadas": 0,
+                "localidades_creadas": 0,
+                "saltadas_por_integridad": 0,
+            },
+        ) as territorio_mock,
     ):
         command.handle(force=False)
 
     load_mock.assert_called_once_with()
     sync_mock.assert_called_once_with()
+    territorio_mock.assert_called_once_with()
 
 
 def test_add_arguments_reconoce_overwrite():

--- a/tests/test_territorio_sync.py
+++ b/tests/test_territorio_sync.py
@@ -1,0 +1,95 @@
+"""Pruebas de la sincronización create-only del fixture territorial."""
+
+import json
+
+import pytest
+
+from core.models import Localidad, Municipio, Provincia
+from core.services.territorio_sync import sync_territorio_desde_fixture
+
+
+pytestmark = pytest.mark.django_db
+
+
+def _fixture(path):
+    path.write_text(
+        json.dumps(
+            [
+                {
+                    "model": "core.provincia",
+                    "pk": 101,
+                    "fields": {"nombre": "Córdoba"},
+                },
+                {
+                    "model": "core.municipio",
+                    "pk": 102,
+                    "fields": {"nombre": "Capital", "provincia": 101},
+                },
+                {
+                    "model": "core.municipio",
+                    "pk": 103,
+                    "fields": {"nombre": "Interior", "provincia": 101},
+                },
+                {
+                    "model": "core.localidad",
+                    "pk": 104,
+                    "fields": {"nombre": "VILLA", "municipio": 102},
+                },
+                {
+                    "model": "core.localidad",
+                    "pk": 105,
+                    "fields": {"nombre": "Villa", "municipio": 103},
+                },
+                {
+                    "model": "core.localidad",
+                    "pk": 106,
+                    "fields": {"nombre": "Nueva", "municipio": 102},
+                },
+            ],
+            ensure_ascii=False,
+            indent=2,
+        ),
+        encoding="utf-8",
+    )
+
+
+def test_sync_crea_solo_faltantes_normaliza_y_es_idempotente(tmp_path):
+    provincia = Provincia.objects.create(pk=10, nombre="CÓRDOBA")
+    capital = Municipio.objects.create(pk=11, nombre="cApItAl", provincia=provincia)
+    Municipio.objects.create(pk=12, nombre="INTERIOR", provincia=provincia)
+    localidad_existente = Localidad.objects.create(
+        pk=13, nombre="vÍlla", municipio=capital
+    )
+    Localidad.objects.create(pk=14, nombre="Intacta", municipio=capital)
+    fixture_path = tmp_path / "territorio.json"
+    _fixture(fixture_path)
+
+    primer_resultado = sync_territorio_desde_fixture(fixture_path)
+
+    provincia.refresh_from_db()
+    capital.refresh_from_db()
+    localidad_existente.refresh_from_db()
+    assert provincia.pk == 10 and provincia.nombre == "CÓRDOBA"
+    assert capital.pk == 11 and capital.nombre == "cApItAl"
+    assert localidad_existente.pk == 13 and localidad_existente.nombre == "vÍlla"
+    assert primer_resultado == {
+        "provincias_creadas": 0,
+        "municipios_creadas": 0,
+        "localidades_creadas": 2,
+        "saltadas_por_integridad": 0,
+    }
+    assert Localidad.objects.filter(municipio=capital).count() == 3
+    assert (
+        Localidad.objects.filter(nombre="Villa", municipio__nombre="INTERIOR").count()
+        == 1
+    )
+
+    segundo_resultado = sync_territorio_desde_fixture(fixture_path)
+
+    assert segundo_resultado == {
+        "provincias_creadas": 0,
+        "municipios_creadas": 0,
+        "localidades_creadas": 0,
+        "saltadas_por_integridad": 0,
+    }
+    assert Localidad.objects.count() == 4


### PR DESCRIPTION
## Qué hace

Completa el catálogo territorial de SISOC con las instancias faltantes según **BAHRA** (Base de Asentamientos Humanos de la República Argentina, publicada vía IGN/georef en `apis.datos.gob.ar`, bajada 2026-07-17):

| Alta | Cantidad | PKs |
|---|---|---|
| Municipios oficiales (IGN) | 75 | 100000–100100 |
| Pseudo-municipios (nombre de departamento) | 26 | (misma secuencia) |
| Localidades | **6.438** (444 simples, 23 componentes, 47 entidades, 5.924 parajes) | 100000–106437 |

Excluido: 13 bases antárticas. Descartes anti-duplicado: 8.102 ya existentes, 109 por anclaje conservador, 11 duplicados internos BAHRA.

## Cómo llega a producción (sin tocar PKs existentes)

- El fixture `localidad_municipio_provincia.json` crece **append-only** (cero líneas modificadas; PKs nuevos desde 100000 para no chocar con filas creadas orgánicamente por GESTIONAR).
- `sync_territorio_desde_fixture()` (create-only, matching por nombre normalizado NFKD/casefold) corre al final de `load_fixtures` en cada arranque — mismo patrón que `sync_catalogo_intervenciones`. Nunca actualiza ni borra; usa el PK del fixture solo si está libre; `IntegrityError` aislado por fila.

## Decisiones

- Asentamientos sin municipio asignado por IGN (~3.2k): anclados a un municipio con el nombre de su **departamento** (reutilizando homónimos) para que sean navegables en los selects provincia→municipio→localidad.
- 9 asentamientos con municipio de provincia vecina (ruido del join espacial IGN): anclados al departamento de **su propia provincia** (auditable: `municipio_cross_provincia_anclado_a_depto=9`).
- Reproducible con `scripts/actualizar_territorio_desde_bahra.py` (ver registro en `docs/registro/cambios/2026-07-17-bajada-bahra-territorio.md`).

## Validación

- ✅ 5/5 tests en contenedor (`test_territorio_sync`, `test_load_fixtures_command`, `test_actualizar_territorio_desde_bahra`).
- ✅ pylint 10.00/10, black limpio.
- ✅ End-to-end real: arranque del stack contra una DB MySQL con datos preexistentes → `Territorio sincronizado: provincias=0, municipios=101, localidades=6438, saltadas_por_integridad=0`; segunda corrida = 0 altas (idempotente).
- ✅ Integridad del fixture verificada: entradas previas intactas, 0 claves naturales duplicadas, 0 FKs inválidas.

## Riesgo a monitorear

Primer deploy crea ~6.5k filas vía sync (una vez, segundos). La normalización aproxima la collation ai_ci de MySQL; ante divergencias raras hace skip con warning sin tocar datos.

🤖 Generated with [Claude Code](https://claude.com/claude-code)