### PR TITLE
fix(comedores): restringir código de proyecto por programa

### DIFF
--- a/comedores/forms/comedor_form.py
+++ b/comedores/forms/comedor_form.py
@@ -9,12 +9,13 @@ from comedores.models import (
     Referente,
     ImagenComedor,
     Nomina,
+    Programas,
     EstadoActividad,
     EstadoProceso,
     EstadoDetalle,
 )
 from comedores.services.estado_manager import registrar_cambio_estado
-from comedores.utils import is_pnud_comedor
+from comedores.utils import is_pnud_comedor, permite_codigo_de_proyecto
 
 from core.models import Municipio, Provincia
 from core.models import Localidad
@@ -263,6 +264,12 @@ class ComedorForm(forms.ModelForm):
         else:
             self.fields["organizacion"].queryset = Organizacion.objects.none()
 
+        self.codigo_de_proyecto_programa_ids = ",".join(
+            str(programa.pk)
+            for programa in Programas.objects.only("id", "nombre")
+            if permite_codigo_de_proyecto(programa)
+        )
+
     def _can_edit_estado_fields(self):
         user = self.current_user
         if not user or not getattr(user, "is_authenticated", False):
@@ -470,6 +477,9 @@ class ComedorForm(forms.ModelForm):
             != Comedor.CATEGORIA_ESPACIO_OTRA
         ):
             cleaned_data["categoria_espacio_comunitario_otra"] = ""
+
+        if not permite_codigo_de_proyecto(cleaned_data.get("programa")):
+            cleaned_data["codigo_de_proyecto"] = None
 
         estado_actividad = cleaned_data.get("estado_general")
         estado_proceso = cleaned_data.get("subestado")

--- a/comedores/migrations/0052_issue_2169_codigo_proyecto.py
+++ b/comedores/migrations/0052_issue_2169_codigo_proyecto.py
@@ -1,0 +1,41 @@
+import unicodedata
+
+from django.db import migrations
+
+
+def _normalizar_nombre(nombre):
+    sin_acentos = unicodedata.normalize("NFD", nombre or "")
+    sin_acentos = "".join(
+        caracter for caracter in sin_acentos if not unicodedata.combining(caracter)
+    )
+    return " ".join(sin_acentos.lower().split())
+
+
+def limpiar_codigos_alimentar_comunidad(apps, schema_editor):
+    """Elimina códigos que no aplican al programa Alimentar Comunidad."""
+    comedor_model = apps.get_model("comedores", "Comedor")
+    programa_model = apps.get_model("comedores", "Programas")
+    programas_alimentar_ids = [
+        programa.pk
+        for programa in programa_model.objects.only("id", "nombre")
+        if _normalizar_nombre(programa.nombre) == "alimentar comunidad"
+    ]
+
+    if programas_alimentar_ids:
+        comedor_model.objects.filter(programa_id__in=programas_alimentar_ids).update(
+            codigo_de_proyecto=None
+        )
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ("comedores", "0051_comedor_categoria_espacio_comunitario"),
+    ]
+
+    operations = [
+        migrations.RunPython(
+            limpiar_codigos_alimentar_comunidad,
+            migrations.RunPython.noop,
+        ),
+    ]

--- a/comedores/templates/comedor/comedor_form.html
+++ b/comedores/templates/comedor/comedor_form.html
@@ -87,7 +87,9 @@
                         <div class="form-group row">
                             <div class="col-md-4">{{ form.organizacion|as_crispy_field }}</div>
                             <div class="col-md-4">{{ form.programa|as_crispy_field }}</div>
-                            <div class="col-md-2">
+                            <div id="codigo-proyecto-wrapper"
+                                 class="col-md-2"
+                                 data-programa-ids="{{ form.codigo_de_proyecto_programa_ids }}">
                                 {{ form.codigo_de_proyecto|as_crispy_field }}
                                 <span class="field-tooltip">
                                     <i class="fas fa-info-circle"></i>
@@ -545,6 +547,31 @@
 
             categoriaInput.addEventListener("change", actualizarOtraCategoria);
             actualizarOtraCategoria();
+        }());
+
+        (function () {
+            var programaInput = document.getElementById("id_programa");
+            var codigoWrapper = document.getElementById("codigo-proyecto-wrapper");
+            var codigoInput = document.getElementById("id_codigo_de_proyecto");
+
+            if (!programaInput || !codigoWrapper || !codigoInput) {
+                return;
+            }
+
+            var programasPermitidos = codigoWrapper.dataset.programaIds
+                .split(",")
+                .filter(Boolean);
+
+            function actualizarCodigoProyecto() {
+                var permitido = programasPermitidos.indexOf(programaInput.value) !== -1;
+                codigoWrapper.classList.toggle("d-none", !permitido);
+                if (!permitido) {
+                    codigoInput.value = "";
+                }
+            }
+
+            programaInput.addEventListener("change", actualizarCodigoProyecto);
+            actualizarCodigoProyecto();
         }());
     </script>
 

