### PR TITLE
fix(ci): evitar la autoaprobacion en sincronizacion descendente

### DIFF
--- a/.github/workflows/sync-main-downstream.yml
+++ b/.github/workflows/sync-main-downstream.yml
@@ -23,7 +23,7 @@ jobs:
 
         steps:
             - name: Integrar main y desplegar ramas inferiores
-              uses: actions/github-script@v7
+              uses: actions/github-script@v8
               with:
                   script: |
                       const owner = context.repo.owner;
@@ -101,16 +101,6 @@ jobs:
                               `PR #${pull.number} no es integrable sin intervencion: ${pull.html_url}`,
                             );
                           }
-
-                          await github.rest.pulls.createReview({
-                            owner,
-                            repo,
-                            pull_number: pull.number,
-                            commit_id: pull.head.sha,
-                            event: "APPROVE",
-                            body: "Aprobacion automatica del Plan A para sincronizar main hacia una rama inferior.",
-                          });
-                          core.info(`PR #${pull.number} aprobado automaticamente.`);
 
                           const merged = await github.rest.pulls.merge({
                             owner,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+<!-- AUTO-GENERATED RELEASE START: 2026-07-22 -->
+# Versión SISOC 22.07.2026
+
+## Actualizaciones
+
+- [sin-area] fix(ci): evitar la autoaprobacion en sincronizacion descendente. (PR #2112)
+<!-- AUTO-GENERATED RELEASE END: 2026-07-22 -->
+
 <!-- AUTO-GENERATED RELEASE START: 2026-07-15 -->
 # Versión SISOC 15.07.2026
 

--- a/docs/contexto/features/pr-2112-fix-ci-evitar-la-autoaprobacion-en-sincronizacion-descendente.md
+++ b/docs/contexto/features/pr-2112-fix-ci-evitar-la-autoaprobacion-en-sincronizacion-descendente.md
@@ -1,0 +1,43 @@
+# Contexto de feature PR #2112 - fix(ci): evitar la autoaprobacion en sincronizacion descendente
+
+## Resumen
+
+- PR: https://github.com/dsocial118/SISOC/pull/2112
+- Base: `main`
+- Rama origen: `codex/fix-downstream-sync-autoapprove`
+- Autor: `juanikitro`
+
+## Contexto funcional
+
+- No informado explícitamente; inferir desde el título del PR y el diff.
+
+## Arquitectura tocada
+
+- El alcance incluye automatización o tooling de CI/CD.
+
+## Decisiones y supuestos detectados
+
+- Tipo de cambio declarado: No informado
+- Área principal declarada: No informada
+- Impacto usuario declarado: No informado
+- Riesgos / rollback: No informado
+
+## Design system y UI
+
+- Sin cambios visibles de UI o design system detectados en el diff.
+
+## Memoria operativa para agentes
+
+- Empezar por `docs/registro/prs/PR-2112.md` para contexto resumido del PR.
+- Revisar primero estos archivos del diff:
+- `.github/workflows/sync-main-downstream.yml`
+- Documentación sugerida para ampliar contexto:
+- `docs/indice.md`
+- `docs/ia/CONTEXT_HYGIENE.md`
+- `docs/ia/ARCHITECTURE.md`
+- `docs/ia/TESTING.md`
+
+## Trazabilidad
+
+- Documento generado automáticamente desde el evento de `pull_request`.
+- Si este PR cambia de título, el archivo se renombrará para mantener el slug alineado.

--- a/docs/registro/prs/PR-2112.md
+++ b/docs/registro/prs/PR-2112.md
@@ -1,0 +1,46 @@
+# PR #2112 - fix(ci): evitar la autoaprobacion en sincronizacion descendente
+
+## Metadata
+
+- PR: https://github.com/dsocial118/SISOC/pull/2112
+- Base: `main`
+- Rama origen: `codex/fix-downstream-sync-autoapprove`
+- Autor: `juanikitro`
+- Última actualización: `2026-07-20T15:17:41Z`
+
+## Resumen operativo
+
+- Tipo de cambio: No informado
+- Área principal: No informada
+- Contexto funcional: No informado explícitamente; revisar título, diff y documentación relacionada.
+- Resumen para changelog: No informado
+- Impacto usuario: No informado
+
+## Áreas afectadas
+
+- `.github/workflows`
+
+## Archivos relevantes del diff
+
+- `.github/workflows/sync-main-downstream.yml`
+
+## Validación declarada
+
+- Pruebas automáticas: No informado en el PR.
+- Pruebas manuales: No informado en el PR.
+
+## Riesgos y rollback
+
+- No informado explícitamente en el PR.
+
+## Documentación sugerida para lectura
+
+- `docs/indice.md`
+- `docs/ia/CONTEXT_HYGIENE.md`
+- `docs/ia/ARCHITECTURE.md`
+- `docs/ia/TESTING.md`
+
+## Notas para continuidad
+
+- Este documento es generado automáticamente desde el contexto del PR y sirve como índice rápido para revisión y futuras sesiones de agentes.
+- Si la metadata del body del PR está incompleta, varias secciones usarán fallbacks derivados del título o del diff.

--- a/docs/registro/releases/pending/2026-07-22-pr-2112.md
+++ b/docs/registro/releases/pending/2026-07-22-pr-2112.md
@@ -1,0 +1,19 @@
+---
+pr: 2112
+release_date: 2026-07-22
+category: Actualizaciones
+area: sin-area
+title: fix(ci): evitar la autoaprobacion en sincronizacion descendente
+summary: fix(ci): evitar la autoaprobacion en sincronizacion descendente
+impact: No informado
+source_url: https://github.com/dsocial118/SISOC/pull/2112
+---
+# Release note preliminar PR #2112
+
+- Fecha objetivo de release: 2026-07-22
+- Categoría: Actualizaciones
+- Área: sin-area
+- Título del PR: fix(ci): evitar la autoaprobacion en sincronizacion descendente
+- Resumen: fix(ci): evitar la autoaprobacion en sincronizacion descendente
+- Impacto usuario: No informado
+- Fuente: https://github.com/dsocial118/SISOC/pull/2112


### PR DESCRIPTION
## Que cambia

- Actualiza `actions/github-script` de v7 a v8 para usar Node 24.
- Elimina la aprobacion automatica del PR creado por `github-actions[bot]`.

## Por que

GitHub no permite que el autor de un pull request lo apruebe. El workflow fallaba antes del merge de `main` hacia `development` y `homologacion`.

## Impacto

La ruleset actual exige cero aprobaciones, por lo que el workflow puede continuar con el merge y el dispatch de deploy sin una identidad adicional ni credenciales nuevas.

## Validacion

- `git diff --check`
- Sintaxis del bloque JavaScript con `node --check`
- Confirmacion de que la ruleset exige `required_approving_review_count: 0`

No se ejecuto `actionlint` porque no esta instalado localmente.