### PR TITLE
Issues 2158 y 2159: PDFs de nómina y documentos múltiples

### DIFF
--- a/comedores/templates/comedor/nomina_asistencia_historial.html
+++ b/comedores/templates/comedor/nomina_asistencia_historial.html
@@ -83,8 +83,7 @@
             {% if asistencia_periodos %}
                 <div class="nomina-period-list">
                     {% for item in asistencia_periodos %}
-                        <a href="?periodo={{ item.periodo_referencia|date:'Y-m-d' }}"
-                           class="nomina-period-card">
+                        <div class="nomina-period-card">
                             <div>
                                 <p class="nomina-period-title">Periodo {{ item.periodo_referencia|date:"m/Y" }}</p>
                                 <p class="nomina-period-meta">Asistencia mensual</p>
@@ -93,8 +92,22 @@
                                 <strong>{{ item.total_asistentes }}</strong>
                                 <span>asistentes</span>
                             </div>
-                            <i class="fas fa-chevron-right nomina-period-icon"></i>
-                        </a>
+                            <div class="d-flex align-items-center gap-2">
+                                {% if item.documento_nomina %}
+                                    <a href="{{ item.documento_nomina.archivo.url }}"
+                                       class="btn btn-outline-light btn-sm"
+                                       target="_blank"
+                                       rel="noopener"
+                                       download>
+                                        <i class="fas fa-file-pdf"></i> Descargar PDF
+                                    </a>
+                                {% endif %}
+                                <a href="?periodo={{ item.periodo_referencia|date:'Y-m-d' }}"
+                                   class="btn btn-outline-light btn-sm">
+                                    Ver detalle <i class="fas fa-chevron-right"></i>
+                                </a>
+                            </div>
+                        </div>
                     {% endfor %}
                 </div>
             {% else %}

--- a/comedores/views/nomina.py
+++ b/comedores/views/nomina.py
@@ -19,7 +19,11 @@ from comedores.models import Nomina
 from comedores.services.comedor_service import ComedorService, normalize_nomina_tab
 from comedores.utils import comedor_usa_admision_para_nomina, is_pnud_comedor
 from core.soft_delete.view_helpers import SoftDeleteDeleteViewMixin
-from pwa.models import ActividadEspacioPWA, RegistroAsistenciaNominaPWA
+from pwa.models import (
+    ActividadEspacioPWA,
+    NominaDestinatariosDocumentoPWA,
+    RegistroAsistenciaNominaPWA,
+)
 from pwa.services.nomina_service import sync_nomina_asistencia_actividades_web
 from pwa.utils import parse_periodo_referencia
 
@@ -148,6 +152,17 @@ def _get_asistencia_nomina_context(request, *, admision_id=None, comedor_id=None
         .annotate(total_asistentes=Count("id"))
         .order_by("-periodo_referencia")
     )
+    documentos = NominaDestinatariosDocumentoPWA.objects.filter(
+        comedor_id=comedor_id,
+        periodo_referencia__in=[item["periodo_referencia"] for item in periodos],
+    ).order_by("periodo_referencia", "-version", "-fecha_generacion", "-id")
+    documentos_por_periodo = {}
+    for documento in documentos:
+        documentos_por_periodo.setdefault(documento.periodo_referencia, documento)
+    for item in periodos:
+        item["documento_nomina"] = documentos_por_periodo.get(
+            item["periodo_referencia"]
+        )
     periodo_seleccionado = parse_periodo_referencia(request.GET.get("periodo"))
 
     asistentes = []
@@ -264,6 +279,7 @@ class NominaAsistenciaHistorialView(LoginRequiredMixin, TemplateView):
                 **_get_asistencia_nomina_context(
                     self.request,
                     admision_id=admision.pk,
+                    comedor_id=admision.comedor_id,
                 ),
             }
         )

--- a/comedores/views/nomina.py
+++ b/comedores/views/nomina.py
@@ -21,8 +21,10 @@ from comedores.utils import comedor_usa_admision_para_nomina, is_pnud_comedor
 from core.soft_delete.view_helpers import SoftDeleteDeleteViewMixin
 from pwa.models import (
     ActividadEspacioPWA,
-    NominaDestinatariosDocumentoPWA,
     RegistroAsistenciaNominaPWA,
+)
+from pwa.services.nomina_destinatarios_pdf_service import (
+    get_latest_nomina_destinatarios_documents_by_period,
 )
 from pwa.services.nomina_service import sync_nomina_asistencia_actividades_web
 from pwa.utils import parse_periodo_referencia
