### PR TITLE
fix(organizaciones): restaurar Simple Asociación como tipo

### DIFF
--- a/docs/registro/cambios/2026-07-29-issue-2163-simple-asociacion.md
+++ b/docs/registro/cambios/2026-07-29-issue-2163-simple-asociacion.md
@@ -1,27 +1,36 @@
-# 2026-07-29 - Simple Asociación como subtipo de Personería Jurídica
+# 2026-07-29/31 - Simple Asociación como tipo y subtipo de entidad
 
 ## Contexto
 
-El seguimiento del issue #2163 aclaró que `Simple Asociación (art. 187 CCCN)`
-debe ser un subtipo de `Personería Jurídica`, no un tipo principal.
+El documento de referencia del issue #2163 enumera
+`Simple Asociación (art. 187 CCCN)` en dos niveles del catálogo:
+
+- como tipo principal de entidad;
+- como subtipo de `Personería Jurídica`.
+
+La primera corrección conservó sólo el subtipo. El comentario del 31 de julio
+aclaró que ambos registros deben coexistir.
 
 ## Cambios aplicados
 
-- El catálogo inicial ubica `Simple Asociación (art. 187 CCCN)` como subtipo
-  activo de `Personería Jurídica`.
-- La migración correctiva reasigna las organizaciones creadas con el tipo
-  principal incorrecto y elimina ese tipo del catálogo.
-- Los subtipos personalizados existentes bajo el tipo incorrecto se preservan
-  y se reasignan a `Personería Jurídica`.
+- El catálogo mantiene `Simple Asociación (art. 187 CCCN)` como subtipo activo
+  de `Personería Jurídica`.
+- Una migración posterior restaura el mismo nombre como tipo principal sin
+  modificar organizaciones ni subtipos existentes.
+- El fixture conserva el subtipo existente. El tipo principal se crea por
+  migración para no acoplarlo a un PK fijo incompatible con el cargador de
+  fixtures, que actualiza registros por clave primaria.
 
 ## Impacto y rollback
 
-- Las organizaciones sin subtipo bajo el tipo incorrecto pasan a usar el nuevo
-  subtipo `Simple Asociación (art. 187 CCCN)`.
-- La migración no tiene reversa automática: restaurar el estado anterior
-  requeriría una migración correctiva o un backup previo.
+- Las organizaciones reasignadas previamente a `Personería Jurídica` y al
+  subtipo `Simple Asociación (art. 187 CCCN)` conservan esa clasificación.
+- Las altas y ediciones de organizaciones también pueden seleccionar
+  `Simple Asociación (art. 187 CCCN)` como tipo principal.
+- La migración no elimina el tipo en reversa para no comprometer referencias
+  que puedan crearse después de aplicarla.
 
 ## Validación
 
-- Prueba focalizada de migración para el catálogo y las organizaciones ya
-  cargadas.
+- Prueba focalizada de migración para verificar la coexistencia del tipo y el
+  subtipo, su idempotencia y la conservación de referencias existentes.

--- a/organizaciones/migrations/0019_restaurar_simple_asociacion_tipo.py
+++ b/organizaciones/migrations/0019_restaurar_simple_asociacion_tipo.py
@@ -1,0 +1,33 @@
+from django.db import migrations
+
+
+NOMBRE_SIMPLE_ASOCIACION = "Simple Asociación (art. 187 CCCN)"
+
+
+def restaurar_simple_asociacion_como_tipo(apps, schema_editor):
+    TipoEntidad = apps.get_model("organizaciones", "TipoEntidad")
+
+    simple_asociacion = (
+        TipoEntidad.objects.filter(nombre__iexact=NOMBRE_SIMPLE_ASOCIACION)
+        .order_by("pk")
+        .first()
+    )
+    if simple_asociacion is None:
+        TipoEntidad.objects.create(nombre=NOMBRE_SIMPLE_ASOCIACION)
+    elif simple_asociacion.nombre != NOMBRE_SIMPLE_ASOCIACION:
+        simple_asociacion.nombre = NOMBRE_SIMPLE_ASOCIACION
+        simple_asociacion.save(update_fields=["nombre"])
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ("organizaciones", "0018_corregir_simple_asociacion_subtipo"),
+    ]
+
+    operations = [
+        migrations.RunPython(
+            restaurar_simple_asociacion_como_tipo,
+            migrations.RunPython.noop,
+        ),
+    ]

