### PR TITLE
fix(ci): recover QA deployment validation

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -72,7 +72,17 @@ jobs:
                       return 1
                   }
 
-                  wait_for "migraciones de QA" 30 docker compose -f "$APP_ROOT/docker-compose.deploy.yml" --project-directory "$APP_ROOT" exec -T django python manage.py migrate --check
+                  show_django_diagnostics() {
+                      echo "::group::Diagnostico del servicio django de QA"
+                      docker compose -f "$APP_ROOT/docker-compose.deploy.yml" --project-directory "$APP_ROOT" ps || true
+                      docker compose -f "$APP_ROOT/docker-compose.deploy.yml" --project-directory "$APP_ROOT" logs --tail 200 django || true
+                      echo "::endgroup::"
+                  }
+
+                  if ! wait_for "migraciones de QA" 30 docker compose -f "$APP_ROOT/docker-compose.deploy.yml" --project-directory "$APP_ROOT" exec -T django python manage.py migrate --check; then
+                      show_django_diagnostics
+                      exit 1
+                  fi
                   wait_for "healthcheck de QA" 30 bash "$APP_ROOT/scripts/infra/healthcheck_qa.sh"
                   deployed_sha="$(git -C "$APP_ROOT" rev-parse HEAD)"
                   [[ "$deployed_sha" == "$EXPECTED_SHA" ]]
@@ -155,7 +165,17 @@ jobs:
                       return 1
                   }
 
-                  wait_for "migraciones de HML" 30 docker compose -f "$APP_ROOT/docker-compose.deploy.yml" -f "$APP_ROOT/docker-compose.produccion.yml" --project-directory "$APP_ROOT" exec -T django python manage.py migrate --check
+                  show_django_diagnostics() {
+                      echo "::group::Diagnostico del servicio django de HML"
+                      docker compose -f "$APP_ROOT/docker-compose.deploy.yml" -f "$APP_ROOT/docker-compose.produccion.yml" --project-directory "$APP_ROOT" ps || true
+                      docker compose -f "$APP_ROOT/docker-compose.deploy.yml" -f "$APP_ROOT/docker-compose.produccion.yml" --project-directory "$APP_ROOT" logs --tail 200 django || true
+                      echo "::endgroup::"
+                  }
+
+                  if ! wait_for "migraciones de HML" 30 docker compose -f "$APP_ROOT/docker-compose.deploy.yml" -f "$APP_ROOT/docker-compose.produccion.yml" --project-directory "$APP_ROOT" exec -T django python manage.py migrate --check; then
+                      show_django_diagnostics
+                      exit 1
+                  fi
                   wait_for "healthcheck de HML" 30 bash "$APP_ROOT/scripts/infra/healthcheck_hml.sh"
                   deployed_sha="$(git -C "$APP_ROOT" rev-parse HEAD)"
                   [[ "$deployed_sha" == "$EXPECTED_SHA" ]]

--- a/docs/registro/cambios/2026-07-28-recuperacion-qa-pwa-y-diagnostico.md
+++ b/docs/registro/cambios/2026-07-28-recuperacion-qa-pwa-y-diagnostico.md
@@ -1,0 +1,28 @@
+# Recuperación de QA: fixtures PWA y diagnóstico de despliegue
+
+## Contexto
+
+La validación `pytest` de `development` quedó bloqueada después de incorporar
+la regla que oculta en PWA los comedores que no tienen programa. Dos fixtures
+todavía creaban comedores sin programa, y la suite de nómina refería
+`Programas` sin importarlo.
+
+El despliegue de QA llega a reconstruir el stack, pero el chequeo posterior de
+migraciones agotó sus reintentos sin dejar el estado del contenedor que lo
+impedía.
+
+## Cambio
+
+- Los fixtures de las pruebas PWA crean comedores con el programa
+  `Abordaje Comunitario`, que representa un comedor visible en PWA.
+- La suite de nómina importa explícitamente `Programas`.
+- Los jobs de QA y homologación muestran `docker compose ps` y las últimas 200
+  líneas del servicio `django` sólo cuando `migrate --check` no se vuelve
+  disponible. Esto permite diferenciar un arranque lento de un contenedor
+  detenido sin exponer información durante un deploy sano.
+
+## Validación esperada
+
+- Ejecutar las suites PWA afectadas con pytest.
+- Confirmar en CI que `pytest` vuelve a pasar y que el job de QA informa el
+  estado real del servicio si la disponibilidad sigue fallando.

--- a/tests/test_pwa_nomina_api.py
+++ b/tests/test_pwa_nomina_api.py
@@ -10,7 +10,7 @@ from rest_framework.test import APIClient
 
 from admisiones.models.admisiones import Admision
 from ciudadanos.models import Ciudadano
-from comedores.models import Comedor, Nomina
+from comedores.models import Comedor, Nomina, Programas
 from comedores.views.nomina import _get_asistencia_nomina_context
 from core.models import Dia, Provincia, Sexo
 from pwa.models import (

--- a/tests/test_users_services_pwa.py
+++ b/tests/test_users_services_pwa.py
@@ -5,7 +5,7 @@ from django.contrib.auth import get_user_model
 from django.core.exceptions import PermissionDenied, ValidationError
 from django.db import IntegrityError
 
-from comedores.models import Comedor
+from comedores.models import Comedor, Programas
 from core.models import Provincia
 from organizaciones.models import Organizacion
 from users.models import AccesoComedorPWA
@@ -23,17 +23,20 @@ from users.services_pwa import (
 @pytest.fixture
 def comedores(db):
     provincia = Provincia.objects.create(nombre="Santa Fe")
+    programa = Programas.objects.create(nombre="Abordaje Comunitario")
     organizacion_1 = Organizacion.objects.create(nombre="Organización 1")
     organizacion_2 = Organizacion.objects.create(nombre="Organización 2")
     comedor_1 = Comedor.objects.create(
         nombre="Comedor 1",
         provincia=provincia,
         organizacion=organizacion_1,
+        programa=programa,
     )
     comedor_2 = Comedor.objects.create(
         nombre="Comedor 2",
         provincia=provincia,
         organizacion=organizacion_2,
+        programa=programa,
     )
     return comedor_1, comedor_2
 


### PR DESCRIPTION
## Resumen
- corrige los fixtures PWA que quedaron incompatibles con la regla de visibilidad por programa
- agrega el import faltante de `Programas` en la suite de nómina
- ante un fallo de `migrate --check`, QA y HML ahora muestran el estado y los últimos logs de Django para diagnosticar el arranque

## Validación
- `python -m pytest -n 4 tests/test_pwa_nomina_api.py tests/test_users_services_pwa.py` (28 passed)
- `python -m black --check tests/test_pwa_nomina_api.py tests/test_users_services_pwa.py`
- `git diff --check`
- parseo YAML de `.github/workflows/deploy.yml`

La fusión queda deliberadamente pendiente hasta que CI verde confirme la recuperación.