### PR TITLE
docs(infra): registrar retiro Stage 2 MySQL QA

### DIFF
--- a/AGENT_REPO_MAP.md
+++ b/AGENT_REPO_MAP.md
@@ -593,7 +593,7 @@ La siguiente tabla mezcla hechos observados con inferencias explicitas cuando no
 | logging/errores/fallbacks | `docs/ia/ERRORS_LOGGING.md` |
 | estilo/template | `docs/ia/STYLE_GUIDE.md` |
 | PWA | `docs/implementaciones/pwa_backend.md`, `docs/seguridad/security_baseline_pwa.md` |
-| deploy/infra | `docs/operacion/infraestructura.md`, `docs/operacion/instalacion.md` |
+| deploy/infra | `docs/operacion/infraestructura.md`, `docs/operacion/instalacion.md`, `docs/infra/QA_OPERATIONS.md`, `docs/infra/ENVIRONMENT_DATABASES.md` |
 
 ## Notas utiles sobre calidad y arquitectura
 

--- a/docs/infra/ENVIRONMENT_DATABASES.md
+++ b/docs/infra/ENVIRONMENT_DATABASES.md
@@ -1,6 +1,7 @@
 # Bases de datos canonicas por entorno
 
-Fuente: definicion operativa confirmada por el responsable el 2026-07-13.
+Fuente: definicion operativa confirmada por el responsable el 2026-07-13 y
+actualizada con el retiro Stage 2 de QA el 2026-07-21.
 
 ## Politica
 
@@ -30,13 +31,13 @@ futura. No son canonicos actualmente.
 
 - `.env` de QA apunta a `10.80.9.18:3306`, schema `sisoc_local`.
 - `10.80.9.18:3306` es alcanzable desde `qa-old`.
-- MySQL local en `qa-old` quedo inactivo y deshabilitado en Stage 1; no hay
-  proceso ni listener 3306 local.
-- `/var/lib/mysql` ocupa 43 GB y contiene multiples schemas historicos/analiticos;
-  los mayores son `dw_PA` (~17.8 GB), `sisoc_local` (~6.9 GB),
-  `SISOC_Comedores` (~4.2 GB), `DW_DD` (~2.0 GB) y `DW_HSU` (~1.4 GB).
+- Stage 2 retiro los paquetes `mysql-server`, `mysql-server-8.0` y
+  `mysql-server-core-8.0`, sin `autoremove`; no queda unidad, binario ni
+  listener MySQL local.
+- El datadir local `/var/lib/mysql` de 43 GB fue eliminado. El filesystem
+  raiz quedo en 34% de uso, con 62 GB libres.
 - El preflight final confirmo cero clientes inesperados, eventos, canales de
   replica o miembros de Group Replication. La conexion inicial era interna.
-- `/var/lib/mysql` y paquetes quedan intactos hasta 2026-07-20 para rollback.
-- Backup de Stage 1:
-  `/var/backups/sisoc/mysql-local-retirement/20260713_115645`.
+- Se conserva el backup de metadatos de Stage 1 en
+  `/var/backups/sisoc/mysql-local-retirement/20260713_115645`; no contiene
+  un datadir recuperable y no habilita rollback del MySQL local.

--- a/docs/infra/QA_INVENTORY.md
+++ b/docs/infra/QA_INVENTORY.md
@@ -1,8 +1,9 @@
 # QA - Inventario inicial de infraestructura
 
-Estado: Fases 1 a 4 completadas, corte 2026-07-13. La auditoria inicial fue solo
-lectura; luego se aplicaron el mantenimiento de disco, su cron y el Stage 1
-aprobado de retiro del MySQL local. No se reinicio la aplicacion, no se editaron
+Estado: Fases 1 a 4 completadas el 2026-07-13 y retiro Stage 2 del MySQL local
+aplicado el 2026-07-21. La auditoria inicial fue solo lectura; luego se
+aplicaron el mantenimiento de disco, su cron, el Stage 1 reversible y el
+retiro irreversible aprobado. No se reinicio la aplicacion, no se editaron
 configuraciones criticas, no se ejecutaron deploys/migraciones ni se imprimieron
 secretos.
 
