### PR TITLE
feat(organizaciones): mostrar programa en comedores asociados

### DIFF
--- a/docs/registro/cambios/2026-07-28-programa-comedores-asociados.md
+++ b/docs/registro/cambios/2026-07-28-programa-comedores-asociados.md
@@ -1,0 +1,13 @@
+# Programa en comedores asociados de Organización
+
+## Cambio
+
+El detalle de Organización ahora muestra el programa de cada comedor asociado
+en una columna específica. Para los comedores históricos sin programa cargado,
+la vista muestra `-`.
+
+## Alcance técnico
+
+La consulta del detalle incorpora la relación `programa` mediante `select_related`
+para evitar consultas adicionales por fila. No se modificaron datos, modelos,
+migraciones, rutas ni permisos.

--- a/organizaciones/templates/organizacion_detail.html
+++ b/organizaciones/templates/organizacion_detail.html
@@ -840,6 +840,7 @@
                                         <tr>
                                             <th>Nombre</th>
                                             <th>Tipo</th>
+                                            <th>Programa</th>
                                             <th>Ubicación</th>
                                             <th>Dirección</th>
                                             <th>Referente</th>
@@ -856,6 +857,7 @@
                                                               text-decoration: underline">{{ comedor.nombre }}</a>
                                                 </td>
                                                 <td>{{ comedor.tipocomedor.nombre|default:'-' }}</td>
+                                                <td>{{ comedor.programa.nombre|default:'-' }}</td>
                                                 <td>
                                                     <div>
                                                         <div style="font-size: 0.9rem;">{{ comedor.provincia.nombre|default:'-' }}</div>

--- a/organizaciones/tests.py
+++ b/organizaciones/tests.py
@@ -7,10 +7,11 @@ from django.contrib.auth.models import User, Permission
 from django.test import RequestFactory, TestCase, Client
 from django.urls import reverse
 
-from organizaciones.models import Organizacion, TipoEntidad
-from organizaciones.views import OrganizacionDetailView
-from organizaciones.forms import OrganizacionForm
+from comedores.models import Comedor, Programas, TipoDeComedor
 from core.models import Provincia
+from organizaciones.models import Organizacion, TipoEntidad
+from organizaciones.forms import OrganizacionForm
+from organizaciones.views import OrganizacionDetailView
 
 
 class CuilDuplicadoTemplateTests(TestCase):
@@ -67,6 +68,44 @@ class OrganizacionDetailViewTests(TestCase):
 
         self.assertFalse(context["avales"])
         self.assertEqual(context["tipo_entidad"], tipo_entidad)
+
+    def test_detalle_muestra_programas_de_comedores_y_fallback(self):
+        """El tab de comedores muestra el catálogo y conserva los sin programa."""
+        user = User.objects.create_superuser(
+            username="admin", email="admin@example.com", password="secret"
+        )
+        organizacion = Organizacion.objects.create(nombre="Organización Programa")
+        programas = [
+            Programas.objects.create(nombre="Alimentar comunidad"),
+            Programas.objects.create(nombre="Abordaje comunitario - Línea Secos"),
+            Programas.objects.create(nombre="Abordaje comunitario - Línea Tradicional"),
+        ]
+        for index, programa in enumerate(programas, start=1):
+            Comedor.objects.create(
+                nombre=f"Comedor con programa {index}",
+                organizacion=organizacion,
+                programa=programa,
+            )
+        tipo_comedor = TipoDeComedor.objects.create(nombre="Comunitario")
+        Comedor.objects.create(
+            nombre="Comedor histórico sin programa",
+            organizacion=organizacion,
+            tipocomedor=tipo_comedor,
+        )
+
+        self.client.force_login(user)
+        response = self.client.get(
+            reverse("organizacion_detalle", kwargs={"pk": organizacion.pk})
+        )
+
+        self.assertEqual(response.status_code, 200)
+        self.assertContains(response, "<th>Programa</th>", html=True)
+        for programa in programas:
+            self.assertContains(response, programa.nombre)
+        self.assertRegex(
+            response.content.decode(),
+            r"(?s)Comedor histórico sin programa.*?<td>Comunitario</td>\s*<td>-</td>",
+        )
 
 
 class CuilDuplicadoFormTests(TestCase):

--- a/organizaciones/views.py
+++ b/organizaciones/views.py
@@ -777,7 +777,12 @@ class OrganizacionDetailView(LoginRequiredMixin, DetailView):
 
         # Obtener comedores asociados a la organización
         comedores = self.object.comedor_set.select_related(
-            "tipocomedor", "provincia", "municipio", "localidad", "referente"
+            "tipocomedor",
+            "provincia",
+            "municipio",
+            "localidad",
+            "referente",
+            "programa",
         ).all()
         context["comedores"] = comedores
         context["comedores_count"] = comedores.count()


### PR DESCRIPTION
## Resumen

- agrega la columna **Programa** al tab de Comedores Asociados del detalle de Organización;
- muestra el nombre del catálogo y `-` para comedores históricos sin programa;
- precarga la relación para evitar consultas N+1 y agrega cobertura de regresión.

## Validación

- `pytest organizaciones/tests.py -k detalle_muestra_programas_de_comedores_y_fallback -q`
- `black --check organizaciones/views.py organizaciones/tests.py`
- `djlint organizaciones/templates/organizacion_detail.html --check`
- `pylint organizaciones/views.py organizaciones/tests.py`
- `git diff --check`

Closes #2164