### PR TITLE
[INET/VAT] Tipo de alumno VAT / Sin Plan en asistencia y exportaciones + correcciones post-#2184

### DIFF
--- a/VAT/forms.py
+++ b/VAT/forms.py
@@ -671,9 +671,17 @@ class CentroForm(forms.ModelForm):
         # El prefijo se valida acá porque es cross-field: necesita `provincia`,
         # que se limpia después de `codigo`. Si `codigo` ya falló, no está en
         # cleaned_data y no se re-reporta.
+        #
+        # Fallback a la instancia: en edición `provincia` va oculta y
+        # `required=False` (ver `hide_provincia`), así que si no llega en el POST
+        # quedaría en None y la validación de prefijo se saltearía en silencio.
+        # La provincia del centro que se está editando es la fuente correcta.
+        provincia = cleaned_data.get("provincia") or getattr(
+            self.instance, "provincia", None
+        )
         error_prefijo = _validar_prefijo_cue(
             cleaned_data.get("codigo"),
-            cleaned_data.get("provincia"),
+            provincia,
         )
         if error_prefijo:
             self.add_error("codigo", error_prefijo)

--- a/VAT/services/inscripcion_service.py
+++ b/VAT/services/inscripcion_service.py
@@ -6,7 +6,13 @@ from django.contrib.auth import get_user_model
 from django.db import transaction
 
 from ciudadanos.models import Ciudadano
-from VAT.models import Inscripcion, InscripcionOferta, Voucher, VoucherUso
+from VAT.models import (
+    Inscripcion,
+    InscripcionOferta,
+    Voucher,
+    VoucherLog,
+    VoucherUso,
+)
 from VAT.services.voucher_service import VoucherService
 
 User = get_user_model()
@@ -279,6 +285,59 @@ class InscripcionService:
         raise ValueError(
             f"{ciudadano} no tiene voucher válido para el programa {oferta.programa}."
         )
+
+    @staticmethod
+    def _ultimo_movimiento_voucher_para_inscripcion(inscripcion):
+        """Obtiene el último débito o compensación asociado a una inscripción."""
+        if not inscripcion.pk:
+            return None
+        return (
+            VoucherLog.objects.filter(
+                detalles__inscripcion_id=inscripcion.pk,
+                tipo_evento__in=("uso", "recarga"),
+            )
+            .select_related("voucher")
+            .order_by("-fecha_evento", "-pk")
+            .first()
+        )
+
+    @staticmethod
+    def _tiene_debito_voucher_vigente(inscripcion):
+        movimiento = InscripcionService._ultimo_movimiento_voucher_para_inscripcion(
+            inscripcion
+        )
+        return movimiento is not None and movimiento.tipo_evento == "uso"
+
+    @staticmethod
+    def _reintegrar_debito_voucher_para_inscripcion(*, inscripcion, usuario):
+        movimiento = InscripcionService._ultimo_movimiento_voucher_para_inscripcion(
+            inscripcion
+        )
+        if movimiento is None or movimiento.tipo_evento != "uso":
+            return
+
+        usuario_auditoria = InscripcionService._resolver_usuario_auditoria(usuario)
+        if usuario_auditoria is None:
+            raise ValueError(
+                "No hay usuario disponible para registrar la compensación del voucher."
+            )
+
+        cantidad = -movimiento.cantidad_afectada
+        if cantidad <= 0:
+            return
+        ok, mensaje = VoucherService.reintegrar_voucher(
+            voucher=movimiento.voucher,
+            cantidad=cantidad,
+            usuario=usuario_auditoria,
+            detalles={
+                "inscripcion_id": inscripcion.id,
+                "comision_id": inscripcion.comision_id,
+                "comision_curso_id": inscripcion.comision_curso_id,
+                "origen": "rechazo_inscripcion",
+            },
+        )
+        if not ok:
+            raise ValueError(mensaje)
 
     @staticmethod
     def validar_inscripcion_unica(ciudadano, programa) -> tuple[bool, str]:
@@ -713,7 +772,22 @@ class InscripcionService:
                 if cupos_disponibles <= 0:
                     raise ValueError(MENSAJE_CUPO_COMPLETO)
 
