### PR TITLE
fix(ci): esperar disponibilidad de QA y HML

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -40,21 +40,47 @@ jobs:
                       {
                           echo "### Deploy QA omitido por revision obsoleta"
                           echo "- Evento: \`$EXPECTED_SHA\`"
-                          echo "- origin/development actual: \`$remote_sha\`"
+                          echo "- origin/development actual: \`$remote_sha\`";
                       } >> "$GITHUB_STEP_SUMMARY"
                       exit 0
                   fi
                   echo "Commit previo al deploy para rollback: $(git rev-parse HEAD)"
                   ./scripts/operacion/deploy_refresh.sh --yes --expected-revision "$EXPECTED_SHA"
-                  docker compose -f "$APP_ROOT/docker-compose.deploy.yml" --project-directory "$APP_ROOT" exec -T django python manage.py migrate --check
-                  bash "$APP_ROOT/scripts/infra/healthcheck_qa.sh"
+                  wait_for() {
+                      local description="$1"
+                      local attempts="$2"
+                      local output
+                      local attempt
+                      shift 2
+                      output="$(mktemp)"
+
+                      for ((attempt = 1; attempt <= attempts; attempt++)); do
+                          if "$@" >"$output" 2>&1; then
+                              cat "$output"
+                              rm -f "$output"
+                              return 0
+                          fi
+                          if ((attempt < attempts)); then
+                              echo "[deploy] Esperando $description ($attempt/$attempts)..."
+                              sleep 2
+                          fi
+                      done
+
+                      cat "$output"
+                      rm -f "$output"
+                      echo "::error::$description no estuvo listo luego de $attempts intentos."
+                      return 1
+                  }
+
+                  wait_for "migraciones de QA" 30 docker compose -f "$APP_ROOT/docker-compose.deploy.yml" --project-directory "$APP_ROOT" exec -T django python manage.py migrate --check
+                  wait_for "healthcheck de QA" 30 bash "$APP_ROOT/scripts/infra/healthcheck_qa.sh"
                   deployed_sha="$(git -C "$APP_ROOT" rev-parse HEAD)"
                   [[ "$deployed_sha" == "$EXPECTED_SHA" ]]
                   {
                       echo "### Deploy QA verificado"
                       echo "- Revision desplegada: \`$deployed_sha\`"
                       echo "- Migraciones: \`migrate --check\` OK"
-                      echo "- Health: \`healthcheck_qa.sh\` OK"
+                      echo "- Health: \`healthcheck_qa.sh\` OK";
                   } >> "$GITHUB_STEP_SUMMARY"
 
     deploy-homologacion:
@@ -87,22 +113,57 @@ jobs:
                       {
                           echo "### Deploy HML omitido por revision obsoleta"
                           echo "- Evento: \`$EXPECTED_SHA\`"
-                          echo "- origin/homologacion actual: \`$remote_sha\`"
+                          echo "- origin/homologacion actual: \`$remote_sha\`";
                       } >> "$GITHUB_STEP_SUMMARY"
                       exit 0
+                  fi
+
+                  if ! grep -q -- "--expected-revision" "$APP_ROOT/scripts/operacion/deploy_refresh.sh"; then
+                      [[ "$(git -C "$APP_ROOT" branch --show-current)" == "homologacion" ]] || {
+                          echo "::error::El checkout de HML no esta en la branch homologacion."
+                          exit 1;
+                      }
+                      echo "[deploy] Actualizando el helper local de HML antes del deploy versionado."
+                      git -C "$APP_ROOT" merge --ff-only origin/homologacion
                   fi
                   git -C /sisoc/SISOC-Mobile update-index --refresh
                   echo "Commit previo al deploy para rollback: $(git rev-parse HEAD)"
                   ./scripts/operacion/deploy_refresh.sh --yes --expected-revision "$EXPECTED_SHA" --with-mobile --mobile-dir /sisoc/SISOC-Mobile
