### PR TITLE
feat(release): automatizar promoción development a main

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,3 @@
+# Los runners de deploy ejecutan Bash y GitHub Actions interpreta YAML en Linux.
+*.sh text eol=lf
+.github/workflows/*.yml text eol=lf

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -28,5 +28,6 @@ Vincular el #ISSUE
 - Resumen para changelog:
 - Impacto usuario:
 - Riesgos / rollback:
+- Fecha objetivo de release:
 
 # Capturas de Pantalla

--- a/.github/scripts/release_orchestrator.js
+++ b/.github/scripts/release_orchestrator.js
@@ -1,0 +1,759 @@
+"use strict";
+
+const REQUIRED_CHECKS = [
+  "deploy_guard",
+  "architecture_imports",
+  "gitleaks",
+  "sync_pr_artifacts",
+];
+const BASELINE_CHECK = "release_baseline";
+const SUCCESSFUL_CONCLUSIONS = new Set(["success", "neutral", "skipped"]);
+const FINAL_RELEASE_MARKER = /<!--\s*release-automation:\s*scheduled\s*-->/i;
+const PREPARATION_RELEASE_MARKER = /<!--\s*release-final-pr:\s*(\d+)\s*-->/i;
+const RELEASE_DATE_MARKER = /<!--\s*release-date:\s*(\d{4}-\d{2}-\d{2})\s*-->/i;
+const RELEASE_HEAD_MARKER = /<!--\s*release-head:\s*([0-9a-f]{40})\s*-->/i;
+const RELEASE_PREPARATION_MARKER =
+  /<!--\s*release-preparation:\s*(pending|none|\d+)\s*-->/i;
+const PREPARATION_BRANCH_PATTERN =
+  /^codex\/predeploy-dev-main-\d{8}(?:-[a-z0-9-]+)?$/;
+
+function markerMatch(body, marker) {
+  return (body || "").match(marker);
+}
+
+function parsePreparationFinalNumber(body) {
+  const match = markerMatch(body, PREPARATION_RELEASE_MARKER);
+  const value = match ? Number.parseInt(match[1], 10) : null;
+  return Number.isInteger(value) && value > 0 ? value : null;
+}
+
+function parseReleaseDate(body) {
+  const match = markerMatch(body, RELEASE_DATE_MARKER);
+  if (!match) {
+    return null;
+  }
+
+  const value = match[1];
+  const parsed = new Date(`${value}T00:00:00Z`);
+  if (Number.isNaN(parsed.getTime()) || parsed.toISOString().slice(0, 10) !== value) {
+    return null;
+  }
+  return value;
+}
+
+function parseReleaseHead(body) {
+  const match = markerMatch(body, RELEASE_HEAD_MARKER);
+  return match ? match[1].toLowerCase() : null;
+}
+
+function parseReleasePreparation(body) {
+  const match = markerMatch(body, RELEASE_PREPARATION_MARKER);
+  if (!match) {
+    return null;
+  }
+  if (match[1].toLowerCase() === "pending" || match[1].toLowerCase() === "none") {
+    return match[1].toLowerCase();
+  }
+  const value = Number.parseInt(match[1], 10);
+  return Number.isInteger(value) && value > 0 ? value : null;
+}
+
+function stableTagName(releaseDate) {
+  return `${releaseDate.replaceAll("-", ".")}-stable`;
+}
+
+function isReleaseSnapshotCurrent(pull) {
+  return parseReleaseHead(pull.body) === (pull.head?.sha || "").toLowerCase();
+}
+
+function isInternalPullRequest(pull, repositoryFullName) {
+  return pull.head?.repo?.full_name === repositoryFullName;
+}
+
+function isPreparationPullRequest(pull, repositoryFullName) {
+  return (
+    pull.base?.ref === "development" &&
+    isInternalPullRequest(pull, repositoryFullName) &&
+    PREPARATION_BRANCH_PATTERN.test(pull.head?.ref || "") &&
+    parsePreparationFinalNumber(pull.body) !== null
+  );
+}
+
+function isScheduledFinalPullRequest(pull, repositoryFullName) {
+  return (
+    pull.base?.ref === "main" &&
+    pull.head?.ref === "development" &&
+    isInternalPullRequest(pull, repositoryFullName) &&
+    FINAL_RELEASE_MARKER.test(pull.body || "") &&
+    parseReleaseDate(pull.body) !== null &&
+    parseReleaseHead(pull.body) !== null &&
+    parseReleasePreparation(pull.body) !== null
+  );
+}
+
+function newestCheckRuns(checkRuns) {
+  const byName = new Map();
+  for (const check of checkRuns) {
+    const current = byName.get(check.name);
+    const checkTimestamp = Date.parse(check.completed_at || check.started_at || "") || 0;
+    const currentTimestamp = current
+      ? Date.parse(current.completed_at || current.started_at || "") || 0
+      : -1;
+    if (!current || checkTimestamp >= currentTimestamp) {
+      byName.set(check.name, check);
+    }
+  }
+  return byName;
+}
+
+function requiredChecksState(checkRuns, requiredChecks = REQUIRED_CHECKS) {
+  const latest = newestCheckRuns(checkRuns);
+  const pending = [];
+  const failed = [];
+
+  for (const name of requiredChecks) {
+    const check = latest.get(name);
+    if (!check || check.status !== "completed") {
+      pending.push(name);
+      continue;
+    }
+    if (!SUCCESSFUL_CONCLUSIONS.has(check.conclusion)) {
+      failed.push(`${name} (${check.conclusion || "unknown"})`);
+    }
+  }
+
+  return { pending, failed };
+}
+
+function sleep(milliseconds) {
+  return new Promise((resolve) => setTimeout(resolve, milliseconds));
+}
+
+async function getPull(github, owner, repo, pullNumber) {
+  const response = await github.rest.pulls.get({
+    owner,
+    repo,
+    pull_number: pullNumber,
+  });
+  return response.data;
+}
+
+async function getCheckRuns(github, owner, repo, sha) {
+  const response = await github.rest.checks.listForRef({
+    owner,
+    repo,
+    ref: sha,
+    per_page: 100,
+  });
+  return response.data.check_runs;
+}
+
+async function getRequiredChecksState(github, owner, repo, sha) {
+  return requiredChecksState(await getCheckRuns(github, owner, repo, sha));
+}
+
+async function commentOnce(github, owner, repo, issueNumber, marker, body) {
+  const comments = await github.rest.issues.listComments({
+    owner,
+    repo,
+    issue_number: issueNumber,
+    per_page: 100,
+  });
+  if (comments.data.some((comment) => (comment.body || "").includes(marker))) {
+    return;
+  }
+  await github.rest.issues.createComment({
+    owner,
+    repo,
+    issue_number: issueNumber,
+    body: `${marker}\n${body}`,
+  });
+}
+
+async function markFinalPullRequestReady(github, owner, repo, pullNumber, core) {
+  let pull = await getPull(github, owner, repo, pullNumber);
+  const repositoryFullName = `${owner}/${repo}`;
+  if (!isScheduledFinalPullRequest(pull, repositoryFullName)) {
+    throw new Error(
+      `PR #${pullNumber} no es una promocion programada valida development -> main.`,
+    );
+  }
+
+  if (pull.draft) {
+    await github.graphql(
+      `mutation MarkReady($pullRequestId: ID!) {
+        markPullRequestReadyForReview(input: { pullRequestId: $pullRequestId }) {
+          pullRequest { id isDraft }
+        }
+      }`,
+      { pullRequestId: pull.node_id },
+    );
+    core.info(`PR final #${pull.number} marcado como listo para auto-merge.`);
+    pull = await getPull(github, owner, repo, pullNumber);
+  }
+  return pull;
+}
+
+async function setFinalReleaseHead(github, owner, repo, pullNumber, headSha, core) {
+  const pull = await getPull(github, owner, repo, pullNumber);
+  const repositoryFullName = `${owner}/${repo}`;
+  if (!isScheduledFinalPullRequest(pull, repositoryFullName)) {
+    throw new Error(
+      `PR #${pullNumber} no es una promocion programada valida development -> main.`,
+    );
+  }
+
+  const body = pull.body || "";
+  const updatedBody = RELEASE_HEAD_MARKER.test(body)
+    ? body.replace(RELEASE_HEAD_MARKER, `<!-- release-head: ${headSha} -->`)
+    : `${body.trim()}\n\n<!-- release-head: ${headSha} -->\n`;
+  if (updatedBody === body) {
+    return pull;
+  }
+  const updated = await github.rest.pulls.update({
+    owner,
+    repo,
+    pull_number: pullNumber,
+    body: updatedBody,
+  });
+  core.info(`PR final #${pullNumber} actualizado al snapshot ${headSha}.`);
+  return updated.data;
+}
+
+async function ensureBaselinePending(github, owner, repo, pull, core) {
+  const externalId = `release-baseline:${pull.number}:${pull.base.sha}:${pull.head.sha}`;
+  const latest = newestCheckRuns(await getCheckRuns(github, owner, repo, pull.head.sha));
+  const existing = latest.get(BASELINE_CHECK);
+  if (
+    existing
+    && existing.external_id === externalId
+    && (
+      existing.status !== "completed"
+      || existing.conclusion === "success"
+    )
+  ) {
+    return existing;
+  }
+
+  const created = await github.rest.checks.create({
+    owner,
+    repo,
+    name: BASELINE_CHECK,
+    head_sha: pull.head.sha,
+    status: "in_progress",
+    external_id: externalId,
+    output: {
+      title: "Baseline de rollback pendiente",
+      summary: "La promoción espera el tag del main previo y la validación final de release.",
+    },
+  });
+  core.info(`Check ${BASELINE_CHECK} creado para PR #${pull.number}.`);
+  return created.data;
+}
+
+async function concludeBaseline(
+  github,
+  owner,
+  repo,
+  pull,
+  conclusion,
+  title,
+  summary,
+  core,
+) {
+  const check = await ensureBaselinePending(github, owner, repo, pull, core);
+  if (check.status === "completed" && check.conclusion === conclusion) {
+    return check;
+  }
+  const updated = await github.rest.checks.update({
+    owner,
+    repo,
+    check_run_id: check.id,
+    status: "completed",
+    conclusion,
+    output: { title, summary },
+  });
+  return updated.data;
+}
+
+async function enableAutoMerge(github, pull, core) {
+  if (pull.auto_merge) {
+    return true;
+  }
+  try {
+    await github.graphql(
+      `mutation EnableAutoMerge($pullRequestId: ID!) {
+        enablePullRequestAutoMerge(
+          input: { pullRequestId: $pullRequestId, mergeMethod: MERGE }
+        ) {
+          pullRequest { autoMergeRequest { enabledAt mergeMethod } }
+        }
+      }`,
+      { pullRequestId: pull.node_id },
+    );
+    core.info(`Auto-merge nativo habilitado para PR #${pull.number}.`);
+    return true;
+  } catch (error) {
+    core.warning(
+      `No se pudo habilitar auto-merge para PR #${pull.number}: ${error.message}`,
+    );
+    return false;
+  }
+}
+
+async function disableAutoMerge(github, pull, core) {
+  if (!pull.auto_merge) {
+    return;
+  }
+  try {
+    await github.graphql(
+      `mutation DisableAutoMerge($pullRequestId: ID!) {
+        disablePullRequestAutoMerge(input: { pullRequestId: $pullRequestId }) {
+          pullRequest { autoMergeRequest { enabledAt } }
+        }
+      }`,
+      { pullRequestId: pull.node_id },
+    );
+    core.info(`Auto-merge deshabilitado para PR #${pull.number}.`);
+  } catch (error) {
+    core.warning(
+      `No se pudo deshabilitar auto-merge para PR #${pull.number}: ${error.message}`,
+    );
+  }
+}
+
+async function getTagTarget(github, owner, repo, tagName) {
+  try {
+    const ref = await github.rest.git.getRef({
+      owner,
+      repo,
+      ref: `tags/${tagName}`,
+    });
+    if (ref.data.object.type === "tag") {
+      const tag = await github.rest.git.getTag({
+        owner,
+        repo,
+        tag_sha: ref.data.object.sha,
+      });
+      return tag.data.object.sha;
+    }
+    return ref.data.object.sha;
+  } catch (error) {
+    if (error.status === 404) {
+      return null;
+    }
+    throw error;
+  }
+}
+
+async function ensureStableTag(github, owner, repo, tagName, mainSha, pullNumber) {
+  const existingTarget = await getTagTarget(github, owner, repo, tagName);
+  if (existingTarget) {
+    if (existingTarget !== mainSha) {
+      throw new Error(
+        `El tag ${tagName} ya apunta a ${existingTarget}, no al main actual ${mainSha}.`,
+      );
+    }
+    return { created: false, target: existingTarget };
+  }
+
+  const tag = await github.rest.git.createTag({
+    owner,
+    repo,
+    tag: tagName,
+    message: [
+      `Stable release ${tagName.replace("-stable", "")}`,
+      "",
+      `Baseline de rollback anterior a la promocion del PR #${pullNumber}.`,
+    ].join("\n"),
+    object: mainSha,
+    type: "commit",
+    tagger: {
+      name: "github-actions[bot]",
+      email: "41898282+github-actions[bot]@users.noreply.github.com",
+      date: new Date().toISOString(),
+    },
+  });
+
+  try {
+    await github.rest.git.createRef({
+      owner,
+      repo,
+      ref: `refs/tags/${tagName}`,
+      sha: tag.data.sha,
+    });
+    return { created: true, target: mainSha };
+  } catch (error) {
+    if (error.status !== 422) {
+      throw error;
+    }
+    const racedTarget = await getTagTarget(github, owner, repo, tagName);
+    if (racedTarget === mainSha) {
+      return { created: false, target: racedTarget };
+    }
+    throw new Error(`No se pudo crear el tag estable ${tagName} de forma segura.`);
+  }
+}
+
+async function removeFreshStableTag(github, owner, repo, tagName) {
+  await github.rest.git.deleteRef({
+    owner,
+    repo,
+    ref: `tags/${tagName}`,
+  });
+}
+
+async function ensureStableRelease(
+  github,
+  owner,
+  repo,
+  tagName,
+  mainSha,
+  pullNumber,
+) {
+  try {
+    const existing = await github.rest.repos.getReleaseByTag({
+      owner,
+      repo,
+      tag: tagName,
+    });
+    return existing.data.html_url;
+  } catch (error) {
+    if (error.status !== 404) {
+      throw error;
+    }
+  }
+
+  try {
+    const created = await github.rest.repos.createRelease({
+      owner,
+      repo,
+      tag_name: tagName,
+      target_commitish: mainSha,
+      name: `Rollback baseline ${tagName}`,
+      body: [
+        `Baseline de rollback anterior a la promoción del PR #${pullNumber}.`,
+        `Main previo: ${mainSha}.`,
+      ].join("\n"),
+      draft: false,
+      prerelease: false,
+      generate_release_notes: false,
+    });
+    return created.data.html_url;
+  } catch (error) {
+    if (error.status !== 422) {
+      throw error;
+    }
+    const raced = await github.rest.repos.getReleaseByTag({
+      owner,
+      repo,
+      tag: tagName,
+    });
+    return raced.data.html_url;
+  }
+}
+
+async function blockFinal(github, owner, repo, pull, reason, core) {
+  await disableAutoMerge(github, pull, core);
+  if (!pull.draft) {
+    await concludeBaseline(
+      github,
+      owner,
+      repo,
+      pull,
+      "failure",
+      "Promoción bloqueada",
+      reason,
+      core,
+    );
+  }
+  await commentOnce(
+    github,
+    owner,
+    repo,
+    pull.number,
+    "<!-- release-final-blocked -->",
+    reason,
+  );
+}
+
+async function armFinalForAutoMerge(github, owner, repo, pullNumber, core) {
+  let pull = await markFinalPullRequestReady(github, owner, repo, pullNumber, core);
+  if (!isReleaseSnapshotCurrent(pull)) {
+    await blockFinal(
+      github,
+      owner,
+      repo,
+      pull,
+      "El head de `development` cambió después del snapshot analizado. Se requiere una nueva ejecución de pre-deploy.",
+      core,
+    );
+    return false;
+  }
+  await ensureBaselinePending(github, owner, repo, pull, core);
+  pull = await getPull(github, owner, repo, pullNumber);
+  return enableAutoMerge(github, pull, core);
+}
+
+async function processDraftFinalPullRequests(github, owner, repo, core) {
+  const repositoryFullName = `${owner}/${repo}`;
+  const pulls = await github.rest.pulls.list({
+    owner,
+    repo,
+    state: "open",
+    base: "main",
+    per_page: 100,
+  });
+
+  for (const item of pulls.data) {
+    const pull = await getPull(github, owner, repo, item.number);
+    if (!isScheduledFinalPullRequest(pull, repositoryFullName) || !pull.draft) {
+      continue;
+    }
+
+    const preparation = parseReleasePreparation(pull.body);
+    if (preparation === "pending") {
+      continue;
+    }
+    if (preparation === "none") {
+      await armFinalForAutoMerge(github, owner, repo, pull.number, core);
+      continue;
+    }
+
+    const preparationPull = await getPull(github, owner, repo, preparation);
+    if (!preparationPull.merged || !preparationPull.merge_commit_sha) {
+      continue;
+    }
+    await setFinalReleaseHead(
+      github,
+      owner,
+      repo,
+      pull.number,
+      preparationPull.merge_commit_sha,
+      core,
+    );
+    await armFinalForAutoMerge(github, owner, repo, pull.number, core);
+  }
+}
+
+async function processReadyFinalPullRequests(github, owner, repo, core) {
+  const repositoryFullName = `${owner}/${repo}`;
+  const pulls = await github.rest.pulls.list({
+    owner,
+    repo,
+    state: "open",
+    base: "main",
+    per_page: 100,
+  });
+
+  for (const item of pulls.data) {
+    let pull = await getPull(github, owner, repo, item.number);
+    if (!isScheduledFinalPullRequest(pull, repositoryFullName) || pull.draft) {
+      continue;
+    }
+
+    if (!isReleaseSnapshotCurrent(pull)) {
+      await blockFinal(
+        github,
+        owner,
+        repo,
+        pull,
+        "El head de `development` cambió después del snapshot analizado. Se requiere una nueva ejecución de pre-deploy.",
+        core,
+      );
+      continue;
+    }
+
+    const checks = await getRequiredChecksState(github, owner, repo, pull.head.sha);
+    if (checks.pending.length > 0) {
+      core.info(`PR final #${pull.number}: checks pendientes (${checks.pending.join(", ")}).`);
+      continue;
+    }
+    if (checks.failed.length > 0) {
+      await blockFinal(
+        github,
+        owner,
+        repo,
+        pull,
+        `La promoción automática queda bloqueada: ${checks.failed.join(", ")}.`,
+        core,
+      );
+      continue;
+    }
+
+    const comparison = await github.rest.repos.compareCommits({
+      owner,
+      repo,
+      base: "main",
+      head: "development",
+    });
+    if (comparison.data.behind_by !== 0) {
+      core.info(
+        `PR final #${pull.number}: development aún no contiene el main más nuevo; se espera la sincronización descendente.`,
+      );
+      continue;
+    }
+
+    await ensureBaselinePending(github, owner, repo, pull, core);
+    pull = await getPull(github, owner, repo, pull.number);
+    if (!isReleaseSnapshotCurrent(pull)) {
+      await blockFinal(
+        github,
+        owner,
+        repo,
+        pull,
+        "El head cambió mientras se armaba el baseline de rollback.",
+        core,
+      );
+      continue;
+    }
+
+    const mainBeforeMerge = await github.rest.repos.getBranch({
+      owner,
+      repo,
+      branch: "main",
+    });
+    const tagName = stableTagName(parseReleaseDate(pull.body));
+    const stableTag = await ensureStableTag(
+      github,
+      owner,
+      repo,
+      tagName,
+      mainBeforeMerge.data.commit.sha,
+      pull.number,
+    );
+
+    const refreshedMain = await github.rest.repos.getBranch({
+      owner,
+      repo,
+      branch: "main",
+    });
+    const pullAtGate = await getPull(github, owner, repo, pull.number);
+    if (
+      refreshedMain.data.commit.sha !== mainBeforeMerge.data.commit.sha
+      || pullAtGate.base.sha !== mainBeforeMerge.data.commit.sha
+      || pullAtGate.head.sha !== pull.head.sha
+      || !isReleaseSnapshotCurrent(pullAtGate)
+    ) {
+      if (stableTag.created) {
+        await removeFreshStableTag(github, owner, repo, tagName);
+      }
+      core.info(`PR final #${pull.number}: base o head cambió antes de liberar el baseline.`);
+      continue;
+    }
+
+    const stableUrl = await ensureStableRelease(
+      github,
+      owner,
+      repo,
+      tagName,
+      stableTag.target,
+      pull.number,
+    );
+
+    await concludeBaseline(
+      github,
+      owner,
+      repo,
+      pullAtGate,
+      "success",
+      "Baseline de rollback listo",
+      `Tag: ${tagName}. Main previo: ${stableTag.target}. ${stableUrl}`,
+      core,
+    );
+    await enableAutoMerge(github, pullAtGate, core);
+    core.info(`PR final #${pull.number} listo para que GitHub complete el auto-merge.`);
+  }
+}
+
+async function reportFinalMerge(github, owner, repo, pull, core) {
+  const releaseDate = parseReleaseDate(pull.body);
+  if (!releaseDate) {
+    return;
+  }
+  const tagName = stableTagName(releaseDate);
+  let stableUrl = `https://github.com/${owner}/${repo}/tree/${tagName}`;
+  try {
+    const release = await github.rest.repos.getReleaseByTag({
+      owner,
+      repo,
+      tag: tagName,
+    });
+    stableUrl = release.data.html_url;
+  } catch (error) {
+    core.warning(`No se encontró release para ${tagName}: ${error.message}`);
+  }
+  await commentOnce(
+    github,
+    owner,
+    repo,
+    pull.number,
+    "<!-- release-final-merged -->",
+    [
+      `Promoción integrada en main: ${pull.merge_commit_sha || "SHA no informado"}.`,
+      `Tag de rollback: [${tagName}](${stableUrl}).`,
+      "El deploy queda pendiente de la aprobación del Environment production para el SHA vigente.",
+    ].join("\n"),
+  );
+}
+
+async function run({ github, context, core }) {
+  const { owner, repo } = context.repo;
+
+  if (context.eventName === "pull_request") {
+    const pull = context.payload.pull_request;
+    const repositoryFullName = `${owner}/${repo}`;
+    if (pull?.merged && isPreparationPullRequest(pull, repositoryFullName)) {
+      const finalNumber = parsePreparationFinalNumber(pull.body);
+      if (!pull.merge_commit_sha) {
+        throw new Error(`PR de preparación #${pull.number} no informa merge_commit_sha.`);
+      }
+      const finalPull = await getPull(github, owner, repo, finalNumber);
+      if (parseReleasePreparation(finalPull.body) !== pull.number) {
+        core.warning(
+          `PR de preparación #${pull.number} no coincide con el marker del PR final #${finalNumber}.`,
+        );
+        return;
+      }
+      await setFinalReleaseHead(github, owner, repo, finalNumber, pull.merge_commit_sha, core);
+      await armFinalForAutoMerge(github, owner, repo, finalNumber, core);
+      return;
+    }
+    if (pull?.merged && isScheduledFinalPullRequest(pull, repositoryFullName)) {
+      await reportFinalMerge(github, owner, repo, pull, core);
+    }
+    return;
+  }
+
+  if (context.eventName === "workflow_dispatch") {
+    const finalNumber = Number.parseInt(context.payload.inputs?.release_pr || "", 10);
+    if (!Number.isInteger(finalNumber) || finalNumber <= 0) {
+      throw new Error("workflow_dispatch requiere el input release_pr con el PR final.");
+    }
+    await armFinalForAutoMerge(github, owner, repo, finalNumber, core);
+    await processReadyFinalPullRequests(github, owner, repo, core);
+    return;
+  }
+
+  if (context.eventName === "workflow_run" || context.eventName === "schedule") {
+    await processDraftFinalPullRequests(github, owner, repo, core);
+    await processReadyFinalPullRequests(github, owner, repo, core);
+  }
+}
+
+module.exports = {
+  BASELINE_CHECK,
+  FINAL_RELEASE_MARKER,
+  PREPARATION_BRANCH_PATTERN,
+  REQUIRED_CHECKS,
+  isPreparationPullRequest,
+  isReleaseSnapshotCurrent,
+  isScheduledFinalPullRequest,
+  parsePreparationFinalNumber,
+  parseReleaseDate,
+  parseReleaseHead,
+  parseReleasePreparation,
+  requiredChecksState,
+  run,
+  stableTagName,
+};

--- a/.github/scripts/release_orchestrator.test.js
+++ b/.github/scripts/release_orchestrator.test.js
@@ -1,0 +1,125 @@
+"use strict";
+
+const assert = require("node:assert/strict");
+const test = require("node:test");
+
+const orchestrator = require("./release_orchestrator");
+
+const repositoryFullName = "dsocial118/SISOC";
+
+function pull(overrides = {}) {
+  return {
+    base: { ref: "main" },
+    head: { ref: "development", repo: { full_name: repositoryFullName } },
+    body: [
+      "<!-- release-automation: scheduled -->",
+      "<!-- release-date: 2026-07-29 -->",
+      "<!-- release-head: aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa -->",
+      "<!-- release-preparation: none -->",
+    ].join("\n"),
+    ...overrides,
+  };
+}
+
+test("reconoce un PR final programado y deriva su tag estable", () => {
+  const finalPull = pull({
+    head: {
+      ref: "development",
+      sha: "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+      repo: { full_name: repositoryFullName },
+    },
+  });
+
+  assert.equal(
+    orchestrator.isScheduledFinalPullRequest(finalPull, repositoryFullName),
+    true,
+  );
+  assert.equal(orchestrator.parseReleaseDate(finalPull.body), "2026-07-29");
+  assert.equal(
+    orchestrator.parseReleaseHead(finalPull.body),
+    "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+  );
+  assert.equal(orchestrator.isReleaseSnapshotCurrent(finalPull), true);
+  assert.equal(orchestrator.stableTagName("2026-07-29"), "2026.07.29-stable");
+});
+
+test("rechaza PRs finales que no tienen fecha de release valida", () => {
+  const invalid = pull({ body: "<!-- release-automation: scheduled -->\n<!-- release-date: 2026-02-31 -->\n<!-- release-head: aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa -->" });
+
+  assert.equal(orchestrator.parseReleaseDate(invalid.body), null);
+  assert.equal(
+    orchestrator.isScheduledFinalPullRequest(invalid, repositoryFullName),
+    false,
+  );
+});
+
+test("rechaza un PR final sin el SHA exacto del snapshot", () => {
+  const missingHead = pull({
+    body: "<!-- release-automation: scheduled -->\n<!-- release-date: 2026-07-29 -->",
+  });
+
+  assert.equal(
+    orchestrator.isScheduledFinalPullRequest(missingHead, repositoryFullName),
+    false,
+  );
+});
+
+test("acepta los estados controlados de preparación", () => {
+  assert.equal(orchestrator.parseReleasePreparation("<!-- release-preparation: pending -->"), "pending");
+  assert.equal(orchestrator.parseReleasePreparation("<!-- release-preparation: none -->"), "none");
+  assert.equal(orchestrator.parseReleasePreparation("<!-- release-preparation: 2140 -->"), 2140);
+});
+
+test("detecta cuando development avanzó después del snapshot", () => {
+  const stale = pull({
+    head: {
+      ref: "development",
+      sha: "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+      repo: { full_name: repositoryFullName },
+    },
+  });
+
+  assert.equal(orchestrator.isReleaseSnapshotCurrent(stale), false);
+});
+
+test("solo habilita preparaciones internas con el prefijo controlado", () => {
+  const preparation = pull({
+    base: { ref: "development" },
+    head: {
+      ref: "codex/predeploy-dev-main-20260729",
+      repo: { full_name: repositoryFullName },
+    },
+    body: "<!-- release-final-pr: 2140 -->",
+  });
+
+  assert.equal(orchestrator.parsePreparationFinalNumber(preparation.body), 2140);
+  assert.equal(
+    orchestrator.isPreparationPullRequest(preparation, repositoryFullName),
+    true,
+  );
+  assert.equal(
+    orchestrator.isPreparationPullRequest(
+      pull({
+        base: { ref: "development" },
+        head: { ref: "feature/unsafe", repo: { full_name: repositoryFullName } },
+        body: "<!-- release-final-pr: 2140 -->",
+      }),
+      repositoryFullName,
+    ),
+    false,
+  );
+});
+
+test("clasifica checks faltantes, pendientes y fallidos", () => {
+  const checks = [
+    { name: "deploy_guard", status: "completed", conclusion: "success" },
+    { name: "architecture_imports", status: "in_progress", conclusion: null },
+    { name: "gitleaks", status: "completed", conclusion: "success" },
+    { name: "sync_pr_artifacts", status: "completed", conclusion: "failure" },
+  ];
+
+  assert.deepEqual(orchestrator.requiredChecksState(checks), {
+    pending: ["architecture_imports"],
+    failed: ["sync_pr_artifacts (failure)"],
+  });
+});

--- a/.github/workflows/architecture.yml
+++ b/.github/workflows/architecture.yml
@@ -5,10 +5,12 @@ on:
         branches:
             - main
             - development
+            - homologacion
     push:
         branches:
             - main
             - development
+            - homologacion
 
 permissions:
     contents: read

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -23,6 +23,7 @@ jobs:
               shell: bash
               env:
                   GH_APP_ROOT: "${{ vars.APP_ROOT }}"
+                  EXPECTED_SHA: "${{ github.sha }}"
               run: |
                   set -Eeuo pipefail
 
@@ -33,8 +34,28 @@ jobs:
                   fi
 
                   cd "$APP_ROOT"
+                  git -C "$APP_ROOT" fetch origin --prune
+                  remote_sha="$(git -C "$APP_ROOT" rev-parse origin/development)"
+                  if [[ "$remote_sha" != "$EXPECTED_SHA" ]]; then
+                      {
+                          echo "### Deploy QA omitido por revision obsoleta"
+                          echo "- Evento: \`$EXPECTED_SHA\`"
+                          echo "- origin/development actual: \`$remote_sha\`"
+                      } >> "$GITHUB_STEP_SUMMARY"
+                      exit 0
+                  fi
                   echo "Commit previo al deploy para rollback: $(git rev-parse HEAD)"
-                  ./scripts/operacion/deploy_refresh.sh --yes
+                  ./scripts/operacion/deploy_refresh.sh --yes --expected-revision "$EXPECTED_SHA"
+                  docker compose -f "$APP_ROOT/docker-compose.deploy.yml" --project-directory "$APP_ROOT" exec -T django python manage.py migrate --check
+                  bash "$APP_ROOT/scripts/infra/healthcheck_qa.sh"
+                  deployed_sha="$(git -C "$APP_ROOT" rev-parse HEAD)"
+                  [[ "$deployed_sha" == "$EXPECTED_SHA" ]]
+                  {
+                      echo "### Deploy QA verificado"
+                      echo "- Revision desplegada: \`$deployed_sha\`"
+                      echo "- Migraciones: \`migrate --check\` OK"
+                      echo "- Health: \`healthcheck_qa.sh\` OK"
+                  } >> "$GITHUB_STEP_SUMMARY"
 
     deploy-homologacion:
         if: github.ref == 'refs/heads/homologacion'
@@ -46,6 +67,7 @@ jobs:
               shell: bash
               env:
                   GH_APP_ROOT: "${{ vars.APP_ROOT }}"
+                  EXPECTED_SHA: "${{ github.sha }}"
                   GIT_CONFIG_COUNT: "1"
                   GIT_CONFIG_KEY_0: safe.directory
                   GIT_CONFIG_VALUE_0: /sisoc/SISOC-Mobile
@@ -59,9 +81,29 @@ jobs:
                   fi
 
                   cd "$APP_ROOT"
+                  git -C "$APP_ROOT" fetch origin --prune
+                  remote_sha="$(git -C "$APP_ROOT" rev-parse origin/homologacion)"
+                  if [[ "$remote_sha" != "$EXPECTED_SHA" ]]; then
+                      {
+                          echo "### Deploy HML omitido por revision obsoleta"
+                          echo "- Evento: \`$EXPECTED_SHA\`"
+                          echo "- origin/homologacion actual: \`$remote_sha\`"
+                      } >> "$GITHUB_STEP_SUMMARY"
+                      exit 0
+                  fi
                   git -C /sisoc/SISOC-Mobile update-index --refresh
                   echo "Commit previo al deploy para rollback: $(git rev-parse HEAD)"
-                  ./scripts/operacion/deploy_refresh.sh --yes --with-mobile --mobile-dir /sisoc/SISOC-Mobile
+                  ./scripts/operacion/deploy_refresh.sh --yes --expected-revision "$EXPECTED_SHA" --with-mobile --mobile-dir /sisoc/SISOC-Mobile
+                  docker compose -f "$APP_ROOT/docker-compose.deploy.yml" -f "$APP_ROOT/docker-compose.produccion.yml" --project-directory "$APP_ROOT" exec -T django python manage.py migrate --check
+                  bash "$APP_ROOT/scripts/infra/healthcheck_hml.sh"
+                  deployed_sha="$(git -C "$APP_ROOT" rev-parse HEAD)"
+                  [[ "$deployed_sha" == "$EXPECTED_SHA" ]]
+                  {
+                      echo "### Deploy HML verificado"
+                      echo "- Revision desplegada: \`$deployed_sha\`"
+                      echo "- Migraciones: \`migrate --check\` OK"
+                      echo "- Health: \`healthcheck_hml.sh\` OK"
+                  } >> "$GITHUB_STEP_SUMMARY"
 
     deploy-produccion:
         if: github.ref == 'refs/heads/main'
@@ -73,6 +115,7 @@ jobs:
               shell: bash
               env:
                   GH_APP_ROOT: "${{ vars.APP_ROOT }}"
+                  EXPECTED_SHA: "${{ github.sha }}"
               run: |
                   set -Eeuo pipefail
 
@@ -83,5 +126,26 @@ jobs:
                   fi
 
                   cd "$APP_ROOT"
+                  git -C "$APP_ROOT" fetch origin --prune
+                  remote_sha="$(git -C "$APP_ROOT" rev-parse origin/main)"
+                  if [[ "$remote_sha" != "$EXPECTED_SHA" ]]; then
+                      {
+                          echo "### Deploy produccion omitido por revision obsoleta"
+                          echo "- Evento aprobado: \`$EXPECTED_SHA\`"
+                          echo "- origin/main actual: \`$remote_sha\`"
+                          echo "- Accion requerida: aprobar el job del commit actual."
+                      } >> "$GITHUB_STEP_SUMMARY"
+                      exit 0
+                  fi
                   echo "Commit previo al deploy para rollback: $(git rev-parse HEAD)"
-                  ./scripts/operacion/deploy_refresh.sh --yes --with-mobile --mobile-dir /sisoc/SISOC-Mobile
+                  ./scripts/operacion/deploy_refresh.sh --yes --expected-revision "$EXPECTED_SHA" --with-mobile --mobile-dir /sisoc/SISOC-Mobile
+                  docker compose -f "$APP_ROOT/docker-compose.deploy.yml" -f "$APP_ROOT/docker-compose.produccion.yml" --project-directory "$APP_ROOT" exec -T django python manage.py migrate --check
+                  bash "$APP_ROOT/scripts/infra/healthcheck_prod.sh"
+                  deployed_sha="$(git -C "$APP_ROOT" rev-parse HEAD)"
+                  [[ "$deployed_sha" == "$EXPECTED_SHA" ]]
+                  {
+                      echo "### Deploy produccion verificado"
+                      echo "- Revision desplegada: \`$deployed_sha\`"
+                      echo "- Migraciones: \`migrate --check\` OK"
+                      echo "- Health: \`healthcheck_prod.sh\` OK"
+                  } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -5,10 +5,12 @@ on:
         branches:
             - main
             - development
+            - homologacion
     push:
         branches:
             - main
             - development
+            - homologacion
 
 permissions:
     contents: read
@@ -23,19 +25,34 @@ jobs:
         permissions:
             contents: write
         steps:
+            - name: Determinar si la rama admite autofix
+              id: eligibility
+              shell: bash
+              run: |
+                  if [[ "${{ github.event_name }}" == "pull_request" \
+                    && "${{ github.event.pull_request.head.repo.full_name }}" == "${{ github.repository }}" \
+                    && "${{ github.event.pull_request.head.ref }}" != "development" \
+                    && "${{ github.event.pull_request.head.ref }}" != "homologacion" \
+                    && "${{ github.event.pull_request.head.ref }}" != "main" ]]; then
+                      echo "enabled=true" >> "$GITHUB_OUTPUT"
+                  else
+                      echo "enabled=false" >> "$GITHUB_OUTPUT"
+                  fi
+
             - name: Checkout PR head branch
-              if: github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository
+              if: steps.eligibility.outputs.enabled == 'true'
               uses: actions/checkout@v6.0.2
               with:
                   fetch-depth: 0
                   ref: ${{ github.event.pull_request.head.ref }}
 
-            - name: Skip autofix outside internal pull requests
-              if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name != github.repository
-              run: echo "Autofix solo habilitado para pull requests del mismo repositorio."
+            - name: Omitir autofix para ramas protegidas o externas
+              if: steps.eligibility.outputs.enabled != 'true'
+              run: |
+                  echo "Autofix omitido: solo se permiten branches internas no protegidas."
 
             - name: Set up Python
-              if: github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository
+              if: steps.eligibility.outputs.enabled == 'true'
               uses: actions/setup-python@v6.2.0
               with:
                   python-version: '3.11.15'
@@ -43,23 +60,23 @@ jobs:
                   cache-dependency-path: requirements/lint.txt
 
             - name: Install autofix dependencies
-              if: github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository
+              if: steps.eligibility.outputs.enabled == 'true'
               run: |
                   python -m pip install --upgrade pip
                   pip install -r requirements/lint.txt
 
             - name: Detect changed Python files
               id: detect-changed-python
-              if: github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository
+              if: steps.eligibility.outputs.enabled == 'true'
               run: echo "files=$(python scripts/ci/pr_lint_tools.py changed-files --kind python)" >> "$GITHUB_OUTPUT"
 
             - name: Detect changed templates
               id: detect-changed-templates
-              if: github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository
+              if: steps.eligibility.outputs.enabled == 'true'
               run: echo "files=$(python scripts/ci/pr_lint_tools.py changed-files --kind templates)" >> "$GITHUB_OUTPUT"
 
             - name: Run Black autofix
-              if: github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository && steps.detect-changed-python.outputs.files != '[]'
+              if: steps.eligibility.outputs.enabled == 'true' && steps.detect-changed-python.outputs.files != '[]'
               run: |
                   python - <<'PY'
                   import json
@@ -77,7 +94,7 @@ jobs:
                   PYTHON_FILES_JSON: ${{ steps.detect-changed-python.outputs.files }}
 
             - name: Run DJLint autofix
-              if: github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository && steps.detect-changed-templates.outputs.files != '[]'
+              if: steps.eligibility.outputs.enabled == 'true' && steps.detect-changed-templates.outputs.files != '[]'
               run: |
                   python - <<'PY'
                   import json
@@ -107,11 +124,11 @@ jobs:
                   TEMPLATE_FILES_JSON: ${{ steps.detect-changed-templates.outputs.files }}
 
             - name: Normalize mojibake in changed text files
-              if: github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository
+              if: steps.eligibility.outputs.enabled == 'true'
               run: python scripts/ci/pr_lint_tools.py fix-encoding
 
             - name: Commit and push autofix
-              if: github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository
+              if: steps.eligibility.outputs.enabled == 'true'
               run: |
                   if git diff --quiet; then
                       echo "No hubo cambios automaticos para commitear."

--- a/.github/workflows/pr-docs.yml
+++ b/.github/workflows/pr-docs.yml
@@ -13,6 +13,7 @@ on:
             - edited
         branches:
             - development
+            - homologacion
             - main
 
 jobs:
@@ -38,7 +39,7 @@ jobs:
               run: python scripts/ci/pr_doc_automation.py
 
             - name: Reportar artefactos para ramas protegidas
-              if: github.event.pull_request.head.repo.full_name == github.repository && (github.event.pull_request.head.ref == 'development' || github.event.pull_request.head.ref == 'main')
+              if: github.event.pull_request.head.repo.full_name == github.repository && (github.event.pull_request.head.ref == 'development' || github.event.pull_request.head.ref == 'homologacion' || github.event.pull_request.head.ref == 'main')
               run: |
                   if git diff --quiet -- docs/registro/prs docs/contexto/features docs/registro/releases/pending CHANGELOG.md; then
                     echo "No hay cambios generados para reportar."
@@ -56,7 +57,7 @@ jobs:
                   } >> "$GITHUB_STEP_SUMMARY"
 
             - name: Commit automatico de artefactos
-              if: github.event.pull_request.head.repo.full_name == github.repository && github.event.pull_request.head.ref != 'development' && github.event.pull_request.head.ref != 'main'
+              if: github.event.pull_request.head.repo.full_name == github.repository && github.event.pull_request.head.ref != 'development' && github.event.pull_request.head.ref != 'homologacion' && github.event.pull_request.head.ref != 'main'
               run: |
                   if git diff --quiet -- docs/registro/prs docs/contexto/features docs/registro/releases/pending CHANGELOG.md; then
                     echo "No hay cambios generados para commitear."

--- a/.github/workflows/release-orchestrator.yml
+++ b/.github/workflows/release-orchestrator.yml
@@ -26,10 +26,7 @@ on:
             - completed
 
 permissions:
-    checks: write
-    contents: write
-    issues: write
-    pull-requests: write
+    contents: read
 
 concurrency:
     group: release-orchestrator
@@ -38,6 +35,9 @@ concurrency:
 jobs:
     orchestrate:
         runs-on: ubuntu-latest
+        env:
+            RELEASE_AUTOMATION_APP_CLIENT_ID: ${{ vars.RELEASE_AUTOMATION_APP_CLIENT_ID }}
+            RELEASE_AUTOMATION_APP_PRIVATE_KEY_PRESENT: ${{ secrets.RELEASE_AUTOMATION_APP_PRIVATE_KEY != '' }}
 
         steps:
             - name: Checkout de la automatizacion versionada
@@ -46,16 +46,33 @@ jobs:
                   ref: development
                   persist-credentials: false
 
+            - name: Validar GitHub App de automatizacion
+              if: ${{ env.RELEASE_AUTOMATION_APP_CLIENT_ID == '' || env.RELEASE_AUTOMATION_APP_PRIVATE_KEY_PRESENT != 'true' }}
+              run: |
+                  echo "SETUP_BLOCKED: faltan RELEASE_AUTOMATION_APP_CLIENT_ID (variable) o RELEASE_AUTOMATION_APP_PRIVATE_KEY (secret)."
+                  exit 1
+
+            - name: Generar token temporal de GitHub App
+              id: app-token
+              uses: actions/create-github-app-token@v3
+              with:
+                  client-id: ${{ vars.RELEASE_AUTOMATION_APP_CLIENT_ID }}
+                  private-key: ${{ secrets.RELEASE_AUTOMATION_APP_PRIVATE_KEY }}
+                  permission-checks: write
+                  permission-contents: write
+                  permission-issues: write
+                  permission-pull-requests: write
+
             - name: Evaluar preparaciones y promociones pendientes
               uses: actions/github-script@v8
               env:
-                  RELEASE_AUTOMATION_TOKEN_PRESENT: ${{ secrets.RELEASE_AUTOMATION_TOKEN != '' }}
+                  RELEASE_AUTOMATION_APP_TOKEN_PRESENT: ${{ steps.app-token.outputs.token != '' }}
               with:
-                  github-token: ${{ secrets.RELEASE_AUTOMATION_TOKEN || github.token }}
+                  github-token: ${{ steps.app-token.outputs.token }}
                   script: |
-                      if (process.env.RELEASE_AUTOMATION_TOKEN_PRESENT !== "true") {
+                      if (process.env.RELEASE_AUTOMATION_APP_TOKEN_PRESENT !== "true") {
                         core.setFailed(
-                          "SETUP_BLOCKED: falta el secret RELEASE_AUTOMATION_TOKEN para disparar eventos posteriores a los merges.",
+                          "SETUP_BLOCKED: no se pudo generar el token temporal de la GitHub App de automatizacion.",
                         );
                         return;
                       }

--- a/.github/workflows/release-orchestrator.yml
+++ b/.github/workflows/release-orchestrator.yml
@@ -1,0 +1,63 @@
+name: Orquestar promocion automatica de release
+
+on:
+    schedule:
+        - cron: "47 * * * *"
+    workflow_dispatch:
+        inputs:
+            release_pr:
+                description: Numero del PR final development -> main que debe pasar a ready
+                required: true
+                type: string
+    pull_request:
+        types:
+            - closed
+        branches:
+            - development
+    workflow_run:
+        workflows:
+            - Tests automatizados
+            - Formateo y linteo
+            - Arquitectura (imports)
+            - Escaneo de secretos
+            - Documentacion automatica de PR
+            - Sanity de release
+        types:
+            - completed
+
+permissions:
+    checks: write
+    contents: write
+    issues: write
+    pull-requests: write
+
+concurrency:
+    group: release-orchestrator
+    cancel-in-progress: false
+
+jobs:
+    orchestrate:
+        runs-on: ubuntu-latest
+
+        steps:
+            - name: Checkout de la automatizacion versionada
+              uses: actions/checkout@v6.0.2
+              with:
+                  ref: development
+                  persist-credentials: false
+
+            - name: Evaluar preparaciones y promociones pendientes
+              uses: actions/github-script@v8
+              env:
+                  RELEASE_AUTOMATION_TOKEN_PRESENT: ${{ secrets.RELEASE_AUTOMATION_TOKEN != '' }}
+              with:
+                  github-token: ${{ secrets.RELEASE_AUTOMATION_TOKEN || github.token }}
+                  script: |
+                      if (process.env.RELEASE_AUTOMATION_TOKEN_PRESENT !== "true") {
+                        core.setFailed(
+                          "SETUP_BLOCKED: falta el secret RELEASE_AUTOMATION_TOKEN para disparar eventos posteriores a los merges.",
+                        );
+                        return;
+                      }
+                      const { run } = require(`${process.env.GITHUB_WORKSPACE}/.github/scripts/release_orchestrator.js`);
+                      await run({ github, context, core });

--- a/.github/workflows/secrets.yml
+++ b/.github/workflows/secrets.yml
@@ -5,10 +5,12 @@ on:
         branches:
             - main
             - development
+            - homologacion
     push:
         branches:
             - main
             - development
+            - homologacion
 
 jobs:
     gitleaks:

--- a/.github/workflows/sync-main-downstream.yml
+++ b/.github/workflows/sync-main-downstream.yml
@@ -9,8 +9,7 @@ on:
     workflow_dispatch:
 
 permissions:
-    contents: write
-    pull-requests: write
+    contents: read
 
 concurrency:
     group: sync-main-downstream
@@ -19,18 +18,36 @@ concurrency:
 jobs:
     sync:
         runs-on: ubuntu-latest
+        env:
+            RELEASE_AUTOMATION_APP_CLIENT_ID: ${{ vars.RELEASE_AUTOMATION_APP_CLIENT_ID }}
+            RELEASE_AUTOMATION_APP_PRIVATE_KEY_PRESENT: ${{ secrets.RELEASE_AUTOMATION_APP_PRIVATE_KEY != '' }}
 
         steps:
+            - name: Validar GitHub App de automatizacion
+              if: ${{ env.RELEASE_AUTOMATION_APP_CLIENT_ID == '' || env.RELEASE_AUTOMATION_APP_PRIVATE_KEY_PRESENT != 'true' }}
+              run: |
+                  echo "SETUP_BLOCKED: faltan RELEASE_AUTOMATION_APP_CLIENT_ID (variable) o RELEASE_AUTOMATION_APP_PRIVATE_KEY (secret)."
+                  exit 1
+
+            - name: Generar token temporal de GitHub App
+              id: app-token
+              uses: actions/create-github-app-token@v3
+              with:
+                  client-id: ${{ vars.RELEASE_AUTOMATION_APP_CLIENT_ID }}
+                  private-key: ${{ secrets.RELEASE_AUTOMATION_APP_PRIVATE_KEY }}
+                  permission-contents: write
+                  permission-pull-requests: write
+
             - name: Armar sincronización descendente con auto-merge nativo
               uses: actions/github-script@v8
               env:
-                  RELEASE_AUTOMATION_TOKEN_PRESENT: ${{ secrets.RELEASE_AUTOMATION_TOKEN != '' }}
+                  RELEASE_AUTOMATION_APP_TOKEN_PRESENT: ${{ steps.app-token.outputs.token != '' }}
               with:
-                  github-token: ${{ secrets.RELEASE_AUTOMATION_TOKEN || github.token }}
+                  github-token: ${{ steps.app-token.outputs.token }}
                   script: |
-                      if (process.env.RELEASE_AUTOMATION_TOKEN_PRESENT !== "true") {
+                      if (process.env.RELEASE_AUTOMATION_APP_TOKEN_PRESENT !== "true") {
                         core.setFailed(
-                          "SETUP_BLOCKED: falta el secret RELEASE_AUTOMATION_TOKEN para crear PRs que disparen CI sin aprobación manual.",
+                          "SETUP_BLOCKED: no se pudo generar el token temporal de la GitHub App de automatizacion.",
                         );
                         return;
                       }

--- a/.github/workflows/sync-main-downstream.yml
+++ b/.github/workflows/sync-main-downstream.yml
@@ -9,7 +9,6 @@ on:
     workflow_dispatch:
 
 permissions:
-    actions: write
     contents: write
     pull-requests: write
 
@@ -22,20 +21,44 @@ jobs:
         runs-on: ubuntu-latest
 
         steps:
-            - name: Integrar main y desplegar ramas inferiores
+            - name: Armar sincronización descendente con auto-merge nativo
               uses: actions/github-script@v8
+              env:
+                  RELEASE_AUTOMATION_TOKEN_PRESENT: ${{ secrets.RELEASE_AUTOMATION_TOKEN != '' }}
               with:
+                  github-token: ${{ secrets.RELEASE_AUTOMATION_TOKEN || github.token }}
                   script: |
+                      if (process.env.RELEASE_AUTOMATION_TOKEN_PRESENT !== "true") {
+                        core.setFailed(
+                          "SETUP_BLOCKED: falta el secret RELEASE_AUTOMATION_TOKEN para crear PRs que disparen CI sin aprobación manual.",
+                        );
+                        return;
+                      }
                       const owner = context.repo.owner;
                       const repo = context.repo.repo;
                       const targets = ["development", "homologacion"];
                       const failures = [];
-                      const sleep = (milliseconds) =>
-                        new Promise((resolve) => setTimeout(resolve, milliseconds));
+
+                      const enableAutoMerge = async (pull) => {
+                        if (pull.auto_merge) {
+                          core.info(`PR #${pull.number} ya tiene auto-merge habilitado.`);
+                          return;
+                        }
+                        await github.graphql(
+                          `mutation EnableAutoMerge($pullRequestId: ID!) {
+                            enablePullRequestAutoMerge(
+                              input: { pullRequestId: $pullRequestId, mergeMethod: MERGE }
+                            ) {
+                              pullRequest { autoMergeRequest { enabledAt mergeMethod } }
+                            }
+                          }`,
+                          { pullRequestId: pull.node_id },
+                        );
+                        core.info(`PR #${pull.number} armado para auto-merge nativo.`);
+                      };
 
                       for (const target of targets) {
                         core.startGroup(`Sincronizar main -> ${target}`);
-
                         try {
                           const comparison = await github.rest.repos.compareCommits({
                             owner,
@@ -43,13 +66,12 @@ jobs:
                             base: "main",
                             head: target,
                           });
-
                           if (comparison.data.behind_by === 0) {
                             core.info(`${target} ya contiene todo main; no hay cambios.`);
                             continue;
                           }
 
-                          let pulls = await github.rest.pulls.list({
+                          const pulls = await github.rest.pulls.list({
                             owner,
                             repo,
                             state: "open",
@@ -58,7 +80,6 @@ jobs:
                             per_page: 10,
                           });
                           let pull = pulls.data[0];
-
                           if (!pull) {
                             const created = await github.rest.pulls.create({
                               owner,
@@ -67,11 +88,11 @@ jobs:
                               head: "main",
                               title: `chore(sync): integrar main en ${target}`,
                               body: [
-                                "Sincronizacion descendente automatica.",
+                                "Sincronización descendente automática.",
                                 "",
                                 "- Conserva los cambios exclusivos de la rama destino.",
                                 "- No escribe ni promueve cambios hacia `main`.",
-                                "- Si hay conflictos, este PR queda abierto y el deploy se bloquea.",
+                                "- GitHub hará el merge solo cuando los requisitos de la ruleset estén verdes.",
                               ].join("\n"),
                             });
                             pull = created.data;
@@ -80,72 +101,17 @@ jobs:
                             core.info(`Reutilizando PR #${pull.number}: ${pull.html_url}`);
                           }
 
-                          let mergeable = null;
-                          for (let attempt = 1; attempt <= 12; attempt += 1) {
-                            const current = await github.rest.pulls.get({
+                          pull = (
+                            await github.rest.pulls.get({
                               owner,
                               repo,
                               pull_number: pull.number,
-                            });
-                            pull = current.data;
-                            mergeable = pull.mergeable;
-                            if (mergeable !== null) {
-                              break;
-                            }
-                            core.info(`GitHub aun calcula mergeabilidad (${attempt}/12).`);
-                            await sleep(5000);
-                          }
-
-                          if (mergeable !== true) {
-                            throw new Error(
-                              `PR #${pull.number} no es integrable sin intervencion: ${pull.html_url}`,
-                            );
-                          }
-
-                          const merged = await github.rest.pulls.merge({
-                            owner,
-                            repo,
-                            pull_number: pull.number,
-                            sha: pull.head.sha,
-                            merge_method: "merge",
-                            commit_title: `Merge main into ${target}`,
-                            commit_message: "Sincronizacion descendente automatica del Plan A.",
-                          });
-
-                          if (!merged.data.merged) {
-                            throw new Error(
-                              `GitHub rechazo el merge del PR #${pull.number}: ${merged.data.message}`,
-                            );
-                          }
-
-                          core.info(`PR #${pull.number} integrado en ${target}.`);
-                          let dispatched = false;
-                          for (let attempt = 1; attempt <= 3; attempt += 1) {
-                            try {
-                              await github.rest.actions.createWorkflowDispatch({
-                                owner,
-                                repo,
-                                workflow_id: "deploy.yml",
-                                ref: target,
-                              });
-                              dispatched = true;
-                              break;
-                            } catch (error) {
-                              core.warning(
-                                `Dispatch ${target} fallo (${attempt}/3): ${error.message}`,
-                              );
-                              if (attempt < 3) {
-                                await sleep(5000);
-                              }
-                            }
-                          }
-
-                          if (!dispatched) {
-                            throw new Error(
-                              `No se pudo solicitar deploy para ${target} tras integrar el PR.`,
-                            );
-                          }
-                          core.info(`Deploy solicitado explicitamente para ${target}.`);
+                            })
+                          ).data;
+                          await enableAutoMerge(pull);
+                          core.info(
+                            `GitHub esperará CI y fusionará #${pull.number}; el push resultante activa el deploy del destino.`,
+                          );
                         } catch (error) {
                           failures.push(`${target}: ${error.message}`);
                           core.error(`${target}: ${error.stack ?? error.message}`);

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -8,10 +8,12 @@ on:
     pull_request:
         branches:
             - development
+            - homologacion
             - main
     push:
         branches:
             - development
+            - homologacion
             - main
 
 jobs:
@@ -181,6 +183,87 @@ jobs:
               if: always()
               run: docker compose down -v
 
+    release_quality:
+        if: github.event_name == 'pull_request'
+        runs-on: ubuntu-latest
+
+        steps:
+            - name: Validar evidencia de calidad del pre-deploy
+              uses: actions/github-script@v8
+              with:
+                  script: |
+                      const body = context.payload.pull_request?.body || "";
+                      const missing = [];
+                      const hasTextInSection = (heading) => {
+                        const escaped = heading.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+                        const section = new RegExp(
+                          `^## ${escaped}\\s*\\n([\\s\\S]*?)(?=^## |(?![\\s\\S]))`,
+                          "m",
+                        ).exec(body);
+                        return Boolean(section && section[1].trim());
+                      };
+                      const finalRelease = /<!--\s*release-automation:\s*scheduled\s*-->/i.test(body);
+                      const preparation = /<!--\s*release-final-pr:\s*\d+\s*-->/i.test(body);
+
+                      if (!finalRelease && !preparation) {
+                        core.info("PR fuera del flujo de release automatizado.");
+                        return;
+                      }
+
+                      if (finalRelease) {
+                        if (!/<!--\s*release-date:\s*\d{4}-\d{2}-\d{2}\s*-->/i.test(body)) {
+                          missing.push("marker release-date");
+                        }
+                        if (!/<!--\s*release-head:\s*[0-9a-f]{40}\s*-->/i.test(body)) {
+                          missing.push("marker release-head");
+                        }
+                        if (!/<!--\s*release-preparation:\s*(pending|none|\d+)\s*-->/i.test(body)) {
+                          missing.push("marker release-preparation");
+                        }
+                        for (const heading of [
+                          "Resumen ejecutivo",
+                          "Riesgos bloqueantes",
+                          "Riesgos no bloqueantes",
+                          "Pruebas ejecutadas y resultado",
+                          "Compatibilidad hacia atrás",
+                          "Recomendación final GO/NO-GO con justificación",
+                          "Impacto por módulos",
+                          "Supuestos explícitos",
+                          "Rollback / consideraciones operativas",
+                        ]) {
+                          if (!hasTextInSection(heading)) {
+                            missing.push(`seccion ${heading}`);
+                          }
+                        }
+                      }
+
+                      if (preparation) {
+                        const functionalFix = /<!--\s*release-functional-fix:\s*(true|false)\s*-->/i.exec(body);
+                        if (!functionalFix) {
+                          missing.push("marker release-functional-fix");
+                        } else if (functionalFix[1].toLowerCase() === "true") {
+                          for (const heading of [
+                            "Causa raíz confirmada",
+                            "Prueba de regresión",
+                            "Revisión de calidad",
+                          ]) {
+                            if (!hasTextInSection(heading)) {
+                              missing.push(`seccion ${heading}`);
+                            }
+                          }
+                        } else if (!hasTextInSection("Validación del saneamiento")) {
+                          missing.push("seccion Validación del saneamiento");
+                        }
+                      }
+
+                      if (missing.length > 0) {
+                        core.setFailed(
+                          `El pre-deploy no aporta evidencia suficiente: ${missing.join(", ")}`,
+                        );
+                        return;
+                      }
+                      core.info("Evidencia de calidad de release verificada.");
+
     deploy_guard:
         if: github.event_name == 'pull_request'
         runs-on: ubuntu-latest
@@ -189,9 +272,10 @@ jobs:
             - migrations_check
             - pytest
             - mysql_compat
+            - release_quality
         steps:
             - name: Validate required CI checks
-              uses: actions/github-script@v7
+              uses: actions/github-script@v8
               with:
                   script: |
                       const baseRef = context.payload.pull_request?.base?.ref ?? "";
@@ -205,6 +289,7 @@ jobs:
                         "pytest",
                         "migrations_check",
                         "mysql_compat",
+                        "release_quality",
                       ];
                       if (baseRef === "main") {
                         required.push("release_sanity");

--- a/AGENT_REPO_MAP.md
+++ b/AGENT_REPO_MAP.md
@@ -472,6 +472,9 @@ La siguiente tabla mezcla hechos observados con inferencias explicitas cuando no
 - `.github/workflows/release-orchestrator.yml`
 - `.github/workflows/sync-main-downstream.yml`
 - `.github/workflows/deploy.yml`
+- La automatización de promociones usa una GitHub App privada: variable
+  `RELEASE_AUTOMATION_APP_CLIENT_ID` y secret
+  `RELEASE_AUTOMATION_APP_PRIVATE_KEY`; no sustituirla por un PAT.
 - `.importlinter`
 - `scripts/ci/pr_lint_tools.py`, `scripts/ci/pr_doc_automation.py`
 

--- a/AGENT_REPO_MAP.md
+++ b/AGENT_REPO_MAP.md
@@ -61,7 +61,7 @@ Mapa practico del repositorio `SISOC` para futuros agentes de IA y desarrollador
 | Docker Compose para local | Hecho observado | `docker-compose.yml` |
 | Compose separado para deploy | Hecho observado | `docker-compose.deploy.yml`, `docker-compose.produccion.yml` |
 | GitHub Actions para lint/tests/arquitectura/release sanity | Hecho observado | `.github/workflows/` |
-| Plan A descendente con autoaprobacion acotada | Hecho observado | `.github/workflows/sync-main-downstream.yml`, `docs/operacion/deploy_automatizado.md` |
+| Promoción event-driven y sincronización descendente con gates | Hecho observado | `.github/workflows/release-orchestrator.yml`, `.github/workflows/sync-main-downstream.yml`, `docs/operacion/deploy_automatizado.md` |
 | Helpers de Codex/worktrees | Hecho observado | `scripts/ai/`, `.codex/environments/environment.toml` |
 
 ## Que tipo de proyecto es
@@ -100,7 +100,7 @@ Mapa practico del repositorio `SISOC` para futuros agentes de IA y desarrollador
 - `scripts/ai/codex_task.ps1 <slug>`: crea branch `codex/<slug>`, worktree en `../worktrees/<slug>` y bootstrap.
 - `scripts/ai/codex_run.ps1 up`: bootstrap + levantar entorno.
 - `scripts/ai/codex_run.ps1 validate`: corre `black`, `djlint`, smoke tests y `makemigrations --check`.
-- `scripts/operacion/deploy_refresh.sh`: refresh operativo de deploy.
+- `scripts/operacion/deploy_refresh.sh`: refresh operativo de deploy; acepta un SHA esperado para bloquear una revisión obsoleta antes del downtime.
 
 ## Estructura general del proyecto
 
@@ -469,8 +469,11 @@ La siguiente tabla mezcla hechos observados con inferencias explicitas cuando no
 - `.github/workflows/lint.yml`
 - `.github/workflows/architecture.yml`
 - `.github/workflows/release-sanity.yml`
+- `.github/workflows/release-orchestrator.yml`
+- `.github/workflows/sync-main-downstream.yml`
+- `.github/workflows/deploy.yml`
 - `.importlinter`
-- `scripts/ci/pr_lint_tools.py`
+- `scripts/ci/pr_lint_tools.py`, `scripts/ci/pr_doc_automation.py`
 
 ## Testing, linting, build y deploy
 
@@ -502,7 +505,7 @@ La siguiente tabla mezcla hechos observados con inferencias explicitas cuando no
 | migraciones/modelos | `makemigrations --check --dry-run` + tests del flujo |
 | config global | smoke + `manage.py check` |
 | import boundaries | `lint-imports` si metiste imports nuevos entre apps |
-| release/main | agregar `check --deploy`, `spectacular --validate`, `collectstatic` |
+| release/main | agregar `check --deploy`, `spectacular --validate`, `collectstatic`, gates del PR y baseline `AAAA.MM.DD-stable` |
 
 ### Build/deploy
 
@@ -699,6 +702,9 @@ Marcar esas zonas como `A inferir` hasta relevarlas cuando una tarea real las to
 - `.github/workflows/lint.yml`
 - `.github/workflows/architecture.yml`
 - `.github/workflows/release-sanity.yml`
+- `.github/workflows/release-orchestrator.yml`
+- `.github/workflows/sync-main-downstream.yml`
+- `.github/workflows/deploy.yml`
 - `scripts/ai/codex_run.ps1`
 - `scripts/ai/codex_task.ps1`
 - `.codex/environments/environment.toml`

--- a/docs/operacion/deploy_automatizado.md
+++ b/docs/operacion/deploy_automatizado.md
@@ -17,12 +17,17 @@ correspondiente. El runner local:
 
 1. resuelve `APP_ROOT` desde la variable del Environment;
 2. entra al checkout provisionado en el servidor;
-3. registra `git rev-parse HEAD` como referencia previa de rollback;
-4. ejecuta `./scripts/operacion/deploy_refresh.sh --yes`.
+3. verifica que `origin/<branch>` siga siendo el SHA exacto que disparó el
+   workflow, antes de bajar Docker;
+4. registra `git rev-parse HEAD` como referencia previa de rollback y ejecuta
+   `deploy_refresh.sh --expected-revision <SHA>`;
+5. prueba `migrate --check`, el healthcheck específico del entorno y registra
+   el SHA realmente desplegado en el summary del job.
 
 El script existente conserva las validaciones operativas: lee `ENVIRONMENT`
 desde `.env`, valida branch esperada, ejecuta `docker compose config -q`, baja
-el stack sin volumenes, hace `git pull --ff-only` y levanta con `up -d --build`.
+el stack sin volumenes, hace `git fetch` y un `merge --ff-only` de la referencia
+ya verificada, y levanta con `up -d --build`.
 Cuando incluye SISOC-Mobile, valida que `origin` sea el repositorio publico
 esperado y normaliza las variantes SSH conocidas a HTTPS antes del downtime.
 
@@ -35,15 +40,43 @@ invariante:
 - `homologacion` contiene todo `main` y puede tener extras de HML;
 - `main` no recibe los extras de esas ramas por este mecanismo.
 
-Ante cada push a `main`, y tambien como reconciliacion horaria, el workflow abre
-o reutiliza PRs `main -> development` y `main -> homologacion`. Solo los integra
-si GitHub confirma que no hay conflictos. En ramas que exigen revision, el
-`GITHUB_TOKEN` aprueba exclusivamente ese PR descendente antes de integrarlo;
-el repositorio debe permitir que Actions cree y apruebe pull requests. Luego
-invoca `deploy.yml` de forma explicita sobre la rama actualizada.
+Ante cada push a `main`, y también como reconciliación horaria, el workflow abre
+o reutiliza PRs `main -> development` y `main -> homologacion`, y habilita
+auto-merge nativo. GitHub los integra únicamente cuando los checks requeridos
+por la ruleset están verdes y no hay conflictos. El push resultante activa un
+único deploy de la rama actualizada; no se hace un dispatch adicional.
 
 Un conflicto deja el PR abierto, falla el job y no despliega ese entorno. No se
-usa force push, rebase automatico, PAT ni resolucion automatica de conflictos.
+usan force push, rebase automático ni resolución automática de conflictos. Las
+mutaciones de PR se autentican con el token técnico acotado que se documenta
+más abajo, nunca con un PAT personal ni con un merge directo.
+
+## Promoción semanal `development -> main`
+
+La tarea de Codex se ejecuta los miércoles a las 16:30 y no espera a que CI
+termine. Crea o reutiliza un PR final exacto `development -> main` en draft, y
+un PR temporal `codex/predeploy-dev-main-AAAAMMDD -> development` solo si hay
+saneamiento versionable. Ambos PRs incluyen metadata y evidencia para generar
+los artefactos spec-as-source desde el diff real.
+
+El PR temporal se arma con auto-merge nativo y GitHub lo integra cuando sus
+checks requeridos terminan. `.github/workflows/release-orchestrator.yml`
+continúa por eventos: deja listo el PR final, crea el check pendiente
+`release_baseline` y habilita su auto-merge. Cuando los otros checks están
+verdes y `development` contiene el `main` más reciente, crea el tag anotado
+`AAAA.MM.DD-stable` apuntando al `main` que se reemplaza, publica su release de
+baseline y recién entonces completa `release_baseline`. El tag no se
+sobreescribe: si el nombre ya apunta a otro SHA, el workflow se bloquea para
+conservar un rollback inequívoco.
+
+El body del PR final también fija el SHA de `development` analizado. Un push
+posterior no se promueve por accidente: deja el PR bloqueado hasta que la tarea
+programada vuelva a analizar y actualizar el snapshot.
+
+El PR final no produce un deploy automático sin intervención: el job de
+`production` queda sujeto a Required reviewers del Environment. Si `main`
+avanzó antes de esa aprobación, el job obsoleto se omite y se debe aprobar el
+job del SHA actual.
 
 ## Instalar runner por entorno
 
@@ -122,12 +155,28 @@ APP_ROOT=<ruta-real-del-checkout>
 
 No hardcodear una ruta global: los servidores existentes pueden usar rutas distintas, por ejemplo `/opt/sisoc/SISOC` o `/opt/ssies/SISOC-Backoffice`.
 
-En `production`, configurar Required reviewers. Esa regla materializa la aprobacion manual antes de que el job de produccion corra en el runner self-hosted.
+En `production`, configurar Required reviewers. Esa regla materializa la
+aprobación manual antes de que el job de producción corra en el runner
+self-hosted.
 
-La politica de Actions del repositorio debe permitir que `GITHUB_TOKEN` cree y
-fusione pull requests. El workflow solicita solo `contents: write`,
-`pull-requests: write` y `actions: write`; esta ultima habilita el dispatch
-explicito de `deploy.yml`.
+Crear rulesets separadas: una para `development` y `homologacion` con
+`deploy_guard`, `architecture_imports`, `gitleaks` y `sync_pr_artifacts`; y
+otra exclusiva para `main` con esos cuatro checks más `release_baseline`.
+En ambas, exigir que la rama esté al día y dejar el conteo de aprobaciones en
+cero para estos flujos. Habilitar Auto-merge en el repositorio. Estas opciones
+requieren rol de administrador y complementan, no sustituyen, los gates
+versionados.
+
+Crear también el secret de Actions `RELEASE_AUTOMATION_TOKEN` con un GitHub App
+de servicio o PAT fine-grained de un usuario técnico. Debe tener, como mínimo,
+`Contents`, `Pull requests`, `Checks` e `Issues` en escritura para este
+repositorio (y `Metadata` en lectura); no necesita permisos de `Actions`. No
+usar el `GITHUB_TOKEN` para crear/actualizar los PRs que deben
+disparar otros workflows: GitHub suprime esos eventos o puede pedir aprobación
+manual. El workflow falla con `SETUP_BLOCKED` hasta que el secret exista.
+
+Los workflows habilitan el auto-merge nativo; no hacen merge directo ni
+despachan el deploy de forma explícita.
 
 ## Seguridad
 
@@ -155,7 +204,8 @@ Cada ejecucion del workflow registra el commit que estaba desplegado antes del r
 | El job queda en cola | Runner offline o label incorrecto | Revisar `svc.sh status`, conectividad VPN/local y labels del runner |
 | Falla `APP_ROOT no esta configurado` | Falta variable del Environment | Definir `APP_ROOT` en `qa`, `homologacion` o `production` |
 | Falla por branch esperada | Checkout local en branch equivocada | Corregir branch en el servidor o revisar el mapping del entorno |
-| Falla `git pull --ff-only` | Historial local divergio | Resolver manualmente en el servidor; no usar merge automatico en el runner |
+| Falla `merge --ff-only` o SHA esperado | El checkout o la rama avanzaron fuera del evento | No se bajó Docker; revisar el SHA vigente y reintentar desde el job actual |
 | Falla `Origin inesperado para SISOC-Mobile` | El checkout apunta a otro repositorio | Verificar el remote; no forzar el deploy ni aceptar una URL no documentada |
 | PR descendente queda abierto | Hay conflicto o GitHub rechazo el merge | Resolver por PR en la rama afectada; el deploy queda correctamente bloqueado |
+| Tag estable bloqueado | Ya existe `AAAA.MM.DD-stable` con otro SHA | No sobrescribirlo; decidir explícitamente el tag/baseline antes de promover |
 | Falla Docker | Usuario sin grupo `docker` o daemon detenido | Revisar `id`, `systemctl status docker` y `docker compose version` |

--- a/docs/operacion/deploy_automatizado.md
+++ b/docs/operacion/deploy_automatizado.md
@@ -159,21 +159,30 @@ En `production`, configurar Required reviewers. Esa regla materializa la
 aprobación manual antes de que el job de producción corra en el runner
 self-hosted.
 
-Crear rulesets separadas: una para `development` y `homologacion` con
+Mantener una ruleset base para `development`, `homologacion` y `main` con
 `deploy_guard`, `architecture_imports`, `gitleaks` y `sync_pr_artifacts`; y
-otra exclusiva para `main` con esos cuatro checks más `release_baseline`.
-En ambas, exigir que la rama esté al día y dejar el conteo de aprobaciones en
-cero para estos flujos. Habilitar Auto-merge en el repositorio. Estas opciones
-requieren rol de administrador y complementan, no sustituyen, los gates
-versionados.
+una ruleset exclusiva para `main` que suma `release_baseline`, cuya fuente debe
+ser la GitHub App `SISOC Release Automation`. En ambas,
+exigir que la rama esté al día y dejar el conteo de aprobaciones en cero para
+estos flujos. Habilitar Auto-merge en el repositorio. Estas opciones requieren
+rol de administrador y complementan, no sustituyen, los gates versionados.
 
-Crear también el secret de Actions `RELEASE_AUTOMATION_TOKEN` con un GitHub App
-de servicio o PAT fine-grained de un usuario técnico. Debe tener, como mínimo,
-`Contents`, `Pull requests`, `Checks` e `Issues` en escritura para este
-repositorio (y `Metadata` en lectura); no necesita permisos de `Actions`. No
-usar el `GITHUB_TOKEN` para crear/actualizar los PRs que deben
-disparar otros workflows: GitHub suprime esos eventos o puede pedir aprobación
-manual. El workflow falla con `SETUP_BLOCKED` hasta que el secret exista.
+Crear una GitHub App privada de servicio, instalada solamente en
+`dsocial118/SISOC`, sin webhooks. Debe recibir permisos de repositorio en
+escritura para `Contents`, `Pull requests`, `Checks` e `Issues` (`Metadata` es
+lectura implícita); no necesita permisos de `Actions`. En **Settings → Secrets
+and variables → Actions**, crear:
+
+```text
+Variable: RELEASE_AUTOMATION_APP_CLIENT_ID=<Client ID de la GitHub App>
+Secret:   RELEASE_AUTOMATION_APP_PRIVATE_KEY=<PEM de una private key vigente>
+```
+
+Los workflows generan un installation token temporal, restringido al repositorio
+actual, con `actions/create-github-app-token@v3`. No usar un PAT personal ni el
+`GITHUB_TOKEN`: este último no dispara los workflows posteriores y un PAT no
+puede emitir los check-runs requeridos por `release_baseline`. El workflow falla
+con `SETUP_BLOCKED` hasta que existan la variable y el secreto.
 
 Los workflows habilitan el auto-merge nativo; no hacen merge directo ni
 despachan el deploy de forma explícita.

--- a/docs/registro/cambios/2026-07-23-orquestacion-promocion-automatica.md
+++ b/docs/registro/cambios/2026-07-23-orquestacion-promocion-automatica.md
@@ -1,0 +1,40 @@
+# Orquestación de promoción automática y rollback trazable
+
+## Contexto
+
+La promoción semanal requería que Codex esperara checks y dejaba pasos manuales
+para integrar ramas. Además, un runner de deploy podía obtener una revisión más
+nueva que la aprobada por el Environment.
+
+## Cambios aplicados
+
+- Se agregó un orquestador por eventos y auto-merge nativo para PRs de
+  preparación y el PR final `development -> main`.
+- Se añadieron gates de evidencia para el pre-deploy, incluyendo causa raíz,
+  regresión y revisión independiente cuando hay un fix funcional.
+- La sincronización `main -> development/homologacion` arma auto-merge nativo;
+  el push que realiza GitHub dispara el deploy del destino.
+- El deploy exige el SHA del evento antes del downtime y registra evidencia de
+  migraciones y health luego de actualizar el entorno.
+- El changelog/spec-as-source puede generarse a partir del diff real de la
+  promoción, incluso fuera de un evento `pull_request`.
+
+## Impacto esperado
+
+Los merges rutinarios se completan de manera automática después de los gates.
+La única aprobación operativa esperada es la del Environment `production` para
+el SHA vigente. Cada promoción deja un tag de rollback del `main` previo.
+
+## Validación
+
+- Tests unitarios focalizados de los helpers de documentación, deploy y
+  orquestación.
+- Validación sintáctica de Bash, JavaScript y workflows YAML.
+
+## Riesgos y rollback
+
+- La activación de auto-merge y checks obligatorios depende de un administrador
+  de GitHub; hasta entonces el workflow aplica sus propios gates, pero la
+  protección del repositorio no cambia.
+- Si un tag estable ya existe con otro SHA, la promoción se bloquea. El rollback
+  usa ese tag y el procedimiento documentado para datos/migraciones.

--- a/docs/registro/decisiones/2026-07-23-promocion-automatica-con-tag-estable.md
+++ b/docs/registro/decisiones/2026-07-23-promocion-automatica-con-tag-estable.md
@@ -44,11 +44,14 @@ CI. La promoción a producción conserva una aprobación humana en el Environmen
 - Las rulesets deben exigir los checks definidos en los workflows y permitir
   auto-merge sin aprobación manual. Configurarlas requiere permisos de
   administrador del repositorio.
-- Los workflows usan `RELEASE_AUTOMATION_TOKEN` (GitHub App o PAT técnico) en
-  vez de depender del `GITHUB_TOKEN` para las mutaciones que deben disparar
-  otros workflows. Se limita a `Contents`, `Pull requests`, `Checks` e
-  `Issues` en escritura, más `Metadata` en lectura; el token y su secreto
-  también requieren configuración de administrador.
+- Los workflows usan una GitHub App privada, no un PAT, para las mutaciones que
+  deben disparar otros workflows. Cada job genera un installation token efímero
+  limitado al repositorio actual con `Contents`, `Pull requests`, `Checks` e
+  `Issues` en escritura, más `Metadata` en lectura. La App se configura con la
+  variable `RELEASE_AUTOMATION_APP_CLIENT_ID` y el secret
+  `RELEASE_AUTOMATION_APP_PRIVATE_KEY`; ambos requieren configuración de
+  administrador. La ruleset de `main` fija `release_baseline` a esa misma App
+  como fuente, para no aceptar checks homónimos de otra integración.
 
 ## Referencias
 

--- a/docs/registro/decisiones/2026-07-23-promocion-automatica-con-tag-estable.md
+++ b/docs/registro/decisiones/2026-07-23-promocion-automatica-con-tag-estable.md
@@ -1,0 +1,59 @@
+# 2026-07-23 - Promoción automática con baseline estable
+
+## Estado
+
+- Aceptada.
+
+## Contexto
+
+El pre-deploy semanal debe iniciar a las 16:30, cuando todavía pueden entrar
+cambios en `development`, pero no debe mantener una sesión de Codex esperando
+CI. La promoción a producción conserva una aprobación humana en el Environment
+`production` de GitHub Actions.
+
+## Decisión
+
+- La tarea programada prepara o reutiliza un PR exacto `development -> main` en
+  draft y, si hace falta, un PR temporal de saneamiento hacia `development`.
+- Los PRs se arman para el auto-merge nativo de GitHub; los workflows no hacen
+  `pulls.merge` con `GITHUB_TOKEN`, porque esos merges no disparan los flujos
+  posteriores de CI/deploy. El orquestador recibe eventos de PR y CI, deja
+  listo el PR final y habilita su auto-merge una vez armada la baseline.
+- El PR final declara el SHA de `development` que fue analizado. Si entra otro
+  commit después del snapshot, el workflow bloquea la promoción hasta que una
+  nueva ejecución actualice análisis, changelog y marcador.
+- Justo antes de integrar a `main`, se crea un tag anotado e inmutable con el
+  formato `AAAA.MM.DD-stable`, apuntando al `main` que se va a reemplazar. Si
+  ya existe con otro SHA, la promoción se bloquea en vez de sobrescribir un
+  baseline de rollback.
+- El check requerido `release_baseline` permanece pendiente hasta que el tag y
+  la release del baseline existen. Solo entonces se completa en verde y GitHub
+  puede hacer el merge nativo.
+- Los deploys usan el SHA del evento. Si la rama avanzó antes de aprobar o
+  ejecutar el job, se omiten antes del downtime; nunca hacen deploy de un SHA
+  más nuevo bajo una aprobación anterior.
+
+## Consecuencias
+
+- Codex termina luego de armar el estado verificable; GitHub espera CI y hace
+  los merges, por lo que no hay una sesión larga ni un merge manual rutinario.
+- `main` nuevo debe sincronizarse hacia `development` y volver a pasar gates
+  antes de una promoción; no se puede publicar una base obsoleta.
+- La fecha del tag permite un baseline por día. Una segunda promoción el mismo
+  día con otro `main` requiere una decisión explícita, para no perder rollback.
+- Las rulesets deben exigir los checks definidos en los workflows y permitir
+  auto-merge sin aprobación manual. Configurarlas requiere permisos de
+  administrador del repositorio.
+- Los workflows usan `RELEASE_AUTOMATION_TOKEN` (GitHub App o PAT técnico) en
+  vez de depender del `GITHUB_TOKEN` para las mutaciones que deben disparar
+  otros workflows. Se limita a `Contents`, `Pull requests`, `Checks` e
+  `Issues` en escritura, más `Metadata` en lectura; el token y su secreto
+  también requieren configuración de administrador.
+
+## Referencias
+
+- `.github/workflows/release-orchestrator.yml`
+- `.github/workflows/sync-main-downstream.yml`
+- `.github/workflows/deploy.yml`
+- `scripts/operacion/deploy_refresh.sh`
+- `docs/operacion/deploy_automatizado.md`

--- a/scripts/ci/pr_doc_automation.py
+++ b/scripts/ci/pr_doc_automation.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import argparse
 import json
 import os
 import re
@@ -617,6 +618,15 @@ def extract_pull_request_data(payload: dict[str, Any]) -> PullRequestData:
 
     pull_request = payload["pull_request"]
     repository = payload["repository"]
+    return pull_request_data_from_api(pull_request, repository["full_name"])
+
+
+def pull_request_data_from_api(
+    pull_request: dict[str, Any],
+    repo_full_name: str,
+) -> PullRequestData:
+    """Construye el contexto comun desde la respuesta de la API de GitHub."""
+
     return PullRequestData(
         number=int(pull_request["number"]),
         title=pull_request["title"],
@@ -626,7 +636,7 @@ def extract_pull_request_data(payload: dict[str, Any]) -> PullRequestData:
         head_ref=pull_request["head"]["ref"],
         author=pull_request["user"]["login"],
         updated_at=pull_request["updated_at"],
-        repo_full_name=repository["full_name"],
+        repo_full_name=repo_full_name,
     )
 
 
@@ -666,6 +676,31 @@ def fetch_changed_files(pr: PullRequestData, token: str) -> list[str]:
     return files
 
 
+def fetch_pull_request_data(
+    repo_full_name: str,
+    pull_number: int,
+    token: str,
+) -> PullRequestData:
+    """Obtiene el PR para una ejecucion fuera de un evento de GitHub Actions."""
+
+    encoded_repo = urllib.parse.quote(repo_full_name, safe="/")
+    response_data = github_api_get_json(
+        f"https://api.github.com/repos/{encoded_repo}/pulls/{pull_number}",
+        token,
+    )
+    return pull_request_data_from_api(response_data, repo_full_name)
+
+
+def read_changed_files_file(path: Path) -> list[str]:
+    """Lee un manifiesto de paths, uno por linea, generado desde el diff real."""
+
+    return [
+        line.strip()
+        for line in path.read_text(encoding="utf-8").splitlines()
+        if line.strip()
+    ]
+
+
 def ensure_parent_dirs() -> None:
     """Crea carpetas necesarias para artefactos generados."""
 
@@ -685,11 +720,13 @@ def sync_pr_artifacts(
     pr: PullRequestData,
     token: str,
     today: date | None = None,
+    changed_files: list[str] | None = None,
 ) -> None:
     """Genera todos los artefactos requeridos para un PR."""
 
     ensure_parent_dirs()
-    changed_files = fetch_changed_files(pr, token)
+    if changed_files is None:
+        changed_files = fetch_changed_files(pr, token)
     metadata = parse_pr_body_metadata(pr.body)
 
     pr_document_path = DOCS_PR_DIR / f"PR-{pr.number}.md"
@@ -735,20 +772,60 @@ def sync_pr_artifacts(
     write_text_file(CHANGELOG_PATH, updated_changelog)
 
 
-def main() -> int:
+def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    """Parsea tanto el evento de Actions como una ejecucion controlada de pre-deploy."""
+
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "--event-path",
+        type=Path,
+        help="Payload de pull_request; por defecto usa GITHUB_EVENT_PATH.",
+    )
+    parser.add_argument(
+        "--pr",
+        type=int,
+        help="Numero de PR para consultar por API fuera de GitHub Actions.",
+    )
+    parser.add_argument(
+        "--repository",
+        help="Repositorio owner/name requerido junto con --pr.",
+    )
+    parser.add_argument(
+        "--changed-files-file",
+        type=Path,
+        help="Manifiesto de archivos del diff real que reemplaza la consulta de files del PR.",
+    )
+    args = parser.parse_args(argv)
+    if args.pr is not None and not args.repository:
+        parser.error("--repository es requerido junto con --pr.")
+    if args.pr is None and args.repository:
+        parser.error("--repository solo se admite junto con --pr.")
+    return args
+
+
+def main(argv: list[str] | None = None) -> int:
     """Punto de entrada del script."""
 
-    event_path_value = os.environ.get("GITHUB_EVENT_PATH")
+    args = parse_args(argv)
+    event_path_value = args.event_path or os.environ.get("GITHUB_EVENT_PATH")
     token = os.environ.get("GITHUB_TOKEN")
-    if not event_path_value:
-        raise RuntimeError("GITHUB_EVENT_PATH no está definido.")
     if not token:
         raise RuntimeError("GITHUB_TOKEN no está definido.")
 
-    payload = read_event_payload(Path(event_path_value))
-    pr = extract_pull_request_data(payload)
     try:
-        sync_pr_artifacts(pr, token)
+        if args.pr is not None:
+            pr = fetch_pull_request_data(args.repository, args.pr, token)
+        else:
+            if not event_path_value:
+                raise RuntimeError("GITHUB_EVENT_PATH no está definido.")
+            payload = read_event_payload(Path(event_path_value))
+            pr = extract_pull_request_data(payload)
+        changed_files = (
+            read_changed_files_file(args.changed_files_file)
+            if args.changed_files_file
+            else None
+        )
+        sync_pr_artifacts(pr, token, changed_files=changed_files)
     except urllib.error.HTTPError as exc:
         raise RuntimeError(f"No se pudo consultar la API de GitHub: {exc}") from exc
     return 0

--- a/scripts/operacion/deploy_refresh.sh
+++ b/scripts/operacion/deploy_refresh.sh
@@ -14,6 +14,7 @@ WITH_MOBILE=0
 MOBILE_DIR=""
 MOBILE_SCRIPT=""
 MOBILE_HTTPS_REMOTE="https://github.com/dsocial118/SISOC-Mobile.git"
+EXPECTED_REVISION=""
 
 usage() {
   cat <<'USAGE'
@@ -33,6 +34,8 @@ Opciones:
   --allow-branch-mismatch   No bloquea si la branch actual no coincide
                             con la esperada para ENVIRONMENT.
   --skip-pull               No ejecuta git fetch/pull; solo reinicia Docker.
+  --expected-revision SHA   Exige que la revision a desplegar sea exactamente SHA.
+                            Si origin o HEAD ya avanzaron, bloquea antes de bajar Docker.
   --with-mobile             Tambien despliega SISOC-Mobile.
   --mobile-dir PATH         Ruta del checkout SISOC-Mobile.
                             Default: ../SISOC-Mobile desde la raiz de SISOC.
@@ -125,6 +128,11 @@ parse_args() {
       --allow-dirty) ALLOW_DIRTY=1 ;;
       --allow-branch-mismatch) ALLOW_BRANCH_MISMATCH=1 ;;
       --skip-pull) SKIP_PULL=1 ;;
+      --expected-revision)
+        shift
+        [[ $# -gt 0 ]] || fail "--expected-revision requiere un SHA."
+        EXPECTED_REVISION="$1"
+        ;;
       --with-mobile) WITH_MOBILE=1 ;;
       --mobile-dir)
         shift
@@ -191,6 +199,26 @@ normalize_mobile_origin() {
       fail "Origin inesperado para SISOC-Mobile; revisar origin sin copiar credenciales al log."
       ;;
   esac
+}
+
+validate_expected_revision() {
+  local actual_revision source
+
+  [[ -z "$EXPECTED_REVISION" ]] && return 0
+  [[ "$EXPECTED_REVISION" =~ ^[0-9a-f]{40}$ ]] \
+    || fail "--expected-revision debe ser un SHA completo de 40 caracteres hexadecimales."
+
+  if [[ "$SKIP_PULL" -eq 0 ]]; then
+    source="origin/$CURRENT_BRANCH"
+  else
+    source="HEAD"
+  fi
+
+  actual_revision="$(git -C "$ROOT_DIR" rev-parse "$source")" \
+    || fail "No pude resolver la revision $source para validar el deploy."
+  [[ "$actual_revision" == "$EXPECTED_REVISION" ]] \
+    || fail "La revision esperada $EXPECTED_REVISION ya no coincide con $source ($actual_revision); no se baja Docker."
+  log "revision_verificada=$actual_revision"
 }
 
 compose_for_environment() {
@@ -270,6 +298,7 @@ main() {
   log "root=$ROOT_DIR"
   log "environment=$ENVIRONMENT"
   log "branch=$CURRENT_BRANCH"
+  [[ -n "$EXPECTED_REVISION" ]] && log "expected_revision=$EXPECTED_REVISION"
   log "compose_files=${COMPOSE_FILES[*]}"
   if [[ "$WITH_MOBILE" -eq 1 ]]; then
     log "mobile_root=$MOBILE_DIR"
@@ -288,12 +317,21 @@ main() {
     run git -C "$ROOT_DIR" fetch origin --prune
   fi
 
+  validate_expected_revision
+
   run "${COMPOSE_CMD[@]}" --project-directory "$ROOT_DIR" config -q
 
   run "${COMPOSE_CMD[@]}" --project-directory "$ROOT_DIR" "${DOWN_ARGS[@]}"
 
   if [[ "$SKIP_PULL" -eq 0 ]]; then
-    run git -C "$ROOT_DIR" pull --ff-only origin "$CURRENT_BRANCH"
+    run git -C "$ROOT_DIR" merge --ff-only "origin/$CURRENT_BRANCH"
+  fi
+
+  if [[ -n "$EXPECTED_REVISION" ]]; then
+    deployed_revision="$(git -C "$ROOT_DIR" rev-parse HEAD)" \
+      || fail "No pude resolver la revision desplegada."
+    [[ "$deployed_revision" == "$EXPECTED_REVISION" ]] \
+      || fail "La revision desplegada $deployed_revision no coincide con $EXPECTED_REVISION."
   fi
 
   run "${COMPOSE_CMD[@]}" --project-directory "$ROOT_DIR" up -d --build
@@ -304,6 +342,7 @@ main() {
     run bash "$MOBILE_SCRIPT" "${MOBILE_ARGS[@]}"
   fi
 
+  log "deployed_revision=$(git -C "$ROOT_DIR" rev-parse HEAD)"
   log "Deploy refresh finalizado."
 }
 

--- a/tests/test_deploy_refresh_script.py
+++ b/tests/test_deploy_refresh_script.py
@@ -1,12 +1,20 @@
 import os
-import shutil
 import subprocess
 from pathlib import Path
+
+import pytest
 
 
 REPO_ROOT = Path(__file__).resolve().parents[1]
 DEPLOY_SCRIPT = REPO_ROOT / "scripts" / "operacion" / "deploy_refresh.sh"
 HTTPS_MOBILE_REMOTE = "https://github.com/dsocial118/SISOC-Mobile.git"
+EXPECTED_REVISION = "a" * 40
+
+
+pytestmark = pytest.mark.skipif(
+    os.name == "nt",
+    reason="deploy_refresh.sh se prueba en un host Bash/Linux (WSL o CI)",
+)
 
 
 def _mobile_checkout(tmp_path: Path, remote: str) -> Path:
@@ -17,7 +25,7 @@ def _mobile_checkout(tmp_path: Path, remote: str) -> Path:
 
     script = checkout / "scripts" / "operacion" / "deploy_refresh.sh"
     script.parent.mkdir(parents=True)
-    script.write_text("#!/usr/bin/env bash\nexit 0\n", encoding="utf-8")
+    script.write_bytes(b"#!/usr/bin/env bash\nexit 0\n")
     return checkout
 
 
@@ -28,7 +36,7 @@ def _backend_checkout(tmp_path: Path) -> Path:
 
     script = checkout / "scripts" / "operacion" / "deploy_refresh.sh"
     script.parent.mkdir(parents=True)
-    shutil.copyfile(DEPLOY_SCRIPT, script)
+    script.write_bytes(DEPLOY_SCRIPT.read_bytes().replace(b"\r\n", b"\n"))
     (checkout / "docker-compose.deploy.yml").write_text(
         "services: {}\n",
         encoding="utf-8",
@@ -52,7 +60,9 @@ case "$1 ${2:-} ${3:-}" in
   "remote get-url origin") cat "$repo/.origin" ;;
   "remote set-url origin") printf '%s\\n' "$4" > "$repo/.origin" ;;
   "fetch origin --prune") exit 0 ;;
-  "pull --ff-only origin") exit 0 ;;
+  "rev-parse origin/development ") printf '%s\\n' "${FAKE_ORIGIN_SHA:-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa}" ;;
+  "rev-parse HEAD ") printf '%s\\n' "${FAKE_HEAD_SHA:-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa}" ;;
+  "merge --ff-only origin/development") exit 0 ;;
   *) printf 'git falso: comando inesperado: %s\\n' "$*" >&2; exit 2 ;;
 esac
 """,
@@ -66,6 +76,8 @@ def _run_deploy(
     mobile_checkout: Path,
     *,
     dry_run: bool = True,
+    expected_revision: str | None = None,
+    origin_revision: str | None = None,
 ) -> subprocess.CompletedProcess[str]:
     backend_checkout = _backend_checkout(tmp_path)
     env_file = tmp_path / ".env"
@@ -79,13 +91,16 @@ def _run_deploy(
     env = os.environ.copy()
     env["ENV_FILE"] = str(env_file)
     env["PATH"] = f"{fake_bin}{os.pathsep}{env['PATH']}"
-
     args = [
         "bash",
         str(backend_checkout / "scripts" / "operacion" / "deploy_refresh.sh"),
     ]
+    if origin_revision:
+        env["FAKE_ORIGIN_SHA"] = origin_revision
     if dry_run:
         args.append("--dry-run")
+    if expected_revision:
+        args.extend(["--expected-revision", expected_revision])
     args.extend(
         [
             "--yes",
@@ -139,3 +154,36 @@ def test_mobile_origin_desconocido_bloquea_antes_de_docker(tmp_path):
     assert result.returncode != 0
     assert "Origin inesperado para SISOC-Mobile" in result.stderr
     assert "docker compose" not in result.stdout
+
+
+def test_revision_esperada_desactualizada_bloquea_antes_de_docker(tmp_path):
+    """No deja que un runner despliegue una revision distinta del evento."""
+
+    checkout = _mobile_checkout(tmp_path, HTTPS_MOBILE_REMOTE)
+
+    result = _run_deploy(
+        tmp_path,
+        checkout,
+        expected_revision=EXPECTED_REVISION,
+        origin_revision="b" * 40,
+    )
+
+    assert result.returncode != 0
+    assert "La revision esperada" in result.stderr
+    assert "docker compose" not in result.stdout
+
+
+def test_revision_esperada_valida_se_registra_en_el_deploy(tmp_path):
+    """Con el SHA esperado, el flujo conserva la trazabilidad de la revision."""
+
+    checkout = _mobile_checkout(tmp_path, HTTPS_MOBILE_REMOTE)
+
+    result = _run_deploy(
+        tmp_path,
+        checkout,
+        expected_revision=EXPECTED_REVISION,
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert f"revision_verificada={EXPECTED_REVISION}" in result.stdout
+    assert f"deployed_revision={EXPECTED_REVISION}" in result.stdout

--- a/tests/test_pr_doc_automation_unit.py
+++ b/tests/test_pr_doc_automation_unit.py
@@ -243,3 +243,59 @@ def test_sync_pr_artifacts_genera_docs_y_changelog_para_pr_a_main(
     )
     assert "# Versión SISOC 18.03.2026" in changelog
     assert "Genera documentación de PR y changelog" in changelog
+
+
+def test_manifest_de_diff_reemplaza_la_consulta_remota_de_archivos(
+    tmp_path, monkeypatch
+):
+    """El pre-deploy documenta exactamente el diff que va a promover."""
+
+    monkeypatch.setattr(
+        pr_doc_automation, "DOCS_PR_DIR", tmp_path / "docs/registro/prs"
+    )
+    monkeypatch.setattr(
+        pr_doc_automation,
+        "DOCS_FEATURE_DIR",
+        tmp_path / "docs/contexto/features",
+    )
+    monkeypatch.setattr(
+        pr_doc_automation,
+        "DOCS_RELEASE_PENDING_DIR",
+        tmp_path / "docs/registro/releases/pending",
+    )
+    monkeypatch.setattr(
+        pr_doc_automation,
+        "CHANGELOG_PATH",
+        tmp_path / "CHANGELOG.md",
+    )
+    monkeypatch.setattr(
+        pr_doc_automation,
+        "fetch_changed_files",
+        lambda pr, token: (_ for _ in ()).throw(AssertionError("no debe consultar API")),
+    )
+
+    manifest = tmp_path / "changed-files.txt"
+    manifest.write_text("core/views.py\n\ntemplates/core/home.html\n", encoding="utf-8")
+    changed_files = pr_doc_automation.read_changed_files_file(manifest)
+    pr = pr_doc_automation.PullRequestData(
+        number=16,
+        title="Preparar promocion con diff real",
+        body="- Fecha objetivo de release: 2026-03-18",
+        html_url="https://example.test/pr/16",
+        base_ref="main",
+        head_ref="development",
+        author="tester",
+        updated_at="2026-03-13T12:00:00Z",
+        repo_full_name="org/repo",
+    )
+
+    pr_doc_automation.sync_pr_artifacts(
+        pr,
+        token="fake-token",
+        today=date(2026, 3, 13),
+        changed_files=changed_files,
+    )
+
+    generated = (tmp_path / "docs/registro/prs/PR-16.md").read_text(encoding="utf-8")
+    assert "`core/views.py`" in generated
+    assert "`templates/core/home.html`" in generated

--- a/tests/test_pr_doc_automation_unit.py
+++ b/tests/test_pr_doc_automation_unit.py
@@ -271,7 +271,9 @@ def test_manifest_de_diff_reemplaza_la_consulta_remota_de_archivos(
     monkeypatch.setattr(
         pr_doc_automation,
         "fetch_changed_files",
-        lambda pr, token: (_ for _ in ()).throw(AssertionError("no debe consultar API")),
+        lambda pr, token: (_ for _ in ()).throw(
+            AssertionError("no debe consultar API")
+        ),
     )
 
     manifest = tmp_path / "changed-files.txt"


### PR DESCRIPTION
## Resumen

Automatiza la promoción semanal `development -> main` sin esperar CI en Codex:

- la tarea queda a las 16:30 y arma snapshots/PRs, mientras GitHub continúa por auto-merge nativo;
- agrega el orquestador de release con baseline `AAAA.MM.DD-stable` y GitHub Release antes del merge final;
- bloquea snapshots obsoletos y exige que `development` contenga el `main` vigente;
- conserva como única intervención normal aprobar el Environment `production`.

## Calidad y seguridad

- Los fixes autónomos del pre-deploy exigen causa raíz, prueba de regresión y revisión independiente.
- Los deploys validan el SHA del evento antes de detener servicios y después de desplegar.
- El token técnico usa el mínimo privilegio documentado y el flujo falla cerrado con `SETUP_BLOCKED` si falta.

## Validación

- `node --check .github/scripts/release_orchestrator.js`
- `node --test .github/scripts/release_orchestrator.test.js` (7/7)
- parseo YAML de workflows
- `python -m py_compile` focalizado
- sintaxis Bash
- `python -m pytest -p no:django --noconftest -o addopts= ...` (9 passed, 5 skipped en Windows; el script Bash se ejecuta en WSL/CI)

## Configuración administrativa pendiente

Para activar el comportamiento tras el merge, un administrador debe habilitar Auto-merge, configurar las rulesets requeridas y crear `RELEASE_AUTOMATION_TOKEN`. La cuenta actual tiene permiso de escritura, pero no de administración; por eso no se aplicaron esos ajustes remotos.

## Rollback

Revertir este PR restaura el flujo anterior. Una vez activo, cada promoción deja el baseline anotado y su Release antes de integrar `main`.