### PR TITLE
fix(ci): validar respuesta de merge descendente

### DIFF
--- a/.github/scripts/sync_main_downstream.js
+++ b/.github/scripts/sync_main_downstream.js
@@ -6,6 +6,10 @@ function synchronizationBranch(target) {
   return `${SYNCHRONIZATION_BRANCH_PREFIX}${target}`;
 }
 
+function isCommitSha(value) {
+  return typeof value === "string" && /^(?:[0-9a-f]{40}|[0-9a-f]{64})$/i.test(value);
+}
+
 async function ensureSynchronizationBranch({ github, owner, repo, target, branch }) {
   try {
     await github.rest.git.getRef({
@@ -49,12 +53,12 @@ async function mergeIntoSynchronizationBranch({ github, owner, repo, branch, sou
   }
 
   // A successful non-fast-forward merge returns the resulting commit (201).
-  if (merged?.status === 201 && typeof merged.data?.sha === "string" && merged.data.sha) {
+  if (merged?.status === 201 && isCommitSha(merged.data?.sha)) {
     return;
   }
 
   const detail = merged?.data?.message
-    ?? (merged?.data ? "falta SHA del commit resultante" : "falta cuerpo");
+    ?? (merged?.data ? "falta SHA valido del commit resultante" : "falta cuerpo");
   throw new Error(
     `Respuesta inesperada al incorporar ${source} en ${branch}: ${detail} (status ${merged?.status ?? "desconocido"}).`,
   );

--- a/.github/scripts/sync_main_downstream.js
+++ b/.github/scripts/sync_main_downstream.js
@@ -6,10 +6,6 @@ function synchronizationBranch(target) {
   return `${SYNCHRONIZATION_BRANCH_PREFIX}${target}`;
 }
 
-function isAlreadyUpToDate(result) {
-  return result.data.message === "Already up to date.";
-}
-
 async function ensureSynchronizationBranch({ github, owner, repo, target, branch }) {
   try {
     await github.rest.git.getRef({
@@ -48,21 +44,20 @@ async function mergeIntoSynchronizationBranch({ github, owner, repo, branch, sou
   });
 
   // GitHub returns 204 without a body when the source is already in the base.
-  if (merged?.status === 204 && !merged.data) {
+  if (merged?.status === 204 && merged.data == null) {
     return;
   }
 
-  if (!merged?.data) {
-    throw new Error(
-      `Respuesta inesperada al incorporar ${source} en ${branch}: falta cuerpo (status ${merged?.status ?? "desconocido"}).`,
-    );
+  // A successful non-fast-forward merge returns the resulting commit (201).
+  if (merged?.status === 201 && typeof merged.data?.sha === "string" && merged.data.sha) {
+    return;
   }
 
-  if (!merged.data.merged && !isAlreadyUpToDate(merged)) {
-    throw new Error(
-      `No se pudo incorporar ${source} en ${branch}: ${merged.data.message}`,
-    );
-  }
+  const detail = merged?.data?.message
+    ?? (merged?.data ? "falta SHA del commit resultante" : "falta cuerpo");
+  throw new Error(
+    `Respuesta inesperada al incorporar ${source} en ${branch}: ${detail} (status ${merged?.status ?? "desconocido"}).`,
+  );
 }
 
 async function enableAutoMerge({ github, core, pull }) {

--- a/.github/scripts/sync_main_downstream.test.js
+++ b/.github/scripts/sync_main_downstream.test.js
@@ -43,11 +43,11 @@ test("deploy_guard se ejecuta aunque falle un check requerido", () => {
   );
 });
 
-test("solo acepta el 204 sin cuerpo para la rama destino ya contenida", async () => {
+test("acepta un merge 201 con commit y solo el 204 sin cuerpo cuando ya esta incorporado", async () => {
   const calls = [];
   const errors = [];
   const failures = [];
-  let noContentResponse = { status: 204 };
+  let developmentMergeResponse = { status: 201, data: { sha: "development-merge-sha" } };
   const github = {
     rest: {
       repos: {
@@ -57,9 +57,9 @@ test("solo acepta el 204 sin cuerpo para la rama destino ya contenida", async ()
         merge: async (payload) => {
           calls.push(["merge", payload]);
           if (payload.head === "development") {
-            return noContentResponse;
+            return developmentMergeResponse;
           }
-          return { data: { merged: true } };
+          return { status: 201, data: { sha: "main-merge-sha" } };
         },
       },
       git: {
@@ -163,8 +163,16 @@ test("solo acepta el 204 sin cuerpo para la rama destino ya contenida", async ()
     ["enableAutoMerge", { pullRequestId: "pull-42" }],
   ]);
 
+  const callsBeforeNoContentResponse = calls.length;
+  developmentMergeResponse = { status: 204 };
+  await run({ github, context: { repo: { owner: "acme", repo: "sisoc" } }, core });
+  assert.deepEqual(
+    calls.slice(callsBeforeNoContentResponse).map(([name]) => name),
+    ["closeLegacyPull", "createRef", "merge", "merge", "createPull", "enableAutoMerge"],
+  );
+
   const callsBeforeInvalidResponse = calls.length;
-  noContentResponse = { status: 201 };
+  developmentMergeResponse = { status: 201 };
   await assert.rejects(
     run({ github, context: { repo: { owner: "acme", repo: "sisoc" } }, core }),
     /respuesta inesperada.*status 201/i,

--- a/.github/scripts/sync_main_downstream.test.js
+++ b/.github/scripts/sync_main_downstream.test.js
@@ -47,7 +47,7 @@ test("acepta un merge 201 con commit y solo el 204 sin cuerpo cuando ya esta inc
   const calls = [];
   const errors = [];
   const failures = [];
-  let developmentMergeResponse = { status: 201, data: { sha: "development-merge-sha" } };
+  let developmentMergeResponse = { status: 201, data: { sha: "d".repeat(40) } };
   const github = {
     rest: {
       repos: {
@@ -59,7 +59,7 @@ test("acepta un merge 201 con commit y solo el 204 sin cuerpo cuando ya esta inc
           if (payload.head === "development") {
             return developmentMergeResponse;
           }
-          return { status: 201, data: { sha: "main-merge-sha" } };
+          return { status: 201, data: { sha: "a".repeat(40) } };
         },
       },
       git: {
@@ -171,18 +171,24 @@ test("acepta un merge 201 con commit y solo el 204 sin cuerpo cuando ya esta inc
     ["closeLegacyPull", "createRef", "merge", "merge", "createPull", "enableAutoMerge"],
   );
 
-  const callsBeforeInvalidResponse = calls.length;
-  developmentMergeResponse = { status: 201 };
-  await assert.rejects(
-    run({ github, context: { repo: { owner: "acme", repo: "sisoc" } }, core }),
-    /respuesta inesperada.*status 201/i,
-  );
-  assert.match(errors.at(-1), /respuesta inesperada.*status 201/i);
-  assert.match(failures.at(-1), /development: respuesta inesperada.*status 201/i);
-  assert.deepEqual(
-    calls.slice(callsBeforeInvalidResponse).map(([name]) => name),
-    ["closeLegacyPull", "createRef", "merge"],
-  );
+  for (const invalidResponse of [
+    { status: 201 },
+    { status: 201, data: {} },
+    { status: 201, data: { sha: "not-a-sha" } },
+  ]) {
+    const callsBeforeInvalidResponse = calls.length;
+    developmentMergeResponse = invalidResponse;
+    await assert.rejects(
+      run({ github, context: { repo: { owner: "acme", repo: "sisoc" } }, core }),
+      /respuesta inesperada.*status 201/i,
+    );
+    assert.match(errors.at(-1), /respuesta inesperada.*status 201/i);
+    assert.match(failures.at(-1), /development: respuesta inesperada.*status 201/i);
+    assert.deepEqual(
+      calls.slice(callsBeforeInvalidResponse).map(([name]) => name),
+      ["closeLegacyPull", "createRef", "merge"],
+    );
+  }
 });
 
 test("nombra una rama tecnica aislada por destino", () => {

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 
 ## Corrección de Errores
 
-- [CI/CD] Corrige el manejo de la sincronización descendente y evita promover con evidencia de calidad incompleta. (PR #2192)
+- [CI/CD] Corrige la interpretación de la respuesta del merge descendente y evita promover con evidencia de calidad incompleta. (PR #2192)
 <!-- AUTO-GENERATED RELEASE END: 2026-07-29 -->
 
 <!-- AUTO-GENERATED RELEASE START: 2026-07-22 -->

--- a/docs/contexto/features/pr-2192-release-promover-development-a-main-2026-07-29.md
+++ b/docs/contexto/features/pr-2192-release-promover-development-a-main-2026-07-29.md
@@ -24,8 +24,8 @@
 
 - Tipo de cambio declarado: Fix
 - Área principal declarada: CI/CD
-- Impacto usuario declarado: Sin cambio directo de interfaz; impide que una promoción avance con evidencia incompleta o sin sincronización descendente.
-- Riesgos / rollback: El workflow ejecuta automatización desde development; sólo un 204 sin cuerpo puede ser no-op. El rollback funcional usa el tag estable del main previo.
+- Impacto usuario declarado: Sin cambio directo de interfaz; impide que una promoción avance con una respuesta de sincronización incompleta o inesperada.
+- Riesgos / rollback: El workflow ejecuta automatización desde development; sólo un 201 con SHA válido o un 204 sin cuerpo puede avanzar. El rollback funcional usa el tag estable del main previo.
 
 ## Design system y UI
 

--- a/docs/registro/prs/PR-2192.md
+++ b/docs/registro/prs/PR-2192.md
@@ -6,15 +6,15 @@
 - Base: `main`
 - Rama origen: `development`
 - Autor: `juanikitro`
-- Última actualización: `2026-07-30T02:03:15Z`
+- Última actualización: `2026-07-30T02:26:15Z`
 
 ## Resumen operativo
 
 - Tipo de cambio: Fix
 - Área principal: CI/CD
 - Contexto funcional: Promoción semanal de development a main con recuperación segura de la sincronización descendente y de sus gates de calidad.
-- Resumen para changelog: Corrige el manejo de la sincronización descendente y evita promover con evidencia de calidad incompleta.
-- Impacto usuario: Sin cambio directo de interfaz; impide que una promoción avance con evidencia incompleta o sin sincronización descendente.
+- Resumen para changelog: Corrige la interpretación de la respuesta del merge descendente y evita promover con evidencia de calidad incompleta.
+- Impacto usuario: Sin cambio directo de interfaz; impide que una promoción avance con una respuesta de sincronización incompleta o inesperada.
 
 ## Áreas afectadas
 
@@ -93,12 +93,12 @@
 
 ## Validación declarada
 
-- Pruebas automáticas: Docker 3/3, Node 12/12, git diff --check y revisiones independientes.
-- Pruebas manuales: CI nativa pendiente en #2195 y sincronización descendente posterior.
+- Pruebas automáticas: Node 12/12, git diff --check y revisiones independientes.
+- Pruebas manuales: sincronización descendente nativa pendiente; luego baseline, tag y aprobación de producción.
 
 ## Riesgos y rollback
 
-- El workflow ejecuta automatización desde development; sólo un 204 sin cuerpo puede ser no-op. El rollback funcional usa el tag estable del main previo.
+- El workflow ejecuta automatización desde development; sólo un 201 con SHA válido o un 204 sin cuerpo puede avanzar. El rollback funcional usa el tag estable del main previo.
 
 ## Documentación sugerida para lectura
 

--- a/docs/registro/releases/pending/2026-07-29-pr-2192.md
+++ b/docs/registro/releases/pending/2026-07-29-pr-2192.md
@@ -4,8 +4,8 @@ release_date: 2026-07-29
 category: Corrección de Errores
 area: CI/CD
 title: release: promover development a main (2026-07-29)
-summary: Corrige el manejo de la sincronización descendente y evita promover con evidencia de calidad incompleta
-impact: Sin cambio directo de interfaz; impide que una promoción avance con evidencia incompleta o sin sincronización descendente.
+summary: Corrige la interpretación de la respuesta del merge descendente y evita promover con evidencia de calidad incompleta
+impact: Sin cambio directo de interfaz; impide que una promoción avance con una respuesta de sincronización incompleta o inesperada.
 source_url: https://github.com/dsocial118/SISOC/pull/2192
 ---
 # Release note preliminar PR #2192
@@ -14,6 +14,6 @@ source_url: https://github.com/dsocial118/SISOC/pull/2192
 - Categoría: Corrección de Errores
 - Área: CI/CD
 - Título del PR: release: promover development a main (2026-07-29)
-- Resumen: Corrige el manejo de la sincronización descendente y evita promover con evidencia de calidad incompleta
-- Impacto usuario: Sin cambio directo de interfaz; impide que una promoción avance con evidencia incompleta o sin sincronización descendente.
+- Resumen: Corrige la interpretación de la respuesta del merge descendente y evita promover con evidencia de calidad incompleta
+- Impacto usuario: Sin cambio directo de interfaz; impide que una promoción avance con una respuesta de sincronización incompleta o inesperada.
 - Fuente: https://github.com/dsocial118/SISOC/pull/2192


### PR DESCRIPTION
<!-- release-final-pr: 2192 -->
<!-- release-functional-fix: true -->

## Causa raíz confirmada

El endpoint GitHub REST de merge devolvió `201 Created` con el commit resultante al incorporar `development` en la rama técnica, pero el helper esperaba un booleano `data.merged`. El commit se creó correctamente y el workflow falló al interpretar esa respuesta como error.

## Prueba de regresión

- TDD: la regresión fue roja con una respuesta `201` realista que contiene un SHA de commit y verde tras el fix.
- El seam cubre `201` con SHA hexadecimal válido, `204` sin cuerpo y rechaza `201` sin cuerpo, con cuerpo vacío o SHA inválido.
- Ante cada respuesta inválida verifica `core.error`, `core.setFailed` y que no continúe al merge de `main`, creación de PR ni auto-merge.

## Revisión de calidad

- `node --test .github/scripts/release_orchestrator.test.js .github/scripts/sync_main_downstream.test.js`: 12/12 exitosas.
- `git diff --check`: sin errores.
- Revisiones independientes Standards y Spec: sin hallazgos bloqueantes.
- No modifica datos, permisos, reglas de protección ni contratos de usuario.