### PR TITLE
fix(deploy): bootstrap seguro del helper de produccion

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -218,6 +218,14 @@ jobs:
                       } >> "$GITHUB_STEP_SUMMARY"
                       exit 0
                   fi
+                  if ! grep -q -- "--expected-revision" "$APP_ROOT/scripts/operacion/deploy_refresh.sh"; then
+                      [[ "$(git -C "$APP_ROOT" branch --show-current)" == "main" ]] || {
+                          echo "::error::El checkout de produccion no esta en la branch main."
+                          exit 1;
+                      }
+                      echo "[deploy] Actualizando el helper local de produccion antes del deploy versionado."
+                      git -C "$APP_ROOT" merge --ff-only origin/main
+                  fi
                   echo "Commit previo al deploy para rollback: $(git rev-parse HEAD)"
                   ./scripts/operacion/deploy_refresh.sh --yes --expected-revision "$EXPECTED_SHA" --with-mobile --mobile-dir /sisoc/SISOC-Mobile
                   docker compose -f "$APP_ROOT/docker-compose.deploy.yml" -f "$APP_ROOT/docker-compose.produccion.yml" --project-directory "$APP_ROOT" exec -T django python manage.py migrate --check

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+<!-- AUTO-GENERATED RELEASE START: 2026-07-30 -->
+# Versión SISOC 30.07.2026
+
+## Corrección de Errores
+
+- [CI/CD] Evita que el deploy de producción falle cuando el helper local del runner es anterior al contrato de revisión esperada. (PR #2199)
+<!-- AUTO-GENERATED RELEASE END: 2026-07-30 -->
+
 <!-- AUTO-GENERATED RELEASE START: 2026-07-29 -->
 # Versión SISOC 29.07.2026
 

--- a/docs/contexto/features/pr-2199-release-promocion-development-a-main-2026-07-30.md
+++ b/docs/contexto/features/pr-2199-release-promocion-development-a-main-2026-07-30.md
@@ -1,0 +1,44 @@
+# Contexto de feature PR #2199 - release: promoción development a main 2026-07-30
+
+## Resumen
+
+- PR: https://github.com/dsocial118/SISOC/pull/2199
+- Base: `main`
+- Rama origen: `development`
+- Autor: `juanikitro`
+
+## Contexto funcional
+
+- Promoción semanal de development a main con recuperación segura del bootstrap de deploy de producción.
+
+## Arquitectura tocada
+
+- El alcance incluye automatización o tooling de CI/CD.
+
+## Decisiones y supuestos detectados
+
+- Tipo de cambio declarado: Fix
+- Área principal declarada: CI/CD
+- Impacto usuario declarado: Sin cambio directo de interfaz; habilita la aplicación segura del SHA aprobado en producción.
+- Riesgos / rollback: El bootstrap sólo avanza main mediante fast-forward tras validar el SHA remoto; rollback mediante el tag estable y PR nativo.
+
+## Design system y UI
+
+- Sin cambios visibles de UI o design system detectados en el diff.
+
+## Memoria operativa para agentes
+
+- Empezar por `docs/registro/prs/PR-2199.md` para contexto resumido del PR.
+- Revisar primero estos archivos del diff:
+- `.github/workflows/deploy.yml`
+- `tests/test_deploy_workflow.py`
+- Documentación sugerida para ampliar contexto:
+- `docs/indice.md`
+- `docs/ia/CONTEXT_HYGIENE.md`
+- `docs/ia/ARCHITECTURE.md`
+- `docs/ia/TESTING.md`
+
+## Trazabilidad
+
+- Documento generado automáticamente desde el evento de `pull_request`.
+- Si este PR cambia de título, el archivo se renombrará para mantener el slug alineado.

--- a/docs/registro/prs/PR-2199.md
+++ b/docs/registro/prs/PR-2199.md
@@ -1,0 +1,48 @@
+# PR #2199 - release: promoción development a main 2026-07-30
+
+## Metadata
+
+- PR: https://github.com/dsocial118/SISOC/pull/2199
+- Base: `main`
+- Rama origen: `development`
+- Autor: `juanikitro`
+- Última actualización: `2026-07-30T03:28:55Z`
+
+## Resumen operativo
+
+- Tipo de cambio: Fix
+- Área principal: CI/CD
+- Contexto funcional: Promoción semanal de development a main con recuperación segura del bootstrap de deploy de producción.
+- Resumen para changelog: Evita que el deploy de producción falle cuando el helper local del runner es anterior al contrato de revisión esperada.
+- Impacto usuario: Sin cambio directo de interfaz; habilita la aplicación segura del SHA aprobado en producción.
+
+## Áreas afectadas
+
+- `.github/workflows`
+- `tests`
+
+## Archivos relevantes del diff
+
+- `.github/workflows/deploy.yml`
+- `tests/test_deploy_workflow.py`
+
+## Validación declarada
+
+- Pruebas automáticas: Regresión focalizada, diff check y revisiones independientes; CI pendiente.
+- Pruebas manuales: Verificar baseline/tag nativo, auto-merge final y aprobación del Environment production.
+
+## Riesgos y rollback
+
+- El bootstrap sólo avanza main mediante fast-forward tras validar el SHA remoto; rollback mediante el tag estable y PR nativo.
+
+## Documentación sugerida para lectura
+
+- `docs/indice.md`
+- `docs/ia/CONTEXT_HYGIENE.md`
+- `docs/ia/ARCHITECTURE.md`
+- `docs/ia/TESTING.md`
+
+## Notas para continuidad
+
+- Este documento es generado automáticamente desde el contexto del PR y sirve como índice rápido para revisión y futuras sesiones de agentes.
+- Si la metadata del body del PR está incompleta, varias secciones usarán fallbacks derivados del título o del diff.

--- a/docs/registro/releases/pending/2026-07-30-pr-2199.md
+++ b/docs/registro/releases/pending/2026-07-30-pr-2199.md
@@ -1,0 +1,19 @@
+---
+pr: 2199
+release_date: 2026-07-30
+category: Corrección de Errores
+area: CI/CD
+title: release: promoción development a main 2026-07-30
+summary: Evita que el deploy de producción falle cuando el helper local del runner es anterior al contrato de revisión esperada
+impact: Sin cambio directo de interfaz; habilita la aplicación segura del SHA aprobado en producción.
+source_url: https://github.com/dsocial118/SISOC/pull/2199
+---
+# Release note preliminar PR #2199
+
+- Fecha objetivo de release: 2026-07-30
+- Categoría: Corrección de Errores
+- Área: CI/CD
+- Título del PR: release: promoción development a main 2026-07-30
+- Resumen: Evita que el deploy de producción falle cuando el helper local del runner es anterior al contrato de revisión esperada
+- Impacto usuario: Sin cambio directo de interfaz; habilita la aplicación segura del SHA aprobado en producción.
+- Fuente: https://github.com/dsocial118/SISOC/pull/2199

--- a/tests/test_deploy_workflow.py
+++ b/tests/test_deploy_workflow.py
@@ -26,15 +26,16 @@ def test_deploy_produccion_actualiza_helper_obsoleto_antes_del_deploy_versionado
         '"$EXPECTED_SHA" --with-mobile --mobile-dir /sisoc/SISOC-Mobile'
     )
 
