### PR TITLE
fix(ci): destrabar sincronización descendente pre-deploy 2026-07-29

### DIFF
--- a/.github/scripts/sync_main_downstream.test.js
+++ b/.github/scripts/sync_main_downstream.test.js
@@ -19,6 +19,18 @@ test("el workflow carga la automatizacion desde development, donde existe el hel
   );
 });
 
+test("deploy_guard ejecuta las pruebas de automatizacion de release", () => {
+  const testsWorkflow = fs.readFileSync(
+    path.join(__dirname, "..", "workflows", "tests.yml"),
+    "utf8",
+  );
+
+  assert.match(
+    testsWorkflow,
+    /name: Ejecutar pruebas de automatizacion de release\s+run: node --test \.github\/scripts\/release_orchestrator\.test\.js \.github\/scripts\/sync_main_downstream\.test\.js/,
+  );
+});
+
 test("crea un PR desde una rama tecnica actualizada para development", async () => {
   const calls = [];
   const github = {

--- a/.github/scripts/sync_main_downstream.test.js
+++ b/.github/scripts/sync_main_downstream.test.js
@@ -1,9 +1,23 @@
 "use strict";
 
 const assert = require("node:assert/strict");
+const fs = require("node:fs");
+const path = require("node:path");
 const test = require("node:test");
 
 const { run, synchronizationBranch } = require("./sync_main_downstream");
+
+test("el workflow carga la automatizacion desde development, donde existe el helper", () => {
+  const workflow = fs.readFileSync(
+    path.join(__dirname, "..", "workflows", "sync-main-downstream.yml"),
+    "utf8",
+  );
+
+  assert.match(
+    workflow,
+    /name: Checkout de la automatizacion versionada\s+uses: actions\/checkout@v6\.0\.2\s+with:\s+ref: development/,
+  );
+});
 
 test("crea un PR desde una rama tecnica actualizada para development", async () => {
   const calls = [];

--- a/.github/workflows/sync-main-downstream.yml
+++ b/.github/workflows/sync-main-downstream.yml
@@ -26,7 +26,7 @@ jobs:
             - name: Checkout de la automatizacion versionada
               uses: actions/checkout@v6.0.2
               with:
-                  ref: main
+                  ref: development
                   persist-credentials: false
 
             - name: Validar GitHub App de automatizacion

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -274,6 +274,12 @@ jobs:
             - mysql_compat
             - release_quality
         steps:
+            - name: Checkout code
+              uses: actions/checkout@v6.0.2
+
+            - name: Ejecutar pruebas de automatizacion de release
+              run: node --test .github/scripts/release_orchestrator.test.js .github/scripts/sync_main_downstream.test.js
+
             - name: Validate required CI checks
               uses: actions/github-script@v8
               with:

--- a/AGENT_REPO_MAP.md
+++ b/AGENT_REPO_MAP.md
@@ -489,7 +489,8 @@ La siguiente tabla mezcla hechos observados con inferencias explicitas cuando no
 - El workflow descendente debe checkoutear `development`, donde vive el helper
   versionado; un checkout de `main` falla durante el bootstrap si todavía no
   contiene ese archivo. La regresión se cubre en
-  `.github/scripts/sync_main_downstream.test.js`.
+  `.github/scripts/sync_main_downstream.test.js` y `deploy_guard` ejecuta las
+  pruebas Node de ambos orquestadores.
 - `.github/workflows/deploy.yml`
 - La automatización de promociones usa una GitHub App privada: variable
   `RELEASE_AUTOMATION_APP_CLIENT_ID` y secret

--- a/AGENT_REPO_MAP.md
+++ b/AGENT_REPO_MAP.md
@@ -486,6 +486,10 @@ La siguiente tabla mezcla hechos observados con inferencias explicitas cuando no
 - `.github/scripts/sync_main_downstream.js`: crea y actualiza ramas técnicas
   `automation/sync-main-to-<destino>` para que los PRs descendentes cumplan
   checks estrictos sin mezclar QA/HML en `main`.
+- El workflow descendente debe checkoutear `development`, donde vive el helper
+  versionado; un checkout de `main` falla durante el bootstrap si todavía no
+  contiene ese archivo. La regresión se cubre en
+  `.github/scripts/sync_main_downstream.test.js`.
 - `.github/workflows/deploy.yml`
 - La automatización de promociones usa una GitHub App privada: variable
   `RELEASE_AUTOMATION_APP_CLIENT_ID` y secret

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+<!-- AUTO-GENERATED RELEASE START: 2026-07-29 -->
+# Versión SISOC 29.07.2026
+
+## Corrección de Errores
+
+- [CI/CD] Corrige el bootstrap de la sincronización automática de main hacia QA y HML. (PR #2192)
+<!-- AUTO-GENERATED RELEASE END: 2026-07-29 -->
+
 <!-- AUTO-GENERATED RELEASE START: 2026-07-22 -->
 # Versión SISOC 22.07.2026
 

--- a/docs/contexto/features/pr-2192-release-promover-development-a-main-2026-07-29.md
+++ b/docs/contexto/features/pr-2192-release-promover-development-a-main-2026-07-29.md
@@ -1,0 +1,155 @@
+# Contexto de feature PR #2192 - release: promover development a main (2026-07-29)
+
+## Resumen
+
+- PR: https://github.com/dsocial118/SISOC/pull/2192
+- Base: `main`
+- Rama origen: `development`
+- Autor: `juanikitro`
+
+## Contexto funcional
+
+- Promoción semanal de development a main con recuperación segura de la sincronización descendente.
+
+## Arquitectura tocada
+
+- El PR toca lógica en `services/`, por lo que impacta reglas de negocio u orquestación.
+- Hay cambios en capa API/DRF y conviene revisar contratos de request/response.
+- Hay cambios en vistas web y puede existir impacto en permisos o renderizado.
+- Se modifican templates, con posible impacto visual o de composición UI.
+- Existen cambios de persistencia o migraciones que requieren revisión de datos.
+- El alcance incluye automatización o tooling de CI/CD.
+
+## Decisiones y supuestos detectados
+
+- Tipo de cambio declarado: Fix
+- Área principal declarada: CI/CD
+- Impacto usuario declarado: Sin cambio directo de interfaz; evita que una promoción quede bloqueada antes del deploy.
+- Riesgos / rollback: El workflow ejecuta automatización desde development; revertir a main solo cuando el helper esté promovido. El rollback funcional usa el tag estable del main previo.
+
+## Design system y UI
+
+- El PR toca piezas de UI y conviene revisar consistencia visual con el patrón existente.
+- Archivos visuales relevantes: .github/scripts/release_orchestrator.js, .github/scripts/release_orchestrator.test.js, .github/scripts/sync_main_downstream.js, .github/scripts/sync_main_downstream.test.js, VAT/templates/vat/centros/centro_detail.html, VAT/templates/vat/centros/partials/centro_cursos_panel.html, VAT/templates/vat/oferta_institucional/asistencia_sesion.html, VAT/templates/vat/oferta_institucional/comision_detail.html
+
+## Memoria operativa para agentes
+
+- Empezar por `docs/registro/prs/PR-2192.md` para contexto resumido del PR.
+- Revisar primero estos archivos del diff:
+- `.env.example`
+- `.gitattributes`
+- `.github/pull_request_template.md`
+- `.github/scripts/release_orchestrator.js`
+- `.github/scripts/release_orchestrator.test.js`
+- `.github/scripts/sync_main_downstream.js`
+- `.github/scripts/sync_main_downstream.test.js`
+- `.github/workflows/architecture.yml`
+- `.github/workflows/deploy.yml`
+- `.github/workflows/lint.yml`
+- `.github/workflows/pr-docs.yml`
+- `.github/workflows/release-orchestrator.yml`
+- `.github/workflows/secrets.yml`
+- `.github/workflows/sync-main-downstream.yml`
+- `.github/workflows/tests.yml`
+- `AGENT_REPO_MAP.md`
+- `VAT/forms.py`
+- `VAT/migrations/0050_resultados_comision_curso.py`
+- `VAT/models.py`
+- `VAT/services/inscripcion_service.py`
+- ... y 205 archivo(s) adicional(es) relacionados.
+- Documentación sugerida para ampliar contexto:
+- `docs/indice.md`
+- `docs/ia/CONTEXT_HYGIENE.md`
+- `docs/ia/ARCHITECTURE.md`
+- `docs/ia/TESTING.md`
+- `docs/contexto/features/pr-2080-fixes.md`
+- `docs/contexto/features/pr-2088-fix-users-credenciales-pwa-y-descarga-csv-por-lote.md`
+- `docs/contexto/features/pr-2089-docs-qa-sidebar-guia-de-testeo-roles-simepi-cdi-y-reubicacion-de-alta-egp-2038.md`
+- `docs/contexto/features/pr-2091-comedores-cambios-mes-ejecucion.md`
+- `docs/contexto/features/pr-2095-fix-inicio-corregir-descentrado-y-footer-ausente-en-pantalla-de-inicio-2087.md`
+- `docs/contexto/features/pr-2097-task-ver-todos-los-expedientes.md`
+- `docs/contexto/features/pr-2098-feat-cdi-registrar-asistencia-sobre-nomina.md`
+- `docs/contexto/features/pr-2100-fix-cdi-permitir-destildar-asistencia.md`
+- `docs/contexto/features/pr-2101-fix-layout-evitar-solapamiento-del-sidebar-con-el-footer.md`
+- `docs/contexto/features/pr-2102-fix-layout-priorizar-footer-sobre-sidebar.md`
+- `docs/contexto/features/pr-2103-feat-core-incorporar-municipios-y-localidades-faltantes-desde-bahra.md`
+- `docs/contexto/features/pr-2104-feat-comedores-reemplazar-colaboradores-de-comedores-pnud-via-data-migration.md`
+- `docs/contexto/features/pr-2105-fix-2085-2084-2083-2081-2063-2036-2096-1990-2001-1.md`
+- `docs/contexto/features/pr-2107-chore-sync-integrar-main-en-development.md`
+- `docs/contexto/features/pr-2109-create-0049-merge-20260720-1003-py.md`
+- `docs/contexto/features/pr-2114-chore-sync-integrar-main-en-development.md`
+- `docs/contexto/features/pr-2116-homologacion.md`
+- `docs/contexto/features/pr-2118-fix-organizaciones-corregir-migracion-arca-por-convenio.md`
+- `docs/contexto/features/pr-2119-modificaciones-en-informe-tecnico-complementario-alimentar-comunidad.md`
+- `docs/contexto/features/pr-2121-fix-organizaciones-tolerar-arca-duplicado-por-convenio.md`
+- `docs/contexto/features/pr-2126-docs-architecture-definir-modulos-extraibles.md`
+- `docs/contexto/features/pr-2127-fix-cdi-primeros-dos-documentos.md`
+- `docs/contexto/features/pr-2128-docs-infra-registrar-retiro-stage-2-mysql-qa.md`
+- `docs/contexto/features/pr-2129-fix-comedores-corregir-seguimiento-de-certificaciones.md`
+- `docs/contexto/features/pr-2134-fix-correcciones-en-documentos-de-rendiciones-pwa.md`
+- `docs/contexto/features/pr-2135-fix-organizaciones-sanea-rollback-arca-antes-de-promocion.md`
+- `docs/contexto/features/pr-2139-feat-release-automatizar-promocion-development-a-main.md`
+- `docs/implementaciones/centrodeinfancia_nomina_renaper.md`
+- `docs/ocr.md`
+- `docs/operacion/comandos_administracion.md`
+- `docs/operacion/deploy_automatizado.md`
+- `docs/registro/cambios/2026-07-21-cdi-validaciones-nomina-nino.md`
+- `docs/registro/cambios/2026-07-23-orquestacion-promocion-automatica.md`
+- `docs/registro/cambios/2026-07-27-cdf-exportacion-beneficiarios.md`
+- `docs/registro/cambios/2026-07-27-import-export-admin.md`
+- `docs/registro/cambios/2026-07-27-issue-2153-mover-expedientes-pago.md`
+- `docs/registro/cambios/2026-07-27-restricciones-abm-usuarios-cdi.md`
+- `docs/registro/cambios/2026-07-27-sincronizacion-descendente-con-checks-estrictos.md`
+- `docs/registro/cambios/2026-07-27-vat-comision-resultados-acta.md`
+- `docs/registro/cambios/2026-07-27-vat-cue-unicidad-y-prefijo-provincial.md`
+- `docs/registro/cambios/2026-07-27-vat-inscriptos-aceptar-rechazar-en-lote.md`
+- `docs/registro/cambios/2026-07-27-vat-lista-espera-estado-visual-checkbox.md`
+- `docs/registro/cambios/2026-07-28-deploy-qa-hml-readiness.md`
+- `docs/registro/cambios/2026-07-28-issue-2149-visibilidad-pwa-programa.md`
+- `docs/registro/cambios/2026-07-28-issue-2151-mover-modulo-ocr.md`
+- `docs/registro/cambios/2026-07-28-issue-2163-categorias-espacios.md`
+- `docs/registro/cambios/2026-07-28-issues-2158-2159-pwa.md`
+- `docs/registro/cambios/2026-07-28-programa-comedores-asociados.md`
+- `docs/registro/cambios/2026-07-28-recuperacion-qa-pwa-y-diagnostico.md`
+- `docs/registro/cambios/2026-07-29-bootstrap-sincronizacion-descendente.md`
+- `docs/registro/cambios/2026-07-29-cdf-beneficiarios-botones-centrados.md`
+- `docs/registro/cambios/2026-07-29-issue-2163-simple-asociacion.md`
+- `docs/registro/cambios/2026-07-29-issue-2169-codigo-proyecto.md`
+- `docs/registro/cambios/2026-07-29-issue-2182-cdi-ocultamiento-temporal.md`
+- `docs/registro/cambios/2026-07-29-permiso-validar-comedores.md`
+- `docs/registro/cambios/2026-07-29-usuarios-dni-cuil-tipo.md`
+- `docs/registro/cambios/2026-07-29-vat-reintegro-voucher-rechazo.md`
+- `docs/registro/cambios/2026-07-29-vat-tipo-alumno-vat-sin-plan.md`
+- `docs/registro/decisiones/2026-07-23-promocion-automatica-con-tag-estable.md`
+- `docs/registro/prs/PR-2080.md`
+- `docs/registro/prs/PR-2088.md`
+- `docs/registro/prs/PR-2089.md`
+- `docs/registro/prs/PR-2091.md`
+- `docs/registro/prs/PR-2095.md`
+- `docs/registro/prs/PR-2097.md`
+- `docs/registro/prs/PR-2098.md`
+- `docs/registro/prs/PR-2100.md`
+- `docs/registro/prs/PR-2101.md`
+- `docs/registro/prs/PR-2102.md`
+- `docs/registro/prs/PR-2103.md`
+- `docs/registro/prs/PR-2104.md`
+- `docs/registro/prs/PR-2105.md`
+- `docs/registro/prs/PR-2107.md`
+- `docs/registro/prs/PR-2109.md`
+- `docs/registro/prs/PR-2114.md`
+- `docs/registro/prs/PR-2116.md`
+- `docs/registro/prs/PR-2118.md`
+- `docs/registro/prs/PR-2119.md`
+- `docs/registro/prs/PR-2121.md`
+- `docs/registro/prs/PR-2126.md`
+- `docs/registro/prs/PR-2127.md`
+- `docs/registro/prs/PR-2128.md`
+- `docs/registro/prs/PR-2129.md`
+- `docs/registro/prs/PR-2134.md`
+- `docs/registro/prs/PR-2135.md`
+- `docs/registro/prs/PR-2139.md`
+
+## Trazabilidad
+
+- Documento generado automáticamente desde el evento de `pull_request`.
+- Si este PR cambia de título, el archivo se renombrará para mantener el slug alineado.

--- a/docs/registro/cambios/2026-07-29-bootstrap-sincronizacion-descendente.md
+++ b/docs/registro/cambios/2026-07-29-bootstrap-sincronizacion-descendente.md
@@ -1,0 +1,38 @@
+# Bootstrap de la sincronización descendente
+
+## Contexto
+
+La promoción semanal quedó detenida porque `main` todavía no era ancestro de
+`development`. El workflow de sincronización se ejecutaba desde la rama por
+defecto `development`, pero hacía checkout explícito de `main` antes de cargar
+`.github/scripts/sync_main_downstream.js`.
+
+El helper existe en `development` y no en el SHA vigente de `main`, por lo que
+el job fallaba de forma determinista con `MODULE_NOT_FOUND` antes de crear el
+PR técnico de sincronización.
+
+## Cambio
+
+El checkout de la automatización pasa a `development`, igual que el
+orquestador de release. Así el workflow y el helper se cargan desde la misma
+fuente versionada que GitHub Actions evalúa como rama por defecto.
+
+Se agrega una regresión Node que valida ese contrato de bootstrap en el
+workflow YAML.
+
+## Compatibilidad y seguridad
+
+El cambio no escribe en `main`, no relaja rulesets ni usa PATs. La GitHub App
+sigue creando únicamente PRs técnicos `automation/sync-main-to-<destino>` y
+GitHub conserva el auto-merge sujeto a los checks obligatorios.
+
+Si la política futura exige ejecutar el helper desde `main`, ese archivo debe
+promoverse primero a `main` mediante un flujo compatible; no debe volver a
+apuntarse el checkout a una rama que no lo contiene.
+
+## Validación y rollback
+
+La prueba focalizada cubre el contrato workflow-helper y conserva las pruebas
+de creación de PR técnico y auto-merge. El rollback consiste en restaurar el
+checkout a `main` solo después de confirmar que el helper está presente en el
+SHA de `main` que ejecutará el workflow.

--- a/docs/registro/cambios/2026-07-29-bootstrap-sincronizacion-descendente.md
+++ b/docs/registro/cambios/2026-07-29-bootstrap-sincronizacion-descendente.md
@@ -18,7 +18,8 @@ orquestador de release. Así el workflow y el helper se cargan desde la misma
 fuente versionada que GitHub Actions evalúa como rama por defecto.
 
 Se agrega una regresión Node que valida ese contrato de bootstrap en el
-workflow YAML.
+workflow YAML. `deploy_guard`, que es el check requerido por la ruleset,
+ejecuta esa prueba junto con la del orquestador de release.
 
 ## Compatibilidad y seguridad
 
@@ -33,6 +34,7 @@ apuntarse el checkout a una rama que no lo contiene.
 ## Validación y rollback
 
 La prueba focalizada cubre el contrato workflow-helper y conserva las pruebas
-de creación de PR técnico y auto-merge. El rollback consiste en restaurar el
-checkout a `main` solo después de confirmar que el helper está presente en el
-SHA de `main` que ejecutará el workflow.
+de creación de PR técnico y auto-merge; el check requerido `deploy_guard` las
+ejecuta en cada PR. El rollback consiste en restaurar el checkout a `main` solo
+después de confirmar que el helper está presente en el SHA de `main` que
+ejecutará el workflow.

--- a/docs/registro/prs/PR-2192.md
+++ b/docs/registro/prs/PR-2192.md
@@ -1,0 +1,198 @@
+# PR #2192 - release: promover development a main (2026-07-29)
+
+## Metadata
+
+- PR: https://github.com/dsocial118/SISOC/pull/2192
+- Base: `main`
+- Rama origen: `development`
+- Autor: `juanikitro`
+- Última actualización: `2026-07-30T01:06:29Z`
+
+## Resumen operativo
+
+- Tipo de cambio: Fix
+- Área principal: CI/CD
+- Contexto funcional: Promoción semanal de development a main con recuperación segura de la sincronización descendente.
+- Resumen para changelog: Corrige el bootstrap de la sincronización automática de main hacia QA y HML.
+- Impacto usuario: Sin cambio directo de interfaz; evita que una promoción quede bloqueada antes del deploy.
+
+## Áreas afectadas
+
+- `.env.example`
+- `.gitattributes`
+- `.github/workflows`
+- `AGENT_REPO_MAP.md`
+- `VAT`
+- `admisiones`
+- `centrodefamilia`
+- `centrodeinfancia`
+- `comedores`
+- `config`
+- `core`
+- `docs/contexto`
+- `docs/implementaciones`
+- `docs/indice.md`
+- `docs/ocr.md`
+- `docs/operacion`
+- `docs/registro`
+- `intervenciones`
+- `ocr`
+- `organizaciones`
+- `pwa`
+- `rendicioncuentasmensual`
+- `scripts`
+- `static`
+- `templates`
+- `tests`
+- `users`
+
+## Archivos relevantes del diff
+
+- `.env.example`
+- `.gitattributes`
+- `.github/pull_request_template.md`
+- `.github/scripts/release_orchestrator.js`
+- `.github/scripts/release_orchestrator.test.js`
+- `.github/scripts/sync_main_downstream.js`
+- `.github/scripts/sync_main_downstream.test.js`
+- `.github/workflows/architecture.yml`
+- `.github/workflows/deploy.yml`
+- `.github/workflows/lint.yml`
+- `.github/workflows/pr-docs.yml`
+- `.github/workflows/release-orchestrator.yml`
+- `.github/workflows/secrets.yml`
+- `.github/workflows/sync-main-downstream.yml`
+- `.github/workflows/tests.yml`
+- `AGENT_REPO_MAP.md`
+- `VAT/forms.py`
+- `VAT/migrations/0050_resultados_comision_curso.py`
+- `VAT/models.py`
+- `VAT/services/inscripcion_service.py`
+- `VAT/services/nomina_export.py`
+- `VAT/services/reportes_inscripciones_asistencia.py`
+- `VAT/services/resultados_comision_service.py`
+- `VAT/services/tipo_alumno_service.py`
+- `VAT/services/voucher_service/impl.py`
+- `VAT/templates/vat/centros/centro_detail.html`
+- `VAT/templates/vat/centros/partials/centro_cursos_panel.html`
+- `VAT/templates/vat/oferta_institucional/asistencia_sesion.html`
+- `VAT/templates/vat/oferta_institucional/comision_detail.html`
+- `VAT/templates/vat/reportes/inscripciones_asistencia.html`
+- `VAT/test_comision_detail_template_compartido.py`
+- `VAT/test_tipo_alumno.py`
+- `VAT/tests.py`
+- `VAT/urls.py`
+- `VAT/views/curso.py`
+- `VAT/views/oferta_institucional.py`
+- `admisiones/admin.py`
+- `centrodefamilia/templates/beneficiarios/beneficiarios_list.html`
+- `centrodefamilia/tests/test_beneficiarios_export.py`
+- `centrodefamilia/urls.py`
+- ... y 185 archivo(s) adicional(es) en el diff.
+
+## Validación declarada
+
+- Pruebas automáticas: Node 11/11, git diff --check y revisión independiente.
+- Pruebas manuales: Dispatch nativo pendiente tras integrar la preparación.
+
+## Riesgos y rollback
+
+- El workflow ejecuta automatización desde development; revertir a main solo cuando el helper esté promovido. El rollback funcional usa el tag estable del main previo.
+
+## Documentación sugerida para lectura
+
+- `docs/indice.md`
+- `docs/ia/CONTEXT_HYGIENE.md`
+- `docs/ia/ARCHITECTURE.md`
+- `docs/ia/TESTING.md`
+- `docs/contexto/features/pr-2080-fixes.md`
+- `docs/contexto/features/pr-2088-fix-users-credenciales-pwa-y-descarga-csv-por-lote.md`
+- `docs/contexto/features/pr-2089-docs-qa-sidebar-guia-de-testeo-roles-simepi-cdi-y-reubicacion-de-alta-egp-2038.md`
+- `docs/contexto/features/pr-2091-comedores-cambios-mes-ejecucion.md`
+- `docs/contexto/features/pr-2095-fix-inicio-corregir-descentrado-y-footer-ausente-en-pantalla-de-inicio-2087.md`
+- `docs/contexto/features/pr-2097-task-ver-todos-los-expedientes.md`
+- `docs/contexto/features/pr-2098-feat-cdi-registrar-asistencia-sobre-nomina.md`
+- `docs/contexto/features/pr-2100-fix-cdi-permitir-destildar-asistencia.md`
+- `docs/contexto/features/pr-2101-fix-layout-evitar-solapamiento-del-sidebar-con-el-footer.md`
+- `docs/contexto/features/pr-2102-fix-layout-priorizar-footer-sobre-sidebar.md`
+- `docs/contexto/features/pr-2103-feat-core-incorporar-municipios-y-localidades-faltantes-desde-bahra.md`
+- `docs/contexto/features/pr-2104-feat-comedores-reemplazar-colaboradores-de-comedores-pnud-via-data-migration.md`
+- `docs/contexto/features/pr-2105-fix-2085-2084-2083-2081-2063-2036-2096-1990-2001-1.md`
+- `docs/contexto/features/pr-2107-chore-sync-integrar-main-en-development.md`
+- `docs/contexto/features/pr-2109-create-0049-merge-20260720-1003-py.md`
+- `docs/contexto/features/pr-2114-chore-sync-integrar-main-en-development.md`
+- `docs/contexto/features/pr-2116-homologacion.md`
+- `docs/contexto/features/pr-2118-fix-organizaciones-corregir-migracion-arca-por-convenio.md`
+- `docs/contexto/features/pr-2119-modificaciones-en-informe-tecnico-complementario-alimentar-comunidad.md`
+- `docs/contexto/features/pr-2121-fix-organizaciones-tolerar-arca-duplicado-por-convenio.md`
+- `docs/contexto/features/pr-2126-docs-architecture-definir-modulos-extraibles.md`
+- `docs/contexto/features/pr-2127-fix-cdi-primeros-dos-documentos.md`
+- `docs/contexto/features/pr-2128-docs-infra-registrar-retiro-stage-2-mysql-qa.md`
+- `docs/contexto/features/pr-2129-fix-comedores-corregir-seguimiento-de-certificaciones.md`
+- `docs/contexto/features/pr-2134-fix-correcciones-en-documentos-de-rendiciones-pwa.md`
+- `docs/contexto/features/pr-2135-fix-organizaciones-sanea-rollback-arca-antes-de-promocion.md`
+- `docs/contexto/features/pr-2139-feat-release-automatizar-promocion-development-a-main.md`
+- `docs/implementaciones/centrodeinfancia_nomina_renaper.md`
+- `docs/ocr.md`
+- `docs/operacion/comandos_administracion.md`
+- `docs/operacion/deploy_automatizado.md`
+- `docs/registro/cambios/2026-07-21-cdi-validaciones-nomina-nino.md`
+- `docs/registro/cambios/2026-07-23-orquestacion-promocion-automatica.md`
+- `docs/registro/cambios/2026-07-27-cdf-exportacion-beneficiarios.md`
+- `docs/registro/cambios/2026-07-27-import-export-admin.md`
+- `docs/registro/cambios/2026-07-27-issue-2153-mover-expedientes-pago.md`
+- `docs/registro/cambios/2026-07-27-restricciones-abm-usuarios-cdi.md`
+- `docs/registro/cambios/2026-07-27-sincronizacion-descendente-con-checks-estrictos.md`
+- `docs/registro/cambios/2026-07-27-vat-comision-resultados-acta.md`
+- `docs/registro/cambios/2026-07-27-vat-cue-unicidad-y-prefijo-provincial.md`
+- `docs/registro/cambios/2026-07-27-vat-inscriptos-aceptar-rechazar-en-lote.md`
+- `docs/registro/cambios/2026-07-27-vat-lista-espera-estado-visual-checkbox.md`
+- `docs/registro/cambios/2026-07-28-deploy-qa-hml-readiness.md`
+- `docs/registro/cambios/2026-07-28-issue-2149-visibilidad-pwa-programa.md`
+- `docs/registro/cambios/2026-07-28-issue-2151-mover-modulo-ocr.md`
+- `docs/registro/cambios/2026-07-28-issue-2163-categorias-espacios.md`
+- `docs/registro/cambios/2026-07-28-issues-2158-2159-pwa.md`
+- `docs/registro/cambios/2026-07-28-programa-comedores-asociados.md`
+- `docs/registro/cambios/2026-07-28-recuperacion-qa-pwa-y-diagnostico.md`
+- `docs/registro/cambios/2026-07-29-bootstrap-sincronizacion-descendente.md`
+- `docs/registro/cambios/2026-07-29-cdf-beneficiarios-botones-centrados.md`
+- `docs/registro/cambios/2026-07-29-issue-2163-simple-asociacion.md`
+- `docs/registro/cambios/2026-07-29-issue-2169-codigo-proyecto.md`
+- `docs/registro/cambios/2026-07-29-issue-2182-cdi-ocultamiento-temporal.md`
+- `docs/registro/cambios/2026-07-29-permiso-validar-comedores.md`
+- `docs/registro/cambios/2026-07-29-usuarios-dni-cuil-tipo.md`
+- `docs/registro/cambios/2026-07-29-vat-reintegro-voucher-rechazo.md`
+- `docs/registro/cambios/2026-07-29-vat-tipo-alumno-vat-sin-plan.md`
+- `docs/registro/decisiones/2026-07-23-promocion-automatica-con-tag-estable.md`
+- `docs/registro/prs/PR-2080.md`
+- `docs/registro/prs/PR-2088.md`
+- `docs/registro/prs/PR-2089.md`
+- `docs/registro/prs/PR-2091.md`
+- `docs/registro/prs/PR-2095.md`
+- `docs/registro/prs/PR-2097.md`
+- `docs/registro/prs/PR-2098.md`
+- `docs/registro/prs/PR-2100.md`
+- `docs/registro/prs/PR-2101.md`
+- `docs/registro/prs/PR-2102.md`
+- `docs/registro/prs/PR-2103.md`
+- `docs/registro/prs/PR-2104.md`
+- `docs/registro/prs/PR-2105.md`
+- `docs/registro/prs/PR-2107.md`
+- `docs/registro/prs/PR-2109.md`
+- `docs/registro/prs/PR-2114.md`
+- `docs/registro/prs/PR-2116.md`
+- `docs/registro/prs/PR-2118.md`
+- `docs/registro/prs/PR-2119.md`
+- `docs/registro/prs/PR-2121.md`
+- `docs/registro/prs/PR-2126.md`
+- `docs/registro/prs/PR-2127.md`
+- `docs/registro/prs/PR-2128.md`
+- `docs/registro/prs/PR-2129.md`
+- `docs/registro/prs/PR-2134.md`
+- `docs/registro/prs/PR-2135.md`
+- `docs/registro/prs/PR-2139.md`
+
+## Notas para continuidad
+
+- Este documento es generado automáticamente desde el contexto del PR y sirve como índice rápido para revisión y futuras sesiones de agentes.
+- Si la metadata del body del PR está incompleta, varias secciones usarán fallbacks derivados del título o del diff.

--- a/docs/registro/releases/pending/2026-07-29-pr-2192.md
+++ b/docs/registro/releases/pending/2026-07-29-pr-2192.md
@@ -1,0 +1,19 @@
+---
+pr: 2192
+release_date: 2026-07-29
+category: Corrección de Errores
+area: CI/CD
+title: release: promover development a main (2026-07-29)
+summary: Corrige el bootstrap de la sincronización automática de main hacia QA y HML
+impact: Sin cambio directo de interfaz; evita que una promoción quede bloqueada antes del deploy.
+source_url: https://github.com/dsocial118/SISOC/pull/2192
+---
+# Release note preliminar PR #2192
+
+- Fecha objetivo de release: 2026-07-29
+- Categoría: Corrección de Errores
+- Área: CI/CD
+- Título del PR: release: promover development a main (2026-07-29)
+- Resumen: Corrige el bootstrap de la sincronización automática de main hacia QA y HML
+- Impacto usuario: Sin cambio directo de interfaz; evita que una promoción quede bloqueada antes del deploy.
+- Fuente: https://github.com/dsocial118/SISOC/pull/2192


### PR DESCRIPTION
<!-- release-final-pr: 2192 -->
<!-- release-functional-fix: true -->

## Causa raíz confirmada

El despacho de `sync-main-downstream.yml` se ejecutaba sobre el ref `main`, pero el helper `.github/scripts/sync_main_downstream.js` solo existía en `development`. El run #30503597993 generó correctamente el token temporal de la GitHub App y luego falló con `MODULE_NOT_FOUND`; no fue un problema de credenciales ni de rulesets.

## Prueba de regresión

Se agregó una prueba de contrato que exige que el workflow haga checkout de `development` y que esa prueba sea parte del check requerido `deploy_guard`.
Validación local focalizada: `node --test .github/scripts/release_orchestrator.test.js .github/scripts/sync_main_downstream.test.js` — 11/11 aprobadas. `git diff --check` sin errores.

## Revisión de calidad

Revisión independiente de cumplimiento y de estándares completada. No se identificaron bloqueos: el cambio es acotado, mantiene el token temporal de GitHub App y no incorpora bypasses, PATs ni merge directo.

## Alcance operacional

- Corrige el bootstrap de la sincronización descendente de `main` hacia `development` y `homologacion`.
- Incluye el saneamiento y los artefactos spec-as-source/changelog de la promoción #2192.
- No modifica datos de producción ni contratos de API.

El auto-merge nativo queda condicionado exclusivamente a los checks y rulesets efectivos de `development`.