### PR TITLE
fix(organizaciones): tolerar ARCA duplicado por convenio

### DIFF
--- a/docs/registro/cambios/2026-07-20-fix-migracion-arca-por-convenio.md
+++ b/docs/registro/cambios/2026-07-20-fix-migracion-arca-por-convenio.md
@@ -7,24 +7,30 @@
 ## Objetivo
 
 Permitir que `organizaciones.0016_issue_2083_documentacion_organizacion` se
-ejecute cuando el catálogo de admisiones contiene una Constancia de ARCA por
-cada tipo de convenio.
+ejecute con catálogos históricos que contienen más de una Constancia de ARCA
+para un mismo tipo de convenio.
 
 ## Cambio realizado
 
-- La migración deja de buscar o crear documentación solo por nombre.
 - Cada `ArchivoAdmision` materializado usa la documentación ARCA asociada al
   `tipo_convenio` de su admisión.
-- Si falta o se duplica la documentación para un mismo convenio, la migración
-  falla antes de elegir un destino incorrecto.
+- Ante documentos ARCA duplicados para el mismo convenio, la migración elige
+  de forma determinista el de menor `orden` e `id`, igual que los listados de
+  admisiones.
+- Si no existe documentación ARCA para el convenio, crea una y la asocia a
+  ese convenio; no reutiliza documentación de otro tipo.
+- Para admisiones históricas sin `tipo_convenio`, conserva un documento ARCA
+  sin asociación de convenio.
 
 ## Validación
 
-- Test de regresión con los catálogos jurídico y eclesiástico de ARCA.
+- Tests de regresión para los catálogos jurídico/eclesiástico, documentos
+  duplicados en el mismo convenio, ausencia de catálogo y admisiones sin
+  convenio.
 - Formato Black sobre la migración y el test.
 
 ## Riesgos
 
-- La migración requiere que toda admisión vinculada tenga un `tipo_convenio`
-  con una única Constancia de ARCA asociada, que es el contrato del catálogo
-  vigente.
+- La migración no elimina los documentos duplicados históricos: usa el
+  primero por `orden, id` para preservar datos y evitar una limpieza de
+  catálogo fuera de alcance.

--- a/organizaciones/migrations/0016_issue_2083_documentacion_organizacion.py
+++ b/organizaciones/migrations/0016_issue_2083_documentacion_organizacion.py
@@ -64,9 +64,19 @@ def actualizar_documentacion(apps, schema_editor):
             comedor__organizacion_id=archivo.organizacion_id
         )
         for admision in admisiones.iterator():
-            documento_admision = DocumentacionAdmision.objects.get(
-                nombre="Constancia de ARCA", convenios=admision.tipo_convenio
+            documento_admision = (
+                DocumentacionAdmision.objects.filter(
+                    nombre="Constancia de ARCA", convenios=admision.tipo_convenio
+                )
+                .order_by("orden", "id")
+                .first()
             )
+            if documento_admision is None:
+                documento_admision = DocumentacionAdmision.objects.create(
+                    nombre="Constancia de ARCA", obligatorio=False, orden=0
+                )
+                if admision.tipo_convenio_id is not None:
+                    documento_admision.convenios.add(admision.tipo_convenio)
             ArchivoAdmision.objects.get_or_create(
                 admision_id=admision.id,
                 archivo_organizacion_origen_id=archivo.id,

--- a/organizaciones/test_issue_2083_documentacion_organizacion.py
+++ b/organizaciones/test_issue_2083_documentacion_organizacion.py
@@ -94,3 +94,75 @@ def test_migracion_materializa_arca_en_documento_del_tipo_convenio():
         ).count()
         == 2
     )
