### PR TITLE
feat(legajos): actualizar categorías de organizaciones y espacios comunitarios

### DIFF
--- a/comedores/forms/comedor_form.py
+++ b/comedores/forms/comedor_form.py
@@ -465,6 +465,12 @@ class ComedorForm(forms.ModelForm):
     def clean(self):
         cleaned_data = super().clean()
 
+        if (
+            cleaned_data.get("categoria_espacio_comunitario")
+            != Comedor.CATEGORIA_ESPACIO_OTRA
+        ):
+            cleaned_data["categoria_espacio_comunitario_otra"] = ""
+
         estado_actividad = cleaned_data.get("estado_general")
         estado_proceso = cleaned_data.get("subestado")
         estado_detalle = cleaned_data.get("motivo")

--- a/comedores/migrations/0051_comedor_categoria_espacio_comunitario.py
+++ b/comedores/migrations/0051_comedor_categoria_espacio_comunitario.py
@@ -1,0 +1,56 @@
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ("comedores", "0050_merge_20260720_1400"),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name="comedor",
+            name="categoria_espacio_comunitario",
+            field=models.CharField(
+                blank=True,
+                choices=[
+                    ("asociacion_civil", "Asociación Civil"),
+                    (
+                        "asociacion_vecinal",
+                        "Asociación Vecinal / Sociedad de Fomento",
+                    ),
+                    ("cooperativa_trabajo", "Cooperativa de Trabajo"),
+                    ("fundacion", "Fundación"),
+                    ("grupo_comunitario_base", "Grupo Comunitario de Base"),
+                    ("centro_desarrollo_infantil", "Centro de Desarrollo Infantil"),
+                    ("centro_jubilados", "Centro de Jubilados"),
+                    ("club_social_deportivo", "Club Social y/o Deportivo"),
+                    ("hogar", "Hogar"),
+                    ("institucion_educativa", "Institución Educativa"),
+                    ("institucion_religiosa", "Institución Religiosa"),
+                    (
+                        "movimiento_trabajadores_desocupados",
+                        "Movimiento de Trabajadores Desocupados",
+                    ),
+                    (
+                        "tecnicos_profesionales",
+                        "Organización de Técnicos y Profesionales",
+                    ),
+                    ("otra", "Otra (especificar)"),
+                ],
+                max_length=50,
+                null=True,
+                verbose_name="Categorización de espacio comunitario",
+            ),
+        ),
+        migrations.AddField(
+            model_name="comedor",
+            name="categoria_espacio_comunitario_otra",
+            field=models.CharField(
+                blank=True,
+                max_length=255,
+                null=True,
+                verbose_name="Otra categorización de espacio comunitario",
+            ),
+        ),
+    ]

--- a/comedores/models.py
+++ b/comedores/models.py
@@ -237,8 +237,60 @@ class Comedor(SoftDeleteModelMixin, models.Model):
         dupla (ForeignKey): Dúpla del Comedor/Merendero.
     """
 
-    nombre = models.CharField(
+    CATEGORIA_ESPACIO_ASOCIACION_CIVIL = "asociacion_civil"
+    CATEGORIA_ESPACIO_ASOCIACION_VECINAL = "asociacion_vecinal"
+    CATEGORIA_ESPACIO_COOPERATIVA_TRABAJO = "cooperativa_trabajo"
+    CATEGORIA_ESPACIO_FUNDACION = "fundacion"
+    CATEGORIA_ESPACIO_GRUPO_COMUNITARIO_BASE = "grupo_comunitario_base"
+    CATEGORIA_ESPACIO_CDI = "centro_desarrollo_infantil"
+    CATEGORIA_ESPACIO_CENTRO_JUBILADOS = "centro_jubilados"
+    CATEGORIA_ESPACIO_CLUB_SOCIAL_DEPORTIVO = "club_social_deportivo"
+    CATEGORIA_ESPACIO_HOGAR = "hogar"
+    CATEGORIA_ESPACIO_INSTITUCION_EDUCATIVA = "institucion_educativa"
+    CATEGORIA_ESPACIO_INSTITUCION_RELIGIOSA = "institucion_religiosa"
+    CATEGORIA_ESPACIO_MTD = "movimiento_trabajadores_desocupados"
+    CATEGORIA_ESPACIO_TECNICOS_PROFESIONALES = "tecnicos_profesionales"
+    CATEGORIA_ESPACIO_OTRA = "otra"
+
+    CATEGORIAS_ESPACIO_COMUNITARIO = [
+        (CATEGORIA_ESPACIO_ASOCIACION_CIVIL, "Asociación Civil"),
+        (
+            CATEGORIA_ESPACIO_ASOCIACION_VECINAL,
+            "Asociación Vecinal / Sociedad de Fomento",
+        ),
+        (CATEGORIA_ESPACIO_COOPERATIVA_TRABAJO, "Cooperativa de Trabajo"),
+        (CATEGORIA_ESPACIO_FUNDACION, "Fundación"),
+        (CATEGORIA_ESPACIO_GRUPO_COMUNITARIO_BASE, "Grupo Comunitario de Base"),
+        (CATEGORIA_ESPACIO_CDI, "Centro de Desarrollo Infantil"),
+        (CATEGORIA_ESPACIO_CENTRO_JUBILADOS, "Centro de Jubilados"),
+        (CATEGORIA_ESPACIO_CLUB_SOCIAL_DEPORTIVO, "Club Social y/o Deportivo"),
+        (CATEGORIA_ESPACIO_HOGAR, "Hogar"),
+        (CATEGORIA_ESPACIO_INSTITUCION_EDUCATIVA, "Institución Educativa"),
+        (CATEGORIA_ESPACIO_INSTITUCION_RELIGIOSA, "Institución Religiosa"),
+        (
+            CATEGORIA_ESPACIO_MTD,
+            "Movimiento de Trabajadores Desocupados",
+        ),
+        (
+            CATEGORIA_ESPACIO_TECNICOS_PROFESIONALES,
+            "Organización de Técnicos y Profesionales",
+        ),
+        (CATEGORIA_ESPACIO_OTRA, "Otra (especificar)"),
+    ]
+
+    nombre = models.CharField(max_length=255)
+    categoria_espacio_comunitario = models.CharField(
+        max_length=50,
+        choices=CATEGORIAS_ESPACIO_COMUNITARIO,
+        blank=True,
+        null=True,
+        verbose_name="Categorización de espacio comunitario",
+    )
+    categoria_espacio_comunitario_otra = models.CharField(
         max_length=255,
+        blank=True,
+        null=True,
+        verbose_name="Otra categorización de espacio comunitario",
     )
     organizacion = models.ForeignKey(
         to=Organizacion, blank=True, null=True, on_delete=models.PROTECT
@@ -392,6 +444,20 @@ class Comedor(SoftDeleteModelMixin, models.Model):
 
     def __str__(self) -> str:
         return str(self.nombre)
+
+    def clean(self):
+        super().clean()
+        if (
+            self.categoria_espacio_comunitario == self.CATEGORIA_ESPACIO_OTRA
+            and not (self.categoria_espacio_comunitario_otra or "").strip()
+        ):
+            raise ValidationError(
+                {
+                    "categoria_espacio_comunitario_otra": (
+                        "Especifique la otra categoría de espacio comunitario."
+                    )
+                }
+            )
 
     def get_estado_general_display(self) -> str:
         """