@@ -34,7 +35,7 @@ cutover hacia AWS.
 | Aplicacion | Django/Gunicorn en Docker Compose, NGINX como reverse proxy |
 | URL comprobada | `http://10.80.9.15/` |
 | Health comprobado | `http://127.0.0.1/health/`, HTTP 200 |
-| Filesystem raiz | Antes: 93%, 7.2 GiB libres. Cierre: 77%, 22 GiB libres |
+| Filesystem raiz | Antes: 93%, 7.2 GiB libres. Tras Stage 2: 34%, 62 GB libres |
 | Inodos | 7% usados al cierre; el riesgo era capacidad, no inodos |
 | TLS | No detectado en esta huella; NGINX escucha HTTP/80 |
 
@@ -45,7 +46,7 @@ cutover hacia AWS.
 | `docker` | activo | habilitado | Docker Engine 27.3.1 |
 | `containerd` | activo | habilitado | Runtime de contenedores |
 | `nginx` | activo | habilitado | NGINX 1.18.0 |
-| `mysql` | inactivo | deshabilitado | Stage 1 aplicado; datadir/paquetes conservados para rollback |
+| MySQL server local | no instalado | no aplica | Stage 2 retiro unidad, paquetes y datadir; no hay rollback local |
 | `cron` | activo | habilitado | `sisoc-deploy` tiene una tarea semanal de mantenimiento Docker; cron de root no auditado |
 | `actions.runner.dsocial118-SISOC.sisoc-qa` | activo | habilitado | Corre como `sisoc-deploy` desde `/home/sisoc-deploy/actions-runner/` |
 | `apache2` | fallido | habilitado | Apache esta instalado pero no sirve la app observada |
@@ -67,8 +68,8 @@ acotada. Con `sisoc-deploy` se confirmaron dos contenedores activos,
 | 22/tcp | `0.0.0.0` y `::` | SSH |
 | 80/tcp | `0.0.0.0` | NGINX |
 | 8001/tcp | `0.0.0.0` y `::` | `docker-proxy`, Django/Gunicorn por contrato Compose |
-| 3306/tcp | sin listener al cierre | MySQL local detenido; DB remota en `10.80.9.18:3306` |
-| 33060/tcp | sin listener al cierre | MySQL X Protocol local detenido |
+| 3306/tcp | sin listener | MySQL local retirado; DB remota en `10.80.9.18:3306` |
+| 33060/tcp | sin listener | MySQL X Protocol local retirado |
 | 10000/tcp y udp | `0.0.0.0` | Proceso no confirmado con los permisos actuales |
 | 10050/tcp | `0.0.0.0` y `::` | Proceso no confirmado con los permisos actuales |
 
@@ -91,7 +92,7 @@ reglas de red/ACL externas para evaluar la exposicion real.
 | `/home/sisoc-deploy/actions-runner/` | GitHub Actions runner | servicio systemd activo |
 | `/home/sisoc-deploy/bin/` | Scripts operativos instalados | owner `sisoc-deploy`, scripts modo 750 |
 | `/home/sisoc-deploy/backups/infra/qa/` | Backups de configuracion fuera del repo | directorios 700, archivos 600 |
-| `/var/lib/mysql` | Clon MySQL local heredado | 43 GB, conservado intacto hasta 2026-07-20 |
+| `/var/lib/mysql` | Datadir del clon MySQL local heredado | Eliminado en Stage 2 el 2026-07-21 |
 | `/var/lib/docker` | Datos Docker | contenido no legible sin privilegios |
 
 Existian dos dumps SQL antiguos y grandes fuera del checkout:
@@ -144,7 +145,7 @@ Apache 2.4.52 esta instalado y habilitado, pero la unidad esta fallida.
 | Imagen Python declarada | `python:3.11.15-slim-bookworm`; runtime de contenedor no verificado directamente |
 | Docker Engine | 27.3.1 |
 | Docker Compose | 2.29.7 |