+
+
+def test_migracion_elige_documento_arca_determinista_si_esta_duplicado():
+    convenio = TipoConvenio.objects.create(nombre="Personeria Juridica")
+    documento_esperado = Documentacion.objects.create(
+        nombre="Constancia de ARCA", obligatorio=True, orden=5
+    )
+    documento_esperado.convenios.add(convenio)
+    documento_duplicado = Documentacion.objects.create(
+        nombre="Constancia de ARCA", obligatorio=True, orden=10
+    )
+    documento_duplicado.convenios.add(convenio)
+    admision, archivo = _crear_archivo_arca(
+        convenio,
+        DocumentacionOrganizacion.CATEGORIA_PERSONERIA,
+        "duplicado",
+    )
+
+    _migracion.actualizar_documentacion(global_apps, None)
+
+    archivo_admision = ArchivoAdmision.objects.get(
+        admision_id=admision.id,
+        archivo_organizacion_origen_id=archivo.id,
+    )
+    assert archivo_admision.documentacion_id == documento_esperado.id
+
+
+def test_migracion_crea_documento_arca_para_el_convenio_si_no_existe():
+    convenio = TipoConvenio.objects.create(nombre="Personeria Juridica")
+    otro_convenio = TipoConvenio.objects.create(
+        nombre="Personeria Juridica Eclesiastica"
+    )
+    documento_de_otro_convenio = Documentacion.objects.create(
+        nombre="Constancia de ARCA", obligatorio=True, orden=5
+    )
+    documento_de_otro_convenio.convenios.add(otro_convenio)
+    admision, archivo = _crear_archivo_arca(
+        convenio,
+        DocumentacionOrganizacion.CATEGORIA_PERSONERIA,
+        "sin-catalogo",
+    )
+
+    _migracion.actualizar_documentacion(global_apps, None)
+
+    documento = Documentacion.objects.get(
+        nombre="Constancia de ARCA", convenios=convenio
+    )
+    archivo_admision = ArchivoAdmision.objects.get(
+        admision_id=admision.id,
+        archivo_organizacion_origen_id=archivo.id,
+    )
+    assert documento.id != documento_de_otro_convenio.id
+    assert list(documento.convenios.values_list("id", flat=True)) == [convenio.id]
+    assert archivo_admision.documentacion_id == documento.id
+
+
+def test_migracion_crea_documento_arca_sin_convenio_si_la_admision_no_tiene_tipo():
+    admision, archivo = _crear_archivo_arca(
+        None,
+        DocumentacionOrganizacion.CATEGORIA_PERSONERIA,
+        "sin-tipo-convenio",
+    )
+
+    _migracion.actualizar_documentacion(global_apps, None)
+
+    documento = Documentacion.objects.get(nombre="Constancia de ARCA")
+    archivo_admision = ArchivoAdmision.objects.get(
+        admision_id=admision.id,
+        archivo_organizacion_origen_id=archivo.id,
+    )
+    assert not documento.convenios.exists()
+    assert archivo_admision.documentacion_id == documento.id


### PR DESCRIPTION
## Qué cambia

- La migración `organizaciones.0016_issue_2083_documentacion_organizacion` deja de asumir unicidad de `Documentacion` por nombre y convenio.
- Cuando hay varias Constancias de ARCA para un convenio, usa de forma determinista la de menor `orden` e `id`.
- Si no existe catálogo para el convenio, crea y asocia el documento correcto; las admisiones sin convenio conservan un documento sin asociación.

## Causa raíz

El catálogo histórico de HML puede tener más de una `Constancia de ARCA` para el mismo convenio. `QuerySet.get()` exigía una única fila y detenía la migración con `MultipleObjectsReturned`.

## Validación

- `scripts/ai/codex_run.ps1 test organizaciones/test_issue_2083_documentacion_organizacion.py -q` — 4 passed.
- `scripts/ai/codex_run.ps1 black-check organizaciones/migrations/0016_issue_2083_documentacion_organizacion.py organizaciones/test_issue_2083_documentacion_organizacion.py`.
- `scripts/ai/codex_run.ps1 pylint organizaciones/test_issue_2083_documentacion_organizacion.py`.
- `git diff --check`.

## Riesgo

No elimina duplicados históricos del catálogo; para preservar los datos, la migración usa el primer registro según `orden, id`.