--- a/comedores/utils.py
+++ b/comedores/utils.py
@@ -13,6 +13,12 @@ from rendicioncuentasmensual.models import RendicionCuentaMensual
 # IDs de programa PNUD en la tabla core_programa (prog 3 = PNUD Prog1, prog 4 = PNUD Prog2).
 # Se complementa con la búsqueda por nombre para tolerar entornos donde los IDs difieren.
 _PNUD_PROGRAMA_IDS = frozenset((3, 4))
+_PROGRAMAS_CON_CODIGO_DE_PROYECTO = frozenset(
+    (
+        "abordaje comunitario - linea secos",
+        "abordaje comunitario - linea tradicional",
+    )
+)
 
 
 def is_pnud_comedor(comedor) -> bool:
@@ -42,6 +48,12 @@ def _normalize_programa(nombre: str) -> str:
 def _get_programa_nombre_normalizado(comedor) -> str:
     nombre = str(getattr(getattr(comedor, "programa", None), "nombre", "") or "")
     return _normalize_programa(nombre)
+
+
+def permite_codigo_de_proyecto(programa) -> bool:
+    """Indica si el programa admite código de proyecto en el legajo."""
+    nombre = str(getattr(programa, "nombre", "") or "")
+    return _normalize_programa(nombre) in _PROGRAMAS_CON_CODIGO_DE_PROYECTO
 
 
 def is_prestacion_alimentaria_conformidad_program(comedor) -> bool:

--- a/docs/registro/cambios/2026-07-29-issue-2169-codigo-proyecto.md
+++ b/docs/registro/cambios/2026-07-29-issue-2169-codigo-proyecto.md
@@ -1,0 +1,19 @@
+# Issue 2169 - Código de Proyecto según programa
+
+## Cambio funcional
+
+En alta y edición de comedores, el campo `Código de Proyecto` solo se muestra
+para los programas Abordaje Comunitario - Línea Secos y Línea Tradicional.
+
+La misma regla se aplica en el servidor: si se envía un código para Alimentar
+Comunidad u otro programa no habilitado, se descarta antes de persistirlo.
+
+## Limpieza histórica
+
+La migración `comedores/0052_issue_2169_codigo_proyecto.py` deja en `NULL` el
+código de proyecto de los comedores de Alimentar Comunidad. Es idempotente,
+pero su reversa es `noop`: los valores eliminados no pueden reconstruirse sin
+un respaldo previo.
+
+Antes de aplicarla sobre datos reales se debe registrar el conjunto afectado y
+contar con aprobación explícita para la limpieza.

--- a/tests/test_comedor_form_unit.py
+++ b/tests/test_comedor_form_unit.py
@@ -177,7 +177,9 @@ def test_clean_validates_missing_and_mismatches(mocker):
         ("Otro programa", None),
     ],
 )
-def test_clean_aplica_regla_codigo_de_proyecto(mocker, programa_nombre, codigo_esperado):
+def test_clean_aplica_regla_codigo_de_proyecto(
+    mocker, programa_nombre, codigo_esperado
+):
     form = _build_form_stub()
     actividad = SimpleNamespace(id=1)
     proceso = SimpleNamespace(id=2, estado_actividad_id=1)

--- a/tests/test_comedor_form_unit.py
+++ b/tests/test_comedor_form_unit.py
@@ -168,6 +168,35 @@ def test_clean_validates_missing_and_mismatches(mocker):
     assert any(field == "motivo" for field, _ in errors)
 
 
+@pytest.mark.parametrize(
+    "programa_nombre,codigo_esperado",
+    [
+        ("Abordaje Comunitario - Línea Secos", "SEC1234"),
+        ("Abordaje Comunitario - Línea Tradicional", "TRA1234"),
+        ("Alimentar Comunidad", None),
+        ("Otro programa", None),
+    ],
+)
+def test_clean_aplica_regla_codigo_de_proyecto(mocker, programa_nombre, codigo_esperado):
+    form = _build_form_stub()
+    actividad = SimpleNamespace(id=1)
+    proceso = SimpleNamespace(id=2, estado_actividad_id=1)
+    mocker.patch(
+        "django.forms.models.BaseModelForm.clean",
+        return_value={
+            "programa": SimpleNamespace(nombre=programa_nombre),
+            "codigo_de_proyecto": "SEC1234",
+            "estado_general": actividad,
+            "subestado": proceso,
+            "motivo": None,
+        },
+    )
+
+    cleaned_data = form.clean()
+
+    assert cleaned_data["codigo_de_proyecto"] == codigo_esperado
+
+
 def test_restrict_estado_fields_for_pac_preserves_previous_initials():
     form = _build_form_stub()
     form.instance = SimpleNamespace(programa_id=2)

