### PR TITLE
fix(organizaciones): sanea rollback ARCA antes de promoción

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@
 ## Actualizaciones
 
 - [sin-area] fix(ci): evitar la autoaprobacion en sincronizacion descendente. (PR #2112)
+
+## Corrección de Errores
+
+- [predeploy] Promueve validaciones CDI, certificados de comedores, documentos PWA y saneamiento seguro de la migración ARCA. (PR #2136)
 <!-- AUTO-GENERATED RELEASE END: 2026-07-22 -->
 
 <!-- AUTO-GENERATED RELEASE START: 2026-07-15 -->

--- a/docs/contexto/features/pr-2136-release-promover-development-a-main-2026-07-22.md
+++ b/docs/contexto/features/pr-2136-release-promover-development-a-main-2026-07-22.md
@@ -1,0 +1,85 @@
+# Contexto de feature PR #2136 - release: promover development a main (2026-07-22)
+
+## Resumen
+
+- PR: https://github.com/dsocial118/SISOC/pull/2136
+- Base: `main`
+- Rama origen: `development`
+- Autor: `juanikitro`
+
+## Contexto funcional
+
+- Promoción integral de development a main con saneamiento de migración ARCA.
+
+## Arquitectura tocada
+
+- El PR toca lógica en `services/`, por lo que impacta reglas de negocio u orquestación.
+- Hay cambios en capa API/DRF y conviene revisar contratos de request/response.
+- Hay cambios en vistas web y puede existir impacto en permisos o renderizado.
+- Se modifican templates, con posible impacto visual o de composición UI.
+- Existen cambios de persistencia o migraciones que requieren revisión de datos.
+
+## Decisiones y supuestos detectados
+
+- Tipo de cambio declarado: fix
+- Área principal declarada: predeploy
+- Impacto usuario declarado: Usuarios de CDI, comedores, admisiones y PWA reciben validaciones y documentos corregidos.
+- Riesgos / rollback: Backup DB obligatorio; ARCA requiere restore para rollback.
+
+## Design system y UI
+
+- El PR toca piezas de UI y conviene revisar consistencia visual con el patrón existente.
+- Archivos visuales relevantes: acompanamientos/templates/acompañamiento_detail.html, admisiones/templates/admisiones/admisiones_tecnicos_form.html, admisiones/templates/admisiones/informe_tecnico_complementario_detalle.html, centrodeinfancia/templates/centrodeinfancia/centrodeinfancia_form.html, centrodeinfancia/templates/centrodeinfancia/trabajador_form.html, comedores/templates/comedor/certificaciones_prestaciones_historial.html, comedores/templates/comedor/comedor_convenio_pnud_form.html, comedores/templates/comedor/comedor_detail.html
+
+## Memoria operativa para agentes
+
+- Empezar por `docs/registro/prs/PR-2136.md` para contexto resumido del PR.
+- Revisar primero estos archivos del diff:
+- `AGENTS.md`
+- `AGENT_REPO_MAP.md`
+- `acompanamientos/templates/acompañamiento_detail.html`
+- `acompanamientos/views.py`
+- `admisiones/services/admisiones_service/impl.py`
+- `admisiones/services/informes_service/impl.py`
+- `admisiones/templates/admisiones/admisiones_tecnicos_form.html`
+- `admisiones/templates/admisiones/informe_tecnico_complementario_detalle.html`
+- `admisiones/views/web_views.py`
+- `centrodeinfancia/forms.py`
+- `centrodeinfancia/migrations/0039_alter_trabajador_es_interprete_and_more.py`
+- `centrodeinfancia/migrations/0040_trabajador_campos_verificados_renaper.py`
+- `centrodeinfancia/migrations/0041_trabajador_fecha_actualizacion_and_more.py`
+- `centrodeinfancia/models.py`
+- `centrodeinfancia/templates/centrodeinfancia/centrodeinfancia_form.html`
+- `centrodeinfancia/templates/centrodeinfancia/trabajador_form.html`
+- `centrodeinfancia/tests/test_access_scope_centrodeinfancia.py`
+- `centrodeinfancia/tests/test_automatic_user_provisioning.py`
+- `centrodeinfancia/tests/test_centrodeinfancia_form.py`
+- `centrodeinfancia/tests/test_trabajador_form.py`
+- ... y 66 archivo(s) adicional(es) relacionados.
+- Documentación sugerida para ampliar contexto:
+- `docs/indice.md`
+- `docs/ia/CONTEXT_HYGIENE.md`
+- `docs/ia/ARCHITECTURE.md`
+- `docs/ia/TESTING.md`
+- `docs/ia/MODULAR_BOUNDARIES.md`
+- `docs/infra/ENVIRONMENT_DATABASES.md`
+- `docs/infra/QA_INVENTORY.md`
+- `docs/infra/QA_MIGRATION_NOTES.md`
+- `docs/infra/QA_OPERATIONS.md`
+- `docs/infra/QA_RISKS.md`
+- `docs/infra/QA_ROLLBACK.md`
+- `docs/plans/2026-07-13-qa-local-mysql-retirement-design.md`
+- `docs/registro/cambios/2026-07-14-cdi-validaciones-alta.md`
+- `docs/registro/cambios/2026-07-16-cdi-validaciones-trabajador.md`
+- `docs/registro/cambios/2026-07-20-ajustes-pwa-convenios-rendiciones-documentos.md`
+- `docs/registro/cambios/2026-07-20-fix-migracion-arca-por-convenio.md`
+- `docs/registro/cambios/2026-07-20-issue-2113-informe-tecnico-complementario.md`
+- `docs/registro/cambios/2026-07-21-issue-1901-seguimiento-certificaciones.md`
+- `docs/registro/cambios/2026-07-21-retiro-stage2-mysql-local-qa.md`
+- `docs/registro/cambios/2026-07-22-issue-2133-rendiciones-pwa.md`
+- `docs/registro/decisiones/2026-07-21-modulos-nuevos-extraibles.md`
+
+## Trazabilidad
+
+- Documento generado automáticamente desde el evento de `pull_request`.
+- Si este PR cambia de título, el archivo se renombrará para mantener el slug alineado.

--- a/docs/registro/cambios/2026-07-22-predeploy-migracion-arca-rollback.md
+++ b/docs/registro/cambios/2026-07-22-predeploy-migracion-arca-rollback.md
@@ -1,0 +1,26 @@
+# Pre-deploy: rollback seguro de la migración ARCA
+
+## Fecha
+
+2026-07-22
+
+## Contexto
+
+La migración `organizaciones.0016_issue_2083_documentacion_organizacion`
+materializa archivos ARCA en admisiones, elimina documentación histórica y
+consolida documentos de avales. La reversa anterior solo restauraba parte de
+los archivos y eliminaba los materializados, sin poder reconstruir el catálogo
+ni las asociaciones originales.
+
+## Decisión
+
+La operación se declara explícitamente irreversible con
+`migrations.RunPython.noop` como reversa. Así un rollback de código no realiza
+una reversa parcial que pierda más información o presente un estado como
+restaurado cuando no lo está.
+
+## Consideraciones operativas
+
+Un rollback que necesite deshacer esta migración requiere restaurar un backup
+de base de datos consistente, no ejecutar solo `migrate` hacia atrás. La
+promoción debe conservar el backup verificado previo a aplicar migraciones.

--- a/docs/registro/prs/PR-2136.md
+++ b/docs/registro/prs/PR-2136.md
@@ -1,0 +1,120 @@
+# PR #2136 - release: promover development a main (2026-07-22)
+
+## Metadata
+
+- PR: https://github.com/dsocial118/SISOC/pull/2136
+- Base: `main`
+- Rama origen: `development`
+- Autor: `juanikitro`
+- Última actualización: `2026-07-22T23:23:00Z`
+
+## Resumen operativo
+
+- Tipo de cambio: fix
+- Área principal: predeploy
+- Contexto funcional: Promoción integral de development a main con saneamiento de migración ARCA.
+- Resumen para changelog: Promueve validaciones CDI, certificados de comedores, documentos PWA y saneamiento seguro de la migración ARCA.
+- Impacto usuario: Usuarios de CDI, comedores, admisiones y PWA reciben validaciones y documentos corregidos.
+
+## Áreas afectadas
+
+- `AGENTS.md`
+- `AGENT_REPO_MAP.md`
+- `acompanamientos`
+- `admisiones`
+- `centrodeinfancia`
+- `comedores`
+- `core`
+- `docker`
+- `docs/ia`
+- `docs/indice.md`
+- `docs/infra`
+- `docs/plans`
+- `docs/registro`
+- `organizaciones`
+- `pwa`
+- `rendicioncuentasmensual`
+- `static`
+- `tests`
+
+## Archivos relevantes del diff
+
+- `AGENTS.md`
+- `AGENT_REPO_MAP.md`
+- `acompanamientos/templates/acompañamiento_detail.html`
+- `acompanamientos/views.py`
+- `admisiones/services/admisiones_service/impl.py`
+- `admisiones/services/informes_service/impl.py`
+- `admisiones/templates/admisiones/admisiones_tecnicos_form.html`
+- `admisiones/templates/admisiones/informe_tecnico_complementario_detalle.html`
+- `admisiones/views/web_views.py`
+- `centrodeinfancia/forms.py`
+- `centrodeinfancia/migrations/0039_alter_trabajador_es_interprete_and_more.py`
+- `centrodeinfancia/migrations/0040_trabajador_campos_verificados_renaper.py`
+- `centrodeinfancia/migrations/0041_trabajador_fecha_actualizacion_and_more.py`
+- `centrodeinfancia/models.py`
+- `centrodeinfancia/templates/centrodeinfancia/centrodeinfancia_form.html`
+- `centrodeinfancia/templates/centrodeinfancia/trabajador_form.html`
+- `centrodeinfancia/tests/test_access_scope_centrodeinfancia.py`
+- `centrodeinfancia/tests/test_automatic_user_provisioning.py`
+- `centrodeinfancia/tests/test_centrodeinfancia_form.py`
+- `centrodeinfancia/tests/test_trabajador_form.py`
+- `centrodeinfancia/tests/test_trabajador_model.py`
+- `centrodeinfancia/tests/test_trabajadores_views.py`
+- `centrodeinfancia/views.py`
+- `comedores/api_serializers.py`
+- `comedores/api_views.py`
+- `comedores/forms/convenio_pnud_form.py`
+- `comedores/migrations/0048_issue_2063_convenio_abordaje.py`
+- `comedores/migrations/0049_conformidad_certificacion_pdf.py`
+- `comedores/migrations/0050_merge_20260720_1400.py`
+- `comedores/models.py`
+- `comedores/services/certificacion_prestaciones_service.py`
+- `comedores/templates/comedor/certificaciones_prestaciones_historial.html`
+- `comedores/templates/comedor/comedor_convenio_pnud_form.html`
+- `comedores/templates/comedor/comedor_detail.html`
+- `comedores/urls.py`
+- `comedores/utils.py`
+- `comedores/views/__init__.py`
+- `comedores/views/comedor.py`
+- `core/validators.py`
+- `docker/django/Dockerfile`
+- ... y 46 archivo(s) adicional(es) en el diff.
+
+## Validación declarada
+
+- Pruebas automáticas: CI Docker obligatorio antes de GO.
+- Pruebas manuales: Roles, CDI, documentos PWA, Comedores y health post-deploy.
+
+## Riesgos y rollback
+
+- Backup DB obligatorio; ARCA requiere restore para rollback.
+
+## Documentación sugerida para lectura
+
+- `docs/indice.md`
+- `docs/ia/CONTEXT_HYGIENE.md`
+- `docs/ia/ARCHITECTURE.md`
+- `docs/ia/TESTING.md`
+- `docs/ia/MODULAR_BOUNDARIES.md`
+- `docs/infra/ENVIRONMENT_DATABASES.md`
+- `docs/infra/QA_INVENTORY.md`
+- `docs/infra/QA_MIGRATION_NOTES.md`
+- `docs/infra/QA_OPERATIONS.md`
+- `docs/infra/QA_RISKS.md`
+- `docs/infra/QA_ROLLBACK.md`
+- `docs/plans/2026-07-13-qa-local-mysql-retirement-design.md`
+- `docs/registro/cambios/2026-07-14-cdi-validaciones-alta.md`
+- `docs/registro/cambios/2026-07-16-cdi-validaciones-trabajador.md`
+- `docs/registro/cambios/2026-07-20-ajustes-pwa-convenios-rendiciones-documentos.md`
+- `docs/registro/cambios/2026-07-20-fix-migracion-arca-por-convenio.md`
+- `docs/registro/cambios/2026-07-20-issue-2113-informe-tecnico-complementario.md`
+- `docs/registro/cambios/2026-07-21-issue-1901-seguimiento-certificaciones.md`
+- `docs/registro/cambios/2026-07-21-retiro-stage2-mysql-local-qa.md`
+- `docs/registro/cambios/2026-07-22-issue-2133-rendiciones-pwa.md`
+- `docs/registro/decisiones/2026-07-21-modulos-nuevos-extraibles.md`
+
+## Notas para continuidad
+
+- Este documento es generado automáticamente desde el contexto del PR y sirve como índice rápido para revisión y futuras sesiones de agentes.
+- Si la metadata del body del PR está incompleta, varias secciones usarán fallbacks derivados del título o del diff.

--- a/docs/registro/releases/pending/2026-07-22-pr-2136.md
+++ b/docs/registro/releases/pending/2026-07-22-pr-2136.md
@@ -1,0 +1,19 @@
+---
+pr: 2136
+release_date: 2026-07-22
+category: Corrección de Errores
+area: predeploy
+title: release: promover development a main (2026-07-22)
+summary: Promueve validaciones CDI, certificados de comedores, documentos PWA y saneamiento seguro de la migración ARCA
+impact: Usuarios de CDI, comedores, admisiones y PWA reciben validaciones y documentos corregidos.
+source_url: https://github.com/dsocial118/SISOC/pull/2136
+---
+# Release note preliminar PR #2136
+
+- Fecha objetivo de release: 2026-07-22
+- Categoría: Corrección de Errores
+- Área: predeploy
+- Título del PR: release: promover development a main (2026-07-22)
+- Resumen: Promueve validaciones CDI, certificados de comedores, documentos PWA y saneamiento seguro de la migración ARCA
+- Impacto usuario: Usuarios de CDI, comedores, admisiones y PWA reciben validaciones y documentos corregidos.
+- Fuente: https://github.com/dsocial118/SISOC/pull/2136

--- a/organizaciones/migrations/0016_issue_2083_documentacion_organizacion.py
+++ b/organizaciones/migrations/0016_issue_2083_documentacion_organizacion.py
@@ -119,20 +119,6 @@ def actualizar_documentacion(apps, schema_editor):
         Documentacion.objects.filter(id__in=origen_ids).delete()
 
 
-def revertir_documentacion(apps, schema_editor):
-    Archivo = apps.get_model("organizaciones", "ArchivoOrganizacion")
-    ArchivoAdmision = apps.get_model("admisiones", "ArchivoAdmision")
-    origen_ids = ArchivoAdmision.objects.filter(
-        archivo_organizacion_origen__isnull=False,
-        documentacion__nombre="Constancia de ARCA",
-    ).values_list("archivo_organizacion_origen_id", flat=True)
-    Archivo.objects.filter(id__in=origen_ids).update(deleted_at=None)
-    ArchivoAdmision.objects.filter(
-        archivo_organizacion_origen_id__in=origen_ids,
-        documentacion__nombre="Constancia de ARCA",
-    ).delete()
-
-
 class Migration(migrations.Migration):
 
     dependencies = [
@@ -141,5 +127,5 @@ class Migration(migrations.Migration):
     ]
 
     operations = [
-        migrations.RunPython(actualizar_documentacion, revertir_documentacion),
+        migrations.RunPython(actualizar_documentacion, migrations.RunPython.noop),
     ]

--- a/organizaciones/test_issue_2083_documentacion_organizacion.py
+++ b/organizaciones/test_issue_2083_documentacion_organizacion.py
@@ -2,6 +2,7 @@ import importlib
 
 import pytest
 from django.apps import apps as global_apps
+from django.db import migrations
 
 from admisiones.models.admisiones import (
     Admision,
@@ -166,3 +167,9 @@ def test_migracion_crea_documento_arca_sin_convenio_si_la_admision_no_tiene_tipo
     )
     assert not documento.convenios.exists()
     assert archivo_admision.documentacion_id == documento.id
+
+
+def test_migracion_declara_reversa_noop_para_no_perder_datos_irreversibles():
+    reverse_code = _migracion.Migration.operations[0].reverse_code
+
+    assert reverse_code is migrations.RunPython.noop


### PR DESCRIPTION
## Saneamiento previo a promoción

Se declara irreversible la migración ARCA para evitar que un rollback parcial restaure archivos pero destruya las materializaciones y catálogos que ya no puede reconstruir. Se agrega una prueba de contrato y el registro operativo correspondiente.

## Pruebas ejecutadas

- Contrato RED/GREEN del `reverse_code`: previo falla; actual usa `migrations.RunPython.noop`.
- `python -m compileall` y `git diff --check`: exitosos.
- El pytest focalizado no inició: el Python host no tiene `crispy_forms`.
- La validación de runtime queda delegada a CI Docker (`pytest`, `migrations_check`, `mysql_compat`).

## Riesgos remanentes

- Esta migración de datos requiere backup de base consistente para un rollback real; `migrate` hacia atrás no reconstruye el catálogo histórico.
- No se ejecutaron Docker ni migraciones contra una base local en esta automatización.