### PR TITLE
fix(ci): bloquear promoción cuando fallan tests de Comedores

### DIFF
--- a/.github/scripts/sync_main_downstream.test.js
+++ b/.github/scripts/sync_main_downstream.test.js
@@ -31,6 +31,18 @@ test("deploy_guard ejecuta las pruebas de automatizacion de release", () => {
   );
 });
 
+test("deploy_guard se ejecuta aunque falle un check requerido", () => {
+  const testsWorkflow = fs.readFileSync(
+    path.join(__dirname, "..", "workflows", "tests.yml"),
+    "utf8",
+  );
+
+  assert.match(
+    testsWorkflow,
+    /deploy_guard:\s+if: \$\{\{ always\(\) && github\.event_name == 'pull_request' \}\}/,
+  );
+});
+
 test("crea un PR desde una rama tecnica actualizada para development", async () => {
   const calls = [];
   const github = {

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -265,7 +265,7 @@ jobs:
                       core.info("Evidencia de calidad de release verificada.");
 
     deploy_guard:
-        if: github.event_name == 'pull_request'
+        if: ${{ always() && github.event_name == 'pull_request' }}
         runs-on: ubuntu-latest
         needs:
             - smoke

--- a/docs/contexto/features/pr-2192-release-promover-development-a-main-2026-07-29.md
+++ b/docs/contexto/features/pr-2192-release-promover-development-a-main-2026-07-29.md
@@ -52,11 +52,11 @@
 - `.github/workflows/sync-main-downstream.yml`
 - `.github/workflows/tests.yml`
 - `AGENT_REPO_MAP.md`
+- `CHANGELOG.md`
 - `VAT/forms.py`
 - `VAT/migrations/0050_resultados_comision_curso.py`
 - `VAT/models.py`
-- `VAT/services/inscripcion_service.py`
-- ... y 205 archivo(s) adicional(es) relacionados.
+- ... y 210 archivo(s) adicional(es) relacionados.
 - Documentación sugerida para ampliar contexto:
 - `docs/indice.md`
 - `docs/ia/CONTEXT_HYGIENE.md`
@@ -89,6 +89,7 @@
 - `docs/contexto/features/pr-2134-fix-correcciones-en-documentos-de-rendiciones-pwa.md`
 - `docs/contexto/features/pr-2135-fix-organizaciones-sanea-rollback-arca-antes-de-promocion.md`
 - `docs/contexto/features/pr-2139-feat-release-automatizar-promocion-development-a-main.md`
+- `docs/contexto/features/pr-2192-release-promover-development-a-main-2026-07-29.md`
 - `docs/implementaciones/centrodeinfancia_nomina_renaper.md`
 - `docs/ocr.md`
 - `docs/operacion/comandos_administracion.md`
@@ -148,6 +149,8 @@
 - `docs/registro/prs/PR-2134.md`
 - `docs/registro/prs/PR-2135.md`
 - `docs/registro/prs/PR-2139.md`
+- `docs/registro/prs/PR-2192.md`
+- `docs/registro/releases/pending/2026-07-29-pr-2192.md`
 
 ## Trazabilidad
 

--- a/docs/registro/prs/PR-2192.md
+++ b/docs/registro/prs/PR-2192.md
@@ -6,7 +6,7 @@
 - Base: `main`
 - Rama origen: `development`
 - Autor: `juanikitro`
-- Última actualización: `2026-07-30T01:06:29Z`
+- Última actualización: `2026-07-30T01:31:42Z`
 
 ## Resumen operativo
 
@@ -22,6 +22,7 @@
 - `.gitattributes`
 - `.github/workflows`
 - `AGENT_REPO_MAP.md`
+- `CHANGELOG.md`
 - `VAT`
 - `admisiones`
 - `centrodefamilia`
@@ -64,6 +65,7 @@
 - `.github/workflows/sync-main-downstream.yml`
 - `.github/workflows/tests.yml`
 - `AGENT_REPO_MAP.md`
+- `CHANGELOG.md`
 - `VAT/forms.py`
 - `VAT/migrations/0050_resultados_comision_curso.py`
 - `VAT/models.py`
@@ -87,8 +89,7 @@
 - `admisiones/admin.py`
 - `centrodefamilia/templates/beneficiarios/beneficiarios_list.html`
 - `centrodefamilia/tests/test_beneficiarios_export.py`
-- `centrodefamilia/urls.py`
-- ... y 185 archivo(s) adicional(es) en el diff.
+- ... y 190 archivo(s) adicional(es) en el diff.
 
 ## Validación declarada
 
@@ -132,6 +133,7 @@
 - `docs/contexto/features/pr-2134-fix-correcciones-en-documentos-de-rendiciones-pwa.md`
 - `docs/contexto/features/pr-2135-fix-organizaciones-sanea-rollback-arca-antes-de-promocion.md`
 - `docs/contexto/features/pr-2139-feat-release-automatizar-promocion-development-a-main.md`
+- `docs/contexto/features/pr-2192-release-promover-development-a-main-2026-07-29.md`
 - `docs/implementaciones/centrodeinfancia_nomina_renaper.md`
 - `docs/ocr.md`
 - `docs/operacion/comandos_administracion.md`
@@ -191,6 +193,8 @@
 - `docs/registro/prs/PR-2134.md`
 - `docs/registro/prs/PR-2135.md`
 - `docs/registro/prs/PR-2139.md`
+- `docs/registro/prs/PR-2192.md`
+- `docs/registro/releases/pending/2026-07-29-pr-2192.md`
 
 ## Notas para continuidad
 

--- a/tests/test_comedor_views_unit.py
+++ b/tests/test_comedor_views_unit.py
@@ -362,7 +362,7 @@ def test_comedor_detail_get_context_data_selected_admision_flow(mocker):
     view = module.ComedorDetailView()
     view.request = _Req(user=SimpleNamespace(is_superuser=False), post={})
     view.request.GET = {"admision_id": "1"}
-    view.object = SimpleNamespace(id=7, programa_id=None)
+    view.object = SimpleNamespace(id=7, programa_id=None, dupla=None)
 
     admision_1 = SimpleNamespace(id=1, convenio_numero="C-1")
     admisiones_qs = _AdmisionesQS([admision_1])
@@ -417,7 +417,7 @@ def test_comedor_detail_no_consulta_transacciones_sin_permiso_comedor(mocker):
     view = module.ComedorDetailView()
     view.request = _Req(user=SimpleNamespace(is_superuser=False), post={})
     view.request.GET = {}
-    view.object = SimpleNamespace(id=7, programa_id=None)
+    view.object = SimpleNamespace(id=7, programa_id=None, dupla=None)
 
     mocker.patch(
         "django.views.generic.detail.SingleObjectMixin.get_context_data",
@@ -465,7 +465,7 @@ def test_comedor_detail_consulta_transacciones_con_permiso_comedor(mocker):
     view = module.ComedorDetailView()
     view.request = _Req(user=SimpleNamespace(is_superuser=False), post={})
     view.request.GET = {}
-    view.object = SimpleNamespace(id=7, programa_id=None)
+    view.object = SimpleNamespace(id=7, programa_id=None, dupla=None)
 
     mocker.patch(
         "django.views.generic.detail.SingleObjectMixin.get_context_data",


### PR DESCRIPTION
<!-- release-final-pr: 2192 -->
<!-- release-functional-fix: true -->

## Causa raíz confirmada

El permiso de validación de Comedores incorporó la evaluación de `Comedor.dupla` en `ComedorDetailView`. El modelo real tiene ese `ForeignKey` nullable, pero tres fixtures unitarias usaban `SimpleNamespace` sin `dupla`; por eso `pytest` falló con `AttributeError` antes de evaluar sus aserciones.

La misma ejecución reveló una brecha de CI: `deploy_guard` dependía de `pytest` sin `always()`, por lo que GitHub lo marcó `skipped` cuando `pytest` falló y el auto-merge nativo de #2193 pudo continuar. No se usó bypass.

## Prueba de regresión

- Rojo reproducido en Docker: los tres tests de `ComedorDetailView.get_context_data` fallaron por ausencia de `dupla`.
- Verde focalizado: los mismos tres tests pasan 3/3 con `dupla=None`, que representa el contrato nullable del modelo.
- Nuevo contrato Node: `deploy_guard` debe ejecutarse aunque un check requerido falle.
- `node --test .github/scripts/release_orchestrator.test.js .github/scripts/sync_main_downstream.test.js`: 12/12 aprobadas.
- `git diff --check`: sin errores.

## Revisión de calidad

Dos revisiones independientes (Standards y Spec) no encontraron hallazgos bloqueantes. Confirmaron que el cambio no toca código productivo, permisos, datos ni rulesets; evita que un fallo de CI se convierta en un guard omitido.

## Alcance operacional

- Completa fixtures de Comedores para reflejar el modelo real.
- Hace que el check requerido `deploy_guard` falle explícitamente si uno de sus `needs` falla.
- Actualiza los artefactos spec-as-source de la promoción #2192.

El auto-merge nativo de este PR queda condicionado a las rulesets y checks efectivos de `development`; no se habilita merge directo.