--- a/tests/test_comedores_utils_unit.py
+++ b/tests/test_comedores_utils_unit.py
@@ -36,6 +36,26 @@ def test_normalize_programa_remueve_acentos():
 
 
 # ---------------------------------------------------------------------------
+# permite_codigo_de_proyecto
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "nombre,expected",
+    [
+        ("Abordaje Comunitario - Línea Secos", True),
+        ("abordaje comunitario - linea tradicional", True),
+        ("Alimentar Comunidad", False),
+        ("Abordaje Comunitario", False),
+        ("", False),
+    ],
+)
+def test_permite_codigo_de_proyecto(nombre, expected):
+    programa = SimpleNamespace(nombre=nombre)
+    assert module.permite_codigo_de_proyecto(programa) is expected
+
+
+# ---------------------------------------------------------------------------
 # is_prestacion_alimentaria_conformidad_program
 # ---------------------------------------------------------------------------
 

--- a/tests/test_issue_2169_codigo_proyecto_migration.py
+++ b/tests/test_issue_2169_codigo_proyecto_migration.py
@@ -1,0 +1,54 @@
+"""Contrato de la limpieza de Código de Proyecto para issue #2169."""
+
+import importlib
+from types import SimpleNamespace
+
+import pytest
+
+from comedores.models import Comedor, Programas
+
+
+MIGRATION = importlib.import_module(
+    "comedores.migrations.0052_issue_2169_codigo_proyecto"
+)
+
+
+@pytest.mark.django_db
+def test_limpieza_codigo_proyecto_afecta_solo_alimentar_comunidad():
+    alimentar = Programas.objects.create(nombre="Alimentar Comunidad")
+    secos = Programas.objects.create(nombre="Abordaje Comunitario - Línea Secos")
+    tradicional = Programas.objects.create(
+        nombre="Abordaje Comunitario - Línea Tradicional"
+    )
+    otro = Programas.objects.create(nombre="Otro programa")
+
+    comedor_alimentar = Comedor.objects.create(
+        nombre="PAC", programa=alimentar, codigo_de_proyecto="PAC1234"
+    )
+    comedor_secos = Comedor.objects.create(
+        nombre="Secos", programa=secos, codigo_de_proyecto="SEC1234"
+    )
+    comedor_tradicional = Comedor.objects.create(
+        nombre="Tradicional", programa=tradicional, codigo_de_proyecto="TRA1234"
+    )
+    comedor_otro = Comedor.objects.create(
+        nombre="Otro", programa=otro, codigo_de_proyecto="OTR1234"
+    )
+
+    apps = SimpleNamespace(
+        get_model=lambda app_label, model_name: {
+            ("comedores", "Comedor"): Comedor,
+            ("comedores", "Programas"): Programas,
+        }[(app_label, model_name)]
+    )
+    MIGRATION.limpiar_codigos_alimentar_comunidad(apps, schema_editor=None)
+
+    comedor_alimentar.refresh_from_db()
+    comedor_secos.refresh_from_db()
+    comedor_tradicional.refresh_from_db()
+    comedor_otro.refresh_from_db()
+
+    assert comedor_alimentar.codigo_de_proyecto is None
+    assert comedor_secos.codigo_de_proyecto == "SEC1234"
+    assert comedor_tradicional.codigo_de_proyecto == "TRA1234"
+    assert comedor_otro.codigo_de_proyecto == "OTR1234"


### PR DESCRIPTION
## Resumen
- Muestra Código de Proyecto únicamente para Abordaje Comunitario - Línea Secos y Línea Tradicional.
- Fuerza la limpieza del campo en el servidor para Alimentar Comunidad, otros programas y POST manipulados.
- Incorpora una migración selectiva e idempotente que limpia los valores históricos de Alimentar Comunidad.

Closes #2169

## Validación
- `py -3 -m compileall -q ...` ✅
- `git diff --check` ✅
- `pytest`, `black`, `djlint` y `makemigrations --check --dry-run` no se ejecutaron: el intérprete local no tiene `crispy_forms`, `pytest`, `black` ni `djlint`; el runtime empaquetado tampoco incluye Django.

## Riesgo operativo
La migración borra datos históricos de forma irreversible (reversa `noop`). Antes de aplicarla en datos reales se requiere respaldo y aprobación operativa.