-| MySQL server/client | 8.0.46 |
+| MySQL server local | Retirado en Stage 2; sin unidad ni binario `mysqld` |
 | NGINX | 1.18.0 |
 | Apache | 2.4.52, unidad fallida |
 | Certbot | comando 5.6.0; tambien existe paquete apt 1.21 y timer snap |
@@ -201,24 +202,26 @@ migraciones y otros comandos con escritura de DB no quedan desactivados.
 
 Confirmado en `qa-old`:
 
-- MySQL 8.0.46 local quedo inactivo y deshabilitado en Stage 1.
-- no queda proceso `mysqld` ni listener local 3306/33060.
+- Stage 2 retiro `mysql-server`, `mysql-server-8.0` y
+  `mysql-server-core-8.0`, sin `autoremove`.
+- no queda unidad MySQL local, binario `mysqld`, proceso ni listener local
+  3306/33060.
+- `/var/lib/mysql` fue eliminado; el uso de `/` bajo de 80% a 34%, con
+  62 GB libres.
 - Django no apunta al MySQL local: su configuracion usa `10.80.9.18:3306` y el
   schema `sisoc_local`.
 - El responsable confirmo que todos los entornos usan DB separada: QA
   `10.80.9.18`, HML `10.80.5.48` y PRD `10.80.5.46`.
 - `10.80.9.18:3306` es alcanzable desde el host QA.
 - Tres muestras no mostraron conexiones establecidas al puerto local 3306.
-- El datadir local `/var/lib/mysql` ocupa 43 GB. Aloja 25 schemas de aplicacion o
-  analiticos; los cinco mayores suman aproximadamente 32.4 GB.
-- El preflight root confirmo cero clientes inesperados, eventos, replicas o
-  miembros de Group Replication. La conexion inicial era interna.
-- Backup Stage 1 root-only:
-  `/var/backups/sisoc/mysql-local-retirement/20260713_115645`.
+- El preflight previo a Stage 1 confirmo cero clientes inesperados, eventos,
+  replicas o miembros de Group Replication. La conexion inicial era interna.
+- Backup Stage 1 root-only conservado:
+  `/var/backups/sisoc/mysql-local-retirement/20260713_115645`. Contiene
+  metadatos, no una copia recuperable de los 43 GB eliminados.
 
 No confirmado:
 
-- politica de archivo/eliminacion del datadir local despues de la observacion;
 - tamanio, retencion y estrategia de backup de la DB remota `10.80.9.18`;
 - ultimo backup valido y ultimo restore probado.
 

--- a/docs/infra/QA_MIGRATION_NOTES.md
+++ b/docs/infra/QA_MIGRATION_NOTES.md
@@ -1,6 +1,7 @@
 # QA - Notas iniciales de migracion
 
-Estado: actualizado con inventario operativo, corte 2026-07-13.
+Estado: actualizado con inventario operativo y retiro Stage 2 del MySQL local,
+corte 2026-07-21.
 
 Estas notas no autorizan una migracion. La fuente canonica confirmada es
 `qa-old`; AWS queda como referencia de destino futuro y fuera de alcance actual.
@@ -11,8 +12,8 @@ Estas notas no autorizan una migracion. La fuente canonica confirmada es
    migracion.
 2. Inventariar la DB autoritativa actual en `10.80.9.18` sin mostrar credenciales.
 3. Confirmar backup actual, retencion y restore probado.
-4. Obtener firewall/ACL efectivos y decidir la conservacion del MySQL local ya
-   inventariado antes de Stage 2.
+4. Obtener firewall/ACL efectivos. El MySQL local heredado fue retirado en
+   Stage 2; no incluirlo como fuente de datos ni como activo a migrar.
 5. Acordar si el destino mantiene SITE/DB separados.
 6. Congelar una ventana de cambios y un commit fuente.
 
@@ -211,10 +212,9 @@ destino, devolver trafico al QA viejo y preservar logs/evidencia para diagnostic
 
 1. Inventario del destino cuando se active la migracion AWS u otra.
 2. Tamanio, consistencia y backup de la DB `10.80.9.18`.