--- a/comedores/services/filter_config/impl.py
+++ b/comedores/services/filter_config/impl.py
@@ -30,6 +30,7 @@ FIELD_MAP: Dict[str, str] = {
     "barrio": "barrio",
     "codigo_de_proyecto": "codigo_de_proyecto",
     "es_judicializado": "es_judicializado",
+    "categoria_espacio_comunitario": "categoria_espacio_comunitario",
     # FKs -> nombre
     "organizacion": "organizacion__nombre",
     "programa": "programa__nombre",
@@ -89,6 +90,7 @@ FIELD_TYPES: Dict[str, str] = {
             "estado_proceso",
             "estado_detalle",
             "estado_validacion",
+            "categoria_espacio_comunitario",
         ]
     },
     # Booleanos
@@ -148,6 +150,11 @@ FILTER_FIELDS = [
         "type": "text",
     },
     {"name": "es_judicializado", "label": "Es judicializado?", "type": "boolean"},
+    {
+        "name": "categoria_espacio_comunitario",
+        "label": "Categorización de espacio comunitario",
+        "type": "choice",
+    },
     {"name": "id", "label": "ID", "type": "number"},
     {"name": "id_externo", "label": "ID Externo", "type": "number"},
     {"name": "comienzo", "label": "Comienzo (anio)", "type": "number"},
@@ -176,7 +183,7 @@ FILTER_FIELDS = [
 ]
 
 DEFAULT_FIELD = "nombre"
-FILTERS_UI_CONFIG_CACHE_KEY = "comedores:filters_ui_config:v3"
+FILTERS_UI_CONFIG_CACHE_KEY = "comedores:filters_ui_config:v4"
 FILTERS_UI_CONFIG_CACHE_TTL = 60 * 15
 
 
@@ -189,13 +196,17 @@ def get_filters_ui_config() -> Dict[str, Any]:
 
     fields = [dict(field) for field in FILTER_FIELDS]
 
+    from comedores.models import Comedor
+
+    for field in fields:
+        if field.get("name") == "categoria_espacio_comunitario":
+            field["choices"] = [
+                {"value": value, "label": label}
+                for value, label in Comedor.CATEGORIAS_ESPACIO_COMUNITARIO
+            ]
+
     try:
