### PR TITLE
feat(users): agregar DNI CUIL y tipo informativo

### DIFF
--- a/docs/registro/cambios/2026-07-29-usuarios-dni-cuil-tipo.md
+++ b/docs/registro/cambios/2026-07-29-usuarios-dni-cuil-tipo.md
@@ -1,0 +1,12 @@
+# Usuarios: DNI, CUIL y tipo informativo
+
+Se incorporan DNI, CUIL y Tipo de usuario al ABM de usuarios. Los tres datos
+se persisten en `users.Profile`; el tipo admite Interno, Provincial o Externo y
+es obligatorio únicamente en los formularios de alta y edición.
+
+La clasificación es informativa. No modifica grupos, permisos, acceso mobile,
+roles ni alcances territoriales. El checkbox existente `Es usuario provincial`
+mantiene su semántica de configuración territorial.
+
+DNI y CUIL se conservan como texto opcional, sin validar formato ni unicidad,
+porque el alcance funcional no define esas reglas.

--- a/users/forms.py
+++ b/users/forms.py
@@ -695,6 +695,13 @@ class UserCreationForm(
     forms.ModelForm,
 ):
     password = forms.CharField(widget=forms.PasswordInput, label="Contraseña")
+    dni = forms.CharField(max_length=16, required=False, label="DNI")
+    cuil = forms.CharField(max_length=16, required=False, label="CUIL")
+    tipo_usuario = forms.ChoiceField(
+        choices=Profile.TipoUsuario.choices,
+        widget=forms.RadioSelect,
+        label="Tipo de usuario",
+    )
     groups = forms.ModelMultipleChoiceField(
         queryset=Group.objects.all(),
         required=False,
@@ -747,6 +754,9 @@ class UserCreationForm(
             "username",
             "email",
             "password",
+            "dni",
+            "cuil",
+            "tipo_usuario",
             "groups",
             "user_permissions",
             "es_usuario_provincial",
@@ -824,6 +834,9 @@ class UserCreationForm(
         profile.es_usuario_provincial = self.cleaned_data.get(
             "es_usuario_provincial", False
         )
+        profile.dni = self.cleaned_data.get("dni", "")
+        profile.cuil = self.cleaned_data.get("cuil", "")
+        profile.tipo_usuario = self.cleaned_data["tipo_usuario"]
         profile.provincia = None
         profile.es_coordinador = self.cleaned_data.get("es_coordinador", False)
         profile.rol = self.cleaned_data.get("rol")
@@ -885,6 +898,13 @@ class CustomUserChangeForm(
         label="Contraseña (dejar en blanco para no cambiarla)",
         required=False,
     )
+    dni = forms.CharField(max_length=16, required=False, label="DNI")
+    cuil = forms.CharField(max_length=16, required=False, label="CUIL")
+    tipo_usuario = forms.ChoiceField(
+        choices=Profile.TipoUsuario.choices,
+        widget=forms.RadioSelect,
+        label="Tipo de usuario",
+    )
     groups = forms.ModelMultipleChoiceField(
         queryset=Group.objects.all(),
         required=False,
@@ -937,6 +957,9 @@ class CustomUserChangeForm(
             "username",
             "email",
             "password",
+            "dni",
+            "cuil",
+            "tipo_usuario",
             "groups",
             "user_permissions",
             "es_usuario_provincial",
@@ -967,6 +990,9 @@ class CustomUserChangeForm(
 
         self._setup_territorial_scope_fields(prof)
         if prof:
+            self.fields["dni"].initial = prof.dni
+            self.fields["cuil"].initial = prof.cuil
+            self.fields["tipo_usuario"].initial = prof.tipo_usuario
             self.fields["es_usuario_provincial"].initial = prof.es_usuario_provincial
             self.fields["provincia"].initial = prof.provincia
             self.fields["es_coordinador"].initial = prof.es_coordinador
@@ -1035,6 +1061,9 @@ class CustomUserChangeForm(
             profile.es_usuario_provincial = self.cleaned_data.get(
                 "es_usuario_provincial", False
             )
+            profile.dni = self.cleaned_data.get("dni", "")
+            profile.cuil = self.cleaned_data.get("cuil", "")
+            profile.tipo_usuario = self.cleaned_data["tipo_usuario"]
             profile.provincia = None
             profile.es_coordinador = self.cleaned_data.get("es_coordinador", False)
             profile.rol = self.cleaned_data.get("rol")

--- a/users/migrations/0042_profile_datos_identificatorios.py
+++ b/users/migrations/0042_profile_datos_identificatorios.py
@@ -1,0 +1,35 @@
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ("users", "0041_bootstrap_simepi_cdi_groups"),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name="profile",
+            name="dni",
+            field=models.CharField(blank=True, max_length=16),
+        ),
+        migrations.AddField(
+            model_name="profile",
+            name="cuil",
+            field=models.CharField(blank=True, max_length=16),
+        ),
+        migrations.AddField(
+            model_name="profile",
+            name="tipo_usuario",
+            field=models.CharField(
+                blank=True,
+                choices=[
+                    ("interno", "Interno"),
+                    ("provincial", "Provincial"),
+                    ("externo", "Externo"),
+                ],
+                max_length=10,
+                null=True,
+            ),
+        ),
+    ]

--- a/users/models.py
+++ b/users/models.py
@@ -60,6 +60,10 @@ class Profile(models.Model):
     -------
     user : OneToOneField
         Usuario de Django asociado (relación 1:1)
+    dni, cuil : CharField
+        Datos identificatorios informativos del usuario
+    tipo_usuario : CharField
+        Clasificación informativa independiente de permisos y alcances
     dark_mode : BooleanField
         Preferencia de tema oscuro en la UI
     es_usuario_provincial : BooleanField
@@ -82,7 +86,20 @@ class Profile(models.Model):
     - duplas.models.Dupla: Modelo de equipos técnicos
     """
 
+    class TipoUsuario(models.TextChoices):
+        INTERNO = "interno", "Interno"
+        PROVINCIAL = "provincial", "Provincial"
+        EXTERNO = "externo", "Externo"
+
     user = models.OneToOneField(User, on_delete=models.CASCADE)
+    dni = models.CharField(max_length=16, blank=True)
+    cuil = models.CharField(max_length=16, blank=True)
+    tipo_usuario = models.CharField(
+        max_length=10,
+        choices=TipoUsuario.choices,
+        null=True,
+        blank=True,
+    )
     dark_mode = models.BooleanField(default=True)
     es_usuario_provincial = models.BooleanField(default=False)
     provincia = models.ForeignKey(

--- a/users/templates/user/user_form.html
+++ b/users/templates/user/user_form.html
@@ -38,6 +38,11 @@
                             <div class="col-md-6">{{ form.first_name|as_crispy_field }}</div>
                             <div class="col-md-6">{{ form.last_name|as_crispy_field }}</div>
                         </div>
+                        <div class="row">
+                            <div class="col-md-6">{{ form.dni|as_crispy_field }}</div>
+                            <div class="col-md-6">{{ form.cuil|as_crispy_field }}</div>
+                        </div>
+                        {{ form.tipo_usuario|as_crispy_field }}
                     </div>
                 </div>
 

--- a/users/tests.py
+++ b/users/tests.py
@@ -44,6 +44,7 @@ def _user_form_data(username, scopes, provincia=""):
         "username": username,
         "email": f"{username}@example.com",
         "password": "pass12345",
+        "tipo_usuario": "interno",
         "es_usuario_provincial": "on",
         "provincia": provincia,
         "territorial_scopes": json.dumps(scopes),
@@ -75,6 +76,112 @@ def test_usuario_provincial_sin_alcances_es_valido_y_no_crea_scope():
     assert user.profile.es_usuario_provincial is True
     assert user.profile.provincia_id is None
     assert user.profile.territorial_scopes.count() == 0
+
+
+@pytest.mark.django_db
+def test_alta_usuario_persiste_datos_identificatorios_y_tipo():
+    data = _user_form_data("usuario-identificado", [])
+    data.pop("es_usuario_provincial")
+    data.update(
+        {
+            "dni": "12345678",
+            "cuil": "20-12345678-3",
+            "tipo_usuario": "provincial",
+        }
+    )
+
+    form = UserCreationForm(data=data)
+
+    assert form.is_valid(), form.errors
+    user = form.save()
+
+    user.profile.refresh_from_db()
+    assert user.profile.dni == "12345678"
+    assert user.profile.cuil == "20-12345678-3"
+    assert user.profile.tipo_usuario == "provincial"
+    assert user.profile.es_usuario_provincial is False
+
+
+@pytest.mark.django_db
+def test_alta_usuario_requiere_tipo_usuario():
+    data = _user_form_data("usuario-sin-tipo", [])
+    data.pop("tipo_usuario")
+
+    form = UserCreationForm(data=data)
+
+    assert not form.is_valid()
+    assert "tipo_usuario" in form.errors
+
+
+@pytest.mark.django_db
+def test_alta_usuario_muestra_campos_identificatorios(client):
+    actor = User.objects.create_user(username="admin-usuarios", password="secret")
+    actor.user_permissions.add(
+        Permission.objects.get(content_type__app_label="auth", codename="add_user")
+    )
+    client.force_login(actor)
+
+    response = client.get(reverse("usuario_crear"))
+
+    assert response.status_code == 200
+    assert b"DNI" in response.content
+    assert b"CUIL" in response.content
+    assert b"Tipo de usuario" in response.content
+    assert b"Interno" in response.content
+    assert b"Provincial" in response.content
+    assert b"Externo" in response.content
+
+
+@pytest.mark.django_db
+def test_edicion_usuario_precarga_y_actualiza_datos_identificatorios_y_tipo():
+    user = User.objects.create_user(username="usuario-edicion", password="pass12345")
+    user.profile.dni = "11111111"
+    user.profile.cuil = "20-11111111-1"
+    user.profile.tipo_usuario = "interno"
+    user.profile.save(update_fields=["dni", "cuil", "tipo_usuario"])
+
+    form = CustomUserChangeForm(instance=user)
+
+    assert form.fields["dni"].initial == "11111111"
+    assert form.fields["cuil"].initial == "20-11111111-1"
+    assert form.fields["tipo_usuario"].initial == "interno"
+
+    form = CustomUserChangeForm(
+        instance=user,
+        data={
+            "username": user.username,
+            "email": "",
+            "dni": "22222222",
+            "cuil": "27-22222222-2",
+            "tipo_usuario": "externo",
+            "territorial_scopes": "[]",
+        },
+    )
+
+    assert form.is_valid(), form.errors
+    form.save()
+
+    user.profile.refresh_from_db()
+    assert user.profile.dni == "22222222"
+    assert user.profile.cuil == "27-22222222-2"
+    assert user.profile.tipo_usuario == "externo"
+
+
+@pytest.mark.django_db
+def test_edicion_usuario_requiere_tipo_usuario():
+    user = User.objects.create_user(username="usuario-edicion-sin-tipo", password="x")
+
+    form = CustomUserChangeForm(
+        instance=user,
+        data={
+            "username": user.username,
+            "email": "",
+            "territorial_scopes": "[]",
+        },
+    )
+
+    assert not form.is_valid()
+    assert "tipo_usuario" in form.errors
 
 
 @pytest.mark.django_db
@@ -338,6 +445,7 @@ def test_user_creation_form_limits_groups_and_roles_by_actor_scope():
             "username": "nuevo_usuario",
             "email": "nuevo@example.com",
             "password": "pass12345",
+            "tipo_usuario": "interno",
             "groups": [allowed_group.pk, forbidden_group.pk],
             "user_permissions": [allowed_role.pk, forbidden_role.pk],
             "grupos_asignables": [allowed_group.pk, forbidden_group.pk],
@@ -365,6 +473,7 @@ def test_user_creation_form_rejects_egp_without_province_scope():
             "username": "egp-sin-scope",
             "email": "egp-sin-scope@example.com",
             "password": "pass12345",
+            "tipo_usuario": "interno",
             "groups": [egp.pk],
         },
     )
@@ -428,6 +537,7 @@ def test_user_change_form_no_permite_quitar_scope_a_egp():
             "username": target.username,
             "email": target.email,
             "groups": [egp.pk],
+            "tipo_usuario": "interno",
             "territorial_scopes": "[]",
         },
     )
@@ -454,6 +564,7 @@ def test_user_creation_form_persists_assignable_scope_in_profile():
             "username": "delegador",
             "email": "delegador@example.com",
             "password": "pass12345",
+            "tipo_usuario": "interno",
             "groups": [assignable_group.pk],
             "user_permissions": [assignable_role.pk],
             "grupos_asignables": [assignable_group.pk],
@@ -727,6 +838,7 @@ def test_actor_cdi_no_ve_ni_puede_enviar_campos_administrativos_en_alta(client):
             "username": "trabajador-cdi-restringido",
             "email": "trabajador-cdi@example.com",
             "password": "pass12345",
+            "tipo_usuario": "interno",
             "groups": [trabajador.pk],
             "user_permissions": [permission.pk],
             "es_representante_pwa": "on",
@@ -772,6 +884,7 @@ def test_actor_cdi_preserva_configuracion_administrativa_oculta_en_edicion(clien
         data={
             "username": target.username,
             "email": target.email,
+            "tipo_usuario": "interno",
             "groups": [referente.pk],
             "user_permissions": [forbidden_permission.pk],
             "grupos_asignables": [],


### PR DESCRIPTION
## Resumen

Implementa el issue #2154 para incorporar DNI, CUIL y Tipo de usuario al ABM.

- Persiste los nuevos datos en `users.Profile`.
- Muestra DNI y CUIL, y exige un único Tipo de usuario mediante radio buttons.
- Mantiene independiente el checkbox territorial `Es usuario provincial`.
- Agrega migración, pruebas de alta/edición y registro funcional.

## Impacto

La clasificación es informativa: no cambia permisos, grupos, roles, acceso mobile ni alcances territoriales. Los perfiles históricos conservan el tipo vacío hasta su próxima edición.

## Validación

- `py -3 -m compileall -q users/models.py users/forms.py users/migrations/0042_profile_datos_identificatorios.py users/tests.py`
- `git diff --check`

No se pudo ejecutar `pytest` ni formatters: el Python global no tiene `crispy_forms` ni `black`, el `.venv` referencia un Python inexistente y Docker Desktop no tenía el daemon disponible.