-3. Decision de conservacion o borrado del MySQL local despues del 2026-07-20.
-4. Backup vigente y restore probado.
-5. Crontab de root.
-6. Firewall/ACL efectivos.
-7. Owner de puertos 10000/10050.
-8. Politica de DNS/TLS para QA.
-9. Ventana y responsable de aprobar los side effects automaticos del entrypoint.
+3. Backup vigente y restore probado.
+4. Crontab de root.
+5. Firewall/ACL efectivos.
+6. Owner de puertos 10000/10050.
+7. Politica de DNS/TLS para QA.
+8. Ventana y responsable de aprobar los side effects automaticos del entrypoint.

--- a/docs/infra/QA_OPERATIONS.md
+++ b/docs/infra/QA_OPERATIONS.md
@@ -1,6 +1,7 @@
 # QA - Operaciones
 
-Estado: validado en `qa-old` el 2026-07-13.
+Estado: actualizado en `qa-old` el 2026-07-21, despues del retiro Stage 2
+del MySQL local.
 
 ## Fuente de verdad
 
@@ -9,10 +10,10 @@ Estado: validado en `qa-old` el 2026-07-13.
 - Branch: `development`.
 - Usuario operativo: `sisoc-deploy`.
 - AWS: fuera de alcance; conservar solo como referencia de migracion.
-- DB canonica: `10.80.9.18:3306`; el MySQL local es un remanente ya retirado de
-  servicio mediante Stage 1.
-- MySQL local ocupa 43 GB. Su rol y conexiones fueron clasificados; no borrar
-  `/var/lib/mysql` ni purgar paquetes antes del 2026-07-20 y sin aprobar Stage 2.
+- DB canonica: `10.80.9.18:3306`; no hay MySQL server local en el host de
+  aplicacion.
+- Stage 2 elimino el datadir heredado de 43 GB y los paquetes server locales.
+  No existe rollback local; la DB canonica remota no fue modificada.
 
 ## Estado rapido
 
@@ -21,8 +22,9 @@ Estado: validado en `qa-old` el 2026-07-13.
 /home/sisoc-deploy/bin/healthcheck_qa.sh
 systemctl is-active docker containerd nginx cron \
   actions.runner.dsocial118-SISOC.sisoc-qa