-        from comedores.models import (
-            Comedor,
-            EstadoActividad,
-            EstadoDetalle,
-            EstadoProceso,
-        )
+        from comedores.models import EstadoActividad, EstadoDetalle, EstadoProceso
 
         def build_state_choices(model_cls):
             return [

--- a/comedores/templates/comedor/asignar_dupla_form.html
+++ b/comedores/templates/comedor/asignar_dupla_form.html
@@ -1,7 +1,7 @@
 {% extends "includes/main.html" %};
 {% load static %}
 ;
-{% block title %}Comedor: {{ comedor.nombre }}{% endblock %}
+{% block title %}Espacio Comunitario: {{ comedor.nombre }}{% endblock %}
 ;
 <div class="col-md-2 pt-5">
     <c-dashboard.v-info-box titulo='Beneficiarios' valor='{{ tipo_comedor }}' color='success'>
@@ -13,7 +13,7 @@
 {% block breadcrumb %}
     <ol class="breadcrumb float-sm-right">
         <div class="breadcrumb-item">
-            <a href="{% url 'comedores' %}">Comedores</a>
+            <a href="{% url 'comedores' %}">Espacios Comunitarios</a>
         </div>
         <div class="breadcrumb-item active">
             <a href="{% url 'comedor_detalle' comedor.id %}">{{ comedor.nombre }}</a>

--- a/comedores/templates/comedor/comedor_confirm_delete.html
+++ b/comedores/templates/comedor/comedor_confirm_delete.html
@@ -1,12 +1,12 @@
 {% extends "includes/main.html" %};
 {% load static %}
 ;
-{% block title %}Comedor - {{ comedor.nombre }}{% endblock %}
+{% block title %}Espacio Comunitario - {{ comedor.nombre }}{% endblock %}
 ;
 {% block breadcrumb %}
     <ol class="breadcrumb float-sm-right">
         <div class="breadcrumb-item">
-            <a href="{% url 'comedores' %}">Comedores</a>
+            <a href="{% url 'comedores' %}">Espacios Comunitarios</a>
         </div>
         <div class="breadcrumb-item">
             <a href="{% url 'comedor_detalle' comedor.id %}">{{ comedor.nombre }}</a>

--- a/comedores/templates/comedor/comedor_detail.html
+++ b/comedores/templates/comedor/comedor_detail.html
@@ -3,7 +3,7 @@
 {% block head %}
     <link rel="stylesheet" href="{% static 'custom/css/comedor_detail.css' %}" />
 {% endblock %}
-{% block title %}Comedor: {{ comedor.nombre }}{% endblock %}
+{% block title %}Espacio Comunitario: {{ comedor.nombre }}{% endblock %}
 {% block app-header %}
     <div class="row g-2 align-items-center">
         <div class="col-12 col-lg-auto d-flex justify-content-start">
@@ -253,7 +253,18 @@
                         </div>
                         <div class="col-12 col-lg-7 overflow-auto mt-3 mt-lg-0 comedor-scroll-370">
                             <p class="mb-2">
-                                <i class="bi bi-house-door-fill me-2"></i><strong>Nombre del comedor:</strong> {{ comedor.nombre | default_if_none:"-" }}
+                                <i class="bi bi-house-door-fill me-2"></i><strong>Nombre del espacio comunitario:</strong> {{ comedor.nombre | default_if_none:"-" }}
+                            </p>
+                            <p class="mb-2">
+                                <i class="bi bi-tags me-2"></i><strong>Categorización:</strong>
+                                {% if comedor.categoria_espacio_comunitario %}
+                                    {{ comedor.get_categoria_espacio_comunitario_display }}
+                                    {% if comedor.categoria_espacio_comunitario == "otra" and comedor.categoria_espacio_comunitario_otra %}
+                                        — {{ comedor.categoria_espacio_comunitario_otra }}
+                                    {% endif %}
+                                {% else %}
+                                    -
+                                {% endif %}
                             </p>
                             <p class="mb-2">
                                 <i class="bi bi-geo me-2"></i><strong>Calle:</strong> {{ comedor.calle | default_if_none:"-" }}

--- a/comedores/templates/comedor/comedor_form.html
+++ b/comedores/templates/comedor/comedor_form.html
@@ -1,7 +1,7 @@
 {% extends "includes/main.html" %}
 {% load static crispy_forms_tags %}
-{% block title %}Comedores{% endblock %}
-{% block titulo-pagina %}Comedores{% endblock %}
+{% block title %}Espacios Comunitarios{% endblock %}
+{% block titulo-pagina %}Espacios Comunitarios{% endblock %}
 {% block breadcrumb %}
     {% include 'components/breadcrumb.html' with items=breadcrumb_items %}
 {% endblock %}
@@ -60,7 +60,7 @@
                             </div>
                             <div class="section-title-group">
                                 <h3 class="section-title">Información Básica</h3>
-                                <p class="section-subtitle">Datos generales del comedor/merendero</p>
+                                <p class="section-subtitle">Datos generales del espacio comunitario</p>
                             </div>
                         </div>
                         <div class="section-status">
@@ -77,6 +77,12 @@
                             <div class="col-md-4">{{ form.nombre|as_crispy_field }}</div>
                             <div class="col-md-4">{{ form.id_externo|as_crispy_field }}</div>
                             <div class="col-md-4">{{ form.tipocomedor|as_crispy_field }}</div>
+                        </div>
+                        <div class="form-group row">
+                            <div class="col-md-6">{{ form.categoria_espacio_comunitario|as_crispy_field }}</div>
+                            <div id="categoria-espacio-otra-wrapper" class="col-md-6 d-none">
+                                {{ form.categoria_espacio_comunitario_otra|as_crispy_field }}
+                            </div>
                         </div>
                         <div class="form-group row">
                             <div class="col-md-4">{{ form.organizacion|as_crispy_field }}</div>
@@ -518,6 +524,28 @@
         var ajaxLoadMunicipiosUrl = "{% url 'ajax_load_municipios' %}";
         var ajaxLoadLocalidadesUrl = "{% url 'ajax_load_localidades' %}";
         var ajaxLoadOrganizacionesUrl = "{% url 'ajax_load_organizaciones' %}";
+
+        (function () {
+            var categoriaInput = document.getElementById("id_categoria_espacio_comunitario");
+            var otraWrapper = document.getElementById("categoria-espacio-otra-wrapper");
+            var otraInput = document.getElementById("id_categoria_espacio_comunitario_otra");
+
+            if (!categoriaInput || !otraWrapper || !otraInput) {
+                return;
+            }
+
+            function actualizarOtraCategoria() {
+                var esOtra = categoriaInput.value === "otra";
+                otraWrapper.classList.toggle("d-none", !esOtra);
+                otraInput.required = esOtra;
+                if (!esOtra) {
+                    otraInput.value = "";
+                }
+            }
+
+            categoriaInput.addEventListener("change", actualizarOtraCategoria);
+            actualizarOtraCategoria();
+        }());
     </script>
 
     <!-- Scripts externos -->

--- a/comedores/templates/comedor/comedor_list.html
+++ b/comedores/templates/comedor/comedor_list.html
@@ -1,6 +1,6 @@
 {% extends "includes/main.html" %}
 {% load static %}
-{% block title %}Comedores{% endblock %}
+{% block title %}Espacios Comunitarios{% endblock %}
 {% block breadcrumb %}
     {% include 'components/breadcrumb.html' with items=breadcrumb_items %}
 {% endblock %}
@@ -10,7 +10,7 @@
 
     <div class="comedor-list-container">
         {% url 'comedor_export' as export_url %}
-        {% include 'components/search_bar.html' with titulo="Buscar Comedor/Merendero" placeholder="Buscar por nombre, provincia, municipio, localidad, barrio o calle" help_text="Ingresar nombre, provincia, municipio, localidad, barrio o calle." reset_url=reset_url add_url=add_url button_append=True comedores_filters_mode=True export_url=export_url export_permissions="comedores.view_comedor,admisiones.view_admision,acompanamientos.view_informacionrelevante" export_required_permission="auth.role_exportar_a_csv" export_admin_permissions="auth.role_admin,auth.role_administrador,auth.role_superadmin" %}
+        {% include 'components/search_bar.html' with titulo="Buscar Espacio Comunitario" placeholder="Buscar por nombre, provincia, municipio, localidad, barrio o calle" help_text="Ingresar nombre, provincia, municipio, localidad, barrio o calle." reset_url=reset_url add_url=add_url button_append=True comedores_filters_mode=True export_url=export_url export_permissions="comedores.view_comedor,admisiones.view_admision,acompanamientos.view_informacionrelevante" export_required_permission="auth.role_exportar_a_csv" export_admin_permissions="auth.role_admin,auth.role_administrador,auth.role_superadmin" %}
 
         {% include 'components/comedor_table.html' with comedores=comedores %}
         {% include 'components/pagination.html' with is_paginated=is_paginated page_obj=page_obj prev_text='Volver' next_text='Continuar' %}

--- a/comedores/templates/comedor/nomina_asistencia_historial.html
+++ b/comedores/templates/comedor/nomina_asistencia_historial.html
@@ -5,7 +5,7 @@
 {% block breadcrumb %}
     <ol class="breadcrumb float-sm-right">
         <li class="breadcrumb-item">
-            <a href="{% url 'comedores' %}">Comedores</a>
+            <a href="{% url 'comedores' %}">Espacios Comunitarios</a>
         </li>
         <li class="breadcrumb-item">
             <a href="{% url 'comedor_detalle' object.id %}">{{ object.nombre }}</a>

--- a/comedores/templates/comedor/nomina_detail.html
+++ b/comedores/templates/comedor/nomina_detail.html
@@ -21,7 +21,7 @@
 {% block breadcrumb %}
     <ol class="breadcrumb float-sm-right">
         <li class="breadcrumb-item">
-            <a href="{% url 'comedores' %}">Comedores</a>
+            <a href="{% url 'comedores' %}">Espacios Comunitarios</a>
         </li>
         <li class="breadcrumb-item">
             <a href="{% url 'comedor_detalle' object.id %}">{{ object.nombre }}</a>

--- a/comedores/templates/comedor/rendicion_cuentas_final_detail.html
+++ b/comedores/templates/comedor/rendicion_cuentas_final_detail.html
@@ -8,7 +8,7 @@
 {% block breadcrumb %}
     <ol class="breadcrumb float-sm-right">
         <div class="breadcrumb-item">
-            <a href="{% url 'comedores' %}">Comedores</a>
+            <a href="{% url 'comedores' %}">Espacios Comunitarios</a>
         </div>
         <div class="breadcrumb-item">
             <a href="{% url 'comedor_detalle' rendicion.comedor_id %}">{{ rendicion.comedor_nombre }}</a>

--- a/comedores/templates/comedor/rendicion_cuentas_final_list.html
+++ b/comedores/templates/comedor/rendicion_cuentas_final_list.html
@@ -1,6 +1,6 @@
 {% extends "includes/main.html" %}
 {% load static %}
-{% block title %}Comedores{% endblock %}
+{% block title %}Espacios Comunitarios{% endblock %}
 {% block breadcrumb %}
     {% include 'components/breadcrumb.html' with items=breadcrumb_items %}
 {% endblock %}

--- a/comedores/templates/observacion/observacion_confirm_delete.html
+++ b/comedores/templates/observacion/observacion_confirm_delete.html
@@ -1,12 +1,12 @@
 {% extends "includes/main.html" %};
 {% load static %}
 ;
-{% block title %}Comedor - {{ observacion.comedor.nombre }}{% endblock %}
+{% block title %}Espacio Comunitario - {{ observacion.comedor.nombre }}{% endblock %}
 ;
 {% block breadcrumb %}
     <ol class="breadcrumb float-sm-right">
         <div class="breadcrumb-item">
-            <a href="{% url 'comedores' %}">Comedores</a>
+            <a href="{% url 'comedores' %}">Espacios Comunitarios</a>
         </div>
         <div class="breadcrumb-item">
             <a href="{% url 'comedor_detalle' observacion.comedor.id %}">{{ observacion.comedor.nombre }}</a>

--- a/comedores/templates/observacion/observacion_detail.html
+++ b/comedores/templates/observacion/observacion_detail.html
@@ -1,14 +1,14 @@
 {% extends "includes/main.html" %};
 {% load static %}
 ;
-{% block title %}Observacion - Comedor: {{ observacion.comedor__nombre }}{% endblock %}
+{% block title %}Observacion - Espacio Comunitario: {{ observacion.comedor__nombre }}{% endblock %}
 ;
 {% block titulo-pagina %}Observacion {{ observacion.id }} - Comedor: {{ observacion.comedor__nombre }}{% endblock %}
 ;
 {% block breadcrumb %}
     <ol class="breadcrumb float-sm-right">
         <div class="breadcrumb-item">
-            <a href="{% url 'comedores' %}">Comedores</a>
+            <a href="{% url 'comedores' %}">Espacios Comunitarios</a>
         </div>
         <div class="breadcrumb-item">
             <a href="{% url 'comedor_detalle' observacion.comedor__id %}">{{ observacion.comedor__nombre }}</a>

--- a/comedores/templates/observacion/observacion_form.html
+++ b/comedores/templates/observacion/observacion_form.html
@@ -1,12 +1,12 @@
 {% extends "includes/main.html" %}
 {% load static crispy_forms_tags %}
 ;
-{% block title %}Observacion - Comedores: {{ comedor.nombre }}{% endblock %}
+{% block title %}Observacion - Espacio Comunitario: {{ comedor.nombre }}{% endblock %}
 {% block titulo-pagina %}Observacion{% endblock %}
 {% block breadcrumb %}
     <ol class="breadcrumb float-sm-right px-3">
         <li class="breadcrumb-item">
-            <a href="{% url 'comedores' %}">Comedores</a>
+            <a href="{% url 'comedores' %}">Espacios Comunitarios</a>
         </li>
         <li class="breadcrumb-item">
             <a href="{% url 'comedor_detalle' comedor.id %}">{{ comedor.nombre }}</a>

--- a/comedores/test_issue_2163_categoria_espacio.py
+++ b/comedores/test_issue_2163_categoria_espacio.py
@@ -1,0 +1,26 @@
+"""Cobertura de la categorización visible en el legajo (#2163)."""
+
+from django.urls import reverse
+
+from comedores.models import Comedor
+
+
+def test_legajo_muestra_categoria_y_detalle_de_otra_opcion(
+    client_logged_fixture, comedor_fixture
+):
+    comedor_fixture.categoria_espacio_comunitario = Comedor.CATEGORIA_ESPACIO_OTRA
+    comedor_fixture.categoria_espacio_comunitario_otra = "Mutual vecinal"
+    comedor_fixture.save(
+        update_fields=[
+            "categoria_espacio_comunitario",
+            "categoria_espacio_comunitario_otra",
+        ]
+    )
+
+    response = client_logged_fixture.get(
+        reverse("comedor_detalle", kwargs={"pk": comedor_fixture.pk})
+    )
+
+    assert response.status_code == 200
+    assert "Otra (especificar)" in response.content.decode()
+    assert "Mutual vecinal" in response.content.decode()

--- a/comedores/views/comedor.py
+++ b/comedores/views/comedor.py
@@ -1099,7 +1099,7 @@ class ComedorListView(LoginRequiredMixin, ListView):
             {
                 # Breadcrumb
                 "breadcrumb_items": [
-                    {"text": "Comedores", "url": reverse("comedores")},
+                    {"text": "Espacios Comunitarios", "url": reverse("comedores")},
                     {"text": "Listar", "active": True},
                 ],
                 # Barra de busqueda

--- a/docs/registro/cambios/2026-07-28-issue-2163-categorias-espacios.md
+++ b/docs/registro/cambios/2026-07-28-issue-2163-categorias-espacios.md
@@ -1,0 +1,37 @@
+# 2026-07-28 - Categorías de organizaciones y espacios comunitarios
+
+## Contexto
+
+La tarea #2163 incorpora una tipología actualizada para el legajo de
+Organizaciones y una categorización opcional para los espacios comunitarios.
+
+## Cambios aplicados
+
+- Se normaliza el catálogo de tipos y subtipos de entidades.
+- `Entidad` queda inactiva para nuevas selecciones, preservando organizaciones
+  históricas que la referencian.
+- Las referencias a `Obispado` se migran a `Diócesis – Obispado`.
+- Se agrega al legajo de comedores una categorización opcional, con detalle
+  obligatorio únicamente para `Otra (especificar)`.
+- La categorización se muestra en el legajo y se incorpora a los filtros
+  avanzados.
+- Los títulos principales del módulo pasan a usar `Espacios Comunitarios`.
+
+## Impacto esperado
+
+- No se modifican rutas, permisos, nombres técnicos del módulo ni contratos de
+  GESTIONAR o API.
+- Las organizaciones existentes conservan sus relaciones de catálogo durante
+  la migración.
+
+## Validación
+
+- Pruebas focalizadas de catálogo, formulario, legajo y filtros avanzados.
+- Revisión de consistencia de migraciones pendiente de los checks de entrega.
+
+## Riesgos y rollback
+
+- La migración de catálogo es no reversible de manera automática porque no es
+  posible distinguir luego qué referencias provenían de `Obispado`.
+- El rollback operativo requiere restaurar el backup previo a la migración o
+  una migración correctiva con un criterio de negocio explícito.

--- a/organizaciones/fixtures/tipoentidad_subentidad.json
+++ b/organizaciones/fixtures/tipoentidad_subentidad.json
@@ -1,98 +1,102 @@
 [
-{
+  {
     "model": "organizaciones.tipoentidad",
     "pk": 1,
-    "fields": {
-        "nombre": "Personería jurídica",
-        "descripcion": null
-    }
-},
-{
+    "fields": {"nombre": "Personería Jurídica", "descripcion": null}
+  },
+  {
     "model": "organizaciones.tipoentidad",
     "pk": 2,
-    "fields": {
-        "nombre": "Personería jurídica eclesiástica",
-        "descripcion": null
-    }
-},
-{
+    "fields": {"nombre": "Personería Jurídica Eclesiástica", "descripcion": null}
+  },
+  {
     "model": "organizaciones.tipoentidad",
     "pk": 3,
-    "fields": {
-        "nombre": "Asociación de hecho",
-        "descripcion": null
-    }
-},
-{
-    "model": "organizaciones.subtipoentidad",
-    "pk": 1,
-    "fields": {
-        "nombre": "Asociación civil",
-        "tipo_entidad": 1
-    }
-},
-{
-    "model": "organizaciones.subtipoentidad",
-    "pk": 2,
-    "fields": {
-        "nombre": "Cooperativa",
-        "tipo_entidad": 1
-    }
-},
-{
-    "model": "organizaciones.subtipoentidad",
-    "pk": 3,
-    "fields": {
-        "nombre": "Entidad",
-        "tipo_entidad": 1
-    }
-},
-{
-    "model": "organizaciones.subtipoentidad",
+    "fields": {"nombre": "Asociación de Hecho", "descripcion": null}
+  },
+  {
+    "model": "organizaciones.tipoentidad",
     "pk": 4,
     "fields": {
-        "nombre": "Fundación",
-        "tipo_entidad": 1
+      "nombre": "Simple Asociación (art. 187 CCCN)",
+      "descripcion": null
     }
-},
-{
+  },
+  {
+    "model": "organizaciones.subtipoentidad",
+    "pk": 1,
+    "fields": {"nombre": "Asociación Civil", "activo": true, "tipo_entidad": 1}
+  },
+  {
+    "model": "organizaciones.subtipoentidad",
+    "pk": 2,
+    "fields": {"nombre": "Cooperativa", "activo": true, "tipo_entidad": 1}
+  },
+  {
+    "model": "organizaciones.subtipoentidad",
+    "pk": 3,
+    "fields": {"nombre": "Entidad", "activo": false, "tipo_entidad": 1}
+  },
+  {
+    "model": "organizaciones.subtipoentidad",
+    "pk": 4,
+    "fields": {"nombre": "Fundación", "activo": true, "tipo_entidad": 1}
+  },
+  {
     "model": "organizaciones.subtipoentidad",
     "pk": 5,
-    "fields": {
-        "nombre": "Arquidiócesis",
-        "tipo_entidad": 2
-    }
-},
-{
+    "fields": {"nombre": "Arquidiócesis", "activo": true, "tipo_entidad": 2}
+  },
+  {
     "model": "organizaciones.subtipoentidad",
     "pk": 6,
     "fields": {
-        "nombre": "Diócesis",
-        "tipo_entidad": 2
+      "nombre": "Diócesis – Obispado",
+      "activo": true,
+      "tipo_entidad": 2
     }
-},
-{
+  },
+  {
     "model": "organizaciones.subtipoentidad",
     "pk": 7,
-    "fields": {
-        "nombre": "Parroquias",
-        "tipo_entidad": 2
-    }
-},
-{
+    "fields": {"nombre": "Parroquia", "activo": true, "tipo_entidad": 2}
+  },
+  {
     "model": "organizaciones.subtipoentidad",
     "pk": 8,
     "fields": {
-        "nombre": "Asociación de hecho",
-        "tipo_entidad": 3
+      "nombre": "Asociación de Hecho",
+      "activo": true,
+      "tipo_entidad": 3
     }
-},
-{
+  },
+  {
     "model": "organizaciones.subtipoentidad",
     "pk": 9,
+    "fields": {"nombre": "Obispado", "activo": false, "tipo_entidad": 2}
+  },
+  {
+    "model": "organizaciones.subtipoentidad",
+    "pk": 10,
     "fields": {
-        "nombre": "Obispado",
-        "tipo_entidad": 2
+      "nombre": "Caritas - Asociación Civil",
+      "activo": true,
+      "tipo_entidad": 1
     }
-}
+  },
+  {
+    "model": "organizaciones.subtipoentidad",
+    "pk": 11,
+    "fields": {"nombre": "Prelatura", "activo": true, "tipo_entidad": 2}
+  },
+  {
+    "model": "organizaciones.subtipoentidad",
+    "pk": 12,
+    "fields": {"nombre": "Vicaría", "activo": true, "tipo_entidad": 2}
+  },
+  {
+    "model": "organizaciones.subtipoentidad",
+    "pk": 13,
+    "fields": {"nombre": "Cuasiparroquia", "activo": true, "tipo_entidad": 2}
+  }
 ]

--- a/organizaciones/forms.py
+++ b/organizaciones/forms.py
@@ -4,6 +4,7 @@ from organizaciones.models import (
     Organizacion,
     Firmante,
     Aval,
+    SubtipoEntidad,
 )
 from core.models import Municipio, Provincia, Localidad
 
@@ -44,6 +45,15 @@ class OrganizacionForm(forms.ModelForm):
         self.fields["fecha_vencimiento"].input_formats = ["%Y-%m-%d"]
 
         self.popular_campos_ubicacion()
+        subtipo_actual_id = (
+            self.data.get(self.add_prefix("subtipo_entidad"))
+            if self.is_bound
+            else getattr(self.instance, "subtipo_entidad_id", None)
+        )
+        subtipos = SubtipoEntidad.objects.filter(activo=True)
+        if subtipo_actual_id:
+            subtipos = subtipos | SubtipoEntidad.objects.filter(pk=subtipo_actual_id)
+        self.fields["subtipo_entidad"].queryset = subtipos.order_by("nombre")
 
     def popular_campos_ubicacion(self):
 

--- a/organizaciones/migrations/0017_issue_2163_catalogo_entidades.py
+++ b/organizaciones/migrations/0017_issue_2163_catalogo_entidades.py
@@ -1,0 +1,119 @@
+from django.db import migrations, models
+
+
+def _find_by_name(model, nombre):
+    return model.objects.filter(nombre__iexact=nombre).order_by("pk").first()
+
+
+def _ensure_tipo(TipoEntidad, nombre):
+    tipo = _find_by_name(TipoEntidad, nombre)
+    if tipo is None:
+        return TipoEntidad.objects.create(nombre=nombre)
+    if tipo.nombre != nombre:
+        tipo.nombre = nombre
+        tipo.save(update_fields=["nombre"])
+    return tipo
+
+
+def _ensure_subtipo(SubtipoEntidad, tipo, nombre):
+    subtipo = _find_by_name(SubtipoEntidad, nombre)
+    if subtipo is None:
+        return SubtipoEntidad.objects.create(
+            nombre=nombre,
+            tipo_entidad=tipo,
+            activo=True,
+        )
+
+    updates = []
+    if subtipo.nombre != nombre:
+        subtipo.nombre = nombre
+        updates.append("nombre")
+    if subtipo.tipo_entidad_id != tipo.pk:
+        subtipo.tipo_entidad = tipo
+        updates.append("tipo_entidad")
+    if not subtipo.activo:
+        subtipo.activo = True
+        updates.append("activo")
+    if updates:
+        subtipo.save(update_fields=updates)
+    return subtipo
+
+
+def _migrar_referencias(Organizacion, origen, destino):
+    if origen and origen.pk != destino.pk:
+        Organizacion.objects.filter(subtipo_entidad_id=origen.pk).update(
+            subtipo_entidad_id=destino.pk
+        )
+
+
+def actualizar_catalogo(apps, schema_editor):
+    TipoEntidad = apps.get_model("organizaciones", "TipoEntidad")
+    SubtipoEntidad = apps.get_model("organizaciones", "SubtipoEntidad")
+    Organizacion = apps.get_model("organizaciones", "Organizacion")
+
+    asociacion_hecho = _ensure_tipo(TipoEntidad, "Asociación de Hecho")
+    _ensure_tipo(TipoEntidad, "Simple Asociación (art. 187 CCCN)")
+    personeria_juridica = _ensure_tipo(TipoEntidad, "Personería Jurídica")
+    personeria_eclesiastica = _ensure_tipo(
+        TipoEntidad, "Personería Jurídica Eclesiástica"
+    )
+
+    _ensure_subtipo(
+        SubtipoEntidad,
+        asociacion_hecho,
+        "Asociación de Hecho",
+    )
+    for nombre in (
+        "Asociación Civil",
+        "Caritas - Asociación Civil",
+        "Cooperativa",
+        "Fundación",
+    ):
+        _ensure_subtipo(SubtipoEntidad, personeria_juridica, nombre)
+
+    diocesis_unificada = _ensure_subtipo(
+        SubtipoEntidad,
+        personeria_eclesiastica,
+        "Diócesis – Obispado",
+    )
+    for nombre in (
+        "Arquidiócesis",
+        "Prelatura",
+        "Vicaría",
+        "Parroquia",
+        "Cuasiparroquia",
+    ):
+        _ensure_subtipo(SubtipoEntidad, personeria_eclesiastica, nombre)
+
+    for nombre in ("Diócesis", "Obispado", "Parroquias"):
+        legado = _find_by_name(SubtipoEntidad, nombre)
+        if legado:
+            destino = (
+                _ensure_subtipo(SubtipoEntidad, personeria_eclesiastica, "Parroquia")
+                if nombre == "Parroquias"
+                else diocesis_unificada
+            )
+            _migrar_referencias(Organizacion, legado, destino)
+            legado.activo = False
+            legado.save(update_fields=["activo"])
+
+    entidad = _find_by_name(SubtipoEntidad, "Entidad")
+    if entidad:
+        entidad.activo = False
+        entidad.save(update_fields=["activo"])
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ("organizaciones", "0016_issue_2083_documentacion_organizacion"),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name="subtipoentidad",
+            name="activo",
+            field=models.BooleanField(default=True),
+        ),
+        migrations.RunPython(actualizar_catalogo, migrations.RunPython.noop),
+    ]