+    stale_helper_start = production_step.index(stale_helper_guard)
+    stale_helper_end = production_step.index("\n                  fi\n", stale_helper_start)
+    deploy_start = production_step.index(deploy_versioned)
+    stale_helper_block = production_step[stale_helper_start:stale_helper_end]
+
     assert remote_revision_check in production_step
-    assert stale_helper_guard in production_step
-    assert main_branch_guard in production_step
-    assert fast_forward in production_step
-    assert deploy_versioned in production_step
-    assert production_step.index(remote_revision_check) < production_step.index(
-        stale_helper_guard
+    assert main_branch_guard in stale_helper_block
+    assert fast_forward in stale_helper_block
+    assert production_step.index(remote_revision_check) < stale_helper_start
+    assert stale_helper_end < deploy_start
+    assert stale_helper_block.index(main_branch_guard) < stale_helper_block.index(
+        fast_forward
     )
-    assert production_step.index(stale_helper_guard) < production_step.index(
-        deploy_versioned
-    )
-    assert production_step.index(fast_forward) < production_step.index(deploy_versioned)

--- a/tests/test_deploy_workflow.py
+++ b/tests/test_deploy_workflow.py
@@ -1,0 +1,40 @@
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+DEPLOY_WORKFLOW = REPO_ROOT / ".github" / "workflows" / "deploy.yml"
+
+
+def _production_deploy_step() -> str:
+    workflow = DEPLOY_WORKFLOW.read_text(encoding="utf-8")
+    return workflow.split("    deploy-produccion:\n", maxsplit=1)[1]
+
+
+def test_deploy_produccion_actualiza_helper_obsoleto_antes_del_deploy_versionado():
+    """Un runner con helper previo debe poder alcanzar el deploy del SHA aprobado."""
+
+    production_step = _production_deploy_step()
+    remote_revision_check = 'remote_sha="$(git -C "$APP_ROOT" rev-parse origin/main)"'
+    stale_helper_guard = (
+        'if ! grep -q -- "--expected-revision" '
+        '"$APP_ROOT/scripts/operacion/deploy_refresh.sh"; then'
+    )
+    main_branch_guard = '[[ "$(git -C "$APP_ROOT" branch --show-current)" == "main" ]]'
+    fast_forward = 'git -C "$APP_ROOT" merge --ff-only origin/main'
+    deploy_versioned = (
+        './scripts/operacion/deploy_refresh.sh --yes --expected-revision '
+        '"$EXPECTED_SHA" --with-mobile --mobile-dir /sisoc/SISOC-Mobile'
+    )
+
+    assert remote_revision_check in production_step
+    assert stale_helper_guard in production_step
+    assert main_branch_guard in production_step
+    assert fast_forward in production_step
+    assert deploy_versioned in production_step
+    assert production_step.index(remote_revision_check) < production_step.index(
+        stale_helper_guard
+    )
+    assert production_step.index(stale_helper_guard) < production_step.index(
+        deploy_versioned
+    )
+    assert production_step.index(fast_forward) < production_step.index(deploy_versioned)

--- a/tests/test_deploy_workflow.py
+++ b/tests/test_deploy_workflow.py
@@ -22,12 +22,14 @@ def test_deploy_produccion_actualiza_helper_obsoleto_antes_del_deploy_versionado
     main_branch_guard = '[[ "$(git -C "$APP_ROOT" branch --show-current)" == "main" ]]'
     fast_forward = 'git -C "$APP_ROOT" merge --ff-only origin/main'
     deploy_versioned = (
-        './scripts/operacion/deploy_refresh.sh --yes --expected-revision '
+        "./scripts/operacion/deploy_refresh.sh --yes --expected-revision "
         '"$EXPECTED_SHA" --with-mobile --mobile-dir /sisoc/SISOC-Mobile'
     )
 
     stale_helper_start = production_step.index(stale_helper_guard)
-    stale_helper_end = production_step.index("\n                  fi\n", stale_helper_start)
+    stale_helper_end = production_step.index(
+        "\n                  fi\n", stale_helper_start
+    )
     deploy_start = production_step.index(deploy_versioned)
     stale_helper_block = production_step[stale_helper_start:stale_helper_end]
 


### PR DESCRIPTION
<!-- release-final-pr: 2199 -->
<!-- release-functional-fix: true -->

## Causa raíz confirmada

El job oficial de producción verificaba que `origin/main` coincidiera con el SHA aprobado, pero ejecutaba el `deploy_refresh.sh` local antes de actualizar el checkout. En el runner afectado, ese helper era anterior al contrato `--expected-revision`, por lo que abortaba sin bajar Docker ni aplicar el SHA.

## Prueba de regresión

- La prueba de contrato del workflow exige que, sólo si el helper no contiene `--expected-revision`, la guardia de branch `main` y `git merge --ff-only origin/main` estén dentro de ese bloque y antes del deploy versionado.
- Se observó rojo antes del bloque de bootstrap y verde después.
- Validación focalizada: `py -3 -m pytest -p no:django --noconftest -o addopts='' tests/test_deploy_workflow.py -q` → 1 passed (con advertencia de configuración al desactivar Django).
- `git diff --check` limpio.

## Revisión de calidad

- Revisión Standards: sin bloqueantes; la duplicación acotada con HML es intencional para evitar una abstracción nueva en YAML.
- Revisión Spec: sin bloqueantes; el test cubre guardia, fast-forward y orden antes del deploy.
- La suite Django completa no se ejecutó en el host por dependencia local `crispy_forms`; CI queda como evidencia remota. No se tocaron datos, migraciones, autenticación, permisos ni código de aplicación.

## Alcance operativo

El workflow sólo hace fast-forward del checkout local si `origin/main` ya coincide con `EXPECTED_SHA`, el helper es viejo y la branch local es `main`. Un checkout inesperado o un avance no lineal bloquea el deploy de forma segura.