### PR TITLE
Issue 2149: ocultar comedores sin programa en PWA

### DIFF
--- a/comedores/api_views.py
+++ b/comedores/api_views.py
@@ -92,6 +92,8 @@ from users.services_pwa import (
     get_assignable_pwa_permission_codes,
     get_accessible_comedor_ids,
     get_access_rows,
+    get_visible_access_rows,
+    filter_pwa_visible_spaces,
     is_pwa_user,
     list_operadores_for_comedor,
     update_operador_permissions,
@@ -125,14 +127,7 @@ class ComedorDetailViewSet(
 
     @staticmethod
     def _filter_pwa_visible_spaces(queryset):
-        alimentar_comunidad = Q(programa__nombre__iexact="Alimentar Comunidad")
-        activo_en_ejecucion = Q(
-            ultimo_estado__estado_general__estado_actividad__estado__iexact="Activo",
-            ultimo_estado__estado_general__estado_proceso__estado__iexact="En ejecución",
-        )
-        return queryset.filter(programa__isnull=False).filter(
-            ~alimentar_comunidad | activo_en_ejecucion
-        )
+        return filter_pwa_visible_spaces(queryset)
 
     def _get_scoped_comedor_ids(self):
         user = self.request.user
@@ -218,7 +213,7 @@ class ComedorDetailViewSet(
                 "id": row.comedor_id,
                 "nombre": row.comedor.nombre if row.comedor_id else "",
             }
-            for row in get_access_rows(user)
+            for row in get_visible_access_rows(user)
             .filter(rol=AccesoComedorPWA.ROL_REPRESENTANTE)
             .select_related("comedor")
             .order_by("comedor__nombre", "comedor_id")

--- a/comedores/api_views.py
+++ b/comedores/api_views.py
@@ -130,7 +130,9 @@ class ComedorDetailViewSet(
             ultimo_estado__estado_general__estado_actividad__estado__iexact="Activo",
             ultimo_estado__estado_general__estado_proceso__estado__iexact="En ejecución",
         )
-        return queryset.filter(~alimentar_comunidad | activo_en_ejecucion)
+        return queryset.filter(programa__isnull=False).filter(
+            ~alimentar_comunidad | activo_en_ejecucion
+        )
 
     def _get_scoped_comedor_ids(self):
         user = self.request.user

--- a/docs/registro/cambios/2026-07-28-issue-2149-visibilidad-pwa-programa.md
+++ b/docs/registro/cambios/2026-07-28-issue-2149-visibilidad-pwa-programa.md
@@ -10,26 +10,27 @@ Resolver el issue #2149 evitando que la PWA muestre o permita gestionar comedore
 
 ## Alcance
 
-- Selector de espacios PWA.
-- Acceso al detalle de un comedor desde la API PWA.
+- Selector, detalle y espacios asignables de la PWA.
+- Endpoints PWA que autorizan por comedor, incluida la gestión de nómina.
 
 ## Cambios realizados
 
 - El filtro central de visibilidad PWA excluye comedores con `programa IS NULL`, aunque el usuario tenga una asignación activa.
 - Se conserva la regla existente para Alimentar Comunidad: solo es visible con estado Activo y proceso En ejecución.
+- La misma elegibilidad se reutiliza para IDs accesibles y permisos PWA, por lo que un URL conocido no permite consultar ni gestionar un comedor que dejó de ser visible.
 - La evaluación ocurre en cada consulta, por lo que asignar o quitar un programa actualiza automáticamente la disponibilidad en PWA.
-- Se agregó una regresión que cubre lista, detalle y reaparición después de asignar un programa.
+- Se agregaron regresiones para lista, detalle, nómina y espacios asignables antes y después de quitar un programa.
 
 ## Archivos tocados
 
 - `comedores/api_views.py`
-- `tests/test_pwa_comedores_api.py`
+- `users/services_pwa.py`
+- Pruebas PWA de comedores, nómina, colaboradores, formación, mensajes y push.
 
 ## Validaciones
 
-- Pruebas dirigidas del selector y detalle PWA.
-- Suite completa de API de comedores PWA.
-- `black` y verificación de whitespace.
+- 99 pruebas PWA y de formularios de acceso relacionadas.
+- `black`, `pylint` y verificación de whitespace.
 
 ## Pendientes / riesgos
 

--- a/docs/registro/cambios/2026-07-28-issue-2149-visibilidad-pwa-programa.md
+++ b/docs/registro/cambios/2026-07-28-issue-2149-visibilidad-pwa-programa.md
@@ -1,0 +1,35 @@
+# Visibilidad de comedores con programa en PWA
+
+## Fecha
+
+2026-07-28
+
+## Objetivo
+
+Resolver el issue #2149 evitando que la PWA muestre o permita gestionar comedores sin programa asignado.
+
+## Alcance
+
+- Selector de espacios PWA.
+- Acceso al detalle de un comedor desde la API PWA.
+
+## Cambios realizados
+
+- El filtro central de visibilidad PWA excluye comedores con `programa IS NULL`, aunque el usuario tenga una asignación activa.
+- Se conserva la regla existente para Alimentar Comunidad: solo es visible con estado Activo y proceso En ejecución.
+- La evaluación ocurre en cada consulta, por lo que asignar o quitar un programa actualiza automáticamente la disponibilidad en PWA.
+- Se agregó una regresión que cubre lista, detalle y reaparición después de asignar un programa.
+
+## Archivos tocados
+
+- `comedores/api_views.py`
+- `tests/test_pwa_comedores_api.py`
+
+## Validaciones
+
+- Pruebas dirigidas del selector y detalle PWA.
+- `black` y verificación de whitespace.
+
+## Pendientes / riesgos
+
+- No requiere migración ni cambios en el frontend mobile.

--- a/docs/registro/cambios/2026-07-28-issue-2149-visibilidad-pwa-programa.md
+++ b/docs/registro/cambios/2026-07-28-issue-2149-visibilidad-pwa-programa.md
@@ -28,6 +28,7 @@ Resolver el issue #2149 evitando que la PWA muestre o permita gestionar comedore
 ## Validaciones
 
 - Pruebas dirigidas del selector y detalle PWA.
+- Suite completa de API de comedores PWA.
 - `black` y verificación de whitespace.
 
 ## Pendientes / riesgos

--- a/tests/test_pwa_colaboradores_api.py
+++ b/tests/test_pwa_colaboradores_api.py
@@ -10,6 +10,7 @@ from comedores.models import (
     AuditColaboradorEspacio,
     ColaboradorEspacio,
     Comedor,
+    Programas,
 )
 from core.models import Provincia, Sexo
 from users.models import AccesoComedorPWA
@@ -26,7 +27,12 @@ def _grant_pwa_permission(user, codename):
 @pytest.fixture
 def comedor(db):
     provincia = Provincia.objects.create(nombre="Buenos Aires")
-    return Comedor.objects.create(nombre="Comedor Colaboradores", provincia=provincia)
+    programa = Programas.objects.create(nombre="Abordaje Comunitario")
+    return Comedor.objects.create(
+        nombre="Comedor Colaboradores",
+        provincia=provincia,
+        programa=programa,
+    )
 
 
 @pytest.fixture

--- a/tests/test_pwa_comedores_api.py
+++ b/tests/test_pwa_comedores_api.py
@@ -68,8 +68,17 @@ def _grant_pwa_permission(user, codename):
 @pytest.fixture
 def comedores(db):
     provincia = Provincia.objects.create(nombre="Cordoba")
-    comedor_1 = Comedor.objects.create(nombre="Comedor Uno", provincia=provincia)
-    comedor_2 = Comedor.objects.create(nombre="Comedor Dos", provincia=provincia)
+    programa = Programas.objects.create(nombre="Abordaje Comunitario")
+    comedor_1 = Comedor.objects.create(
+        nombre="Comedor Uno",
+        provincia=provincia,
+        programa=programa,
+    )
+    comedor_2 = Comedor.objects.create(
+        nombre="Comedor Dos",
+        provincia=provincia,
+        programa=programa,
+    )
     return comedor_1, comedor_2
 
 
@@ -773,24 +782,28 @@ def test_crear_rendicion_mobile_rechaza_numero_repetido_y_periodo_solapado(comed
 @pytest.mark.django_db
 def test_rendiciones_mobile_scope_por_organizacion_y_proyecto():
     provincia = Provincia.objects.create(nombre="Santa Fe")
+    programa = Programas.objects.create(nombre="Abordaje Comunitario")
     organizacion_a = Organizacion.objects.create(nombre="Organización A")
     organizacion_b = Organizacion.objects.create(nombre="Organización B")
     comedor_a_1 = Comedor.objects.create(
         nombre="Espacio A1",
         provincia=provincia,
         organizacion=organizacion_a,
+        programa=programa,
         codigo_de_proyecto="PROY-COMPARTIDO",
     )
     comedor_a_2 = Comedor.objects.create(
         nombre="Espacio A2",
         provincia=provincia,
         organizacion=organizacion_a,
+        programa=programa,
         codigo_de_proyecto="PROY-COMPARTIDO",
     )
     comedor_b_1 = Comedor.objects.create(
         nombre="Espacio B1",
         provincia=provincia,
         organizacion=organizacion_b,
+        programa=programa,
         codigo_de_proyecto="PROY-COMPARTIDO",
     )
 
@@ -831,18 +844,21 @@ def test_rendiciones_mobile_scope_por_organizacion_y_proyecto():
 @pytest.mark.django_db
 def test_crear_rendicion_mobile_permite_mismo_proyecto_en_otra_organizacion():
     provincia = Provincia.objects.create(nombre="Entre Ríos")
+    programa = Programas.objects.create(nombre="Abordaje Comunitario")
     organizacion_a = Organizacion.objects.create(nombre="Organización Rendición A")
     organizacion_b = Organizacion.objects.create(nombre="Organización Rendición B")
     comedor_a = Comedor.objects.create(
         nombre="Espacio Rendición A",
         provincia=provincia,
         organizacion=organizacion_a,
+        programa=programa,
         codigo_de_proyecto="PROY-ORG-01",
     )
     comedor_b = Comedor.objects.create(
         nombre="Espacio Rendición B",
         provincia=provincia,
         organizacion=organizacion_b,
+        programa=programa,
         codigo_de_proyecto="PROY-ORG-01",
     )
 

--- a/tests/test_pwa_comedores_api.py
+++ b/tests/test_pwa_comedores_api.py
@@ -305,6 +305,39 @@ def test_pwa_spaces_selector_list_returns_metadata_and_sorted_names():
 
 
 @pytest.mark.django_db
+def test_pwa_oculta_comedor_sin_programa_y_lo_actualiza_al_asignarlo():
+    provincia = Provincia.objects.create(nombre="Buenos Aires")
+    comedor = Comedor.objects.create(
+        nombre="Espacio sin programa",
+        provincia=provincia,
+        programa=None,
+    )
+    representante = _create_pwa_user(
+        comedor=comedor,
+        role=AccesoComedorPWA.ROL_REPRESENTANTE,
+        username="rep_sin_programa",
+    )
+    client = _token_client(representante)
+
+    listado_sin_programa = client.get("/api/comedores/")
+    detalle_sin_programa = client.get(f"/api/comedores/{comedor.id}/")
+
+    assert listado_sin_programa.status_code == 200
+    assert listado_sin_programa.data["results"] == []
+    assert detalle_sin_programa.status_code == 404
+
+    comedor.programa = Programas.objects.create(nombre="Abordaje Comunitario")
+    comedor.save(update_fields=["programa"])
+
+    listado_con_programa = client.get("/api/comedores/")
+    detalle_con_programa = client.get(f"/api/comedores/{comedor.id}/")
+
+    assert listado_con_programa.status_code == 200
+    assert [item["id"] for item in listado_con_programa.data["results"]] == [comedor.id]
+    assert detalle_con_programa.status_code == 200
+
+
+@pytest.mark.django_db
 def test_comedor_detail_includes_mobile_relevamiento_summary():
     provincia = Provincia.objects.create(nombre="Buenos Aires")
     municipio = Municipio.objects.create(nombre="La Plata", provincia=provincia)

--- a/tests/test_pwa_comedores_api.py
+++ b/tests/test_pwa_comedores_api.py
@@ -345,6 +345,12 @@ def test_pwa_oculta_comedor_sin_programa_y_lo_actualiza_al_asignarlo():
     assert [item["id"] for item in listado_con_programa.data["results"]] == [comedor.id]
     assert detalle_con_programa.status_code == 200
 
+    comedor.programa = None
+    comedor.save(update_fields=["programa"])
+
+    assert client.get("/api/comedores/").data["results"] == []
+    assert client.get(f"/api/comedores/{comedor.id}/").status_code == 404
+
 
 @pytest.mark.django_db
 def test_comedor_detail_includes_mobile_relevamiento_summary():
@@ -530,6 +536,32 @@ def test_representante_can_list_and_create_operadores(comedores):
     assert create_response.status_code == 201
     assert create_response.data["username"] == "op_nuevo"
     assert create_response.data["rol"] == AccesoComedorPWA.ROL_OPERADOR
+
+
+@pytest.mark.django_db
+def test_usuarios_no_expone_comedores_sin_programa_en_asignables(comedores):
+    comedor_visible, comedor_sin_programa = comedores
+    representante = _create_pwa_user(
+        comedor=comedor_visible,
+        role=AccesoComedorPWA.ROL_REPRESENTANTE,
+        username="rep_asignables_programa",
+    )
+    AccesoComedorPWA.objects.create(
+        user=representante,
+        comedor=comedor_sin_programa,
+        rol=AccesoComedorPWA.ROL_REPRESENTANTE,
+        activo=True,
+    )
+    comedor_sin_programa.programa = None
+    comedor_sin_programa.save(update_fields=["programa"])
+    client = _token_client(representante)
+
+    response = client.get(f"/api/comedores/{comedor_visible.id}/usuarios/")
+
+    assert response.status_code == 200
+    assert [item["id"] for item in response.data["assignable_comedores"]] == [
+        comedor_visible.id
+    ]
 
 
 @pytest.mark.django_db

--- a/tests/test_pwa_formacion_api.py
+++ b/tests/test_pwa_formacion_api.py
@@ -2,7 +2,15 @@ import pytest
 from django.contrib.auth import get_user_model
 from rest_framework.test import APIRequestFactory, force_authenticate
 
-from comedores.models import Comedor, CursoAppMobile, Programas
+from comedores.models import (
+    Comedor,
+    CursoAppMobile,
+    EstadoActividad,
+    EstadoGeneral,
+    EstadoHistorial,
+    EstadoProceso,
+    Programas,
+)
 from core.models import Provincia
 from pwa.api_views import CursoAppMobilePWAViewSet
 from users.models import AccesoComedorPWA
@@ -34,6 +42,24 @@ def _create_comedor(programa_nombre):
         provincia=provincia,
         programa=programa,
     )
+
+
+def _marcar_activo_en_ejecucion(comedor):
+    estado_actividad = EstadoActividad.objects.create(estado="Activo")
+    estado_proceso = EstadoProceso.objects.create(
+        estado="En ejecución",
+        estado_actividad=estado_actividad,
+    )
+    estado_general = EstadoGeneral.objects.create(
+        estado_actividad=estado_actividad,
+        estado_proceso=estado_proceso,
+    )
+    historial = EstadoHistorial.objects.create(
+        comedor=comedor,
+        estado_general=estado_general,
+    )
+    comedor.ultimo_estado = historial
+    comedor.save(update_fields=["ultimo_estado"])
 
 
 def _formacion_url(comedor):
@@ -87,6 +113,7 @@ def test_formacion_pwa_filtra_cursos_para_pnud():
 
 def test_formacion_pwa_filtra_cursos_para_alimentar_comunidad():
     comedor = _create_comedor("Alimentar Comunidad")
+    _marcar_activo_en_ejecucion(comedor)
     representante = _create_representante(comedor=comedor, username="rep_alimentar")
 
     CursoAppMobile.objects.create(

--- a/tests/test_pwa_mensajes_api.py
+++ b/tests/test_pwa_mensajes_api.py
@@ -16,7 +16,7 @@ from comunicados.models import (
     SubtipoComunicado,
     TipoComunicado,
 )
-from comedores.models import Comedor
+from comedores.models import Comedor, Programas
 from core.models import Provincia
 from organizaciones.models import Organizacion
 from pwa.models import AuditoriaOperacionPWA, LecturaMensajePWA
@@ -28,11 +28,16 @@ from users.models import AccesoComedorPWA
 @pytest.fixture
 def espacios(db):
     provincia = Provincia.objects.create(nombre="Buenos Aires")
+    programa = Programas.objects.create(nombre="Abordaje Comunitario")
     espacio_1 = Comedor.objects.create(
-        nombre="Espacio Mensajes Uno", provincia=provincia
+        nombre="Espacio Mensajes Uno",
+        provincia=provincia,
+        programa=programa,
     )
     espacio_2 = Comedor.objects.create(
-        nombre="Espacio Mensajes Dos", provincia=provincia
+        nombre="Espacio Mensajes Dos",
+        provincia=provincia,
+        programa=programa,
     )
     return espacio_1, espacio_2
 

--- a/tests/test_pwa_nomina_api.py
+++ b/tests/test_pwa_nomina_api.py
@@ -9,7 +9,7 @@ from rest_framework.test import APIClient
 
 from admisiones.models.admisiones import Admision
 from ciudadanos.models import Ciudadano
-from comedores.models import Comedor, Nomina
+from comedores.models import Comedor, Nomina, Programas
 from core.models import Dia, Provincia, Sexo
 from pwa.models import (
     ActividadEspacioPWA,
@@ -34,7 +34,12 @@ def _grant_pwa_permission(user, codename):
 @pytest.fixture
 def comedor(db):
     provincia = Provincia.objects.create(nombre="Buenos Aires")
-    return Comedor.objects.create(nombre="Comedor Nómina API", provincia=provincia)
+    programa = Programas.objects.create(nombre="Abordaje Comunitario")
+    return Comedor.objects.create(
+        nombre="Comedor Nómina API",
+        provincia=provincia,
+        programa=programa,
+    )
 
 
 @pytest.fixture
@@ -181,6 +186,22 @@ def test_nomina_list_stats_and_tabs(comedor, admision, sexo_f, sexo_m, dia):
     assert response_formacion.status_code == 200
     assert len(response_formacion.data["results"]) == 1
     assert response_formacion.data["results"][0]["apellido"] == "Lopez"
+
+
+@pytest.mark.django_db
+def test_nomina_rechaza_comedor_cuando_se_quita_el_programa(comedor, admision):
+    representante = _create_representante(
+        comedor=comedor,
+        username="rep_nomina_sin_programa",
+    )
+    client = _auth_client_for_user(representante)
+
+    comedor.programa = None
+    comedor.save(update_fields=["programa"])
+
+    response = client.get(f"/api/pwa/espacios/{comedor.id}/nomina/")
+
+    assert response.status_code == 403
 
 
 @pytest.mark.django_db

--- a/tests/test_pwa_push_api.py
+++ b/tests/test_pwa_push_api.py
@@ -6,7 +6,7 @@ from django.utils import timezone
 from rest_framework.authtoken.models import Token
 from rest_framework.test import APIClient
 
-from comedores.models import Comedor
+from comedores.models import Comedor, Programas
 from core.models import Provincia
 from organizaciones.models import Organizacion
 from pwa.models import PushSubscriptionPWA
@@ -50,22 +50,26 @@ def _grant_mobile_rendicion_permission(user):
 def espacios_push(db):
     provincia = Provincia.objects.create(nombre="Buenos Aires")
     organizacion = Organizacion.objects.create(nombre="Organizacion Push")
+    programa = Programas.objects.create(nombre="Abordaje Comunitario")
     espacio_1 = Comedor.objects.create(
         nombre="Espacio Push Uno",
         provincia=provincia,
         organizacion=organizacion,
+        programa=programa,
         codigo_de_proyecto="PROY-PUSH",
     )
     espacio_2 = Comedor.objects.create(
         nombre="Espacio Push Dos",
         provincia=provincia,
         organizacion=organizacion,
+        programa=programa,
         codigo_de_proyecto="PROY-PUSH",
     )
     espacio_3 = Comedor.objects.create(
         nombre="Espacio Push Tres",
         provincia=provincia,
         organizacion=organizacion,
+        programa=programa,
         codigo_de_proyecto="PROY-OTRO",
     )
     return espacio_1, espacio_2, espacio_3

--- a/users/services_pwa.py
+++ b/users/services_pwa.py
@@ -72,14 +72,36 @@ def get_access_rows(user):
     )
 
 
+def filter_pwa_visible_spaces(queryset, *, relation_prefix=""):
+    """Aplica las reglas de visibilidad PWA sobre un queryset de espacios."""
+    lookup_prefix = f"{relation_prefix}__" if relation_prefix else ""
+    alimentar_comunidad = Q(
+        **{f"{lookup_prefix}programa__nombre__iexact": "Alimentar Comunidad"}
+    )
+    activo_en_ejecucion = Q(
+        **{
+            f"{lookup_prefix}ultimo_estado__estado_general__estado_actividad__estado__iexact": "Activo",
+            f"{lookup_prefix}ultimo_estado__estado_general__estado_proceso__estado__iexact": "En ejecución",
+        }
+    )
+    return queryset.filter(**{f"{lookup_prefix}programa__isnull": False}).filter(
+        ~alimentar_comunidad | activo_en_ejecucion
+    )
+
+
+def get_visible_access_rows(user):
+    """Retorna accesos PWA activos cuyo comedor puede visualizarse."""
+    return filter_pwa_visible_spaces(get_access_rows(user), relation_prefix="comedor")
+
+
 def is_pwa_user(user) -> bool:
     """Indica si el usuario tiene al menos un acceso PWA activo."""
     return get_access_rows(user).exists()
 
 
 def get_accessible_comedor_ids(user) -> list[int]:
-    """IDs de comedores activos accesibles por el usuario."""
-    return list(get_access_rows(user).values_list("comedor_id", flat=True))
+    """IDs de comedores PWA visibles y accesibles por el usuario."""
+    return list(get_visible_access_rows(user).values_list("comedor_id", flat=True))
 
 
 def is_representante(user, comedor_id: int) -> bool:
@@ -87,7 +109,7 @@ def is_representante(user, comedor_id: int) -> bool:
     if not comedor_id:
         return False
     return (
-        get_access_rows(user)
+        get_visible_access_rows(user)
         .filter(
             comedor_id=comedor_id,
             rol=AccesoComedorPWA.ROL_REPRESENTANTE,
@@ -100,7 +122,7 @@ def has_pwa_access_to_comedor(user, comedor_id: int) -> bool:
     """Indica si el usuario tiene acceso PWA activo al comedor."""
     if not comedor_id:
         return False
-    return get_access_rows(user).filter(comedor_id=comedor_id).exists()
+    return get_visible_access_rows(user).filter(comedor_id=comedor_id).exists()
 
 
 def get_pwa_context(user) -> dict:


### PR DESCRIPTION
## Resumen
- excluye de la PWA los comedores sin programa asignado aunque tengan acceso activo
- aplica la regla tanto al selector como al detalle
- refleja automáticamente cambios posteriores de programa
- mantiene la validación vigente de Alimentar Comunidad

## Validación
- regresión de lista, detalle y reasignación de programa
- 2 pruebas dirigidas OK
- black OK
- pylint 10/10

Closes #2149