--- a/organizaciones/models.py
+++ b/organizaciones/models.py
@@ -33,6 +33,7 @@ class TipoEntidad(models.Model):
 
 class SubtipoEntidad(models.Model):
     nombre = models.CharField(max_length=255, unique=True)
+    activo = models.BooleanField(default=True)
     tipo_entidad = models.ForeignKey(
         TipoEntidad,
         on_delete=models.CASCADE,

--- a/organizaciones/test_issue_2163_catalogo.py
+++ b/organizaciones/test_issue_2163_catalogo.py
@@ -1,0 +1,60 @@
+"""Regresiones del catálogo de entidades para el issue #2163."""
+
+from importlib import import_module
+
+from organizaciones.forms import OrganizacionForm
+from organizaciones.models import Organizacion, SubtipoEntidad, TipoEntidad
+
+
+def test_formulario_omite_subtipos_inactivos_y_conserva_el_legado_en_edicion(db):
+    tipo = TipoEntidad.objects.create(nombre="Personería Jurídica")
+    activo = SubtipoEntidad.objects.create(nombre="Asociación Civil", tipo_entidad=tipo)
+    legado = SubtipoEntidad.objects.create(
+        nombre="Entidad", tipo_entidad=tipo, activo=False
+    )
+    organizacion = Organizacion.objects.create(
+        nombre="Organización histórica",
+        tipo_entidad=tipo,
+        subtipo_entidad=legado,
+    )
+
+    alta = OrganizacionForm()
+    edicion = OrganizacionForm(instance=organizacion)
+
+    assert list(alta.fields["subtipo_entidad"].queryset) == [activo]
+    assert set(edicion.fields["subtipo_entidad"].queryset) == {activo, legado}
+
+
+def test_migracion_unifica_obispado_y_preserva_entidad_historica(db):
+    juridica = TipoEntidad.objects.create(nombre="Personería jurídica")
+    eclesiastica = TipoEntidad.objects.create(nombre="Personería jurídica eclesiástica")
+    obispado = SubtipoEntidad.objects.create(
+        nombre="Obispado", tipo_entidad=eclesiastica
+    )
+    entidad = SubtipoEntidad.objects.create(nombre="Entidad", tipo_entidad=juridica)
+    organizacion_obispado = Organizacion.objects.create(
+        nombre="Diócesis histórica",
+        tipo_entidad=eclesiastica,
+        subtipo_entidad=obispado,
+    )
+    organizacion_entidad = Organizacion.objects.create(
+        nombre="Entidad histórica",
+        tipo_entidad=juridica,
+        subtipo_entidad=entidad,
+    )
+
+    migration = import_module(
+        "organizaciones.migrations.0017_issue_2163_catalogo_entidades"
+    )
+    migration.actualizar_catalogo(import_module("django.apps").apps, None)
+
+    organizacion_obispado.refresh_from_db()
+    organizacion_entidad.refresh_from_db()
+    entidad.refresh_from_db()
+
+    assert organizacion_obispado.subtipo_entidad.nombre == "Diócesis – Obispado"
+    assert organizacion_entidad.subtipo_entidad_id == entidad.pk
+    assert entidad.activo is False
+    assert TipoEntidad.objects.filter(
+        nombre="Simple Asociación (art. 187 CCCN)"
+    ).exists()

--- a/organizaciones/views.py
+++ b/organizaciones/views.py
@@ -1212,7 +1212,7 @@ def sub_tipo_entidad_ajax(request):
     tipo_entidad_id = request.GET.get("tipo_entidad")
     if tipo_entidad_id:
         subtipo_entidades = SubtipoEntidad.objects.filter(
-            tipo_entidad_id=tipo_entidad_id
+            tipo_entidad_id=tipo_entidad_id, activo=True
         ).order_by("nombre")
     else:
         subtipo_entidades = SubtipoEntidad.objects.none()

--- a/tests/test_issue_2163_categoria_espacio.py
+++ b/tests/test_issue_2163_categoria_espacio.py
@@ -1,0 +1,94 @@
+"""Regresiones para la categorización de espacios comunitarios (#2163)."""
+
+import json
+
+import pytest
+from django.core.exceptions import ValidationError
+
+from comedores.forms.comedor_form import ComedorForm
+from comedores.models import Comedor, EstadoActividad, EstadoProceso
+from comedores.services.comedor_service import ComedorService
+from comedores.services.filter_config import FIELD_TYPES, get_filters_ui_config
+from core.models import Provincia
+
+
+def test_categoria_espacio_comunitario_es_opcional_y_otra_requiere_detalle():
+    comedor = Comedor(
+        nombre="Espacio barrial",
+        categoria_espacio_comunitario=Comedor.CATEGORIA_ESPACIO_OTRA,
+    )
+
+    with pytest.raises(ValidationError, match="Especifique la otra categoría"):
+        comedor.full_clean(exclude={"provincia"})
+
+    comedor.categoria_espacio_comunitario_otra = "Mutual vecinal"
+    comedor.full_clean(exclude={"provincia"})
+
+
+def test_filtro_avanzado_expone_categoria_de_espacio_comunitario():
+    config = get_filters_ui_config()
+
+    categoria = next(
+        field
+        for field in config["fields"]
+        if field["name"] == "categoria_espacio_comunitario"
+    )
+
+    assert categoria["type"] == "choice"
+    assert FIELD_TYPES["categoria_espacio_comunitario"] == "choice"
+    assert {choice["value"] for choice in categoria["choices"]} == {
+        value for value, _label in Comedor.CATEGORIAS_ESPACIO_COMUNITARIO
+    }
+
+
+def test_formulario_limpia_detalle_de_otra_categoria_que_ya_no_aplica(db):
+    provincia = Provincia.objects.create(nombre="Chaco")
+    actividad = EstadoActividad.objects.create(estado="Activo")
+    proceso = EstadoProceso.objects.create(
+        estado="En seguimiento", estado_actividad=actividad
+    )
+
+    form = ComedorForm(
+        data={
+            "nombre": "Espacio barrial",
+            "provincia": str(provincia.pk),
+            "estado_general": str(actividad.pk),
+            "subestado": str(proceso.pk),
+            "motivo": "",
+            "categoria_espacio_comunitario": Comedor.CATEGORIA_ESPACIO_HOGAR,
+            "categoria_espacio_comunitario_otra": "Dato obsoleto",
+        }
+    )
+
+    assert form.is_valid(), form.errors
+    assert form.cleaned_data["categoria_espacio_comunitario_otra"] == ""
+
+
+def test_filtro_avanzado_filtra_por_categoria_de_espacio_comunitario(db):
+    provincia = Provincia.objects.create(nombre="Chaco")
+    comedor_match = Comedor.objects.create(
+        nombre="Club barrial",
+        provincia=provincia,
+        categoria_espacio_comunitario=Comedor.CATEGORIA_ESPACIO_CLUB_SOCIAL_DEPORTIVO,
+    )
+    Comedor.objects.create(
+        nombre="Hogar comunitario",
+        provincia=provincia,
+        categoria_espacio_comunitario=Comedor.CATEGORIA_ESPACIO_HOGAR,
+    )
+    filters = json.dumps(
+        {
+            "logic": "AND",
+            "items": [
+                {
+                    "field": "categoria_espacio_comunitario",
+                    "op": "eq",
+                    "value": Comedor.CATEGORIA_ESPACIO_CLUB_SOCIAL_DEPORTIVO,
+                }
+            ],
+        }
+    )
+
+    rows = list(ComedorService.get_filtered_comedores({"filters": filters}))
+
+    assert [row["id"] for row in rows] == [comedor_match.id]


### PR DESCRIPTION
Closes #2163

## Qué cambia

- Incorpora la categorización opcional de Espacios Comunitarios, con detalle obligatorio para “Otra”, visualización en el legajo y filtro avanzado.
- Actualiza el catálogo de tipos/subtipos de Organizaciones, inactiva valores históricos y migra referencias de Obispado a Diócesis – Obispado.
- Ajusta la terminología visible de Comedores a Espacios Comunitarios sin alterar rutas, permisos ni nombres técnicos.
- Incluye migraciones, fixtures, pruebas de regresión y registro del cambio.

## Validación

- `pytest tests/test_issue_2163_categoria_espacio.py organizaciones/test_issue_2163_catalogo.py comedores/test_issue_2163_categoria_espacio.py -q` — 7 passed.
- `black --check` sobre los archivos Python modificados.
- `git diff --check`.

## Pendiente de entorno

- No se ejecutó una migración contra MySQL real ni una prueba E2E de navegador.
- `djlint` excedió el tiempo local sin diagnóstico.