### PR TITLE
fix(organizaciones): corregir Simple Asociación como subtipo

### DIFF
--- a/docs/registro/cambios/2026-07-29-issue-2163-simple-asociacion.md
+++ b/docs/registro/cambios/2026-07-29-issue-2163-simple-asociacion.md
@@ -1,0 +1,27 @@
+# 2026-07-29 - Simple Asociación como subtipo de Personería Jurídica
+
+## Contexto
+
+El seguimiento del issue #2163 aclaró que `Simple Asociación (art. 187 CCCN)`
+debe ser un subtipo de `Personería Jurídica`, no un tipo principal.
+
+## Cambios aplicados
+
+- El catálogo inicial ubica `Simple Asociación (art. 187 CCCN)` como subtipo
+  activo de `Personería Jurídica`.
+- La migración correctiva reasigna las organizaciones creadas con el tipo
+  principal incorrecto y elimina ese tipo del catálogo.
+- Los subtipos personalizados existentes bajo el tipo incorrecto se preservan
+  y se reasignan a `Personería Jurídica`.
+
+## Impacto y rollback
+
+- Las organizaciones sin subtipo bajo el tipo incorrecto pasan a usar el nuevo
+  subtipo `Simple Asociación (art. 187 CCCN)`.
+- La migración no tiene reversa automática: restaurar el estado anterior
+  requeriría una migración correctiva o un backup previo.
+
+## Validación
+
+- Prueba focalizada de migración para el catálogo y las organizaciones ya
+  cargadas.

--- a/organizaciones/fixtures/tipoentidad_subentidad.json
+++ b/organizaciones/fixtures/tipoentidad_subentidad.json
@@ -15,14 +15,6 @@
     "fields": {"nombre": "Asociación de Hecho", "descripcion": null}
   },
   {
-    "model": "organizaciones.tipoentidad",
-    "pk": 4,
-    "fields": {
-      "nombre": "Simple Asociación (art. 187 CCCN)",
-      "descripcion": null
-    }
-  },
-  {
     "model": "organizaciones.subtipoentidad",
     "pk": 1,
     "fields": {"nombre": "Asociación Civil", "activo": true, "tipo_entidad": 1}
@@ -98,5 +90,14 @@
     "model": "organizaciones.subtipoentidad",
     "pk": 13,
     "fields": {"nombre": "Cuasiparroquia", "activo": true, "tipo_entidad": 2}
+  },
+  {
+    "model": "organizaciones.subtipoentidad",
+    "pk": 14,
+    "fields": {
+      "nombre": "Simple Asociación (art. 187 CCCN)",
+      "activo": true,
+      "tipo_entidad": 1
+    }
   }
 ]

--- a/organizaciones/migrations/0018_corregir_simple_asociacion_subtipo.py
+++ b/organizaciones/migrations/0018_corregir_simple_asociacion_subtipo.py
@@ -1,0 +1,70 @@
+from django.db import migrations
+
+
+NOMBRE_SIMPLE_ASOCIACION = "Simple Asociación (art. 187 CCCN)"
+NOMBRE_PERSONERIA_JURIDICA = "Personería Jurídica"
+
+
+def _find_by_name(model, nombre):
+    return model.objects.filter(nombre__iexact=nombre).order_by("pk").first()
+
+
+def corregir_simple_asociacion(apps, schema_editor):
+    TipoEntidad = apps.get_model("organizaciones", "TipoEntidad")
+    SubtipoEntidad = apps.get_model("organizaciones", "SubtipoEntidad")
+    Organizacion = apps.get_model("organizaciones", "Organizacion")
+
+    personeria_juridica = _find_by_name(TipoEntidad, NOMBRE_PERSONERIA_JURIDICA)
+    if personeria_juridica is None:
+        personeria_juridica = TipoEntidad.objects.create(
+            nombre=NOMBRE_PERSONERIA_JURIDICA
+        )
+    elif personeria_juridica.nombre != NOMBRE_PERSONERIA_JURIDICA:
+        personeria_juridica.nombre = NOMBRE_PERSONERIA_JURIDICA
+        personeria_juridica.save(update_fields=["nombre"])
+
+    simple_asociacion = _find_by_name(SubtipoEntidad, NOMBRE_SIMPLE_ASOCIACION)
+    if simple_asociacion is None:
+        simple_asociacion = SubtipoEntidad.objects.create(
+            nombre=NOMBRE_SIMPLE_ASOCIACION,
+            tipo_entidad=personeria_juridica,
+            activo=True,
+        )
+    else:
+        actualizaciones = []
+        if simple_asociacion.tipo_entidad_id != personeria_juridica.pk:
+            simple_asociacion.tipo_entidad = personeria_juridica
+            actualizaciones.append("tipo_entidad")
+        if not simple_asociacion.activo:
+            simple_asociacion.activo = True
+            actualizaciones.append("activo")
+        if actualizaciones:
+            simple_asociacion.save(update_fields=actualizaciones)
+
+    tipo_incorrecto = _find_by_name(TipoEntidad, NOMBRE_SIMPLE_ASOCIACION)
+    if tipo_incorrecto is None or tipo_incorrecto.pk == personeria_juridica.pk:
+        return
+
+    SubtipoEntidad.objects.filter(tipo_entidad_id=tipo_incorrecto.pk).update(
+        tipo_entidad_id=personeria_juridica.pk
+    )
+    organizaciones = Organizacion.objects.filter(tipo_entidad_id=tipo_incorrecto.pk)
+    organizaciones.filter(subtipo_entidad__isnull=True).update(
+        tipo_entidad_id=personeria_juridica.pk,
+        subtipo_entidad_id=simple_asociacion.pk,
+    )
+    organizaciones.exclude(subtipo_entidad__isnull=True).update(
+        tipo_entidad_id=personeria_juridica.pk
+    )
+    tipo_incorrecto.delete()
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ("organizaciones", "0017_issue_2163_catalogo_entidades"),
+    ]
+
+    operations = [
+        migrations.RunPython(corregir_simple_asociacion, migrations.RunPython.noop),
+    ]

