### PR TITLE
fix(organizaciones): corregir migración ARCA por convenio

### DIFF
--- a/docs/registro/cambios/2026-07-20-fix-migracion-arca-por-convenio.md
+++ b/docs/registro/cambios/2026-07-20-fix-migracion-arca-por-convenio.md
@@ -1,0 +1,30 @@
+# Corrección de la migración ARCA por tipo de convenio
+
+## Fecha
+
+2026-07-20
+
+## Objetivo
+
+Permitir que `organizaciones.0016_issue_2083_documentacion_organizacion` se
+ejecute cuando el catálogo de admisiones contiene una Constancia de ARCA por
+cada tipo de convenio.
+
+## Cambio realizado
+
+- La migración deja de buscar o crear documentación solo por nombre.
+- Cada `ArchivoAdmision` materializado usa la documentación ARCA asociada al
+  `tipo_convenio` de su admisión.
+- Si falta o se duplica la documentación para un mismo convenio, la migración
+  falla antes de elegir un destino incorrecto.
+
+## Validación
+
+- Test de regresión con los catálogos jurídico y eclesiástico de ARCA.
+- Formato Black sobre la migración y el test.
+
+## Riesgos
+
+- La migración requiere que toda admisión vinculada tenga un `tipo_convenio`
+  con una única Constancia de ARCA asociada, que es el contrato del catálogo
+  vigente.

--- a/organizaciones/migrations/0016_issue_2083_documentacion_organizacion.py
+++ b/organizaciones/migrations/0016_issue_2083_documentacion_organizacion.py
@@ -56,10 +56,6 @@ def actualizar_documentacion(apps, schema_editor):
             nombre=ARCA_NOMBRE, categoria__in=ARCA_CATEGORIAS
         ).values_list("id", flat=True)
     )
-    documento_admision, _ = DocumentacionAdmision.objects.get_or_create(
-        nombre="Constancia de ARCA",
-        defaults={"obligatorio": False, "orden": 0},
-    )
     archivos_arca = Archivo.objects.filter(
         documentacion_id__in=arca_ids, deleted_at__isnull=True
     )
@@ -68,6 +64,9 @@ def actualizar_documentacion(apps, schema_editor):
             comedor__organizacion_id=archivo.organizacion_id
         )
         for admision in admisiones.iterator():
+            documento_admision = DocumentacionAdmision.objects.get(
+                nombre="Constancia de ARCA", convenios=admision.tipo_convenio
+            )
             ArchivoAdmision.objects.get_or_create(
                 admision_id=admision.id,
                 archivo_organizacion_origen_id=archivo.id,

--- a/organizaciones/test_issue_2083_documentacion_organizacion.py
+++ b/organizaciones/test_issue_2083_documentacion_organizacion.py
@@ -1,0 +1,96 @@
+import importlib
+
+import pytest
+from django.apps import apps as global_apps
+
+from admisiones.models.admisiones import (
+    Admision,
+    ArchivoAdmision,
+    Documentacion,
+    TipoConvenio,
+)
+from comedores.models import Comedor
+from organizaciones.models import (
+    ArchivoOrganizacion,
+    DocumentacionOrganizacion,
+    Organizacion,
+)
+
+
+pytestmark = pytest.mark.django_db
+
+
+_migracion = importlib.import_module(
+    "organizaciones.migrations.0016_issue_2083_documentacion_organizacion"
+)
+
+
+def _crear_archivo_arca(tipo_convenio, categoria, sufijo):
+    organizacion = Organizacion.objects.create(nombre=f"Organizacion {sufijo}")
+    comedor = Comedor.objects.create(
+        nombre=f"Comedor {sufijo}", organizacion=organizacion
+    )
+    admision = Admision.objects.create(comedor=comedor, tipo_convenio=tipo_convenio)
+    documentacion = DocumentacionOrganizacion.objects.create(
+        nombre=_migracion.ARCA_NOMBRE,
+        categoria=categoria,
+    )
+    archivo = ArchivoOrganizacion.objects.create(
+        organizacion=organizacion,
+        documentacion=documentacion,
+        archivo=f"organizaciones/documentacion/arca-{sufijo}.pdf",
+        estado=ArchivoOrganizacion.ESTADO_ACEPTADO,
+    )
+    return admision, archivo
+
+
+def test_migracion_materializa_arca_en_documento_del_tipo_convenio():
+    convenio_juridico = TipoConvenio.objects.create(nombre="Personeria Juridica")
+    convenio_eclesiastico = TipoConvenio.objects.create(
+        nombre="Personeria Juridica Eclesiastica"
+    )
+    documento_juridico = Documentacion.objects.create(
+        nombre="Constancia de ARCA", obligatorio=True, orden=10
+    )
+    documento_juridico.convenios.add(convenio_juridico)
+    documento_eclesiastico = Documentacion.objects.create(
+        nombre="Constancia de ARCA", obligatorio=True, orden=5
+    )
+    documento_eclesiastico.convenios.add(convenio_eclesiastico)
+    admision_juridica, archivo_juridico = _crear_archivo_arca(
+        convenio_juridico,
+        DocumentacionOrganizacion.CATEGORIA_PERSONERIA,
+        "juridico",
+    )
+    admision_eclesiastica, archivo_eclesiastico = _crear_archivo_arca(
+        convenio_eclesiastico,
+        DocumentacionOrganizacion.CATEGORIA_ECLESIASTICA,
+        "eclesiastico",
+    )
+
+    _migracion.actualizar_documentacion(global_apps, None)
+
+    archivos_admision = {
+        archivo.admision_id: archivo
+        for archivo in ArchivoAdmision.objects.filter(
+            archivo_organizacion_origen_id__in=[
+                archivo_juridico.id,
+                archivo_eclesiastico.id,
+            ]
+        )
+    }
+    assert (
+        archivos_admision[admision_juridica.id].documentacion_id
+        == documento_juridico.id
+    )
+    assert (
+        archivos_admision[admision_eclesiastica.id].documentacion_id
+        == documento_eclesiastico.id
+    )
+    assert (
+        ArchivoOrganizacion.all_objects.filter(
+            id__in=[archivo_juridico.id, archivo_eclesiastico.id],
+            deleted_at__isnull=False,
+        ).count()
+        == 2
+    )


### PR DESCRIPTION
## Resumen

Corrige la migración `organizaciones.0016_issue_2083_documentacion_organizacion` para seleccionar la Constancia de ARCA del mismo `tipo_convenio` que la admisión.

## Causa raíz

El catálogo contiene dos documentos válidos llamados `Constancia de ARCA`, uno por convenio. La migración usaba `get_or_create(nombre=...)`, cuyo `get()` fallaba con `MultipleObjectsReturned` antes de materializar los archivos.

## Cambio

- Reemplaza la búsqueda ambigua por `nombre + convenios=admision.tipo_convenio`.
- Agrega un test de regresión con los catálogos jurídico y eclesiástico.
- Registra la decisión y el riesgo de integridad del catálogo.

## Validación

- `pytest organizaciones/test_issue_2083_documentacion_organizacion.py -q` — 1 passed.
- `black --check` sobre la migración y el test.
- `pylint` sobre el test.
- `git diff --check`.

## Riesgo

Una admisión sin una única Constancia de ARCA para su convenio seguirá fallando de forma explícita, en vez de mover el archivo a un catálogo incorrecto.