--- a/organizaciones/test_issue_2163_catalogo.py
+++ b/organizaciones/test_issue_2163_catalogo.py
@@ -99,3 +99,41 @@ def test_migracion_corrige_simple_asociacion_como_subtipo_de_personeria(db):
     assert not TipoEntidad.objects.filter(
         nombre="Simple Asociación (art. 187 CCCN)"
     ).exists()
+
+
+def test_migracion_restaura_simple_asociacion_como_tipo_y_conserva_el_subtipo(db):
+    nombre = "Simple Asociación (art. 187 CCCN)"
+    TipoEntidad.objects.filter(nombre=nombre).delete()
+    SubtipoEntidad.objects.filter(nombre=nombre).delete()
+
+    juridica, _ = TipoEntidad.objects.get_or_create(nombre="Personería Jurídica")
+    simple_subtipo = SubtipoEntidad.objects.create(
+        nombre=nombre,
+        tipo_entidad=juridica,
+    )
+    organizacion = Organizacion.objects.create(
+        nombre="Simple asociación existente",
+        tipo_entidad=juridica,
+        subtipo_entidad=simple_subtipo,
+    )
+
+    migration = import_module(
+        "organizaciones.migrations.0019_restaurar_simple_asociacion_tipo"
+    )
+    migration.restaurar_simple_asociacion_como_tipo(
+        import_module("django.apps").apps, None
+    )
+    migration.restaurar_simple_asociacion_como_tipo(
+        import_module("django.apps").apps, None
+    )
+
+    simple_tipo = TipoEntidad.objects.get(nombre=nombre)
+    simple_subtipo.refresh_from_db()
+    organizacion.refresh_from_db()
+
+    assert simple_tipo.pk != juridica.pk
+    assert TipoEntidad.objects.filter(nombre=nombre).count() == 1
+    assert simple_subtipo.tipo_entidad_id == juridica.pk
+    assert organizacion.tipo_entidad_id == juridica.pk
+    assert organizacion.subtipo_entidad_id == simple_subtipo.pk
+    assert simple_tipo in OrganizacionForm().fields["tipo_entidad"].queryset


### PR DESCRIPTION
Closes #2163

## Qué cambia

- Restaura `Simple Asociación (art. 187 CCCN)` como Tipo de Entidad mediante una migración idempotente.
- Conserva el subtipo activo bajo `Personería Jurídica` y no modifica organizaciones ni subtipos existentes.
- Agrega una regresión para coexistencia de tipo/subtipo, idempotencia y disponibilidad en el formulario.
- Actualiza el registro funcional y documenta por qué el tipo principal no usa un PK fijo en el fixture.

## Causa raíz

La migración correctiva anterior eliminó el tipo principal. El documento y el seguimiento del issue requieren que el mismo valor exista tanto como Tipo de Entidad como subtipo de Personería Jurídica.

## Impacto

Al aplicar la migración, las altas y ediciones de organizaciones podrán seleccionar el tipo principal sin alterar referencias históricas ya reasignadas al subtipo.

## Validación

- `git diff --check`
- Compilación e importación de la migración.
- Creación e idempotencia de la migración sobre SQLite aislado.
- Revisión de especificación y estándares.

## Pendiente de entorno

- Pytest no pudo iniciar localmente porque falta `crispy_forms`; los virtualenvs existentes apuntan a un Python 3.10 inexistente.
- No se ejecutó una migración sobre MySQL real.