--- a/organizaciones/test_issue_2163_catalogo.py
+++ b/organizaciones/test_issue_2163_catalogo.py
@@ -58,3 +58,44 @@ def test_migracion_unifica_obispado_y_preserva_entidad_historica(db):
     assert TipoEntidad.objects.filter(
         nombre="Simple Asociación (art. 187 CCCN)"
     ).exists()
+
+
+def test_migracion_corrige_simple_asociacion_como_subtipo_de_personeria(db):
+    juridica = TipoEntidad.objects.create(nombre="Personería Jurídica")
+    tipo_incorrecto = TipoEntidad.objects.create(
+        nombre="Simple Asociación (art. 187 CCCN)"
+    )
+    subtipo_personalizado = SubtipoEntidad.objects.create(
+        nombre="Simple Asociación histórica", tipo_entidad=tipo_incorrecto
+    )
+    sin_subtipo = Organizacion.objects.create(
+        nombre="Simple asociación sin subtipo", tipo_entidad=tipo_incorrecto
+    )
+    con_subtipo = Organizacion.objects.create(
+        nombre="Simple asociación con subtipo",
+        tipo_entidad=tipo_incorrecto,
+        subtipo_entidad=subtipo_personalizado,
+    )
+
+    migration = import_module(
+        "organizaciones.migrations.0018_corregir_simple_asociacion_subtipo"
+    )
+    migration.corregir_simple_asociacion(import_module("django.apps").apps, None)
+
+    subtipo_personalizado.refresh_from_db()
+    sin_subtipo.refresh_from_db()
+    con_subtipo.refresh_from_db()
+    simple_asociacion = SubtipoEntidad.objects.get(
+        nombre="Simple Asociación (art. 187 CCCN)"
+    )
+
+    assert simple_asociacion.tipo_entidad_id == juridica.pk
+    assert simple_asociacion.activo is True
+    assert subtipo_personalizado.tipo_entidad_id == juridica.pk
+    assert sin_subtipo.tipo_entidad_id == juridica.pk
+    assert sin_subtipo.subtipo_entidad_id == simple_asociacion.pk
+    assert con_subtipo.tipo_entidad_id == juridica.pk
+    assert con_subtipo.subtipo_entidad_id == subtipo_personalizado.pk
+    assert not TipoEntidad.objects.filter(
+        nombre="Simple Asociación (art. 187 CCCN)"
+    ).exists()


### PR DESCRIPTION
## Qué cambia

- Ubica `Simple Asociación (art. 187 CCCN)` como subtipo activo de `Personería Jurídica`.
- Corrige el catálogo creado por el PR #2167: migra organizaciones que hubieran usado el tipo principal erróneo y conserva subtipos personalizados.
- Actualiza el fixture, agrega cobertura focalizada y registra el cambio funcional.

## Por qué

El comentario del issue #2163 aclaró que Simple Asociación debe ser un subtipo de Personería Jurídica.

## Validación

- `git diff --check`
- Validación de sintaxis JSON del fixture
- `py -3 -m compileall` sobre la migración y la prueba

No se pudieron ejecutar Black ni Pytest: Docker no está disponible y el fallback local no puede preparar las dependencias (falta compilador C/C++ para NumPy); además el host no tiene `black` ni `crispy_forms`.