@@ -152,13 +154,10 @@ def _get_asistencia_nomina_context(request, *, admision_id=None, comedor_id=None
         .annotate(total_asistentes=Count("id"))
         .order_by("-periodo_referencia")
     )
-    documentos = NominaDestinatariosDocumentoPWA.objects.filter(
+    documentos_por_periodo = get_latest_nomina_destinatarios_documents_by_period(
         comedor_id=comedor_id,
-        periodo_referencia__in=[item["periodo_referencia"] for item in periodos],
-    ).order_by("periodo_referencia", "-version", "-fecha_generacion", "-id")
-    documentos_por_periodo = {}
-    for documento in documentos:
-        documentos_por_periodo.setdefault(documento.periodo_referencia, documento)
+        periodos=[item["periodo_referencia"] for item in periodos],
+    )
     for item in periodos:
         item["documento_nomina"] = documentos_por_periodo.get(
             item["periodo_referencia"]

--- a/docs/registro/cambios/2026-07-28-issues-2158-2159-pwa.md
+++ b/docs/registro/cambios/2026-07-28-issues-2158-2159-pwa.md
@@ -1,0 +1,56 @@
+# Rendiciones con archivos múltiples e historial de PDF de nómina
+
+## Fecha
+
+2026-07-28
+
+## Objetivo
+
+Resolver los issues #2159 y #2158 en los flujos PWA: permitir la documentación múltiple requerida en rendiciones y mantener disponible el PDF certificado de nómina desde los historiales mobile y web.
+
+## Alcance
+
+- Rendición de cuentas PWA, configuración mobile y validación backend.
+- Historial de asistencia de nómina alimentaria en PWA.
+- Historial de asistencia de nómina en SISOC web.
+- Contrato API de períodos y detalle de asistencia.
+
+## Archivos tocados
+
+- `rendicioncuentasmensual/models.py`
+- `pwa/api_views.py`
+- `comedores/views/nomina.py`
+- `comedores/templates/comedor/nomina_asistencia_historial.html`
+- `tests/test_pwa_comedores_api.py`
+- `tests/test_pwa_nomina_api.py`
+- `mobile/src/features/home/rendicionOffline.ts`
+- `mobile/src/api/nominaApi.ts`
+- `mobile/src/features/home/SpaceNominaAttendancePeriodsPage.tsx`
+
+## Cambios realizados
+
+- Los Formularios III de Prestación Alimentaria y SIPH admiten múltiples archivos tanto en mobile como en backend.
+- `Comprobante/s` deja de ser obligatorio para presentar una rendición.
+- La API de asistencia relaciona cada período alimentario con el último PDF de nómina persistido.
+- La PWA permite descargar el PDF directamente desde la tarjeta del período y conserva el detalle para consulta.
+- SISOC web ofrece la misma descarga en su historial de asistencia.
+- El PDF alimentario no se expone en el historial filtrado por formación.
+- Se agregó cobertura de regresión para la configuración documental, la carga múltiple, la obligatoriedad, el contrato API y el contexto web.
+
+## Supuestos
+
+- Se reutiliza `NominaDestinatariosDocumentoPWA`, que ya persiste un PDF por espacio, período y versión.
+- La descarga usa la URL del storage existente, del mismo modo que la respuesta actual al generar el PDF.
+- Los cambios de configuración documental no requieren migración de base de datos.
+
+## Validaciones ejecutadas
+
+- Pruebas dirigidas de rendiciones PWA.
+- Pruebas dirigidas de API y contexto web del historial de nómina.
+- Typecheck y ESLint de los archivos mobile modificados.
+- `black` para Python y `djlint` para el template modificado.
+- Verificación de whitespace mediante `git diff --check` en los repositorios raíz y mobile.
+
+## Pendientes / riesgos
+
+- No quedan pendientes funcionales conocidos dentro del alcance de los issues #2158 y #2159.

--- a/docs/registro/cambios/2026-07-28-issues-2158-2159-pwa.md
+++ b/docs/registro/cambios/2026-07-28-issues-2158-2159-pwa.md
@@ -23,9 +23,16 @@ Resolver los issues #2159 y #2158 en los flujos PWA: permitir la documentación 
 - `comedores/templates/comedor/nomina_asistencia_historial.html`
 - `tests/test_pwa_comedores_api.py`
 - `tests/test_pwa_nomina_api.py`
-- `mobile/src/features/home/rendicionOffline.ts`
-- `mobile/src/api/nominaApi.ts`
-- `mobile/src/features/home/SpaceNominaAttendancePeriodsPage.tsx`
+
+## Cambios coordinados en SISOC-Mobile
+
+La interfaz PWA se actualizó en el repositorio
+[`dsocial118/SISOC-Mobile`](https://github.com/dsocial118/SISOC-Mobile), commit
+[`77bc6fec`](https://github.com/dsocial118/SISOC-Mobile/commit/77bc6fec40173590a36f1da56b6707f2a26516b8):
+
+- `src/features/home/rendicionOffline.ts`
+- `src/api/nominaApi.ts`
+- `src/features/home/SpaceNominaAttendancePeriodsPage.tsx`
 
 ## Cambios realizados
 

--- a/pwa/api_views.py
+++ b/pwa/api_views.py
@@ -40,6 +40,7 @@ from pwa.models import (
     ActividadEspacioPWA,
     CatalogoActividadPWA,
     InscriptoActividadEspacioPWA,
+    NominaDestinatariosDocumentoPWA,
     NominaObservacionPWA,
     RegistroAsistenciaNominaPWA,
 )
@@ -836,12 +837,28 @@ class NominaEspacioPWAViewSet(viewsets.ViewSet):
         return queryset
 
     @staticmethod
-    def _serialize_attendance_period(periodo_referencia, total):
+    def _serialize_attendance_period(
+        periodo_referencia, total, documento_nomina=None, request=None
+    ):
         return {
             "periodo_referencia": periodo_referencia,
             "periodo_label": periodo_referencia.strftime("%m/%Y"),
             "total_asistentes": total,
+            "nomina_destinatarios_documento": serialize_nomina_destinatarios_documento(
+                documento_nomina,
+                request=request,
+            ),
         }
+
+    def _attendance_documents_by_period(self, periodos):
+        documentos = NominaDestinatariosDocumentoPWA.objects.filter(
+            comedor_id=self.kwargs["comedor_id"],
+            periodo_referencia__in=periodos,
+        ).order_by("periodo_referencia", "-version", "-fecha_generacion", "-id")
+        latest_by_period = {}
+        for documento in documentos:
+            latest_by_period.setdefault(documento.periodo_referencia, documento)
+        return latest_by_period
 
     _parse_periodo_referencia = staticmethod(parse_periodo_referencia)
 
@@ -1044,11 +1061,18 @@ class NominaEspacioPWAViewSet(viewsets.ViewSet):
 
     def periodos_asistencia(self, request, comedor_id=None):
         tab = request.query_params.get("tab", "consolidada")
-        periodos = (
+        periodos = list(
             self._attendance_queryset(tab)
             .values("periodo_referencia")
             .annotate(total_asistentes=Count("id"))
             .order_by("-periodo_referencia")
+        )
+        documentos_by_period = (
+            self._attendance_documents_by_period(
+                [row["periodo_referencia"] for row in periodos]
+            )
+            if tab == "alimentaria"
+            else {}
         )
         return Response(
             {
@@ -1057,6 +1081,8 @@ class NominaEspacioPWAViewSet(viewsets.ViewSet):
                     self._serialize_attendance_period(
                         row["periodo_referencia"],
                         row["total_asistentes"],
+                        documentos_by_period.get(row["periodo_referencia"]),
+                        request,
                     )
                     for row in periodos
                 ],
@@ -1077,11 +1103,21 @@ class NominaEspacioPWAViewSet(viewsets.ViewSet):
         asistentes = list(
             self._attendance_queryset(tab).filter(periodo_referencia=periodo_referencia)
         )
+        documento_nomina = (
+            self._attendance_documents_by_period([periodo_referencia]).get(
+                periodo_referencia
+            )
+            if tab == "alimentaria"
+            else None
+        )
         return Response(
             {
                 "tab": tab,
                 **self._serialize_attendance_period(
-                    periodo_referencia, len(asistentes)
+                    periodo_referencia,
+                    len(asistentes),
+                    documento_nomina,
+                    request,
                 ),
                 "asistentes": [
                     self._serialize_attendance_attendee(registro)

--- a/pwa/api_views.py
+++ b/pwa/api_views.py
@@ -40,7 +40,6 @@ from pwa.models import (
     ActividadEspacioPWA,
     CatalogoActividadPWA,
     InscriptoActividadEspacioPWA,
-    NominaDestinatariosDocumentoPWA,
     NominaObservacionPWA,
     RegistroAsistenciaNominaPWA,
 )
@@ -70,6 +69,7 @@ from pwa.services.nomina_service import (
     update_nomina_persona,
 )
 from pwa.services.nomina_destinatarios_pdf_service import (
+    get_latest_nomina_destinatarios_documents_by_period,
     serialize_nomina_destinatarios_documento,
 )
 from pwa.utils import parse_periodo_referencia
@@ -851,14 +851,10 @@ class NominaEspacioPWAViewSet(viewsets.ViewSet):
         }
 
     def _attendance_documents_by_period(self, periodos):
-        documentos = NominaDestinatariosDocumentoPWA.objects.filter(
+        return get_latest_nomina_destinatarios_documents_by_period(
             comedor_id=self.kwargs["comedor_id"],
-            periodo_referencia__in=periodos,
-        ).order_by("periodo_referencia", "-version", "-fecha_generacion", "-id")
-        latest_by_period = {}
-        for documento in documentos:
-            latest_by_period.setdefault(documento.periodo_referencia, documento)
-        return latest_by_period
+            periodos=periodos,
+        )
 
     _parse_periodo_referencia = staticmethod(parse_periodo_referencia)
 

--- a/pwa/services/nomina_destinatarios_pdf_service.py
+++ b/pwa/services/nomina_destinatarios_pdf_service.py
@@ -368,6 +368,17 @@ def serialize_nomina_destinatarios_documento(documento, request=None):
     }
 
 
+def get_latest_nomina_destinatarios_documents_by_period(*, comedor_id, periodos):
+    documentos = NominaDestinatariosDocumentoPWA.objects.filter(
+        comedor_id=comedor_id,
+        periodo_referencia__in=periodos,
+    ).order_by("periodo_referencia", "-version", "-fecha_generacion", "-id")
+    latest_by_period = {}
+    for documento in documentos:
+        latest_by_period.setdefault(documento.periodo_referencia, documento)
+    return latest_by_period
+
+
 def generar_nomina_destinatarios_pdf(
     *,
     comedor,

--- a/rendicioncuentasmensual/models.py
+++ b/rendicioncuentasmensual/models.py
@@ -86,7 +86,7 @@ class DocumentacionAdjunta(SoftDeleteModelMixin, models.Model):
             "codigo": CATEGORIA_FORMULARIO_III_ALIMENTARIO,
             "label": "Formulario III - Desagregado por Facturas Prestación Alimentaria",
             "required": True,
-            "multiple": False,
+            "multiple": True,
             "order": 3,
         },
         {
@@ -94,7 +94,7 @@ class DocumentacionAdjunta(SoftDeleteModelMixin, models.Model):
             "label": "Formulario III - Desagregado por Facturas SIPH",
             "description": "Este documento es obligatorio si presentó actividades para este Convenio",
             "required": False,
-            "multiple": False,
+            "multiple": True,
             "order": 4,
         },
         {
@@ -136,7 +136,7 @@ class DocumentacionAdjunta(SoftDeleteModelMixin, models.Model):
         {
             "codigo": CATEGORIA_COMPROBANTES,
             "label": "Comprobante/s",
-            "required": True,
+            "required": False,
             "multiple": True,
             "order": 10,
         },

--- a/tests/test_pwa_comedores_api.py
+++ b/tests/test_pwa_comedores_api.py
@@ -879,7 +879,6 @@ def test_adjuntar_y_presentar_rendicion(comedores, settings, tmp_path):
         DocumentacionAdjunta.CATEGORIA_FORMULARIO_III_ALIMENTARIO,
         DocumentacionAdjunta.CATEGORIA_FORMULARIO_V_ALIMENTARIO,
         DocumentacionAdjunta.CATEGORIA_EXTRACTO_BANCARIO,
-        DocumentacionAdjunta.CATEGORIA_COMPROBANTES,
     ]
     for categoria in categorias_obligatorias:
         archivo = SimpleUploadedFile(
@@ -893,6 +892,23 @@ def test_adjuntar_y_presentar_rendicion(comedores, settings, tmp_path):
             format="multipart",
         )
         assert upload_response.status_code == 201
+
+    for categoria in (
+        DocumentacionAdjunta.CATEGORIA_FORMULARIO_III_ALIMENTARIO,
+        DocumentacionAdjunta.CATEGORIA_FORMULARIO_III_SIPH,
+    ):
+        for indice in range(2):
+            archivo = SimpleUploadedFile(
+                f"{categoria}-{indice}.pdf",
+                b"%PDF-1.4 test content",
+                content_type="application/pdf",
+            )
+            upload_response = client.post(
+                f"/api/comedores/{comedor_1.id}/rendiciones/{rendicion.id}/documentacion/",
+                {"archivo": archivo, "categoria": categoria},
+                format="multipart",
+            )
+            assert upload_response.status_code == 201
 
     detail_response = client.get(
         f"/api/comedores/{comedor_1.id}/rendiciones/{rendicion.id}/",
@@ -908,6 +924,24 @@ def test_adjuntar_y_presentar_rendicion(comedores, settings, tmp_path):
     )
     assert formulario_i["required"] is False
     assert formulario_i["archivos"] == []
+    comprobantes = next(
+        item
+        for item in detail_response.data["documentacion"]
+        if item["codigo"] == DocumentacionAdjunta.CATEGORIA_COMPROBANTES
+    )
+    assert comprobantes["required"] is False
+    assert comprobantes["archivos"] == []
+    for codigo_multiple in (
+        DocumentacionAdjunta.CATEGORIA_FORMULARIO_III_ALIMENTARIO,
+        DocumentacionAdjunta.CATEGORIA_FORMULARIO_III_SIPH,
+    ):
+        categoria_multiple = next(
+            item
+            for item in detail_response.data["documentacion"]
+            if item["codigo"] == codigo_multiple
+        )
+        assert categoria_multiple["multiple"] is True
+        assert len(categoria_multiple["archivos"]) >= 2
     for codigo_siph in (
         DocumentacionAdjunta.CATEGORIA_FORMULARIO_III_SIPH,
         DocumentacionAdjunta.CATEGORIA_FORMULARIO_V_SIPH,

--- a/tests/test_pwa_nomina_api.py
+++ b/tests/test_pwa_nomina_api.py
@@ -3,6 +3,7 @@ from datetime import date
 import pytest
 from django.contrib.auth import get_user_model
 from django.contrib.auth.models import Permission
+from django.core.files.uploadedfile import SimpleUploadedFile
 from django.utils import timezone
 from rest_framework.authtoken.models import Token
 from rest_framework.test import APIClient
@@ -10,6 +11,7 @@ from rest_framework.test import APIClient
 from admisiones.models.admisiones import Admision
 from ciudadanos.models import Ciudadano
 from comedores.models import Comedor, Nomina
+from comedores.views.nomina import _get_asistencia_nomina_context
 from core.models import Dia, Provincia, Sexo
 from pwa.models import (
     ActividadEspacioPWA,
@@ -607,6 +609,84 @@ def test_nomina_bulk_attendance_alimentaria_syncs_current_period(
     )
     assert repetida.status_code == 400
     assert "periodo" in repetida.data["detail"]
+
+
+@pytest.mark.django_db
+def test_historial_asistencia_expone_pdf_en_api_y_contexto_web(
+    comedor, admision, sexo_f, settings, tmp_path
+):
+    settings.MEDIA_ROOT = str(tmp_path)
+    representante = _create_representante(comedor=comedor, username="rep_historial_pdf")
+    client = _auth_client_for_user(representante)
+    ciudadano = Ciudadano.objects.create(
+        nombre="Ana",
+        apellido="Pérez",
+        documento=30111222,
+        fecha_nacimiento="1990-01-01",
+        sexo=sexo_f,
+    )
+    nomina = Nomina.objects.create(
+        admision=admision,
+        ciudadano=ciudadano,
+        estado=Nomina.ESTADO_ACTIVO,
+    )
+    NominaEspacioPWA.objects.create(
+        nomina=nomina,
+        asistencia_alimentaria=True,
+        asistencia_actividades=True,
+        activo=True,
+    )
+    periodo = date(2026, 5, 1)
+    RegistroAsistenciaNominaPWA.objects.create(
+        nomina=nomina,
+        periodo_referencia=periodo,
+        tomado_por=representante,
+    )
+    documento = NominaDestinatariosDocumentoPWA.objects.create(
+        comedor=comedor,
+        periodo_referencia=periodo,
+        archivo=SimpleUploadedFile(
+            "nomina-mayo.pdf",
+            b"%PDF-1.4 historial",
+            content_type="application/pdf",
+        ),
+        cantidad_destinatarios=1,
+        generado_por=representante,
+    )
+
+    list_response = client.get(
+        f"/api/pwa/espacios/{comedor.id}/nomina/asistencias-periodos/",
+        {"tab": "alimentaria"},
+    )
+    assert list_response.status_code == 200
+    item = list_response.data["results"][0]
+    assert item["nomina_destinatarios_documento"]["id"] == documento.id
+    assert item["nomina_destinatarios_documento"]["archivo_url"].endswith(
+        "/nomina-mayo.pdf"
+    )
+
+    detail_response = client.get(
+        f"/api/pwa/espacios/{comedor.id}/nomina/asistencias-periodo/",
+        {"tab": "alimentaria", "periodo": "2026-05"},
+    )
+    assert detail_response.status_code == 200
+    assert detail_response.data["nomina_destinatarios_documento"]["id"] == documento.id
+
+    formacion_response = client.get(
+        f"/api/pwa/espacios/{comedor.id}/nomina/asistencias-periodos/",
+        {"tab": "formacion"},
+    )
+    assert formacion_response.status_code == 200
+    assert (
+        formacion_response.data["results"][0]["nomina_destinatarios_documento"] is None
+    )
+
+    web_context = _get_asistencia_nomina_context(
+        type("Request", (), {"GET": {}})(),
+        admision_id=admision.id,
+        comedor_id=comedor.id,
+    )
+    assert web_context["asistencia_periodos"][0]["documento_nomina"] == documento
 
 
 @pytest.mark.django_db

--- a/tests/test_pwa_nomina_api.py
+++ b/tests/test_pwa_nomina_api.py
@@ -653,6 +653,18 @@ def test_historial_asistencia_expone_pdf_en_api_y_contexto_web(
         cantidad_destinatarios=1,
         generado_por=representante,
     )
+    documento_actualizado = NominaDestinatariosDocumentoPWA.objects.create(
+        comedor=comedor,
+        periodo_referencia=periodo,
+        version=2,
+        archivo=SimpleUploadedFile(
+            "nomina-mayo-v2.pdf",
+            b"%PDF-1.4 historial actualizado",
+            content_type="application/pdf",
+        ),
+        cantidad_destinatarios=1,
+        generado_por=representante,
+    )
 
     list_response = client.get(
         f"/api/pwa/espacios/{comedor.id}/nomina/asistencias-periodos/",
@@ -660,9 +672,9 @@ def test_historial_asistencia_expone_pdf_en_api_y_contexto_web(
     )
     assert list_response.status_code == 200
     item = list_response.data["results"][0]
-    assert item["nomina_destinatarios_documento"]["id"] == documento.id
+    assert item["nomina_destinatarios_documento"]["id"] == documento_actualizado.id
     assert item["nomina_destinatarios_documento"]["archivo_url"].endswith(
-        "/nomina-mayo.pdf"
+        "/nomina-mayo-v2.pdf"
     )
 
     detail_response = client.get(
@@ -670,7 +682,10 @@ def test_historial_asistencia_expone_pdf_en_api_y_contexto_web(
         {"tab": "alimentaria", "periodo": "2026-05"},
     )
     assert detail_response.status_code == 200
-    assert detail_response.data["nomina_destinatarios_documento"]["id"] == documento.id
+    assert (
+        detail_response.data["nomina_destinatarios_documento"]["id"]
+        == documento_actualizado.id
+    )
 
     formacion_response = client.get(
         f"/api/pwa/espacios/{comedor.id}/nomina/asistencias-periodos/",
@@ -686,7 +701,10 @@ def test_historial_asistencia_expone_pdf_en_api_y_contexto_web(
         admision_id=admision.id,
         comedor_id=comedor.id,
     )
-    assert web_context["asistencia_periodos"][0]["documento_nomina"] == documento
+    assert (
+        web_context["asistencia_periodos"][0]["documento_nomina"]
+        == documento_actualizado
+    )
 
 
 @pytest.mark.django_db


### PR DESCRIPTION
## Resumen
- habilita múltiples archivos en los Formularios III Alimentario y SIPH
- hace optativo Comprobante/s en rendiciones PWA
- agrega descarga persistente del PDF de nómina en los historiales mobile y web
- expone el PDF asociado desde la API de períodos de asistencia

## Validación
- pruebas de regresión dirigidas: 3 passed
- TypeScript y ESLint mobile
- black, djlint y diff checks

Closes #2158
Closes #2159