-systemctl is-active mysql    # esperado durante observacion: inactive
-systemctl is-enabled mysql   # esperado durante observacion: disabled
+systemctl show mysql -p LoadState --value || true # esperado: not-found
+command -v mysqld || true                         # esperado: sin salida
+ss -lntp 'sport = :3306'                           # esperado: sin listener
 ```
 
 El health actual prueba contenedores y HTTP. No demuestra por si solo una consulta
@@ -30,9 +32,9 @@ exitosa a la base de datos.
 
 ## Disco y mantenimiento Docker
 
-Estado posterior a la limpieza del 2026-07-13:
+Estado observado despues del retiro Stage 2 el 2026-07-21:
 
-- `/`: 97 GB totales, 71 GB usados, 22 GB libres, 77%.
+- `/`: 97 GB totales, 31 GB usados, 62 GB libres, 34%.
 - imagenes: 2, ambas activas;
 - volumenes Docker: 0;
 - build cache restante: 1.79 GB, preservado por la retencion.
@@ -94,27 +96,22 @@ Snapshot posterior con cron y scripts instalados:
 No pegar logs completos en tickets o chats: pueden contener PII, URLs o datos
 operativos.
 
-## MySQL local heredado
+## MySQL local heredado retirado
 
-Django usa `10.80.9.18`; el MySQL local conserva un datadir clonado de 43 GB.
-Stage 1 fue aplicado el 2026-07-13: servicio inactivo/deshabilitado, sin listener,
-datadir y paquetes intactos. Observar hasta 2026-07-20.
+Django usa `10.80.9.18`. Stage 1 dejo el MySQL local inactivo/deshabilitado
+el 2026-07-13; tras la observacion aprobada, Stage 2 del 2026-07-21 purgo
+`mysql-server`, `mysql-server-8.0` y `mysql-server-core-8.0` sin
+`autoremove`, y elimino `/var/lib/mysql`.
 
-```bash
-bash scripts/infra/retire_qa_local_mysql_stage1.sh
-```
+No queda unidad `mysql.service`, binario `mysqld`, listener local ni
+datadir. El backup root-only
+`/var/backups/sisoc/mysql-local-retirement/20260713_115645` se conserva
+solo como evidencia de Stage 1; no permite reactivar ni recuperar el clon
+local.
 
-Backup root-only:
-`/var/backups/sisoc/mysql-local-retirement/20260713_115645`.
-
-Durante la observacion verificar QA, DB remota y que MySQL local no se reactive:
-
-```bash
-systemctl is-active mysql || true
-systemctl is-enabled mysql || true
-ss -lntp 'sport = :3306'
-curl --max-time 8 -fsS http://127.0.0.1/health/
-```
+No ejecutar `retire_qa_local_mysql_stage1.sh` nuevamente: presupone un
+servicio y datadir que ya no existen. Si alguna vez se evaluara una nueva DB
+local, debe ser una decision de arquitectura separada, no un rollback.
 
 ## Restart y deploy
 

--- a/docs/infra/QA_RISKS.md
+++ b/docs/infra/QA_RISKS.md
@@ -1,9 +1,10 @@
 # QA - Riesgos iniciales de infraestructura
 
-Estado: actualizado despues del mantenimiento aprobado, corte 2026-07-13.
+Estado: actualizado despues del mantenimiento aprobado y del retiro Stage 2 del
+MySQL local, corte 2026-07-21.
 
 La clasificacion prioriza continuidad, seguridad y migrabilidad. Se aplicaron
-la limpieza Docker, la eliminacion aprobada de dos dumps y el Stage 1 reversible
+la limpieza Docker, la eliminacion aprobada de dos dumps y el retiro Stage 2
 del MySQL local, todos documentados y sin reiniciar la aplicacion.
 
 ## Riesgos criticos
@@ -19,30 +20,30 @@ Impacto: se puede documentar, migrar, respaldar o apagar el servidor equivocado.
 Accion segura: reconciliar la documentacion sin tocar destinos ni GitHub
 Environment.
 
-### 2. Filesystem raiz mitigado de 93% a 77%
+### 2. Filesystem raiz recuperado a 34%
 
-La limpieza Docker y la eliminacion aprobada de dos dumps antiguos dejaron 22 GB
-libres. Docker ya no es el componente principal conocido. Media ocupa 2.8 GiB y
-el datadir MySQL local ya fue identificado como el principal consumo restante:
-43 GB preservados para rollback hasta decidir Stage 2.
+La limpieza Docker, la eliminacion aprobada de dos dumps antiguos y Stage 2
+dejaron 62 GB libres. Docker ya no es el componente principal conocido; el
+datadir MySQL local de 43 GB ya no existe.
 
-Impacto: fallas de build, escritura de logs, MySQL, Docker o deploy; posible caida
-abrupta.
+Impacto residual: el espacio ya no bloquea el deploy, pero logs, media y Docker
+pueden volver a crecer si no se mantiene el monitoreo.
 
-Accion segura: mantener el cron conservador y observar que MySQL no se reactive.
-No borrar datos MySQL antes del 2026-07-20 ni sin aprobar Stage 2.
+Accion segura: mantener el cron conservador y monitorear semanalmente capacidad
+y journal del mantenimiento.
 
-### 3. MySQL local heredado conserva 43 GB (exposicion mitigada)
+### 3. Retiro Stage 2 del MySQL local irreversible
 
-MySQL 8.0.46 conserva 43 GB en 25 schemas no de sistema. Stage 1 lo dejo inactivo,
-deshabilitado y sin listener. El preflight confirmo cero clientes inesperados,
-eventos o replicacion. Los datos y paquetes siguen intactos para rollback.
+Stage 2 purgo los paquetes server y elimino el datadir local de 43 GB. No queda
+unidad, binario ni listener local. La aplicacion continuo en la DB canonica
+`10.80.9.18`; no se uso `autoremove`.
 
-Impacto pendiente: 43 GB ocupados y riesgo de perder datos historicos si Stage 2
-los elimina sin decidir conservacion.
+Impacto aceptado: ya no existe rollback del clon historico local. El backup de
+Stage 1 conserva metadatos operativos, no los datos eliminados.
 
-Accion segura: observar hasta 2026-07-20. Borrar datos o purgar paquetes requiere
-una aprobacion posterior y una decision explicita de conservacion.
+Accion segura: no reinstalar MySQL local ni usar ese backup como fuente de
+restauracion. Cualquier nueva instancia local requiere una decision de
+arquitectura y plan de datos separado.
 
 El responsable confirmo que este MySQL local no forma parte de la arquitectura:
 QA usa `10.80.9.18`. La instancia heredada debe retirarse por etapas, no asumirse
@@ -102,8 +103,8 @@ de colision futura de puertos. No deshabilitar hasta conocer por que existe.
 
 ### Acceso privilegiado incompleto para cerrar el inventario
 
-Se obtuvo acceso puntual suficiente para inventariar MySQL local y aplicar su
-Stage 1 aprobado. Todavia falta verificar firewall/ACL, crontab root y la
+Se obtuvo acceso puntual suficiente para inventariar y retirar el MySQL local
+en Stages 1 y 2. Todavia falta verificar firewall/ACL, crontab root y la
 configuracion efectiva completa de NGINX y servicios.
 
 ### Bind mount del repo completo y contenedores como root
@@ -181,8 +182,8 @@ realidad observada es CD self-hosted en QA viejo.
 
 1. Mantener inventario, operaciones y rollback actualizados.
 2. Monitorear semanalmente disco y journal del mantenimiento.
-3. Verificar durante la observacion que MySQL local permanezca inactivo y sin
-   clientes dependientes.
+3. Mantener ausente el MySQL local; no introducir una dependencia nueva del
+   host de aplicacion.
 4. Pedir evidencia de backup/retencion/restore de `10.80.9.18`.
 5. Comparar GitHub Environment `qa` y label del runner sin cambiar valores.
 
@@ -192,7 +193,7 @@ realidad observada es CD self-hosted en QA viejo.
 - cambiar bind de MySQL, firewall, puertos o ACL;
 - cambiar permisos/owners de logs, repo o `.env`;
 - deshabilitar Apache, Certbot u otro servicio;
-- borrar `/var/lib/mysql` o purgar paquetes server en Stage 2;
+- reinstalar MySQL local o intentar reconstruir sus datos historicos;
 - ampliar la limpieza a logs, datos, cache reciente o el archivo no trackeado;
 - modificar NGINX, Compose, entrypoint, runner, cron o deploy;
 - reiniciar/redeployar, porque dispara escrituras en DB;
@@ -201,9 +202,8 @@ realidad observada es CD self-hosted en QA viejo.
 
 ## No conviene tocar todavia
 
-1. El datadir MySQL local hasta terminar la observacion y decidir conservacion.
-2. El QA canonico hasta planificar y validar formalmente una migracion.
-3. El archivo no trackeado hasta identificarlo en una sesion controlada.
-4. Crontab root y monitoreo historico hasta saber que jobs/agentes existen.
-5. Apache/Certbot hasta descartar dependencias ocultas.
-6. El orden del deploy sin antes definir rollback, backup y ventana de prueba.
+1. El QA canonico hasta planificar y validar formalmente una migracion.
+2. El archivo no trackeado hasta identificarlo en una sesion controlada.
+3. Crontab root y monitoreo historico hasta saber que jobs/agentes existen.
+4. Apache/Certbot hasta descartar dependencias ocultas.
+5. El orden del deploy sin antes definir rollback, backup y ventana de prueba.

--- a/docs/infra/QA_ROLLBACK.md
+++ b/docs/infra/QA_ROLLBACK.md
@@ -1,6 +1,6 @@
 # QA - Rollback operativo
 
-Estado: validado para el mantenimiento de disco del 2026-07-13.
+Estado: actualizado el 2026-07-21 tras el retiro Stage 2 del MySQL local.
 
 ## Backup de referencia
 
@@ -60,20 +60,18 @@ journalctl -t sisoc-qa-disk-cleanup --since today --no-pager
 Si falla health pero los contenedores siguen activos, preservar evidencia y no
 reiniciar: el mantenimiento no toca runtime y el problema puede ser independiente.
 
-## Retiro Stage 1 del MySQL local
+## MySQL local retirado en Stage 2
 
-Stage 1 no borra `/var/lib/mysql` ni paquetes. Si se necesita restaurar el
-servicio local:
+Stage 2 purgo los paquetes server y elimino `/var/lib/mysql` el 2026-07-21.
+Por lo tanto, ya no existe rollback local mediante
+`systemctl enable --now mysql`.
 
-Backup de referencia:
-`/var/backups/sisoc/mysql-local-retirement/20260713_115645`.
+El backup de referencia
+`/var/backups/sisoc/mysql-local-retirement/20260713_115645` se conserva solo
+como evidencia de la configuracion, identidad y metadatos de Stage 1; no
+contiene los datos ni habilita recuperar la instancia eliminada.
 
-```bash
-sudo systemctl enable --now mysql
-sudo systemctl is-active mysql
-sudo ss -lntp 'sport = :3306'
-```
-
-Luego verificar que Django siga conectado a `10.80.9.18`; no cambiar `.env` ni
-reiniciar contenedores como parte de este rollback. El script de Stage 1 ejecuta
-este rollback automaticamente si falla una validacion posterior al stop.
+Ante un incidente, no reinstalar MySQL local ni modificar `.env` como supuesto
+rollback. Verificar primero que Django mantenga su conexion con la DB canonica
+`10.80.9.18`; cualquier nueva instancia local requiere aprobacion y un plan de
+datos independiente.

--- a/docs/plans/2026-07-13-qa-local-mysql-retirement-design.md
+++ b/docs/plans/2026-07-13-qa-local-mysql-retirement-design.md
@@ -1,15 +1,16 @@
 # Retiro del MySQL local heredado en QA
 
-Estado: Stage 1 aplicado y verificado el 2026-07-13. Observacion hasta
-2026-07-20; Stage 2 no aprobado.
+Estado: Stage 1 aplicado y verificado el 2026-07-13. Tras la observacion y la
+aprobacion explicita, Stage 2 fue aplicado el 2026-07-21.
 
 ## Evidencia
 
 - Django configura `10.80.9.18:3306` y conecta por TCP a `ltestsql-ssies`.
-- El MySQL local corre en `mdsldmz-ssies-test` (`10.80.9.15`).
+- El MySQL local corria en `mdsldmz-ssies-test` (`10.80.9.15`).
 - Ambos reportan el UUID `36dc97f5-e84d-11ee-ab3e-00505681952d`, evidencia de
   un datadir clonado sin regenerar `auto.cnf`, no de una misma instancia.
-- El datadir local ocupa 43 GB y contiene multiples schemas historicos/analiticos.
+- El datadir local ocupaba 43 GB y contenia multiples schemas
+  historicos/analiticos.
 - Antes de Stage 1, MySQL local estaba activo, habilitado y expuesto en
   `0.0.0.0:3306`.
 
@@ -34,23 +35,24 @@ Separar el retiro en dos etapas.
 7. Ante cualquier fallo, ejecutar rollback automatico con
    `systemctl enable --now mysql`.
 
-### Stage 2: irreversible, no aprobado todavia
+### Stage 2: irreversible, aplicado
 
-Despues de siete dias sin dependencia observada:
+Despues de la observacion sin dependencia confirmada, se recibio aprobacion
+explicita para eliminar el clon local:
 
-- decidir si los datos deben archivarse fuera del host;
-- borrar el datadir solo con aprobacion explicita;
-- retirar paquetes `mysql-server*`, conservando cliente/librerias requeridos;
-- verificar espacio, aplicacion y ausencia del listener.
+- no se creo un nuevo archivo de los datos historicos; se conserva solo el
+  backup de metadatos Stage 1;
+- se purgaron `mysql-server`, `mysql-server-8.0` y
+  `mysql-server-core-8.0`, sin `autoremove`;
+- se elimino `/var/lib/mysql`;
+- la unidad, binario y listeners locales quedaron ausentes;
+- QA siguio respondiendo HTTP 200 y el filesystem paso de 80% a 34% de uso,
+  con 62 GB libres.
 
 ## Rollback
 
-Mientras el datadir y paquetes se conserven:
-
-```bash
-sudo systemctl enable --now mysql
-sudo systemctl is-active mysql
-sudo ss -lntp 'sport = :3306'
-```
-
-No hace falta reiniciar Django para el rollback del servicio local.
+El rollback de Stage 1 expiro al aplicar Stage 2: ya no existen los paquetes ni
+el datadir requeridos para iniciar el servicio local. No reinstalar MySQL ni
+cambiar el routing de Django como sustituto de rollback. La aplicacion continua
+con la DB canonica remota `10.80.9.18`; una nueva DB local requeriria una
+decision de arquitectura y un plan de datos independiente.

--- a/docs/registro/cambios/2026-07-21-retiro-stage2-mysql-local-qa.md
+++ b/docs/registro/cambios/2026-07-21-retiro-stage2-mysql-local-qa.md
@@ -1,0 +1,36 @@
+# 2026-07-21 - Retiro Stage 2 del MySQL local de QA
+
+## Contexto
+
+El MySQL local heredado de `qa-old` (`mdsldmz-ssies-test`) ya llevaba la
+ventana de observacion de Stage 1 sin dependencias confirmadas. Django usa la
+DB canonica remota `10.80.9.18` (`ltestsql-ssies`), no el clon local de
+43 GB.
+
+## Cambios aplicados
+
+- Con aprobacion explicita se purgaron solamente `mysql-server`,
+  `mysql-server-8.0` y `mysql-server-core-8.0`.
+- No se ejecuto `autoremove`, por lo que no se solicito retirar cliente ni
+  librerias MySQL.
+- Se elimino `/var/lib/mysql`.
+- Se conserva
+  `/var/backups/sisoc/mysql-local-retirement/20260713_115645` como evidencia
+  de Stage 1; contiene metadatos, no una copia recuperable del datadir.
+
+## Validacion
+
+- El guard de Stage 2 verifico que Django seguia conectado a
+  `10.80.9.18|ltestsql-ssies|sisoc_local` antes y despues de la purga.
+- No se reinicio ni redesplego la aplicacion.
+- La inspeccion posterior por SSH confirmo unidad MySQL `not-found`, ausencia
+  de binario, paquetes, listeners 3306/33060 y `/var/lib/mysql`.
+- QA respondio HTTP 200 en `/health/`.
+- El filesystem raiz paso de 80% a 34% de uso, con 62 GB libres.
+
+## Riesgos y seguimiento
+
+El retiro es irreversible para el clon historico local. No reinstalar MySQL
+local ni usar el backup de Stage 1 como supuesto rollback. Sigue pendiente
+obtener evidencia de backup, retencion y restore probado de la DB canonica
+remota.


### PR DESCRIPTION
## Qué cambia

Registra el retiro irreversible Stage 2 del MySQL local heredado de QA.

- documenta la purga de los paquetes server y la eliminación de `/var/lib/mysql`;
- actualiza operaciones, inventario, riesgos, rollback y notas de migración;
- deja explícito que QA usa la DB canónica remota y que no existe rollback local;
- incorpora el registro operativo del cambio y actualiza el mapa de contexto para tareas de infraestructura.

## Motivo e impacto

El clon local llevaba la observación de Stage 1 sin dependencias confirmadas. Su retiro liberó aproximadamente 43 GB; el filesystem raíz quedó en 34% de uso, con 62 GB libres. No se reinició ni redesplegó la aplicación.

## Validación

- El guard ejecutado en QA verificó la identidad de DB remota antes y después de la purga.
- Inspección posterior por SSH: sin unidad, binario, paquetes server, listeners 3306/33060 ni `/var/lib/mysql`.
- QA respondió HTTP 200 en `/health/`.
- `git diff --check origin/development...HEAD` y búsqueda de referencias QA obsoletas, correctos.

## Riesgo pendiente

El retiro es irreversible para el clon local. El backup Stage 1 conserva metadatos, no los datos eliminados. Sigue pendiente evidencia de backup, retención y restore probado de la DB canónica remota.