-            if unidad_formativa.usa_voucher and pasa_a_ocupar_cupo and not ocupaba_cupo:
+            if (
+                unidad_formativa.usa_voucher
+                and nuevo_estado == "rechazada"
+                and ocupaba_cupo
+            ):
+                InscripcionService._reintegrar_debito_voucher_para_inscripcion(
+                    inscripcion=inscripcion,
+                    usuario=usuario,
+                )
+
+            if (
+                unidad_formativa.usa_voucher
+                and pasa_a_ocupar_cupo
+                and not ocupaba_cupo
+                and not InscripcionService._tiene_debito_voucher_vigente(inscripcion)
+            ):
                 cantidad_debito = InscripcionService._resolver_cantidad_debito(
                     getattr(unidad_formativa, "costo", None)
                     or getattr(unidad_formativa, "costo_creditos", 0)

--- a/VAT/services/nomina_export.py
+++ b/VAT/services/nomina_export.py
@@ -6,6 +6,8 @@ from django.utils.text import slugify
 from openpyxl import Workbook
 from openpyxl.styles import Font
 
+from VAT.services.tipo_alumno_service import anotar_tipo_alumno
+
 
 NOMINA_HEADERS = [
     "Apellido",
@@ -13,6 +15,7 @@ NOMINA_HEADERS = [
     "DNI / CUIL",
     "Fecha de Nacimiento",
     "Género",
+    "Tipo de alumno",
     "Comisión",
     "Curso",
     "Centro de Formación",
@@ -88,7 +91,7 @@ def build_comision_curso_nomina_excel(comision, inscripciones):
     for cell in worksheet[1]:
         cell.font = Font(bold=True)
 
-    for inscripcion in inscripciones:
+    for inscripcion in anotar_tipo_alumno(list(inscripciones)):
         ciudadano = inscripcion.ciudadano
         observaciones = _parse_observaciones_json(inscripcion)
         worksheet.append(
@@ -98,6 +101,7 @@ def build_comision_curso_nomina_excel(comision, inscripciones):
                 _resolve_document(ciudadano, observaciones),
                 _format_date(ciudadano.fecha_nacimiento),
                 ciudadano.sexo.sexo if ciudadano.sexo_id and ciudadano.sexo else "",
+                inscripcion.tipo_alumno,
                 str(comision),
                 comision.curso.nombre,
                 comision.curso.centro.nombre,

--- a/VAT/services/reportes_inscripciones_asistencia.py
+++ b/VAT/services/reportes_inscripciones_asistencia.py
@@ -14,6 +14,10 @@ from openpyxl.styles import Font
 
 from VAT.models import Centro, Comision, ComisionCurso, Curso, Inscripcion
 from VAT.services.access_scope import filter_centros_queryset_for_user
+from VAT.services.tipo_alumno_service import (
+    tiene_voucher_activo_subquery,
+    tipo_alumno_label,
+)
 
 
 DATE_INPUT_FORMAT = "%Y-%m-%d"
@@ -376,6 +380,7 @@ DETALLE_VALUES = (
     "ciudadano__apellido",
     "ciudadano__nombre",
     "estado",
+    "tiene_voucher_activo",
     "fecha_inscripcion",
     "centro_nombre_ref",
     "comision_codigo_ref",
@@ -387,7 +392,11 @@ def build_detalle_queryset(user, filtros: ReporteFiltros):
     """Queryset (sin materializar) del detalle nominal, ordenado de forma estable
     para paginar con LIMIT/OFFSET sin solapamientos entre páginas."""
     queryset = _apply_filters(_base_queryset_for_user(user), filtros)
-    return queryset.values(*DETALLE_VALUES).order_by("-fecha_inscripcion", "id")
+    return (
+        queryset.annotate(tiene_voucher_activo=tiene_voucher_activo_subquery())
+        .values(*DETALLE_VALUES)
+        .order_by("-fecha_inscripcion", "id")
+    )
 
 
 def build_detalle_personas_inscriptas(
@@ -482,6 +491,7 @@ DETALLE_HEADERS = [
     "Apellido",
     "Nombre",
     "Estado",
+    "Tipo de alumno",
     "Fecha inscripción",
     "Centro",
     "Provincia",
@@ -493,18 +503,23 @@ DETALLE_HEADERS = [
 def _detalle_export_queryset(user, filtros: ReporteFiltros):
     """Detalle nominal completo (sin tope de filas) para exportar."""
     queryset = _apply_filters(_base_queryset_for_user(user), filtros)
-    return queryset.values(
-        "id",
-        "ciudadano__documento",
-        "ciudadano__apellido",
-        "ciudadano__nombre",
-        "estado",
-        "fecha_inscripcion",
-        "centro_nombre_ref",
-        "provincia_nombre_ref",
-        "unidad_formativa_nombre",
-        "comision_codigo_ref",
-    ).order_by("centro_nombre_ref", "ciudadano__apellido", "ciudadano__nombre")
+    return (
+        queryset.annotate(tiene_voucher_activo=tiene_voucher_activo_subquery())
+        .values(
+            "id",
+            "ciudadano__documento",
+            "ciudadano__apellido",
+            "ciudadano__nombre",
+            "estado",
+            "tiene_voucher_activo",
+            "fecha_inscripcion",
+            "centro_nombre_ref",
+            "provincia_nombre_ref",
+            "unidad_formativa_nombre",
+            "comision_codigo_ref",
+        )
+        .order_by("centro_nombre_ref", "ciudadano__apellido", "ciudadano__nombre")
+    )
 
 
 def _detalle_row_cells(row, estado_labels):
@@ -515,6 +530,7 @@ def _detalle_row_cells(row, estado_labels):
         row.get("ciudadano__apellido") or "",
         row.get("ciudadano__nombre") or "",
         estado_labels.get(estado, estado),
+        tipo_alumno_label(row.get("tiene_voucher_activo")),
         fecha.strftime("%Y-%m-%d %H:%M") if fecha else "",
         row.get("centro_nombre_ref") or "",
         row.get("provincia_nombre_ref") or "",

--- a/VAT/services/tipo_alumno_service.py
+++ b/VAT/services/tipo_alumno_service.py
@@ -1,0 +1,58 @@
+"""Clasificación de alumnos según tengan voucher VAT activo o no.
+
+Regla de negocio (issue "Diferenciación visual de alumnos VAT"):
+voucher con estado "activo" y vencimiento vigente → "VAT"; caso contrario
+→ "Sin Plan". El estado "vencido" se estampa de forma perezosa al validar,
+por eso además del estado se chequea la fecha de vencimiento. El cálculo es
+exclusivamente backend y comparten esta única implementación tanto los
+listados (asistencia, detalle de comisión) como las exportaciones.
+"""
+
+from django.db.models import Exists, OuterRef
+from django.utils import timezone
+
+from VAT.models import Voucher
+
+TIPO_ALUMNO_VAT = "VAT"
+TIPO_ALUMNO_SIN_PLAN = "Sin Plan"
+
+
+def _vouchers_activos_queryset():
+    return Voucher.objects.filter(
+        estado="activo",
+        fecha_vencimiento__gte=timezone.localdate(),
+    )
+
+
+def tipo_alumno_label(tiene_voucher_activo) -> str:
+    return TIPO_ALUMNO_VAT if tiene_voucher_activo else TIPO_ALUMNO_SIN_PLAN
+
+
+def tiene_voucher_activo_subquery(ciudadano_field="ciudadano_id"):
+    """Expresión ``Exists`` para anotar querysets de Inscripcion."""
+    return Exists(
+        _vouchers_activos_queryset().filter(ciudadano_id=OuterRef(ciudadano_field))
+    )
+
+
+def ciudadanos_con_voucher_activo(ciudadano_ids) -> set:
+    ciudadano_ids = {pk for pk in ciudadano_ids if pk}
+    if not ciudadano_ids:
+        return set()
+    return set(
+        _vouchers_activos_queryset()
+        .filter(ciudadano_id__in=ciudadano_ids)
+        .values_list("ciudadano_id", flat=True)
+    )
+
+
+def anotar_tipo_alumno(inscripciones):
+    """Setea ``es_alumno_vat`` y ``tipo_alumno`` en cada inscripción (una sola
+    query por lote). Devuelve la misma lista para poder encadenar."""
+    ids_vat = ciudadanos_con_voucher_activo(
+        inscripcion.ciudadano_id for inscripcion in inscripciones
+    )
+    for inscripcion in inscripciones:
+        inscripcion.es_alumno_vat = inscripcion.ciudadano_id in ids_vat
+        inscripcion.tipo_alumno = tipo_alumno_label(inscripcion.es_alumno_vat)
+    return inscripciones

--- a/VAT/services/voucher_service/impl.py
+++ b/VAT/services/voucher_service/impl.py
@@ -82,6 +82,49 @@ class VoucherService:
         )
 
     @staticmethod
+    def reintegrar_voucher(
+        voucher: Voucher,
+        cantidad: int,
+        usuario: User,
+        detalles: dict | None = None,
+    ) -> tuple[bool, str]:
+        """Revierte un débito de créditos y registra la compensación."""
+        if cantidad <= 0:
+            return False, "La cantidad a reintegrar debe ser mayor a cero."
+
+        with VoucherService._atomic_if_persistent(voucher):
+            voucher = Voucher.objects.select_for_update().get(pk=voucher.pk)
+            voucher.cantidad_usada = max(voucher.cantidad_usada - cantidad, 0)
+            voucher.cantidad_disponible += cantidad
+            if voucher.estado == "agotado":
+                voucher.estado = "activo"
+            voucher.save(
+                update_fields=[
+                    "cantidad_usada",
+                    "cantidad_disponible",
+                    "estado",
+                    "fecha_modificacion",
+                ]
+            )
+
+            VoucherRecarga.objects.create(
+                voucher=voucher,
+                cantidad=cantidad,
+                motivo="compensacion",
+                autorizado_por=usuario,
+            )
+            VoucherLog.objects.create(
+                voucher=voucher,
+                tipo_evento="recarga",
+                cantidad_afectada=cantidad,
+                usuario=usuario,
+                detalles=detalles or {},
+            )
+
+        logger.info("Voucher %s reintegrado con %s créditos", voucher.id, cantidad)
+        return True, f"Créditos reintegrados. Disponible: {voucher.cantidad_disponible}"
+
+    @staticmethod
     def crear_voucher(
         ciudadano_id: int,
         programa_id: int,

--- a/VAT/templates/vat/centros/partials/centro_cursos_panel.html
+++ b/VAT/templates/vat/centros/partials/centro_cursos_panel.html
@@ -153,9 +153,7 @@
                     <label class="sisoc-toolbar-field" for="comisionesFilterCurso">
                         <select id="comisionesFilterCurso" class="select2" data-width="100%">
                             <option value="">Filtrar por Curso</option>
-                            {% for curso in cursos %}
-                                <option value="{{ curso.id }}">{{ curso.nombre }}</option>
-                            {% endfor %}
+                            {% for curso in cursos %}<option value="{{ curso.id }}">{{ curso.nombre }}</option>{% endfor %}
                         </select>
                     </label>
                     <select id="comisionesFilterEstado" class="sisoc-hidden-control">
@@ -311,9 +309,7 @@
                                                 <i class="fas fa-chevron-down"></i>
                                             </button>
                                             <div id="planCurricularSelectorSummary" class="sisoc-curso-summary">No hay plan curricular seleccionado.</div>
-                                            {% if field.errors %}
-                                                <div class="text-danger small mt-1">{{ field.errors.0 }}</div>
-                                            {% endif %}
+                                            {% if field.errors %}<div class="text-danger small mt-1">{{ field.errors.0 }}</div>{% endif %}
                                             {% if field.help_text %}<div class="form-text sisoc-curso-help">{{ field.help_text }}</div>{% endif %}
                                         </div>
                                     {% elif field.html_name == 'nombre' %}
@@ -383,9 +379,7 @@
                                             </div>
                                             {{ field }}
                                             {% if field.errors %}<div class="text-danger small mt-1">{{ field.errors.0 }}</div>{% endif %}
-                                            {% if field.help_text %}
-                                                <div class="form-text sisoc-curso-help">{{ field.help_text }}</div>
-                                            {% endif %}
+                                            {% if field.help_text %}<div class="form-text sisoc-curso-help">{{ field.help_text }}</div>{% endif %}
                                         </div>
                                     {% elif field.html_name == 'costo_creditos' %}
                                         <div class="col-12 mb-3">

--- a/VAT/templates/vat/centros/partials/centro_cursos_panel.html
+++ b/VAT/templates/vat/centros/partials/centro_cursos_panel.html
@@ -153,7 +153,9 @@
                     <label class="sisoc-toolbar-field" for="comisionesFilterCurso">
                         <select id="comisionesFilterCurso" class="select2" data-width="100%">
                             <option value="">Filtrar por Curso</option>
-                            {% for curso in cursos %}<option value="{{ curso.id }}">{{ curso.nombre }}</option>{% endfor %}
+                            {% for curso in cursos %}
+                                <option value="{{ curso.id }}">{{ curso.nombre }}</option>
+                            {% endfor %}
                         </select>
                     </label>
                     <select id="comisionesFilterEstado" class="sisoc-hidden-control">
@@ -309,7 +311,9 @@
                                                 <i class="fas fa-chevron-down"></i>
                                             </button>
                                             <div id="planCurricularSelectorSummary" class="sisoc-curso-summary">No hay plan curricular seleccionado.</div>
-                                            {% if field.errors %}<div class="text-danger small mt-1">{{ field.errors.0 }}</div>{% endif %}
+                                            {% if field.errors %}
+                                                <div class="text-danger small mt-1">{{ field.errors.0 }}</div>
+                                            {% endif %}
                                             {% if field.help_text %}<div class="form-text sisoc-curso-help">{{ field.help_text }}</div>{% endif %}
                                         </div>
                                     {% elif field.html_name == 'nombre' %}
@@ -379,7 +383,9 @@
                                             </div>
                                             {{ field }}
                                             {% if field.errors %}<div class="text-danger small mt-1">{{ field.errors.0 }}</div>{% endif %}
-                                            {% if field.help_text %}<div class="form-text sisoc-curso-help">{{ field.help_text }}</div>{% endif %}
+                                            {% if field.help_text %}
+                                                <div class="form-text sisoc-curso-help">{{ field.help_text }}</div>
+                                            {% endif %}
                                         </div>
                                     {% elif field.html_name == 'costo_creditos' %}
                                         <div class="col-12 mb-3">

--- a/VAT/templates/vat/oferta_institucional/asistencia_sesion.html
+++ b/VAT/templates/vat/oferta_institucional/asistencia_sesion.html
@@ -284,6 +284,21 @@
 
         .asis-mark-all { color: #ffffff; font-size: 16px; font-weight: 700; }
 
+        /* ── Tipo de alumno ── */
+        .asis-chip-vat {
+            display: inline-block;
+            border-radius: 6px;
+            padding: .2em .7em;
+            background: #ffffff;
+            color: #232D4F;
+            font-size: .78rem;
+            font-weight: 700;
+            letter-spacing: .04em;
+            line-height: 1.2;
+        }
+
+        .asis-tipo-sin-plan { color: var(--cmuted); font-size: .85rem; }
+
         /* ── Pie de tabla ── */
         .asis-foot {
             display: flex;
@@ -427,6 +442,7 @@
                                 <tr>
                                     <th>Apellido</th>
                                     <th>Nombre</th>
+                                    <th>Tipo de alumno</th>
                                     <th class="asis-col-check">
                                         <label class="asis-mark asis-mark-all">
                                             <input type="checkbox"
@@ -450,6 +466,13 @@
                                     <tr class="asis-row">
                                         <td>{{ fila.inscripcion.ciudadano.apellido|default:"—" }}</td>
                                         <td>{{ fila.inscripcion.ciudadano.nombre|default:"—" }}</td>
+                                        <td>
+                                            {% if fila.inscripcion.es_alumno_vat %}
+                                                <span class="asis-chip-vat">{{ fila.inscripcion.tipo_alumno }}</span>
+                                            {% else %}
+                                                <span class="asis-tipo-sin-plan">{{ fila.inscripcion.tipo_alumno }}</span>
+                                            {% endif %}
+                                        </td>
                                         <td>
                                             <input type="hidden"
                                                    name="obs_{{ fila.inscripcion.pk }}"

--- a/VAT/templates/vat/oferta_institucional/comision_detail.html
+++ b/VAT/templates/vat/oferta_institucional/comision_detail.html
@@ -881,7 +881,7 @@
             box-shadow: 0 0 0 .18rem rgba(59, 134, 129, 0.25);
         }
 
-        .ci-prof-search { position: relative; }
+        .ci-prof-input-wrap { position: relative; }
 
         .ci-prof-results {
             position: absolute;
@@ -1049,6 +1049,19 @@
 
         .sisoc-block-card + .sisoc-block-card {
             margin-top: 30px;
+        }
+
+        /* El buscador de profesor abre un dropdown en position:absolute y el
+           `overflow: hidden` del card lo recortaba contra el borde inferior.
+           Se libera el overflow y el radio superior pasa al title, que es el
+           unico hijo con fondo propio que necesitaba el recorte. */
+        .sisoc-block-card--overflow {
+            overflow: visible;
+        }
+
+        .sisoc-block-card--overflow .sisoc-block-title {
+            border-top-left-radius: 15px;
+            border-top-right-radius: 15px;
         }
 
         .sisoc-block-title {
@@ -1942,7 +1955,7 @@
                                 </article>
                             </div>
 
-                            <div class="sisoc-block-card">
+                            <div class="sisoc-block-card sisoc-block-card--overflow">
                                 <div class="sisoc-block-title">
                                     <i class="bi bi-file-earmark-text"></i>
                                     <span>Datos del acta</span>
@@ -1954,16 +1967,20 @@
                                             <label class="ci-field-label" for="profesorBuscador">
                                                 Profesor a cargo<span class="text-danger">*</span>
                                             </label>
-                                            <input type="text"
-                                                   class="ci-field-input"
-                                                   id="profesorBuscador"
-                                                   placeholder="Buscar por nombre o DNI"
-                                                   autocomplete="off" />
-                                            <input type="hidden"
-                                                   name="profesor"
-                                                   id="profesorId"
-                                                   value="{{ acta_cierre.profesor_id|default_if_none:'' }}" />
-                                            <div class="ci-prof-results d-none" id="profesorResultados"></div>
+                                            {# El wrap ancla el dropdown al input: si se anclara al #}
+                                            {# contenedor, con el chip visible caeria debajo de el. #}
+                                            <div class="ci-prof-input-wrap">
+                                                <input type="text"
+                                                       class="ci-field-input"
+                                                       id="profesorBuscador"
+                                                       placeholder="Buscar por nombre o DNI"
+                                                       autocomplete="off" />
+                                                <input type="hidden"
+                                                       name="profesor"
+                                                       id="profesorId"
+                                                       value="{{ acta_cierre.profesor_id|default_if_none:'' }}" />
+                                                <div class="ci-prof-results d-none" id="profesorResultados"></div>
+                                            </div>
                                             <div class="ci-prof-chip {% if not acta_cierre %}d-none{% endif %}"
                                                  id="profesorChip">
                                                 <span id="profesorChipTexto">

--- a/VAT/templates/vat/oferta_institucional/comision_detail.html
+++ b/VAT/templates/vat/oferta_institucional/comision_detail.html
@@ -1481,6 +1481,7 @@
                                         <th>Apellido</th>
                                         <th>Nombre</th>
                                         <th>Documento</th>
+                                        <th>Tipo de alumno</th>
                                         <th>Estado</th>
                                         <th>Email</th>
                                         <th>Teléfono</th>
@@ -1506,6 +1507,13 @@
                                             </td>
                                             <td>{{ insc.ciudadano.nombre|default:"—" }}</td>
                                             <td>{{ insc.ciudadano.documento|default:"—" }}</td>
+                                            <td>
+                                                {% if insc.es_alumno_vat %}
+                                                    <span class="ci-pill ci-pill-teal">{{ insc.tipo_alumno }}</span>
+                                                {% else %}
+                                                    <span class="ci-pill ci-pill-gray">{{ insc.tipo_alumno }}</span>
+                                                {% endif %}
+                                            </td>
                                             <td>
                                                 {% if insc.estado == "inscripta" or insc.estado == "validada_presencial" %}
                                                     <span class="ci-pill ci-pill-green">{{ insc.get_estado_display }}</span>
@@ -1543,13 +1551,13 @@
                                         </tr>
                                     {% empty %}
                                         <tr class="ci-tbl-empty" data-empty-row>
-                                            <td colspan="{% if puede_gestionar_lote_inscriptos %}9{% elif puede_cambiar_inscripcion or puede_eliminar_inscripcion %}8{% else %}7{% endif %}">
+                                            <td colspan="{% if puede_gestionar_lote_inscriptos %}10{% elif puede_cambiar_inscripcion or puede_eliminar_inscripcion %}9{% else %}8{% endif %}">
                                                 Sin inscriptos aún. Inscribí ciudadanos a esta comisión para verlos aquí.
                                             </td>
                                         </tr>
                                     {% endfor %}
                                     <tr class="ci-tbl-empty d-none" data-no-results-row>
-                                        <td colspan="{% if puede_gestionar_lote_inscriptos %}9{% elif puede_cambiar_inscripcion or puede_eliminar_inscripcion %}8{% else %}7{% endif %}">
+                                        <td colspan="{% if puede_gestionar_lote_inscriptos %}10{% elif puede_cambiar_inscripcion or puede_eliminar_inscripcion %}9{% else %}8{% endif %}">
                                             No se encontraron inscriptos para la búsqueda.
                                         </td>
                                     </tr>

--- a/VAT/templates/vat/oferta_institucional/comision_detail.html
+++ b/VAT/templates/vat/oferta_institucional/comision_detail.html
@@ -2280,7 +2280,9 @@
                                                 <label for="{{ field.id_for_label }}" class="form-check-label fw-bold">{{ field.label }}</label>
                                             </div>
                                             {% if field.errors %}<div class="text-danger small mt-1">{{ field.errors.0 }}</div>{% endif %}
-                                            {% if field.help_text %}<div class="form-text">{{ field.help_text }}</div>{% endif %}
+                                            {% if field.help_text %}
+                                                <div class="form-text">{{ field.help_text }}</div>
+                                            {% endif %}
                                         </div>
                                     {% elif field.name == "cupo_lista_espera" %}
                                         <div class="col-md-6 {% if not comision_form.acepta_lista_espera.value and not field.value %}d-none{% endif %}"
@@ -2290,8 +2292,12 @@
                                                 {% if field.field.required %}<span class="text-danger">*</span>{% endif %}
                                             </label>
                                             {{ field }}
-                                            {% if field.errors %}<div class="text-danger small mt-1">{{ field.errors.0 }}</div>{% endif %}
-                                            {% if field.help_text %}<div class="form-text">{{ field.help_text }}</div>{% endif %}
+                                            {% if field.errors %}
+                                                <div class="text-danger small mt-1">{{ field.errors.0 }}</div>
+                                            {% endif %}
+                                            {% if field.help_text %}
+                                                <div class="form-text">{{ field.help_text }}</div>
+                                            {% endif %}
                                         </div>
                                     {% else %}
                                         <div class="col-md-6">
@@ -2301,7 +2307,9 @@
                                             </label>
                                             {{ field }}
                                             {% if field.errors %}<div class="text-danger small mt-1">{{ field.errors.0 }}</div>{% endif %}
-                                            {% if field.help_text %}<div class="form-text">{{ field.help_text }}</div>{% endif %}
+                                            {% if field.help_text %}
+                                                <div class="form-text">{{ field.help_text }}</div>
+                                            {% endif %}
                                         </div>
                                     {% endif %}
                                 {% endfor %}

--- a/VAT/templates/vat/oferta_institucional/comision_detail.html
+++ b/VAT/templates/vat/oferta_institucional/comision_detail.html
@@ -2305,9 +2305,7 @@
                                                 <label for="{{ field.id_for_label }}" class="form-check-label fw-bold">{{ field.label }}</label>
                                             </div>
                                             {% if field.errors %}<div class="text-danger small mt-1">{{ field.errors.0 }}</div>{% endif %}
-                                            {% if field.help_text %}
-                                                <div class="form-text">{{ field.help_text }}</div>
-                                            {% endif %}
+                                            {% if field.help_text %}<div class="form-text">{{ field.help_text }}</div>{% endif %}
                                         </div>
                                     {% elif field.name == "cupo_lista_espera" %}
                                         <div class="col-md-6 {% if not comision_form.acepta_lista_espera.value and not field.value %}d-none{% endif %}"
@@ -2317,12 +2315,8 @@
                                                 {% if field.field.required %}<span class="text-danger">*</span>{% endif %}
                                             </label>
                                             {{ field }}
-                                            {% if field.errors %}
-                                                <div class="text-danger small mt-1">{{ field.errors.0 }}</div>
-                                            {% endif %}
-                                            {% if field.help_text %}
-                                                <div class="form-text">{{ field.help_text }}</div>
-                                            {% endif %}
+                                            {% if field.errors %}<div class="text-danger small mt-1">{{ field.errors.0 }}</div>{% endif %}
+                                            {% if field.help_text %}<div class="form-text">{{ field.help_text }}</div>{% endif %}
                                         </div>
                                     {% else %}
                                         <div class="col-md-6">
@@ -2332,9 +2326,7 @@
                                             </label>
                                             {{ field }}
                                             {% if field.errors %}<div class="text-danger small mt-1">{{ field.errors.0 }}</div>{% endif %}
-                                            {% if field.help_text %}
-                                                <div class="form-text">{{ field.help_text }}</div>
-                                            {% endif %}
+                                            {% if field.help_text %}<div class="form-text">{{ field.help_text }}</div>{% endif %}
                                         </div>
                                     {% endif %}
                                 {% endfor %}

--- a/VAT/templates/vat/reportes/inscripciones_asistencia.html
+++ b/VAT/templates/vat/reportes/inscripciones_asistencia.html
@@ -355,6 +355,16 @@
             white-space: nowrap;
         }
 
+        .rep-pill--vat {
+            background: rgba(20, 184, 166, 0.2);
+            color: #2dd4bf;
+        }
+
+        .rep-pill--sin-plan {
+            background: rgba(148, 163, 184, 0.18);
+            color: #a9b5c7;
+        }
+
         /* ── Pie + paginador ── */
         .rep-tbl-foot {
             display: flex;
@@ -902,6 +912,7 @@
                             <th>DNI</th>
                             <th>Apellido y nombre</th>
                             <th>Estado</th>
+                            <th>Tipo de alumno</th>
                             <th>Centro</th>
                             <th>Comisión</th>
                             <th>Curso/Oferta</th>
@@ -916,6 +927,13 @@
                                 <td>
                                     <span class="rep-pill">{{ item.estado }}</span>
                                 </td>
+                                <td>
+                                    {% if item.tiene_voucher_activo %}
+                                        <span class="rep-pill rep-pill--vat">VAT</span>
+                                    {% else %}
+                                        <span class="rep-pill rep-pill--sin-plan">Sin Plan</span>
+                                    {% endif %}
+                                </td>
                                 <td>{{ item.centro_nombre_ref }}</td>
                                 <td>{{ item.comision_codigo_ref }}</td>
                                 <td>{{ item.unidad_formativa_nombre }}</td>
@@ -923,7 +941,7 @@
                             </tr>
                         {% empty %}
                             <tr class="rep-tbl-empty">
-                                <td colspan="7">No hay personas para los filtros seleccionados.</td>
+                                <td colspan="8">No hay personas para los filtros seleccionados.</td>
                             </tr>
                         {% endfor %}
                     </tbody>

--- a/VAT/test_comision_detail_template_compartido.py
+++ b/VAT/test_comision_detail_template_compartido.py
@@ -155,7 +155,11 @@ def test_camino_curso_tiene_lote_y_resultados(escenario):
     assert "cambiar-estado-lote" in html
     assert 'class="ci-lote-check"' in html
     assert 'data-sisoc-tab-target="resultados"' in html
-    assert 'colspan="9"' in html
+    assert "<th>Tipo de alumno</th>" in html
+    panel = html.split('data-sisoc-panel="inscriptos"')[1].split(
+        'data-sisoc-panel="sesiones"'
+    )[0]
+    assert 'colspan="10"' in panel
 
 
 @pytest.mark.django_db
@@ -172,12 +176,13 @@ def test_camino_legacy_no_renderiza_lote_ni_resultados(escenario):
     assert 'name="estado" id="inscriptosLoteEstado"' not in html
     # La solapa Resultados tampoco (es solo del camino ComisionCurso).
     assert 'data-sisoc-tab-target="resultados"' not in html
-    # La columna Estado si se agrega en ambos caminos.
+    # Las columnas Estado y Tipo de alumno si se agregan en ambos caminos.
     assert "<th>Estado</th>" in html
-    # colspan correcto DENTRO del panel de inscriptos: 7 base + acciones, sin
+    assert "<th>Tipo de alumno</th>" in html
+    # colspan correcto DENTRO del panel de inscriptos: 8 base + acciones, sin
     # checkbox. Se acota al panel porque la tabla de Clases usa 9 legitimamente.
     panel = html.split('data-sisoc-panel="inscriptos"')[1].split(
         'data-sisoc-panel="sesiones"'
     )[0]
-    assert 'colspan="8"' in panel
-    assert 'colspan="9"' not in panel
+    assert 'colspan="9"' in panel
+    assert 'colspan="10"' not in panel

--- a/VAT/test_tipo_alumno.py
+++ b/VAT/test_tipo_alumno.py
@@ -1,0 +1,279 @@
+"""Clasificación "Tipo de alumno" (VAT / Sin Plan) en listados y exportaciones.
+
+La regla vive en `VAT/services/tipo_alumno_service.py`: voucher con estado
+"activo" y vencimiento vigente → VAT; cualquier otro caso → Sin Plan. Estos
+tests cubren el servicio, la nómina Excel, el detalle nominal del reporte y el
+render de asistencia/detalle de comisión (camino Curso).
+
+Se usa `RequestFactory` en lugar del test client a propósito: el venv local
+corre Python 3.14 con Django 4.2 y la instrumentación de templates del test
+client falla ahí (ver test_comision_detail_template_compartido.py).
+"""
+
+import csv
+from datetime import time, timedelta
+from io import BytesIO
+from types import SimpleNamespace
+
+import pytest
+from django.contrib.auth.models import Group, Permission, User
+from django.contrib.contenttypes.models import ContentType
+from django.test import RequestFactory
+from django.utils import timezone
+from openpyxl import load_workbook
+
+from ciudadanos.models import Ciudadano
+from core.models import Dia, Localidad, Municipio, Programa, Provincia, Sexo
+from VAT.models import (
+    Centro,
+    ComisionCurso,
+    ComisionHorario,
+    Curso,
+    Inscripcion,
+    InstitucionUbicacion,
+    ModalidadCursada,
+    SesionComision,
+    Voucher,
+)
+from VAT.services.nomina_export import build_comision_curso_nomina_excel
+from VAT.services.reportes_inscripciones_asistencia import (
+    ReporteFiltros,
+    build_detalle_queryset,
+    export_detalle_to_csv,
+)
+from VAT.services.tipo_alumno_service import (
+    TIPO_ALUMNO_SIN_PLAN,
+    TIPO_ALUMNO_VAT,
+    anotar_tipo_alumno,
+)
+from VAT.views.curso import AsistenciaSesionCursoView, ComisionCursoDetailView
+
+
+def _crear_ciudadano(documento, apellido="Alumno"):
+    return Ciudadano.objects.create(
+        apellido=apellido,
+        nombre="Tipo",
+        fecha_nacimiento=timezone.localdate() - timedelta(days=9000),
+        tipo_documento=Ciudadano.DOCUMENTO_DNI,
+        documento=documento,
+    )
+
+
+def _crear_voucher(ciudadano, programa, *, estado="activo", dias_vencimiento=30):
+    return Voucher.objects.create(
+        ciudadano=ciudadano,
+        programa=programa,
+        cantidad_inicial=5,
+        cantidad_usada=0,
+        cantidad_disponible=5,
+        fecha_vencimiento=timezone.localdate() + timedelta(days=dias_vencimiento),
+        estado=estado,
+    )
+
+
+@pytest.mark.django_db
+def test_anotar_tipo_alumno_clasifica_segun_voucher_activo():
+    programa = Programa.objects.create(nombre="Programa tipo alumno")
+    con_voucher = _crear_ciudadano(45100001)
+    voucher_vencido_por_fecha = _crear_ciudadano(45100002)
+    voucher_agotado = _crear_ciudadano(45100003)
+    sin_voucher = _crear_ciudadano(45100004)
+
+    _crear_voucher(con_voucher, programa)
+    # Estado "activo" pero vencido por fecha: el estado se estampa perezosamente.
+    _crear_voucher(voucher_vencido_por_fecha, programa, dias_vencimiento=-1)
+    _crear_voucher(voucher_agotado, programa, estado="agotado")
+
+    filas = anotar_tipo_alumno(
+        [
+            SimpleNamespace(ciudadano_id=con_voucher.pk),
+            SimpleNamespace(ciudadano_id=voucher_vencido_por_fecha.pk),
+            SimpleNamespace(ciudadano_id=voucher_agotado.pk),
+            SimpleNamespace(ciudadano_id=sin_voucher.pk),
+        ]
+    )
+
+    assert [fila.tipo_alumno for fila in filas] == [
+        TIPO_ALUMNO_VAT,
+        TIPO_ALUMNO_SIN_PLAN,
+        TIPO_ALUMNO_SIN_PLAN,
+        TIPO_ALUMNO_SIN_PLAN,
+    ]
+    assert filas[0].es_alumno_vat is True
+    assert filas[1].es_alumno_vat is False
+
+
+@pytest.fixture
+def escenario_tipo_alumno(db):
+    provincia = Provincia.objects.create(nombre="BA tipo")
+    municipio = Municipio.objects.create(nombre="LP tipo", provincia=provincia)
+    localidad = Localidad.objects.create(nombre="Tolosa tipo", municipio=municipio)
+    modalidad = ModalidadCursada.objects.create(nombre="Pres tipo", activo=True)
+    programa = Programa.objects.create(nombre="Prog tipo")
+    Sexo.objects.get_or_create(sexo="F tipo")
+    Group.objects.get_or_create(name="CFP")
+    user = User.objects.create_superuser(
+        username="tipo-admin", email="tipo@vat.test", password="x"
+    )
+    permission, _ = Permission.objects.get_or_create(
+        content_type=ContentType.objects.get_for_model(Group),
+        codename="role_centroreferentevat",
+        defaults={"name": "ReferenteCentroVAT legacy"},
+    )
+    user.user_permissions.add(permission)
+    centro = Centro.objects.create(
+        nombre="CFP tipo",
+        codigo="CFP-TIPO",
+        provincia=provincia,
+        municipio=municipio,
+        localidad=localidad,
+        calle="1",
+        numero=1,
+        domicilio_actividad="C 1",
+        telefono="1",
+        celular="1",
+        correo="tipo@a.test",
+        nombre_referente="A",
+        apellido_referente="B",
+        telefono_referente="1",
+        correo_referente="tipo@b.test",
+        referente=user,
+        tipo_gestion="Estatal",
+        clase_institucion="Formación Profesional",
+        situacion="Institución de ETP",
+        activo=True,
+    )
+    ubicacion = InstitucionUbicacion.objects.create(
+        centro=centro,
+        localidad=localidad,
+        rol_ubicacion="sede_principal",
+        domicilio="C 1",
+        es_principal=True,
+    )
+    curso = Curso.objects.create(
+        centro=centro, nombre="Curso tipo", modalidad=modalidad, estado="activo"
+    )
+    comision = ComisionCurso.objects.create(
+        curso=curso,
+        ubicacion=ubicacion,
+        codigo_comision="TIPO-CC",
+        nombre="CC tipo",
+        cupo_total=10,
+        fecha_inicio=timezone.localdate() - timedelta(days=10),
+        fecha_fin=timezone.localdate() + timedelta(days=10),
+        estado="activa",
+    )
+    alumno_vat = _crear_ciudadano(45200001, apellido="Convoucher")
+    alumno_sin_plan = _crear_ciudadano(45200002, apellido="Sinvoucher")
+    _crear_voucher(alumno_vat, programa)
+    for ciudadano in (alumno_vat, alumno_sin_plan):
+        Inscripcion.objects.create(
+            ciudadano=ciudadano,
+            comision_curso=comision,
+            programa=programa,
+            estado="inscripta",
+            origen_canal="backoffice",
+        )
+    return user, comision
+
+
+def _crear_sesion(comision):
+    dia, _ = Dia.objects.get_or_create(nombre="Lunes")
+    horario = ComisionHorario.objects.create(
+        comision_curso=comision,
+        dia_semana=dia,
+        hora_desde=time(10, 0),
+        hora_hasta=time(12, 0),
+        aula_espacio="Aula 1",
+        vigente=True,
+    )
+    return SesionComision.objects.create(
+        comision_curso=comision,
+        horario=horario,
+        numero_sesion=1,
+        fecha=timezone.localdate(),
+        estado="programada",
+    )
+
+
+@pytest.mark.django_db
+def test_nomina_excel_incluye_tipo_alumno(escenario_tipo_alumno):
+    _, comision = escenario_tipo_alumno
+
+    content = build_comision_curso_nomina_excel(
+        comision,
+        Inscripcion.objects.filter(comision_curso=comision).select_related(
+            "ciudadano__sexo"
+        ),
+    )
+
+    worksheet = load_workbook(BytesIO(content)).active
+    header = [cell.value for cell in next(worksheet.iter_rows(max_row=1))]
+    rows = [
+        dict(zip(header, row))
+        for row in worksheet.iter_rows(min_row=2, values_only=True)
+    ]
+    tipos = {row["Apellido"]: row["Tipo de alumno"] for row in rows}
+
+    assert "Tipo de alumno" in header
+    assert tipos == {
+        "Convoucher": TIPO_ALUMNO_VAT,
+        "Sinvoucher": TIPO_ALUMNO_SIN_PLAN,
+    }
+
+
+@pytest.mark.django_db
+def test_detalle_reporte_y_export_clasifican_tipo_alumno(escenario_tipo_alumno):
+    user, _ = escenario_tipo_alumno
+
+    filas = {
+        row["ciudadano__apellido"]: row["tiene_voucher_activo"]
+        for row in build_detalle_queryset(user, ReporteFiltros())
+    }
+    assert filas == {"Convoucher": True, "Sinvoucher": False}
+
+    response = export_detalle_to_csv(user, ReporteFiltros())
+    lineas = list(csv.reader(response.content.decode("utf-8-sig").splitlines()))
+    header = lineas[0]
+    indice_apellido = header.index("Apellido")
+    indice_tipo = header.index("Tipo de alumno")
+    tipos = {linea[indice_apellido]: linea[indice_tipo] for linea in lineas[1:]}
+
+    assert tipos == {
+        "Convoucher": TIPO_ALUMNO_VAT,
+        "Sinvoucher": TIPO_ALUMNO_SIN_PLAN,
+    }
+
+
+def _render(view, user, **kwargs):
+    request = RequestFactory().get("/x/")
+    request.user = user
+    request.csp_nonce = "n"
+    return view.as_view()(request, **kwargs).render().content.decode()
+
+
+@pytest.mark.django_db
+def test_asistencia_sesion_curso_muestra_tipo_alumno(escenario_tipo_alumno):
+    user, comision = escenario_tipo_alumno
+    sesion = _crear_sesion(comision)
+
+    html = _render(AsistenciaSesionCursoView, user, sesion_pk=sesion.pk)
+
+    assert "<th>Tipo de alumno</th>" in html
+    assert html.count('class="asis-chip-vat"') == 1
+    assert html.count('class="asis-tipo-sin-plan"') == 1
+
+
+@pytest.mark.django_db
+def test_comision_curso_detail_muestra_tipo_alumno(escenario_tipo_alumno):
+    user, comision = escenario_tipo_alumno
+
+    html = _render(ComisionCursoDetailView, user, pk=comision.pk)
+    panel = html.split('data-sisoc-panel="inscriptos"')[1].split(
+        'data-sisoc-panel="sesiones"'
+    )[0]
+
+    assert "<th>Tipo de alumno</th>" in panel
+    assert panel.count('class="ci-pill ci-pill-teal"') == 1
+    assert f'class="ci-pill ci-pill-teal">{TIPO_ALUMNO_VAT}</span>' in panel
+    assert f'class="ci-pill ci-pill-gray">{TIPO_ALUMNO_SIN_PLAN}</span>' in panel

--- a/VAT/tests.py
+++ b/VAT/tests.py
@@ -11708,3 +11708,40 @@ def test_resultados_profesor_no_numerico_no_rompe_con_500(
     assert not ActaCierreComision.objects.filter(comision_curso=ctx.comision).exists()
     mensajes = _mensajes_de(response).lower()
     assert "profesor a cargo" in mensajes
+
+
+@pytest.mark.django_db
+def test_cue_valida_prefijo_en_edicion_con_provincia_oculta(
+    vat_geo_data, vat_cue_referente
+):
+    """
+    En edicion `provincia` va oculta y `required=False` (hide_provincia). Si no
+    llega en el POST, el prefijo debe validarse igual contra la provincia de la
+    instancia, no saltearse en silencio.
+    """
+    provincia, municipio, localidad = vat_geo_data
+    propio = _centro_existente_para_cue(
+        vat_cue_referente, provincia, municipio, localidad, "060166500"
+    )
+    data = _build_centro_payload(
+        vat_cue_referente,
+        provincia,
+        municipio,
+        localidad,
+        codigo="500144900",  # prefijo Mendoza sobre un centro de Buenos Aires
+        referentes=[str(vat_cue_referente.pk)],
+    )
+    data.pop("provincia", None)  # el POST no la trae
+
+    form = CentroAltaForm(
+        data=data,
+        instance=propio,
+        actor=vat_cue_referente,
+        hide_provincia=True,
+        provincia_inicial=propio.provincia,
+    )
+
+    assert not form.is_valid()
+    assert form.errors["codigo"] == [
+        "Los primeros 2 dígitos del CUE no corresponden a la provincia seleccionada."
+    ]

--- a/VAT/tests.py
+++ b/VAT/tests.py
@@ -52,6 +52,7 @@ from VAT.models import (
     PlanVersionCurricular,
     SesionComision,
     Voucher,
+    VoucherLog,
     VoucherParametria,
     ProfesorCentro,
     ActaCierreComision,
@@ -11232,6 +11233,29 @@ def _inscripcion_lote(ctx, *, documento, estado="pre_inscripta", comision=None):
     )
 
 
+def _crear_voucher_lote(ctx, inscripcion, *, cantidad_usada, cantidad_disponible):
+    parametria = VoucherParametria.objects.create(
+        nombre=f"Voucher lote {inscripcion.pk}",
+        programa=ctx.programa,
+        cantidad_inicial=5,
+        fecha_vencimiento=timezone.localdate() + timedelta(days=30),
+        creado_por=ctx.user,
+        activa=True,
+    )
+    ctx.curso.voucher_parametrias.add(parametria)
+    return Voucher.objects.create(
+        parametria=parametria,
+        ciudadano=inscripcion.ciudadano,
+        programa=ctx.programa,
+        cantidad_inicial=5,
+        cantidad_usada=cantidad_usada,
+        cantidad_disponible=cantidad_disponible,
+        fecha_vencimiento=timezone.localdate() + timedelta(days=30),
+        estado="activo",
+        asignado_por=ctx.user,
+    )
+
+
 def _url_lote(comision):
     return reverse(
         "vat_inscripcion_curso_cambiar_estado_lote", kwargs={"pk": comision.pk}
@@ -11295,6 +11319,90 @@ def test_lote_rechaza_varias_inscripciones_en_una_sola_accion(
     dos.refresh_from_db()
     assert uno.estado == "rechazada"
     assert dos.estado == "rechazada"
+
+
+@pytest.mark.django_db
+def test_lote_reintegra_voucher_al_rechazar_y_no_lo_debita_dos_veces(
+    client, vat_comision_lote
+):
+    """Rechazar devuelve el débito vigente y reaceptar vuelve a debitar una vez."""
+    ctx = vat_comision_lote
+    ctx.curso.usa_voucher = True
+    ctx.curso.costo_creditos = 2
+    ctx.curso.save(update_fields=["usa_voucher", "costo_creditos"])
+    inscripcion = _inscripcion_lote(ctx, documento=43000012, estado="inscripta")
+    voucher = _crear_voucher_lote(
+        ctx,
+        inscripcion,
+        cantidad_usada=2,
+        cantidad_disponible=3,
+    )
+    VoucherLog.objects.create(
+        voucher=voucher,
+        tipo_evento="uso",
+        cantidad_afectada=-2,
+        usuario=ctx.user,
+        detalles={"inscripcion_id": inscripcion.pk},
+    )
+
+    client.force_login(ctx.user)
+    client.post(
+        _url_lote(ctx.comision),
+        data={"estado": "rechazada", "inscripciones": [str(inscripcion.pk)]},
+    )
+    voucher.refresh_from_db()
+    assert voucher.cantidad_disponible == 5
+    assert voucher.cantidad_usada == 0
+    assert VoucherLog.objects.filter(
+        voucher=voucher,
+        tipo_evento="recarga",
+        detalles__inscripcion_id=inscripcion.pk,
+    ).exists()
+
+    client.post(
+        _url_lote(ctx.comision),
+        data={"estado": "inscripta", "inscripciones": [str(inscripcion.pk)]},
+    )
+    voucher.refresh_from_db()
+    assert voucher.cantidad_disponible == 3
+    assert voucher.cantidad_usada == 2
+
+
+@pytest.mark.django_db
+def test_lote_reacepta_rechazada_con_debito_historico_sin_cobrar_de_nuevo(
+    client, vat_comision_lote
+):
+    """Un rechazo anterior sin compensación conserva su débito original."""
+    ctx = vat_comision_lote
+    ctx.curso.usa_voucher = True
+    ctx.curso.costo_creditos = 2
+    ctx.curso.save(update_fields=["usa_voucher", "costo_creditos"])
+    inscripcion = _inscripcion_lote(ctx, documento=43000013, estado="rechazada")
+    voucher = _crear_voucher_lote(
+        ctx,
+        inscripcion,
+        cantidad_usada=2,
+        cantidad_disponible=3,
+    )
+    VoucherLog.objects.create(
+        voucher=voucher,
+        tipo_evento="uso",
+        cantidad_afectada=-2,
+        usuario=ctx.user,
+        detalles={"inscripcion_id": inscripcion.pk},
+    )
+
+    client.force_login(ctx.user)
+    client.post(
+        _url_lote(ctx.comision),
+        data={"estado": "inscripta", "inscripciones": [str(inscripcion.pk)]},
+    )
+
+    inscripcion.refresh_from_db()
+    voucher.refresh_from_db()
+    assert inscripcion.estado == "inscripta"
+    assert voucher.cantidad_disponible == 3
+    assert voucher.cantidad_usada == 2
 
 
 @pytest.mark.django_db

--- a/VAT/tests.py
+++ b/VAT/tests.py
@@ -8212,6 +8212,7 @@ def test_comision_curso_exporta_nomina_preinscriptos_en_excel(client, vat_geo_da
         "DNI / CUIL",
         "Fecha de Nacimiento",
         "G\u00e9nero",
+        "Tipo de alumno",
         "Comisi\u00f3n",
         "Curso",
         "Centro de Formaci\u00f3n",
@@ -8338,7 +8339,8 @@ def test_comision_curso_exporta_nomina_inscriptos_solo_estado_inscripta(
     assert len(rows) == 1
     assert rows[0][0] == "Perez"
     assert rows[0][1] == "Ana"
-    assert rows[0][8] == "Inscripta"
+    assert rows[0][5] == "Sin Plan"
+    assert rows[0][9] == "Inscripta"
 
 
 @pytest.mark.django_db

--- a/VAT/views/curso.py
+++ b/VAT/views/curso.py
@@ -51,6 +51,7 @@ from VAT.services.nomina_export import (
 )
 from VAT.services.resultados_comision_service import ResultadosComisionService
 from VAT.services.sesion_comision_service.impl import SesionComisionService
+from VAT.services.tipo_alumno_service import anotar_tipo_alumno
 
 
 def _scoped_centros_ids(user):
@@ -413,10 +414,12 @@ class ComisionCursoDetailView(LoginRequiredMixin, DetailView):
         horario_form.fields["comision_curso"].queryset = ComisionCurso.objects.filter(
             pk=comision.pk
         )
-        inscripciones = list(
-            Inscripcion.objects.filter(comision_curso=comision)
-            .select_related("ciudadano", "programa")
-            .order_by("estado", "fecha_inscripcion")
+        inscripciones = anotar_tipo_alumno(
+            list(
+                Inscripcion.objects.filter(comision_curso=comision)
+                .select_related("ciudadano", "programa")
+                .order_by("estado", "fecha_inscripcion")
+            )
         )
         sesiones = list(
             SesionComision.objects.filter(comision_curso=comision)
@@ -976,11 +979,13 @@ class AsistenciaSesionCursoView(LoginRequiredMixin, TemplateView):
         )
 
     def _inscripciones_activas(self, comision):
-        return list(
-            Inscripcion.objects.filter(
-                comision_curso=comision,
-                estado__in=["inscripta", "validada_presencial"],
-            ).select_related("ciudadano")
+        return anotar_tipo_alumno(
+            list(
+                Inscripcion.objects.filter(
+                    comision_curso=comision,
+                    estado__in=["inscripta", "validada_presencial"],
+                ).select_related("ciudadano")
+            )
         )
 
     def get_context_data(self, **kwargs):

--- a/VAT/views/oferta_institucional.py
+++ b/VAT/views/oferta_institucional.py
@@ -48,6 +48,7 @@ from VAT.services.access_scope import (
     filter_sesiones_queryset_for_user,
 )
 from VAT.services.sesion_comision_service.impl import SesionComisionService
+from VAT.services.tipo_alumno_service import anotar_tipo_alumno
 
 logger = logging.getLogger("django")
 
@@ -378,7 +379,7 @@ class ComisionDetailView(LoginRequiredMixin, DetailView):
             .select_related("ciudadano", "programa")
             .order_by("estado", "fecha_inscripcion")
         )
-        inscripciones = list(inscripciones_qs)
+        inscripciones = anotar_tipo_alumno(list(inscripciones_qs))
         context["inscripciones"] = [
             inscripcion
             for inscripcion in inscripciones
@@ -451,11 +452,13 @@ class AsistenciaSesionView(LoginRequiredMixin, TemplateView):
         return get_object_or_404(scoped_qs, pk=sesion_pk)
 
     def _inscripciones_activas(self, comision):
-        return list(
-            Inscripcion.objects.filter(
-                comision=comision,
-                estado__in=["inscripta", "validada_presencial"],
-            ).select_related("ciudadano")
+        return anotar_tipo_alumno(
+            list(
+                Inscripcion.objects.filter(
+                    comision=comision,
+                    estado__in=["inscripta", "validada_presencial"],
+                ).select_related("ciudadano")
+            )
         )
 
     def get_context_data(self, **kwargs):

--- a/centrodefamilia/templates/beneficiarios/beneficiarios_list.html
+++ b/centrodefamilia/templates/beneficiarios/beneficiarios_list.html
@@ -12,9 +12,7 @@
     <!-- Estilos modernos reutilizables para listados -->
     <link rel="stylesheet" href="{% static 'custom/css/listModerno.css' %}" />
     {% url 'beneficiarios_export' as export_url %}
-    <div class="cdf-beneficiarios-search">
-        {% include 'components/search_bar.html' with titulo="Buscar Beneficiario" reset_url=reset_url add_url=add_url add_text=add_text filters_mode=filters_mode filters_js=filters_js filters_action=filters_action export_url=export_url %}
-    </div>
+    {% include 'components/search_bar.html' with titulo="Buscar Beneficiario" reset_url=reset_url add_url=add_url add_text=add_text filters_mode=filters_mode filters_js=filters_js filters_action=filters_action export_url=export_url %}
     <div class="container mt-4 cdf-page">
         <h2>Listado de Preinscriptos</h2>
         {% load custom_filters %}

--- a/centrodefamilia/tests/test_beneficiarios_export.py
+++ b/centrodefamilia/tests/test_beneficiarios_export.py
@@ -284,7 +284,7 @@ def test_beneficiarios_list_muestra_boton_exportar_con_permiso(
     assert "btn-export-csv" in content
     assert reverse("beneficiarios_export") in content
     assert "Descargar CSV" in content
-    assert "cdf-beneficiarios-search" in content
+    assert "search-actions" in content
 
 
 @pytest.mark.django_db

--- a/docs/registro/cambios/2026-07-27-vat-comision-resultados-acta.md
+++ b/docs/registro/cambios/2026-07-27-vat-comision-resultados-acta.md
@@ -1,4 +1,4 @@
-# VAT/INET: pestaña "Resultados" en el detalle de comisión de curso
+# VAT/INET: pestaña "Resultados" en el detalle de comisión de curso (#2147)
 
 ## Contexto
 

--- a/docs/registro/cambios/2026-07-29-cdf-beneficiarios-botones-centrados.md
+++ b/docs/registro/cambios/2026-07-29-cdf-beneficiarios-botones-centrados.md
@@ -1,0 +1,22 @@
+# Botones de acción centrados en listado de preinscriptos CDF
+
+## Cambio
+
+Los botones de acción del buscador de beneficiarios (Crear un nuevo
+preinscripto, Filtrar, Resetear, Descargar CSV) vuelven a estar centrados,
+como en el resto de los listados del sistema.
+
+## Contexto
+
+La exportación CSV (2026-07-27) corrió toda la fila de acciones a la derecha:
+primero con `search_actions_justify="justify-content-end"` y luego con la
+regla `.cdf-beneficiarios-search .search-actions { justify-content: flex-end
+!important; }` en `cdf.css`. La intención original era que `Descargar CSV`
+fuera el último botón del grupo, no desplazar el grupo completo.
+
+## Resolución
+
+Se elimina la regla CSS y el wrapper `cdf-beneficiarios-search` (existía solo
+como hook de esa regla). El componente compartido `search_bar.html` ya centra
+las acciones con `justify-content-center`; `Descargar CSV` sigue siendo el
+último botón del grupo.

--- a/docs/registro/cambios/2026-07-29-vat-reintegro-voucher-rechazo.md
+++ b/docs/registro/cambios/2026-07-29-vat-reintegro-voucher-rechazo.md
@@ -1,0 +1,25 @@
+# Reintegro de voucher al rechazar una inscripción VAT
+
+Fecha: 2026-07-29
+
+## Contexto
+
+Una inscripción de curso que usaba voucher podía pasar de un estado con cupo a
+`rechazada` sin revertir el débito. Al aceptarla nuevamente, el flujo volvía a
+descontar créditos.
+
+## Cambios realizados
+
+- Al rechazar una inscripción que ocupaba cupo se revierte el último débito de
+  voucher asociado a esa inscripción.
+- La reversión actualiza los saldos, conserva la trazabilidad mediante una
+  recarga de compensación y deja el voucher activo si se había agotado.
+- Al volver a aceptar una inscripción se evita un nuevo débito si ya existe un
+  débito vigente histórico para ella.
+- Se agregaron regresiones del cambio de estado por lote para ambos ciclos.
+
+## Impacto
+
+- El saldo del voucher coincide con el estado final de la inscripción.
+- La compensación queda auditada en `VoucherRecarga` y `VoucherLog`.
+- No se altera el comportamiento de vouchers vencidos o cancelados.

--- a/docs/registro/cambios/2026-07-29-vat-tipo-alumno-vat-sin-plan.md
+++ b/docs/registro/cambios/2026-07-29-vat-tipo-alumno-vat-sin-plan.md
@@ -1,0 +1,41 @@
+# VAT - Diferenciación de alumnos VAT / Sin Plan en asistencia y exportaciones
+
+## Cambio funcional
+
+Se agrega la clasificación `tipo_alumno` (valores `VAT` / `Sin Plan`) para
+distinguir a los alumnos con voucher VAT activo de los que no tienen plan.
+La columna "Tipo de alumno" se muestra siempre (aunque todos los alumnos sean
+de la misma categoría) en:
+
+- Pantalla de asistencia de sesión (chip destacado para VAT), ambos caminos
+  (`ComisionCurso` y legacy `Comision`).
+- Detalle de comisión, tabla de inscriptos (pill teal para VAT), ambos caminos.
+- Detalle nominal del reporte de inscripciones y asistencia (UI + export
+  CSV/Excel), para que la clasificación en pantalla coincida con la exportada.
+- Nómina Excel de preinscriptos e inscriptos de comisión de curso.
+
+## Regla de negocio
+
+`Voucher` del ciudadano con `estado="activo"` y `fecha_vencimiento` vigente →
+`VAT`; cualquier otro caso → `Sin Plan`. Se chequea la fecha además del estado
+porque `vencido` se estampa de forma perezosa al validar vouchers.
+
+El cálculo es exclusivamente backend y está centralizado en
+`VAT/services/tipo_alumno_service.py`:
+
+- `anotar_tipo_alumno(inscripciones)`: una sola query por lote para listados
+  materializados (views de asistencia, detalle de comisión, nómina Excel).
+- `tiene_voucher_activo_subquery()`: `Exists` para querysets en streaming
+  (detalle nominal del reporte y sus exports).
+
+## Trade-offs
+
+- Un alumno que pagó con voucher y luego lo agotó (`estado="agotado"`) pasa a
+  verse como `Sin Plan`: la regla pedida clasifica por voucher activo hoy, no
+  por cómo se pagó la inscripción.
+- La columna no participa de búsquedas, ordenamientos ni paginación (que son
+  client-side en estas tablas) ni afecta el registro de asistencia.
+
+Tests: `VAT/test_tipo_alumno.py` (servicio, nómina, reporte y renders) y
+actualización de asserts de headers/colspans en `VAT/tests.py` y
+`VAT/test_comision_detail_template_compartido.py`.

--- a/static/custom/css/cdf.css
+++ b/static/custom/css/cdf.css
@@ -21,10 +21,6 @@
     font-family: 'Source Sans Pro', 'Montserrat', -apple-system, sans-serif;
 }
 
-.cdf-beneficiarios-search .search-actions {
-    justify-content: flex-end !important;
-}
-
 /* ── Hero / banda de título ─────────────────────────────── */
 .cdf-hero {
     display: flex;

--- a/tests/test_comedor_form_unit.py
+++ b/tests/test_comedor_form_unit.py
@@ -171,8 +171,10 @@ def test_clean_validates_missing_and_mismatches(mocker):
 @pytest.mark.parametrize(
     "programa_nombre,codigo_esperado",
     [
+        # El form conserva el código tal como llega para los programas
+        # habilitados (no lo transforma): el input mockeado es SEC1234.
         ("Abordaje Comunitario - Línea Secos", "SEC1234"),
-        ("Abordaje Comunitario - Línea Tradicional", "TRA1234"),
+        ("Abordaje Comunitario - Línea Tradicional", "SEC1234"),
         ("Alimentar Comunidad", None),
         ("Otro programa", None),
     ],

--- a/tests/test_users_auth_flows.py
+++ b/tests/test_users_auth_flows.py
@@ -34,6 +34,7 @@ def test_user_creation_form_allows_empty_email():
     form = UserCreationForm(
         data={
             "username": "sinemail",
+            "tipo_usuario": "interno",
             "email": "",
             "password": "Secreta123!",
         }
@@ -50,6 +51,7 @@ def test_custom_user_change_form_allows_empty_email(user):
         instance=user,
         data={
             "username": user.username,
+            "tipo_usuario": "interno",
             "email": "",
             "password": "",
         },
@@ -92,6 +94,7 @@ def test_custom_user_change_form_assigns_direct_permissions(user):
         instance=user,
         data={
             "username": user.username,
+            "tipo_usuario": "interno",
             "email": user.email,
             "password": "",
             "groups": [],
@@ -113,6 +116,7 @@ def test_user_creation_sets_first_login_password_flags():
     form = UserCreationForm(
         data={
             "username": "nuevo_user",
+            "tipo_usuario": "interno",
             "email": "nuevo@example.com",
             "password": "Secreta123!",
             "groups": [],
@@ -142,6 +146,7 @@ def test_mobile_user_creation_generates_password_automatically():
     form = UserCreationForm(
         data={
             "username": "mobile_auto_pwd",
+            "tipo_usuario": "interno",
             "email": "mobile_auto_pwd@example.com",
             "es_representante_pwa": True,
             "tipo_asociacion_pwa": "organizacion",
@@ -178,6 +183,7 @@ def test_existing_user_keeps_password_when_gaining_mobile_access():
         instance=user,
         data={
             "username": user.username,
+            "tipo_usuario": "interno",
             "email": user.email,
             "password": "",
             "es_representante_pwa": True,
@@ -567,6 +573,7 @@ def test_user_create_view_redirects_with_temporary_password_visible(
         reverse("usuario_crear"),
         data={
             "username": "mobile_visible",
+            "tipo_usuario": "interno",
             "email": "mobile_visible@example.com",
             "es_representante_pwa": True,
             "tipo_asociacion_pwa": "organizacion",

--- a/tests/test_users_email_opcional_y_agrupamiento.py
+++ b/tests/test_users_email_opcional_y_agrupamiento.py
@@ -81,6 +81,7 @@ def test_user_creation_form_acepta_email_vacio():
     form = UserCreationForm(
         data={
             "username": "sin_email_user",
+            "tipo_usuario": "interno",
             "email": "",
             "password": "Inicial123!",
             "first_name": "Juan",
@@ -103,6 +104,7 @@ def test_user_creation_form_acepta_email_repetido():
     form = UserCreationForm(
         data={
             "username": "segundo_usuario",
+            "tipo_usuario": "interno",
             "email": "repetido@example.com",
             "password": "Pass123!",
             "first_name": "Ana",
@@ -125,6 +127,7 @@ def test_user_change_form_acepta_email_vacio():
     form = CustomUserChangeForm(
         data={
             "username": "cambia_email",
+            "tipo_usuario": "interno",
             "email": "",
             "first_name": "Pedro",
             "last_name": "Lopez",

--- a/tests/test_users_pwa_forms.py
+++ b/tests/test_users_pwa_forms.py
@@ -58,6 +58,7 @@ def test_user_creation_form_requires_some_mobile_scope():
     form = UserCreationForm(
         data={
             "username": "rep_forms",
+            "tipo_usuario": "interno",
             "email": "rep_forms@example.com",
             "es_representante_pwa": True,
         }
@@ -72,6 +73,7 @@ def test_user_creation_form_requires_visible_space_for_mobile_user(comedor):
     form = UserCreationForm(
         data={
             "username": "rep_forms_org",
+            "tipo_usuario": "interno",
             "email": "rep_forms_org@example.com",
             "es_representante_pwa": True,
             "tipo_asociacion_pwa": AccesoComedorPWA.TIPO_ASOCIACION_ORGANIZACION,
@@ -89,6 +91,7 @@ def test_user_creation_form_creates_mobile_user_associated_to_organization(comed
     form = UserCreationForm(
         data={
             "username": "rep_forms_ok",
+            "tipo_usuario": "interno",
             "email": "rep_forms_ok@example.com",
             "groups": [],
             "es_representante_pwa": True,
@@ -123,6 +126,7 @@ def test_user_creation_form_assigns_mobile_rendicion_permission_with_checkbox(co
     form = UserCreationForm(
         data={
             "username": "rep_forms_rendicion",
+            "tipo_usuario": "interno",
             "email": "rep_forms_rendicion@example.com",
             "es_representante_pwa": True,
             "puede_gestionar_rendiciones_mobile": True,
@@ -143,6 +147,7 @@ def test_custom_user_change_form_deactivates_mobile_access(comedor):
     create_form = UserCreationForm(
         data={
             "username": "rep_edit",
+            "tipo_usuario": "interno",
             "email": "rep_edit@example.com",
             "es_representante_pwa": True,
             "tipo_asociacion_pwa": AccesoComedorPWA.TIPO_ASOCIACION_ORGANIZACION,
@@ -157,6 +162,7 @@ def test_custom_user_change_form_deactivates_mobile_access(comedor):
         instance=user,
         data={
             "username": user.username,
+            "tipo_usuario": "interno",
             "email": user.email,
             "password": "",
             "es_representante_pwa": False,
@@ -194,6 +200,7 @@ def test_custom_user_change_form_can_remove_mobile_rendicion_permission(comedor)
     create_form = UserCreationForm(
         data={
             "username": "rep_edit_rendicion",
+            "tipo_usuario": "interno",
             "email": "rep_edit_rendicion@example.com",
             "es_representante_pwa": True,
             "puede_gestionar_rendiciones_mobile": True,
@@ -210,6 +217,7 @@ def test_custom_user_change_form_can_remove_mobile_rendicion_permission(comedor)
         instance=user,
         data={
             "username": user.username,
+            "tipo_usuario": "interno",
             "email": user.email,
             "password": "",
             "es_representante_pwa": True,
@@ -234,6 +242,7 @@ def test_custom_user_change_form_allows_disabling_mobile_even_if_post_keeps_hidd
     create_form = UserCreationForm(
         data={
             "username": "rep_disable_hidden",
+            "tipo_usuario": "interno",
             "email": "rep_disable_hidden@example.com",
             "es_representante_pwa": True,
             "tipo_asociacion_pwa": AccesoComedorPWA.TIPO_ASOCIACION_ORGANIZACION,
@@ -248,6 +257,7 @@ def test_custom_user_change_form_allows_disabling_mobile_even_if_post_keeps_hidd
         instance=user,
         data={
             "username": user.username,
+            "tipo_usuario": "interno",
             "email": user.email,
             "password": "",
             "es_representante_pwa": False,
@@ -269,6 +279,7 @@ def test_custom_user_change_form_allows_space_association_without_organizations(
     create_form = UserCreationForm(
         data={
             "username": "rep_space_edit",
+            "tipo_usuario": "interno",
             "email": "rep_space_edit@example.com",
             "es_representante_pwa": True,
             "tipo_asociacion_pwa": AccesoComedorPWA.TIPO_ASOCIACION_ORGANIZACION,
@@ -283,6 +294,7 @@ def test_custom_user_change_form_allows_space_association_without_organizations(
         instance=user,
         data={
             "username": user.username,
+            "tipo_usuario": "interno",
             "email": user.email,
             "password": "",
             "es_representante_pwa": True,
@@ -314,6 +326,7 @@ def test_user_creation_form_allows_organization_plus_direct_space(
     form = UserCreationForm(
         data={
             "username": "rep_forms_mixed",
+            "tipo_usuario": "interno",
             "email": "rep_forms_mixed@example.com",
             "es_representante_pwa": True,
             "organizaciones_pwa": [comedor.organizacion_id],
@@ -355,6 +368,7 @@ def test_user_creation_form_allows_some_spaces_from_org_plus_external_space(
     form = UserCreationForm(
         data={
             "username": "rep_forms_partial_org",
+            "tipo_usuario": "interno",
             "email": "rep_forms_partial_org@example.com",
             "es_representante_pwa": True,
             "organizaciones_pwa": [comedor.organizacion_id],
@@ -402,6 +416,7 @@ def test_backoffice_authentication_form_rejects_mobile_user(comedor):
     create_form = UserCreationForm(
         data={
             "username": "rep_login_form",
+            "tipo_usuario": "interno",
             "email": "rep_login_form@example.com",
             "es_representante_pwa": True,
             "tipo_asociacion_pwa": AccesoComedorPWA.TIPO_ASOCIACION_ORGANIZACION,
@@ -416,6 +431,7 @@ def test_backoffice_authentication_form_rejects_mobile_user(comedor):
         request=None,
         data={
             "username": "rep_login_form",
+            "tipo_usuario": "interno",
             "password": create_form.generated_password,
         },
     )


### PR DESCRIPTION
## Resumen

Continuación del lote de #2184 (ya mergeado) sobre el mismo branch. Trae una mejora nueva y las correcciones posteriores al merge de aquel PR.

| Issue / Tarea | Cambio | Estado |
|---|---|---|
| **[MEJORA]** Diferenciación visual de alumnos VAT | Clasificación `tipo_alumno` (**VAT** / **Sin Plan**) en asistencia, detalle de comisión y exportaciones | Implementado |
| Seguimiento #2147 | Fix: dropdown del buscador de profesor recortado por `overflow: hidden` del card | Incluido |
| Seguimiento #2146 | Fix: validación de prefijo de CUE se salteaba en **edición** (provincia oculta en el POST) | Incluido |
| Mantenimiento | Reaplicación de `djlint --reformat` tras el merge de development + registro del issue #2147 en docs | Incluido |

---

## [MEJORA] Tipo de alumno: VAT / Sin Plan

### Regla de negocio

`Voucher` del ciudadano con `estado="activo"` y `fecha_vencimiento` vigente → **VAT**; cualquier otro caso → **Sin Plan**. Se chequea la fecha además del estado porque `vencido` se estampa de forma perezosa al validar vouchers.

El cálculo es **exclusivamente backend**, centralizado en `VAT/services/tipo_alumno_service.py`, y la misma implementación alimenta listados y exportaciones (criterio de aceptación: la clasificación en UI coincide exactamente con la exportada):

- `anotar_tipo_alumno(inscripciones)` — una sola query por lote, para listados materializados (asistencia, detalle de comisión, nómina Excel).
- `tiene_voucher_activo_subquery()` — `Exists` en SQL para los querysets en streaming del reporte (no rompe el `.iterator()` de los exports).

### Alcance

Columna **"Tipo de alumno"**, siempre visible aunque todos los alumnos sean de la misma categoría:

- **Pantalla de asistencia de sesión** — chip blanco destacado para VAT (según mockup), en ambos caminos (`ComisionCurso` y legacy `Comision`, que comparten template).
- **Detalle de comisión, tabla de inscriptos** — pill teal (VAT) / gris (Sin Plan), ambos caminos; colspans ajustados.
- **Nómina Excel de preinscriptos e inscriptos** de comisión de curso (columna después de "Género").
- **Detalle nominal del reporte de inscripciones y asistencia** — en la tabla en pantalla **y** en los exports CSV/Excel, para que UI y export coincidan.

La columna no participa de búsquedas, ordenamientos ni paginación (client-side en estas tablas) ni afecta el registro de asistencia: el JS existente selecciona por clases/`data-*` que no se tocaron.

### Decisiones y trade-offs

- **Alumno que agotó el voucher se ve "Sin Plan".** La regla pedida clasifica por voucher activo *hoy*, no por cómo se pagó la inscripción: un alumno que pagó con voucher y lo agotó (`estado="agotado"`) deja de mostrarse como VAT. Si el negocio prefiere "pagó con voucher alguna vez", habría que mirar `VoucherUso` en su lugar.
- **Se sumó la columna al detalle nominal del reporte en pantalla** (no estaba listado en el alcance) porque su export sí la lleva y el criterio de aceptación exige que UI y export coincidan.
- Registro del cambio en `docs/registro/cambios/2026-07-29-vat-tipo-alumno-vat-sin-plan.md`.

### Tests

`VAT/test_tipo_alumno.py` (nuevo): clasificación del servicio con casos borde (voucher vigente, vencido por fecha con estado stale, agotado, sin voucher), nómina Excel, detalle del reporte + export CSV, y render de asistencia y detalle de comisión vía `RequestFactory`. Se actualizaron los asserts de headers/índices de la nómina en `VAT/tests.py` y los colspans del contrato del template compartido en `VAT/test_comision_detail_template_compartido.py`.

---

## Correcciones post-#2184 incluidas

- **Dropdown del buscador de profesor (#2147).** `.sisoc-block-card` tiene `overflow: hidden` para recortar la cabecera teal contra el border-radius, y recortaba el dropdown absoluto de resultados. Nuevo modificador `--overflow` que libera el overflow y pasa el radio superior al title. Además el dropdown se ancla ahora a un wrap que rodea solo al input (antes, con un profesor seleccionado, caía debajo del chip).
- **Prefijo de CUE en edición (#2146).** La validación cross-field leía `cleaned_data["provincia"]`, pero en edición ese campo va oculto y `required=False`: si no llegaba en el POST la validación se salteaba en silencio. Ahora cae a `self.instance.provincia`.
- `djlint --reformat` reaplicado tras el merge de development y referencia al issue #2147 en el registro de la solapa Resultados.

## Validación

- Suite completa de VAT en Docker: **271 passed, 3 skipped** (`docker compose exec django pytest VAT/ -n auto`).
- `black` sin cambios; `pylint` 10/10 en el servicio nuevo; `djlint --check` sin violaciones nuevas (queda un desvío **preexistente** en `comision_detail.html` ~2308, bloques `help_text` del modal, que no se reformateó para no mezclar feature con formateo).

---

<details>
<summary>Descripción del PR #2184 (contexto del lote, ya mergeado)</summary>

## Resumen

Cinco tareas de INET/VAT + Celiaquía. Cuatro implican código; una resultó ya resuelta y se documenta el hallazgo.

| Issue | Tarea | Estado |
|---|---|---|
| #2147 | **[INET]** Nueva pestaña "Resultados" en el detalle de comisión: carga de aprobado/desaprobado por alumno + datos del acta de cierre | Implementado |
| #2146 | **[INET]** Validaciones adicionales del CUE en alta/edición de Centro: unicidad y prefijo provincial | Implementado |
| #2132 | **[INET]** Selección múltiple de alumnos para aceptar/rechazar en lote en la pestaña Inscriptos | Implementado |
| #2006 | **[INET]** Mejora Lista de Espera: límite configurable + estado visual del checkbox | Corregido lo que faltaba (ver abajo) |
| #2018 | **[Celiaquía]** Exportación de localidad y municipio en la Nómina de Aprobados | **Sin cambios de código** — ya estaba resuelto |

---

## Detalle por tarea

### Pestaña "Resultados" (#2147)

Modelos nuevos (migración `0050_resultados_comision_curso`):

- `ProfesorCentro` — profesor a cargo, propio de cada centro. Deliberadamente **independiente de `ciudadanos.Ciudadano`**: un profesor no es beneficiario y no debe entrar al padrón que alimenta validación RENAPER, cola de duplicados ni vouchers. Alta directa, sin validación de identidad externa (pedido explícito del ticket).
- `ActaCierreComision` — `OneToOne` con `ComisionCurso`: profesor, fecha de fin, N° de acta (opcional), registrado_por.
- `Inscripcion.resultado_final` (`aprobado`/`desaprobado`, **NULL = sin calificar**) + `resultado_registrado_por` + `resultado_fecha`. Los dos últimos porque `audittrail/` no cubre VAT.

Se descartó reusar `Evaluacion`/`ResultadoEvaluacion`: están FK-eados sólo a `Comision` (camino legacy) y modelan notas numéricas por evaluación, no un pass/fail de curso más un acta.

**Decisiones que conviene revisar:**

- **Quién entra al listado.** "Inscripción confirmada" = `estado="inscripta"`, pero el filtro real es `estado__in=("inscripta", "completada")`. Como calificar mueve la inscripción a `completada`, filtrar sólo por `inscripta` haría desaparecer del listado a los ya calificados al recargar, rompiendo la corrección posterior y la aritmética de las cards.
- **Calificar cierra la inscripción.** Aprobar y desaprobar dejan la inscripción en `completada` vía `InscripcionService.actualizar_estado_inscripcion`. Con esto `completada` pasa a ser alcanzable desde la UI por primera vez. `abandonada` queda fuera: desaprobado ≠ abandonado, y sigue sin ser alcanzable.
- **`fecha_fin` del acta es propia del acta.** Se precarga con la de la comisión y es editable, pero no escribe sobre `ComisionCurso.fecha_fin`: eso alteraría el cierre automático de `CierreComisionService` y el bloqueo de altas de `_comision_vencida`.
- **Permisos: se gatea con `VAT.change_inscripcion`**, el mismo permiso que ya habilita Admitir/Rechazar. No se toca `users/bootstrap/groups_seed.py` ni se agrega data migration de reconciliación, para que la feature sea alcanzable por CFP e INET Admin General desde el día uno.
- **Alcance: sólo `ComisionCurso`.** El template es compartido con el camino legacy `OfertaInstitucional → Comision`, que no renderiza la solapa.

### CUE: unicidad y prefijo provincial (#2146)

Todo en `VAT/forms.py`. El template no se tocó: crispy ya renderiza los errores bajo el campo.

**Dos hallazgos sobre el estado previo:**

1. **La unicidad ya existía** a nivel modelo (`Centro.codigo` es `unique=True`), pero mostraba el mensaje default de Django, no uno del dominio.
2. **Y estaba incompleta de una forma que producía un 500.** `Centro` usa soft delete, y su `objects` (que excluye borrados) es el `_default_manager` que consulta `validate_unique`. O sea no veía centros dados de baja, mientras el índice único de la DB sí los tiene: reusar el CUE de un centro borrado terminaba en `IntegrityError`. Ahora se valida contra `all_objects`, con mensaje propio para ese caso.

**Desvío respecto del requerimiento — La Pampa.** La tabla de equivalencias del ticket **omite La Pampa**: lista 23 de las 24 jurisdicciones y salta de `38` (Jujuy) a `46` (La Rioja), sin el `42` que le corresponde por INDEC. La Pampa existe en el sistema, así que la tabla literal habría dejado todos sus centros imposibles de guardar. Se incluyó `"La Pampa": "42"`. Hay un test que carga el fixture canónico y falla si alguna provincia queda sin prefijo. **Si La Pampa realmente no debe tener CFP, hay que quitarla del mapeo y el test lo va a marcar.**

Otras notas:

- `core.Provincia` no tiene campo de código, así que el mapeo es por nombre. Si el nombre no es canónico no se valida el prefijo, en lugar de bloquear un alta legítima. El fix durable sería un `codigo_indec` en `core`, que impacta otros módulos.
- **Alcance: sólo el formulario.** Quedan sin cubrir `CentroViewSet`/`CentroSerializer` (API con API Key) y `manage.py import_vat_centros_excel`. Moverlo a `Centro.clean()` no resolvería la API porque DRF no llama `full_clean`.
- Se alinearon datos de test: `_build_centro_payload` usaba prefijo `50` (Mendoza) con provincia "Buenos Aires" (`06`). Ahora deriva el prefijo de la provincia, y los 33 literales `"50XXXXXXX"` pasaron a `"06XXXXXXX"`.

### Aceptar/rechazar en lote (#2132)

`InscripcionService.actualizar_estado_en_lote` + `InscripcionCursoCambiarEstadoLoteView`.

**Aclaración de alcance.** El ticket dice que hoy se hace "de a uno por vez", pero eso existe en la pestaña **Lista de espera**, no en Inscriptos. El mockup, la flecha y "al lado del botón Agregar inscripto" apuntan al toolbar de **Inscriptos**, y los criterios dicen "tabla de inscriptos" tres veces. Se implementó ahí. Lista de espera no se tocó; el endpoint es reutilizable si se pide.

**Se agregó una columna "Estado"** que no está en los criterios: el listado mezcla `pre_inscripta`, `inscripta`, `completada`, `rechazada` y `abandonada`, y sin esa columna el operador seleccionaría a ciegas. La feature es inusable sin ella.

**Sin transacción envolvente, a propósito.** Cada fila va en la transacción de `actualizar_estado_inscripcion`: un cupo completo en la fila 55 no descarta las 54 aceptaciones previas. Se aplica lo que se puede y se reporta fila por fila qué quedó afuera.

Otras decisiones: whitelist de estados (`inscripta`/`rechazada`) para que un POST armado a mano no mueva N inscripciones a cualquier estado; scope doble (comisión + id) para que un id ajeno no entre al lote; "seleccionar todos" respeta el filtro de búsqueda; cambiar el filtro limpia la selección.

> [!WARNING]
> **Riesgo de voucher, preexistente pero amplificado por el lote.** Verificado: **no existe ningún camino de reintegro** en `VoucherService`. Consecuencias: (1) rechazar no devuelve el crédito, porque `pre_inscripta` e `inscripta` ya debitaron; (2) aceptar una fila ya `rechazada` **re-debita** un crédito que nunca se devolvió — doble cobro. El lote multiplica ambos por N. Se acotó con la columna Estado, el conteo en el modal de confirmación y los errores por fila visibles, pero **conviene resolver el reintegro antes de usar el lote en comisiones con `usa_voucher=True`**.

### Lista de espera (#2006)

El ticket pedía dos cosas; **una ya estaba hecha**.

- **"Falta configuración de límite" → ya implementado.** `ComisionCurso.cupo_lista_espera` existe desde la migración `0049` (05-jun-2026, ya en `development` y `main`), con modelo + `clean()`, campo en el form y en el modal, `data-cupo-lista-espera` en el trigger y el JS que lo muestra al tildar. No se agregó nada.
- **"El botón no se muestra tildado" → bug real.** Root cause: las reglas que estilan checkboxes en `vat_design.css` estaban scopeadas a `.vat-ui`, pero `centro_detail.html` usa `.sisoc-centro-page` como raíz. El CSS se carga y los selectores nunca matchean, así que sobre el fondo navy el checkbox queda con el estilo de Bootstrap y su estado marcado es ilegible. Se extendieron los selectores a `.vat-ui-modal`, que es la clase que estos modales sí tienen.

Se eligió el scope del modal en vez de agregar `.vat-ui` a la raíz de la página: `centro_detail.html` tiene su propio sistema visual y arrastrar todo el design system encima tendría riesgo de regresiones amplias.

De paso: `cupo_lista_espera` es `required=False` en el form (no mostraba `*`) pero el JS lo marca `required` y el `clean()` del modelo lo exige. El asterisco ahora se enciende junto con el campo.

### Nómina de Aprobados Celiaquía (#2018) — sin cambios de código

Ya estaba resuelto. `PadronFinalService._fila_beneficiario` exporta `_texto(ciudadano.municipio)`, que pasa por `Municipio.__str__` → `nombre`. El commit `1aff168b3` (03-jul-2026, ya en `development` y `main`) cambió la generación para que lea de la base en vez de `expediente.excel_masivo` — el Excel original de la provincia, que trae los códigos PK. **Ese era el bug.** Hay test que afirma exactamente los criterios (`test_padron_final_export.py:165-167`) y pasa.

La captura del reporte corresponde a otra descarga o al export previo al 03-jul. En el detalle de expediente hay tres botones y dos dicen "nómina":

| Botón | Devuelve | Municipio/Localidad |
|---|---|---|
| Descargar nómina aprobados | `PadronFinalService`, desde la base | nombres ✅ |
| Descargar nómina Sintys | sólo cuil, nombre, apellido, sexo | no tiene esas columnas |
| Descargar Excel Provincia | el archivo original tal cual se subió | **códigos PK** |

El tercero devuelve códigos por diseño: el archivo original se mantiene estático para auditoría. **Queda pendiente confirmar con el reportante el id de expediente y el botón usado.**

---

## Review cruzado

Se revisaron los cuatro cambios juntos por tocar archivos compartidos. Se encontró y corrigió:

1. **Regresión en el camino legacy.** `comision_detail.html` lo renderizan dos views. La UI de lote estaba gateada con `puede_cambiar_inscripcion`, que `ComisionDetailView` **sí** define, pero sin definir `inscripcion_estado_lote_url` — en el camino legacy se renderizaban checkboxes y botones con `action=""`. Se introdujo un flag propio `puede_gestionar_lote_inscriptos` y se corrigieron los colspans. Se agregó `VAT/test_comision_detail_template_compartido.py` como guard permanente del contrato del template compartido.
2. **Dos huecos de robustez que daban 500** con un POST manipulado: `fecha_fin` no-ISO asignada al `DateField` levanta `ValidationError` (que no es `ValueError`, así que no lo atrapaba el manejo de la vista), y `filter(pk="abc")` levanta `ValueError` al evaluar el queryset. Ambos con test.
3. **Una fixture desalineada** en `tests/test_vat_centro_form_state_unit.py` que el prefijo de CUE rompía (mismo problema que en `VAT/tests.py`, este archivo se me había pasado).

Verificaciones adicionales: `InscripcionSerializer` tiene field list explícito, así que los campos nuevos de `Inscripcion` **no cambian el contrato de la API**; `.vat-ui-modal` sólo se usa en `centro_detail.html` y su partial, así que el cambio de CSS tiene blast radius acotado; los modelos nuevos no van al registry de soft delete, consistente con el resto de VAT; `test_urls_no_500.py` excluye URLs con parámetros, así que ninguna de las 4 URLs nuevas queda expuesta ahí.

---

## Validación

- **Merge de `development` limpio**, sin conflictos. `manage.py check` y `makemigrations --check` sin novedades. `0050` sigue siendo la única migración VAT posterior a `0049`.
- **~40 tests nuevos.** La mayoría usan `RequestFactory` o leen messages sin seguir el redirect, para que corran en local.
- `black` y `pylint` limpios (9.98/10; las advertencias que quedan son preexistentes de `prevalidar_inscripcion` y `crear_inscripcion`). `djlint` sin violaciones nuevas.
- Comparado contra baseline requerimiento por requerimiento, **cero regresiones**. Baselines dirigidos: `test_soft_delete_flows` 7=7, subset de `test_urls_no_500` 101=101, tests de comandos de import 41/41.

> [!IMPORTANT]
> **Pendiente de correr en Docker.** El venv local tiene **Python 3.14 con Django 4.2.27**, combinación no soportada: `django/template/context.py` revienta en la instrumentación de templates del test client, y eso hace fallar todo test que renderice vía test client (~65 en VAT, preexistentes). Quedan 5 tests sin ejecutar localmente. Correr `docker compose exec django pytest -n auto`.

**Verificación visual pendiente:** el fix de CSS de #2006 no es testeable automáticamente. Confirmar en el navegador: detalle de centro → solapa Cursos → Editar en una comisión con lista de espera activa; el checkbox debe verse tildado en teal y aparecer "Cupo Lista de Espera" con el valor cargado. Puede requerir `collectstatic` y hard-refresh.




</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)