-                  docker compose -f "$APP_ROOT/docker-compose.deploy.yml" -f "$APP_ROOT/docker-compose.produccion.yml" --project-directory "$APP_ROOT" exec -T django python manage.py migrate --check
-                  bash "$APP_ROOT/scripts/infra/healthcheck_hml.sh"
+                  wait_for() {
+                      local description="$1"
+                      local attempts="$2"
+                      local output
+                      local attempt
+                      shift 2
+                      output="$(mktemp)"
+
+                      for ((attempt = 1; attempt <= attempts; attempt++)); do
+                          if "$@" >"$output" 2>&1; then
+                              cat "$output"
+                              rm -f "$output"
+                              return 0
+                          fi
+                          if ((attempt < attempts)); then
+                              echo "[deploy] Esperando $description ($attempt/$attempts)..."
+                              sleep 2
+                          fi
+                      done
+
+                      cat "$output"
+                      rm -f "$output"
+                      echo "::error::$description no estuvo listo luego de $attempts intentos."
+                      return 1
+                  }
+
+                  wait_for "migraciones de HML" 30 docker compose -f "$APP_ROOT/docker-compose.deploy.yml" -f "$APP_ROOT/docker-compose.produccion.yml" --project-directory "$APP_ROOT" exec -T django python manage.py migrate --check
+                  wait_for "healthcheck de HML" 30 bash "$APP_ROOT/scripts/infra/healthcheck_hml.sh"
                   deployed_sha="$(git -C "$APP_ROOT" rev-parse HEAD)"
                   [[ "$deployed_sha" == "$EXPECTED_SHA" ]]
                   {
                       echo "### Deploy HML verificado"
                       echo "- Revision desplegada: \`$deployed_sha\`"
                       echo "- Migraciones: \`migrate --check\` OK"
-                      echo "- Health: \`healthcheck_hml.sh\` OK"
+                      echo "- Health: \`healthcheck_hml.sh\` OK";
                   } >> "$GITHUB_STEP_SUMMARY"
 
     deploy-produccion:
@@ -133,7 +194,7 @@ jobs:
                           echo "### Deploy produccion omitido por revision obsoleta"
                           echo "- Evento aprobado: \`$EXPECTED_SHA\`"
                           echo "- origin/main actual: \`$remote_sha\`"
-                          echo "- Accion requerida: aprobar el job del commit actual."
+                          echo "- Accion requerida: aprobar el job del commit actual.";
                       } >> "$GITHUB_STEP_SUMMARY"
                       exit 0
                   fi
@@ -147,5 +208,5 @@ jobs:
                       echo "### Deploy produccion verificado"
                       echo "- Revision desplegada: \`$deployed_sha\`"
                       echo "- Migraciones: \`migrate --check\` OK"
-                      echo "- Health: \`healthcheck_prod.sh\` OK"
+                      echo "- Health: \`healthcheck_prod.sh\` OK";
                   } >> "$GITHUB_STEP_SUMMARY"

--- a/docs/operacion/deploy_automatizado.md
+++ b/docs/operacion/deploy_automatizado.md
@@ -24,6 +24,14 @@ correspondiente. El runner local:
 5. prueba `migrate --check`, el healthcheck específico del entorno y registra
    el SHA realmente desplegado en el summary del job.
 
+Como el entrypoint del contenedor aplica migraciones durante el arranque, QA y
+homologación consultan ambos checks mediante sondeo acotado: continúan apenas
+las migraciones y el healthcheck responden, o publican el último error después
+del límite. Para homologación, si el checkout local aún no admite
+`--expected-revision`, el workflow hace primero un `merge --ff-only` de la
+revisión ya verificada; así conserva la validación de SHA sin requerir una
+intervención manual de bootstrap.
+
 El script existente conserva las validaciones operativas: lee `ENVIRONMENT`
 desde `.env`, valida branch esperada, ejecuta `docker compose config -q`, baja
 el stack sin volumenes, hace `git fetch` y un `merge --ff-only` de la referencia

--- a/docs/registro/cambios/2026-07-28-deploy-qa-hml-readiness.md
+++ b/docs/registro/cambios/2026-07-28-deploy-qa-hml-readiness.md
@@ -1,0 +1,26 @@
+# Espera de disponibilidad en deploy de QA y HML
+
+Fecha: 2026-07-28
+
+## Cambio
+
+El workflow de despliegue espera de forma acotada que terminen las migraciones
+del entrypoint y que responda el healthcheck de QA y homologación antes de
+declarar el deploy fallido.
+
+En homologación incorpora además un bootstrap seguro: si el helper local no
+reconoce `--expected-revision`, actualiza solo el checkout de la branch
+`homologacion` mediante `merge --ff-only` después de validar el SHA remoto.
+
+## Motivo
+
+El workflow verificaba migraciones inmediatamente después de levantar los
+contenedores. Eso podía observar el estado intermedio del entrypoint y fallar
+aunque el proceso siguiera aplicándolas. HML tampoco podía actualizar su
+helper local porque invocaba una opción nueva antes de refrescar el checkout.
+
+## Alcance y resguardo
+
+No se cambia el comportamiento de producción. Los reintentos tienen un límite
+de 30 intentos con dos segundos entre ellos y muestran la última salida si no
+se alcanza disponibilidad.


### PR DESCRIPTION
## Qué cambia

- Espera con sondeo acotado hasta que migraciones y healthchecks estén disponibles en QA y HML.
- Arranca HML de forma segura cuando su checkout local todavía no soporta --expected-revision.
- Documenta la secuencia y el límite de espera.

## Causa raíz

El workflow verificaba migraciones inmediatamente después de iniciar contenedores, mientras el entrypoint todavía ejecutaba migrate --noinput. Además, HML invocaba una opción nueva antes de actualizar su helper local.

## Validación

- git diff --check
- Parseo YAML
- ash -n -c de los tres scripts de deploy