### PR TITLE
fix(sidebar): mover OCR fuera de Administración

### DIFF
--- a/core/tests/test_sidebar_menu.py
+++ b/core/tests/test_sidebar_menu.py
@@ -135,3 +135,49 @@ def test_sidebar_ubica_expedientes_de_pago_cuarto_en_comedores(client):
     assert comedores_block.index("Acompañamiento") < comedores_block.index(
         "Expedientes de Pago"
     )
+
+
+def test_sidebar_muestra_ocr_a_usuario_con_solo_permiso_ocr(client):
+    user_model = get_user_model()
+    user = user_model.objects.create_user(
+        username="sidebar_ocr",
+        password="testpass123",
+    )
+    user.user_permissions.add(
+        Permission.objects.get(content_type__app_label="ocr", codename="use_ocr")
+    )
+    client.force_login(user)
+
+    response = client.get(reverse("inicio"))
+
+    assert response.status_code == 200
+
+    content = response.content.decode()
+    assert reverse("ocr_upload") in content
+    assert "<p>OCR</p>" in content
+    assert "Administración del sistema" not in content
+
+
+def test_sidebar_ubica_ocr_entre_configuracion_y_comunicados(client):
+    user_model = get_user_model()
+    user = user_model.objects.create_superuser(
+        username="sidebar_ocr_admin",
+        password="testpass123",
+    )
+    client.force_login(user)
+
+    response = client.get(reverse("inicio"))
+
+    assert response.status_code == 200
+
+    content = response.content.decode()
+    admin_start = content.index("Administración del sistema")
+    config_start = content.index("Configuración de Comedores")
+    admin_block = content[admin_start:config_start]
+
+    assert reverse("ocr_upload") not in admin_block
+    assert re.search(
+        r'style="order: 5">.*?<p>Configuración de Comedores</p>', content, re.S
+    )
+    assert re.search(r'style="order: 6">.*?<p>OCR</p>', content, re.S)
+    assert re.search(r'style="order: 7;.*?<p>Comunicados</p>', content, re.S)

--- a/docs/ocr.md
+++ b/docs/ocr.md
@@ -4,7 +4,8 @@ Extracción de texto a partir de imágenes y PDFs usando Tesseract OCR.
 
 ## Uso (pantalla)
 
-1. Ir a **Administración del sistema → OCR** en el sidebar.
+1. Ir a la sección **OCR** del sidebar, entre **Configuración de Comedores** y
+   **Comunicados**.
 2. Seleccionar uno o varios archivos (JPG, JPEG, PNG o PDF).
 3. (Opcional) En **Opciones de calidad** se pueden desactivar, por lote, el
    preprocesado de imagen, la capa de texto del PDF y la auto-orientación.

--- a/docs/registro/cambios/2026-07-28-issue-2151-mover-modulo-ocr.md
+++ b/docs/registro/cambios/2026-07-28-issue-2151-mover-modulo-ocr.md
@@ -1,0 +1,18 @@
+# Issue 2151: mover módulo OCR en el sidebar
+
+## Objetivo
+
+Hacer visible el acceso al módulo OCR para usuarios que poseen el permiso
+`ocr.use_ocr`, sin depender de que tengan acceso a Administración del sistema.
+
+## Cambios
+
+- OCR deja de estar dentro de Administración del sistema y pasa a ser una
+  sección principal del sidebar.
+- La sección queda entre Configuración de Comedores y Comunicados.
+- Se conservan la URL `/ocr/` y el permiso `ocr.use_ocr`; no se amplía el
+  acceso a usuarios sin ese permiso.
+
+## Validación
+
+- `scripts/ai/codex_run.ps1 test core/tests/test_sidebar_menu.py ocr/tests/test_views.py -q`

--- a/ocr/tests/test_views.py
+++ b/ocr/tests/test_views.py
@@ -34,6 +34,17 @@ class OCRUploadViewTest(TestCase):
         response = self.client.get(self.url)
         self.assertRedirects(response, f"/login/?next={self.url}")
 
+    def test_authenticated_user_without_ocr_permission_is_denied(self):
+        user_without_permission = User.objects.create_user(
+            username="without_ocr_permission",
+            password="pass",
+        )
+        self.client.force_login(user_without_permission)
+
+        response = self.client.get(self.url)
+
+        self.assertEqual(response.status_code, 403)
+
     def test_get_renders_form(self):
         self._login()
         response = self.client.get(self.url)

--- a/templates/includes/sidebar/opciones.html
+++ b/templates/includes/sidebar/opciones.html
@@ -38,7 +38,7 @@
     {% if not vat_sidebar_only %}
         <!-- COMUNICADOS -->
         <li class="nav-item nav-main-item {% if 'comunicados' in pagina_actual %}menu-open{% endif %}"
-            style="order: 6;
+            style="order: 7;
                    border-bottom: 1px solid var(--sidebar-border-color)">
             <a href="#"
                class="nav-link {% if 'comunicados' in pagina_actual %}active{% endif %}">
@@ -115,15 +115,6 @@
                         <p>Parametrías de Voucher</p>
                     </a>
                 </li>
-                {% if perms.ocr.use_ocr or request.user.is_superuser %}
-                    <li class="nav-item">
-                        <a href="{% url 'ocr_upload' %}"
-                           class="nav-link nav-dot ms-2 {% if 'ocr/' in pagina_actual %}active{% endif %}">
-                            <i class="nav-icon bi bi-file-text"></i>
-                            <p>OCR</p>
-                        </a>
-                    </li>
-                {% endif %}
             </ul>
         </li>
     {% endif %}
@@ -178,6 +169,17 @@
                 {% endif %}
             </ul>
         </li>
+    {% endif %}
+    {% if not vat_sidebar_only %}
+        {% if perms.ocr.use_ocr or request.user.is_superuser %}
+            <li class="nav-item nav-main-item" style="order: 6">
+                <a href="{% url 'ocr_upload' %}"
+                   class="nav-link {% if 'ocr/' in pagina_actual %}active{% endif %}">
+                    <i class="nav-icon bi bi-file-text"></i>
+                    <p>OCR</p>
+                </a>
+            </li>
+        {% endif %}
     {% endif %}
     {% if not vat_sidebar_only %}
         {% tableros_para_sidebar as tableros %}


### PR DESCRIPTION
## Resumen

Mueve el acceso a OCR fuera de `Administración del sistema` y lo incorpora como sección principal entre **Configuración de Comedores** y **Comunicados**.

## Causa raíz

El endpoint `/ocr/` ya autorizaba mediante `ocr.use_ocr`, pero su enlace estaba anidado en un bloque del sidebar que solo se renderiza para usuarios administrativos. Por eso un usuario con solo el permiso OCR no podía descubrir ni acceder al módulo desde la navegación.

## Cambios

- Conserva la URL y el permiso `ocr.use_ocr`; no amplía autorizaciones.
- Reubica OCR como acceso principal y conserva su estado activo.
- Agrega regresiones para visibilidad, orden y acceso directo denegado sin permiso.
- Actualiza la guía operativa y el registro del cambio.

## Validación

- `scripts/ai/codex_run.ps1 test core/tests/test_sidebar_menu.py ocr/tests/test_views.py -q` — 21 passed
- `scripts/ai/codex_run.ps1 black-check core/tests/test_sidebar_menu.py ocr/tests/test_views.py`
- `scripts/ai/codex_run.ps1 djlint-check templates/includes/sidebar/opciones.html`
- `git diff --check`

Closes #2151