### PR TITLE
fix(ci): manejar respuesta 204 de sincronizacion descendente

### DIFF
--- a/.github/scripts/sync_main_downstream.js
+++ b/.github/scripts/sync_main_downstream.js
@@ -47,6 +47,11 @@ async function mergeIntoSynchronizationBranch({ github, owner, repo, branch, sou
     commit_message: "Actualizacion segura de la rama temporal de sincronizacion descendente.",
   });
 
+  // GitHub returns 204 without a body when the source is already in the base.
+  if (!merged?.data) {
+    return;
+  }
+
   if (!merged.data.merged && !isAlreadyUpToDate(merged)) {
     throw new Error(
       `No se pudo incorporar ${source} en ${branch}: ${merged.data.message}`,

--- a/.github/scripts/sync_main_downstream.js
+++ b/.github/scripts/sync_main_downstream.js
@@ -48,8 +48,14 @@ async function mergeIntoSynchronizationBranch({ github, owner, repo, branch, sou
   });
 
   // GitHub returns 204 without a body when the source is already in the base.
-  if (!merged?.data) {
+  if (merged?.status === 204 && !merged.data) {
     return;
+  }
+
+  if (!merged?.data) {
+    throw new Error(
+      `Respuesta inesperada al incorporar ${source} en ${branch}: falta cuerpo (status ${merged?.status ?? "desconocido"}).`,
+    );
   }
 
   if (!merged.data.merged && !isAlreadyUpToDate(merged)) {

--- a/.github/scripts/sync_main_downstream.test.js
+++ b/.github/scripts/sync_main_downstream.test.js
@@ -43,8 +43,9 @@ test("deploy_guard se ejecuta aunque falle un check requerido", () => {
   );
 });
 
-test("crea un PR si GitHub responde sin cuerpo para la rama destino ya contenida", async () => {
+test("solo acepta el 204 sin cuerpo para la rama destino ya contenida", async () => {
   const calls = [];
+  let noContentResponse = { status: 204 };
   const github = {
     rest: {
       repos: {
@@ -54,7 +55,7 @@ test("crea un PR si GitHub responde sin cuerpo para la rama destino ya contenida
         merge: async (payload) => {
           calls.push(["merge", payload]);
           if (payload.head === "development") {
-            return undefined;
+            return noContentResponse;
           }
           return { data: { merged: true } };
         },
@@ -158,6 +159,12 @@ test("crea un PR si GitHub responde sin cuerpo para la rama destino ya contenida
     }],
     ["enableAutoMerge", { pullRequestId: "pull-42" }],
   ]);
+
+  noContentResponse = { status: 201 };
+  await assert.rejects(
+    run({ github, context: { repo: { owner: "acme", repo: "sisoc" } }, core }),
+    /respuesta inesperada.*status 201/i,
+  );
 });
 
 test("nombra una rama tecnica aislada por destino", () => {

--- a/.github/scripts/sync_main_downstream.test.js
+++ b/.github/scripts/sync_main_downstream.test.js
@@ -43,7 +43,7 @@ test("deploy_guard se ejecuta aunque falle un check requerido", () => {
   );
 });
 
-test("crea un PR desde una rama tecnica actualizada para development", async () => {
+test("crea un PR si GitHub responde sin cuerpo para la rama destino ya contenida", async () => {
   const calls = [];
   const github = {
     rest: {
@@ -53,6 +53,9 @@ test("crea un PR desde una rama tecnica actualizada para development", async () 
         }),
         merge: async (payload) => {
           calls.push(["merge", payload]);
+          if (payload.head === "development") {
+            return undefined;
+          }
           return { data: { merged: true } };
         },
       },

--- a/.github/scripts/sync_main_downstream.test.js
+++ b/.github/scripts/sync_main_downstream.test.js
@@ -45,6 +45,8 @@ test("deploy_guard se ejecuta aunque falle un check requerido", () => {
 
 test("solo acepta el 204 sin cuerpo para la rama destino ya contenida", async () => {
   const calls = [];
+  const errors = [];
+  const failures = [];
   let noContentResponse = { status: 204 };
   const github = {
     rest: {
@@ -103,10 +105,11 @@ test("solo acepta el 204 sin cuerpo para la rama destino ya contenida", async ()
   const core = {
     endGroup() {},
     error(message) {
-      throw new Error(message);
+      errors.push(message);
     },
     info() {},
     setFailed(message) {
+      failures.push(message);
       throw new Error(message);
     },
     startGroup() {},
@@ -160,10 +163,17 @@ test("solo acepta el 204 sin cuerpo para la rama destino ya contenida", async ()
     ["enableAutoMerge", { pullRequestId: "pull-42" }],
   ]);
 
+  const callsBeforeInvalidResponse = calls.length;
   noContentResponse = { status: 201 };
   await assert.rejects(
     run({ github, context: { repo: { owner: "acme", repo: "sisoc" } }, core }),
     /respuesta inesperada.*status 201/i,
+  );
+  assert.match(errors.at(-1), /respuesta inesperada.*status 201/i);
+  assert.match(failures.at(-1), /development: respuesta inesperada.*status 201/i);
+  assert.deepEqual(
+    calls.slice(callsBeforeInvalidResponse).map(([name]) => name),
+    ["closeLegacyPull", "createRef", "merge"],
   );
 });
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 
 ## Corrección de Errores
 
-- [CI/CD] Corrige el bootstrap de la sincronización automática de main hacia QA y HML. (PR #2192)
+- [CI/CD] Corrige el manejo de la sincronización descendente y evita promover con evidencia de calidad incompleta. (PR #2192)
 <!-- AUTO-GENERATED RELEASE END: 2026-07-29 -->
 
 <!-- AUTO-GENERATED RELEASE START: 2026-07-22 -->

--- a/docs/contexto/features/pr-2192-release-promover-development-a-main-2026-07-29.md
+++ b/docs/contexto/features/pr-2192-release-promover-development-a-main-2026-07-29.md
@@ -9,7 +9,7 @@
 
 ## Contexto funcional
 
-- Promoción semanal de development a main con recuperación segura de la sincronización descendente.
+- Promoción semanal de development a main con recuperación segura de la sincronización descendente y de sus gates de calidad.
 
 ## Arquitectura tocada
 
@@ -24,8 +24,8 @@
 
 - Tipo de cambio declarado: Fix
 - Área principal declarada: CI/CD
-- Impacto usuario declarado: Sin cambio directo de interfaz; evita que una promoción quede bloqueada antes del deploy.
-- Riesgos / rollback: El workflow ejecuta automatización desde development; revertir a main solo cuando el helper esté promovido. El rollback funcional usa el tag estable del main previo.
+- Impacto usuario declarado: Sin cambio directo de interfaz; impide que una promoción avance con evidencia incompleta o sin sincronización descendente.
+- Riesgos / rollback: El workflow ejecuta automatización desde development; sólo un 204 sin cuerpo puede ser no-op. El rollback funcional usa el tag estable del main previo.
 
 ## Design system y UI
 

--- a/docs/registro/prs/PR-2192.md
+++ b/docs/registro/prs/PR-2192.md
@@ -6,15 +6,15 @@
 - Base: `main`
 - Rama origen: `development`
 - Autor: `juanikitro`
-- Última actualización: `2026-07-30T01:31:42Z`
+- Última actualización: `2026-07-30T02:03:15Z`
 
 ## Resumen operativo
 
 - Tipo de cambio: Fix
 - Área principal: CI/CD
-- Contexto funcional: Promoción semanal de development a main con recuperación segura de la sincronización descendente.
-- Resumen para changelog: Corrige el bootstrap de la sincronización automática de main hacia QA y HML.
-- Impacto usuario: Sin cambio directo de interfaz; evita que una promoción quede bloqueada antes del deploy.
+- Contexto funcional: Promoción semanal de development a main con recuperación segura de la sincronización descendente y de sus gates de calidad.
+- Resumen para changelog: Corrige el manejo de la sincronización descendente y evita promover con evidencia de calidad incompleta.
+- Impacto usuario: Sin cambio directo de interfaz; impide que una promoción avance con evidencia incompleta o sin sincronización descendente.
 
 ## Áreas afectadas
 
@@ -93,12 +93,12 @@
 
 ## Validación declarada
 
-- Pruebas automáticas: Node 11/11, git diff --check y revisión independiente.
-- Pruebas manuales: Dispatch nativo pendiente tras integrar la preparación.
+- Pruebas automáticas: Docker 3/3, Node 12/12, git diff --check y revisiones independientes.
+- Pruebas manuales: CI nativa pendiente en #2195 y sincronización descendente posterior.
 
 ## Riesgos y rollback
 
-- El workflow ejecuta automatización desde development; revertir a main solo cuando el helper esté promovido. El rollback funcional usa el tag estable del main previo.
+- El workflow ejecuta automatización desde development; sólo un 204 sin cuerpo puede ser no-op. El rollback funcional usa el tag estable del main previo.
 
 ## Documentación sugerida para lectura
 

--- a/docs/registro/releases/pending/2026-07-29-pr-2192.md
+++ b/docs/registro/releases/pending/2026-07-29-pr-2192.md
@@ -4,8 +4,8 @@ release_date: 2026-07-29
 category: Corrección de Errores
 area: CI/CD
 title: release: promover development a main (2026-07-29)
-summary: Corrige el bootstrap de la sincronización automática de main hacia QA y HML
-impact: Sin cambio directo de interfaz; evita que una promoción quede bloqueada antes del deploy.
+summary: Corrige el manejo de la sincronización descendente y evita promover con evidencia de calidad incompleta
+impact: Sin cambio directo de interfaz; impide que una promoción avance con evidencia incompleta o sin sincronización descendente.
 source_url: https://github.com/dsocial118/SISOC/pull/2192
 ---
 # Release note preliminar PR #2192
@@ -14,6 +14,6 @@ source_url: https://github.com/dsocial118/SISOC/pull/2192
 - Categoría: Corrección de Errores
 - Área: CI/CD
 - Título del PR: release: promover development a main (2026-07-29)
-- Resumen: Corrige el bootstrap de la sincronización automática de main hacia QA y HML
-- Impacto usuario: Sin cambio directo de interfaz; evita que una promoción quede bloqueada antes del deploy.
+- Resumen: Corrige el manejo de la sincronización descendente y evita promover con evidencia de calidad incompleta
+- Impacto usuario: Sin cambio directo de interfaz; impide que una promoción avance con evidencia incompleta o sin sincronización descendente.
 - Fuente: https://github.com/dsocial118/SISOC/pull/2192


### PR DESCRIPTION
<!-- release-final-pr: 2192 -->
<!-- release-functional-fix: true -->

## Causa raíz confirmada

El endpoint REST de merge de GitHub responde `204 No Content` cuando la rama fuente ya está contenida en la base. La rama técnica de sincronización nace desde `development`; al intentar incorporarla de nuevo, el helper recibía esa respuesta sin `data` y desreferenciaba `merged.data`, por lo que abortaba antes de crear el PR técnico.

## Prueba de regresión

- El seam `run()` simula el `204` sin cuerpo y verifica que el flujo continúe hasta crear el PR técnico y armar su auto-merge nativo.
- Simula un `201` sin cuerpo y verifica `core.error`, `core.setFailed` y que no continúe al merge de `main`, creación de PR ni auto-merge.
- `node --test .github/scripts/release_orchestrator.test.js .github/scripts/sync_main_downstream.test.js`: 12/12 aprobadas.
- `git diff --check`: sin errores.

## Revisión de calidad

Dos revisiones independientes, Standards y Spec, no encontraron hallazgos bloqueantes. La primera observación de Spec llevó a acotar el manejo exclusivamente a `status === 204` y a reforzar el test de fallo observable.

## Alcance operacional

- No modifica rulesets, credenciales, ramas protegidas ni el comportamiento de aplicación.
- No hay merge directo, bypass, rebase, force-push ni borrado.
- El PR deja que GitHub continúe sólo mediante checks y auto-merge nativo.