### PR TITLE
feat(centrodefamilia): fecha de nacimiento y CUIL del responsable en preinscriptos

### DIFF
--- a/centrodefamilia/services/beneficiarios_service/impl.py
+++ b/centrodefamilia/services/beneficiarios_service/impl.py
@@ -41,6 +41,14 @@ logger = logging.getLogger("django")
 logger = logging.getLogger("django")
 
 
+def formatear_fecha_nacimiento(fecha, vacio="-"):
+    """Formatea la fecha de nacimiento para listado y exportación (dd/mm/aaaa)."""
+
+    if not fecha:
+        return vacio
+    return fecha.strftime("%d/%m/%Y")
+
+
 def _normalize_genero(value):
     """Devuelve el código de género aceptado a partir de entradas humanas."""
 
@@ -519,14 +527,20 @@ def buscar_cuil_beneficiario(request, cuil):
 def get_beneficiarios_list_context(request=None):
     """Configuración para la lista de beneficiarios."""
     headers = [
-        {"title": "CUIL", "width": "12%", "sortable": True, "sort_key": "cuil"},
+        {"title": "CUIL", "width": "10%", "sortable": True, "sort_key": "cuil"},
         {
             "title": "Apellido y Nombre",
-            "width": "20%",
+            "width": "16%",
             "sortable": True,
             "sort_key": "apellido_nombre",
         },
-        {"title": "DNI", "width": "10%", "sortable": True, "sort_key": "dni"},
+        {"title": "DNI", "width": "9%", "sortable": True, "sort_key": "dni"},
+        {
+            "title": "Fecha de nacimiento",
+            "width": "10%",
+            "sortable": True,
+            "sort_key": "fecha_nacimiento_display",
+        },
         {
             "title": "Género",
             "width": "8%",
@@ -535,19 +549,25 @@ def get_beneficiarios_list_context(request=None):
         },
         {
             "title": "Responsable",
-            "width": "20%",
+            "width": "16%",
             "sortable": True,
             "sort_key": "responsable_nombre",
         },
         {
+            "title": "CUIL del responsable",
+            "width": "11%",
+            "sortable": True,
+            "sort_key": "responsable_cuil",
+        },
+        {
             "title": "Provincia",
-            "width": "15%",
+            "width": "10%",
             "sortable": True,
             "sort_key": "provincia",
         },
         {
             "title": "Municipio",
-            "width": "15%",
+            "width": "10%",
             "sortable": True,
             "sort_key": "municipio",
         },
@@ -556,8 +576,10 @@ def get_beneficiarios_list_context(request=None):
         {"name": "cuil"},
         {"name": "apellido_nombre"},
         {"name": "dni"},
+        {"name": "fecha_nacimiento_display"},
         {"name": "genero_display"},
         {"name": "responsable_nombre"},
+        {"name": "responsable_cuil"},
         {"name": "provincia"},
         {"name": "municipio"},
     ]
@@ -649,9 +671,13 @@ def prepare_beneficiarios_for_display(beneficiarios):
     for beneficiario in beneficiarios:
         beneficiario.apellido_nombre = f"{beneficiario.apellido}, {beneficiario.nombre}"
         beneficiario.genero_display = beneficiario.get_genero_display()
+        beneficiario.fecha_nacimiento_display = formatear_fecha_nacimiento(
+            beneficiario.fecha_nacimiento
+        )
         beneficiario.responsable_nombre = (
             f"{beneficiario.responsable.apellido}, {beneficiario.responsable.nombre}"
         )
+        beneficiario.responsable_cuil = beneficiario.responsable.cuil
 
 
 def prepare_responsables_for_display(responsables):

--- a/centrodefamilia/templates/beneficiarios/beneficiarios_list.html
+++ b/centrodefamilia/templates/beneficiarios/beneficiarios_list.html
@@ -12,7 +12,7 @@
     <!-- Estilos modernos reutilizables para listados -->
     <link rel="stylesheet" href="{% static 'custom/css/listModerno.css' %}" />
     {% url 'beneficiarios_export' as export_url %}
-    {% include 'components/search_bar.html' with titulo="Buscar Beneficiario" reset_url=reset_url add_url=add_url add_text=add_text filters_mode=filters_mode filters_js=filters_js filters_action=filters_action export_url=export_url %}
+    {% include 'components/search_bar.html' with titulo="Buscar Beneficiario" reset_url=reset_url add_url=add_url add_text=add_text filters_mode=filters_mode filters_js=filters_js filters_action=filters_action export_url=export_url export_permissions=export_permissions %}
     <div class="container mt-4 cdf-page">
         <h2>Listado de Preinscriptos</h2>
         {% load custom_filters %}

--- a/centrodefamilia/tests/test_beneficiarios_export.py
+++ b/centrodefamilia/tests/test_beneficiarios_export.py
@@ -29,15 +29,36 @@ def _grant_export_role(user):
     return User.objects.get(pk=user.pk)
 
 
-@pytest.fixture
-def usuario_con_permisos(db):
-    user = User.objects.create_user(username="cdf-export", password="x")
+def _grant_cdf_sse_role(user):
+    content_type = ContentType.objects.get_for_model(Group)
+    permission, _ = Permission.objects.get_or_create(
+        content_type=content_type,
+        codename="role_cdf_sse",
+        defaults={"name": "CDF SSE"},
+    )
+    user.user_permissions.add(permission)
+    return User.objects.get(pk=user.pk)
+
+
+def _crear_usuario_listado(username):
+    user = User.objects.create_user(username=username, password="x")
     user.user_permissions.add(
         Permission.objects.get(
             content_type__app_label="centrodefamilia", codename="view_centro"
         )
     )
-    return _grant_export_role(user)
+    return user
+
+
+@pytest.fixture
+def usuario_con_permisos(db):
+    return _grant_export_role(_crear_usuario_listado("cdf-export"))
+
+
+@pytest.fixture
+def usuario_cdf_sse(db):
+    """Rol CDF SSE: exporta preinscriptos sin el rol transversal de CSV."""
+    return _grant_cdf_sse_role(_crear_usuario_listado("cdf-sse"))
 
 
 @pytest.fixture
@@ -185,6 +206,40 @@ def test_export_respeta_filtros_territoriales_y_nombra_archivo(
 
 
 @pytest.mark.django_db
+def test_export_incluye_fecha_nacimiento_y_cuil_de_responsable(
+    client, usuario_con_permisos, beneficiarios
+):
+    client.force_login(usuario_con_permisos)
+    response = client.get(reverse("beneficiarios_export"))
+
+    content = b"".join(response.streaming_content).decode("utf-8-sig")
+    rows = list(csv.DictReader(StringIO(content), delimiter=";"))
+    row = next(row for row in rows if row["CUIL"] == "20451112223")
+
+    assert row["Fecha de nacimiento"] == "04/03/2012"
+    assert row["CUIL del responsable"] == "20285551113"
+
+
+@pytest.mark.django_db
+def test_export_respeta_orden_por_cuil_de_responsable(
+    client, usuario_con_permisos, beneficiarios
+):
+    client.force_login(usuario_con_permisos)
+    response = client.get(
+        reverse("beneficiarios_export"),
+        {"sort": "responsable_cuil", "direction": "desc"},
+    )
+
+    content = b"".join(response.streaming_content).decode("utf-8-sig")
+    rows = list(csv.DictReader(StringIO(content), delimiter=";"))
+
+    assert [row["CUIL del responsable"] for row in rows] == [
+        "20285551114",
+        "20285551113",
+    ]
+
+
+@pytest.mark.django_db
 def test_export_respeta_orden_visible_por_cuil(
     client, usuario_con_permisos, beneficiarios
 ):
@@ -289,15 +344,51 @@ def test_beneficiarios_list_muestra_boton_exportar_con_permiso(
 
 @pytest.mark.django_db
 def test_beneficiarios_list_oculta_boton_exportar_sin_permiso(client, db):
-    user = User.objects.create_user(username="cdf-list-sin-export", password="x")
-    user.user_permissions.add(
-        Permission.objects.get(
-            content_type__app_label="centrodefamilia", codename="view_centro"
-        )
-    )
+    user = _crear_usuario_listado("cdf-list-sin-export")
     client.force_login(user)
 
     response = client.get(reverse("beneficiarios_list"))
 
     assert response.status_code == 200
     assert "btn-export-csv" not in response.content.decode()
+
+
+@pytest.mark.django_db
+def test_beneficiarios_list_muestra_boton_exportar_para_cdf_sse(
+    client, usuario_cdf_sse
+):
+    client.force_login(usuario_cdf_sse)
+    response = client.get(reverse("beneficiarios_list"))
+
+    assert response.status_code == 200
+    content = response.content.decode()
+    assert "btn-export-csv" in content
+    assert reverse("beneficiarios_export") in content
+
+
+@pytest.mark.django_db
+def test_export_permite_rol_cdf_sse(client, usuario_cdf_sse, beneficiarios):
+    client.force_login(usuario_cdf_sse)
+    response = client.get(reverse("beneficiarios_export"))
+
+    assert response.status_code == 200
+
+    content = b"".join(response.streaming_content).decode("utf-8-sig")
+    rows = list(csv.DictReader(StringIO(content), delimiter=";"))
+
+    assert {row["CUIL"] for row in rows} == {"20451112223", "20451112224"}
+
+
+@pytest.mark.django_db
+def test_beneficiarios_list_muestra_fecha_nacimiento_y_cuil_de_responsable(
+    client, usuario_con_permisos, beneficiarios
+):
+    client.force_login(usuario_con_permisos)
+    response = client.get(reverse("beneficiarios_list"))
+
+    assert response.status_code == 200
+    content = response.content.decode()
+    assert "Fecha de nacimiento" in content
+    assert "CUIL del responsable" in content
+    assert "04/03/2012" in content
+    assert "20285551113" in content

--- a/centrodefamilia/views/beneficiarios.py
+++ b/centrodefamilia/views/beneficiarios.py
@@ -7,6 +7,7 @@ from django.views.decorators.csrf import ensure_csrf_cookie
 
 from centrodefamilia.forms import BeneficiarioForm, ResponsableForm
 from centrodefamilia.models import Beneficiario, Responsable
+from centrodefamilia.views.beneficiarios_export import BeneficiariosExportView
 
 from centrodefamilia.services.beneficiarios_service import (
     manejar_request_beneficiarios,
@@ -72,6 +73,11 @@ class BeneficiariosListView(LoginRequiredMixin, ListView):
                 "filters_config": get_beneficiarios_filters_ui_config(),
                 "seccion_filtros_favoritos": SeccionesFiltrosFavoritos.CDF_BENEFICIARIOS,
                 "add_text": "Crear un nuevo Preinscripto",
+                # `firstof` en search_bar.html renderiza el valor como texto:
+                # se pasa la lista de permisos separada por comas.
+                "export_permissions": ",".join(
+                    BeneficiariosExportView.export_permission_codes
+                ),
             }
         )
         return context

--- a/centrodefamilia/views/beneficiarios_export.py
+++ b/centrodefamilia/views/beneficiarios_export.py
@@ -4,13 +4,19 @@ import unicodedata
 
 from django.contrib import messages
 from django.contrib.auth.mixins import LoginRequiredMixin
+from django.core.exceptions import PermissionDenied
 from django.http import HttpResponseRedirect
 from django.urls import reverse
 from django.views.generic import View
 
-from centrodefamilia.services.beneficiarios_service import get_filtered_beneficiarios
+from centrodefamilia.access import ROLE_CDF_SSE_PERMISSION
+from centrodefamilia.services.beneficiarios_service import (
+    formatear_fecha_nacimiento,
+    get_filtered_beneficiarios,
+)
 from core.mixins import CSVExportMixin
 from core.services.advanced_filters.payload import extract_raw_filters, load_payload
+from iam.services import user_has_any_permission_codes
 
 FILTERS_PARAM_NAME = "filters"
 FILENAME_FIELDS_PRIORITY = ("provincia", "municipio", "localidad")
@@ -19,8 +25,10 @@ SORT_FIELDS = {
     "cuil": ("cuil",),
     "apellido_nombre": ("apellido", "nombre"),
     "dni": ("dni",),
+    "fecha_nacimiento_display": ("fecha_nacimiento",),
     "genero_display": ("genero",),
     "responsable_nombre": ("responsable__apellido", "responsable__nombre"),
+    "responsable_cuil": ("responsable__cuil",),
     "provincia": ("provincia__nombre",),
     "municipio": ("municipio__nombre",),
 }
@@ -39,14 +47,33 @@ def _neutralize_csv_formula(value):
 
 class BeneficiariosExportView(LoginRequiredMixin, CSVExportMixin, View):
     export_filename = "listado_beneficiarios.csv"
+    # El rol CDF SSE exporta el padrón de preinscriptos sin necesitar el rol
+    # transversal de exportación a CSV.
+    export_permission_codes = (
+        CSVExportMixin.export_permission_code,
+        ROLE_CDF_SSE_PERMISSION,
+    )
+
+    def check_export_permission(self, request):
+        if not request.user.is_authenticated:
+            raise PermissionDenied
+
+        if not user_has_any_permission_codes(
+            request.user, self.export_permission_codes
+        ):
+            raise PermissionDenied
+
+        return True
 
     def get_export_columns(self):
         return [
             ("CUIL", "cuil"),
             ("Apellido y Nombre", "custom_apellido_nombre"),
             ("DNI", "dni"),
+            ("Fecha de nacimiento", "custom_fecha_nacimiento"),
             ("Género", "custom_genero"),
             ("Responsable", "custom_responsable"),
+            ("CUIL del responsable", "responsable.cuil"),
             ("Provincia", "provincia.nombre"),
             ("Municipio", "municipio.nombre"),
         ]
@@ -54,6 +81,8 @@ class BeneficiariosExportView(LoginRequiredMixin, CSVExportMixin, View):
     def resolve_field(self, obj, field_path):
         if field_path == "custom_apellido_nombre":
             value = f"{obj.apellido}, {obj.nombre}"
+        elif field_path == "custom_fecha_nacimiento":
+            value = formatear_fecha_nacimiento(obj.fecha_nacimiento, vacio="")
         elif field_path == "custom_genero":
             value = obj.get_genero_display()
         elif field_path == "custom_responsable":

--- a/docs/registro/cambios/2026-07-27-cdf-exportacion-beneficiarios.md
+++ b/docs/registro/cambios/2026-07-27-cdf-exportacion-beneficiarios.md
@@ -13,6 +13,10 @@ La descarga conserva el permiso de acceso al listado
 textuales que comienzan con caracteres de fórmula de planilla se prefijan con
 una comilla simple para que Excel los trate como texto.
 
+Actualización: desde `2026-07-31-cdf-beneficiarios-columnas-y-export-sse.md` el
+rol `auth.role_cdf_sse` también habilita la descarga, como alternativa a
+`auth.role_exportar_a_csv`.
+
 ## Contrato de exportación
 
 El endpoint reutiliza los filtros del listado y acepta únicamente las columnas

--- a/docs/registro/cambios/2026-07-31-cdf-beneficiarios-columnas-y-export-sse.md
+++ b/docs/registro/cambios/2026-07-31-cdf-beneficiarios-columnas-y-export-sse.md
@@ -1,0 +1,47 @@
+# Listado de preinscriptos CDF: fecha de nacimiento, CUIL del responsable y export para CDF SSE
+
+## Cambio
+
+El listado de preinscriptos de Centro de Familia (`/beneficiarios/beneficiarios/`)
+muestra dos columnas nuevas:
+
+- `Fecha de nacimiento` del beneficiario, formateada `dd/mm/aaaa`.
+- `CUIL del responsable`.
+
+Ambas quedan entre las columnas existentes (fecha de nacimiento después de DNI,
+CUIL del responsable después de Responsable), son ordenables y se agregan al CSV
+de exportación para que el archivo siga reflejando el listado visible.
+
+## Seguridad y permisos
+
+La descarga del listado ahora acepta dos permisos alternativos:
+`auth.role_exportar_a_csv` (rol transversal de exportación) o `auth.role_cdf_sse`.
+El rol CDF SSE, que ya administra el padrón de preinscriptos, no tenía el rol
+transversal y por eso no veía el botón `Descargar CSV`.
+
+La habilitación se declara una sola vez en
+`BeneficiariosExportView.export_permission_codes` y el listado la reutiliza para
+decidir la visibilidad del botón, de modo que vista y template no puedan
+divergir. El permiso de acceso al listado (`centrodefamilia.view_centro`) no
+cambia, así que el alcance sigue acotado a quien ya puede ver preinscriptos: no
+se otorga exportación a CSV en otros módulos.
+
+## Trade-offs
+
+- El ordenamiento por click sigue siendo client-side sobre la página visible
+  (comportamiento existente de `listSort.js`): la fecha se compara como texto
+  `dd/mm/aaaa`. La exportación, en cambio, replica el orden en la base con
+  `SORT_FIELDS` (`fecha_nacimiento` y `responsable__cuil`), por lo que el CSV
+  queda ordenado correctamente.
+- Las dos columnas se agregan como visibles por defecto. Los usuarios que ya
+  guardaron una preferencia de columnas para este listado deben habilitarlas
+  desde "Configurar columnas", porque las preferencias persistidas mandan sobre
+  los defaults.
+
+## Validación
+
+`centrodefamilia/tests/test_beneficiarios_export.py` cubre las columnas nuevas en
+el CSV, el orden por CUIL del responsable, la descarga con rol CDF SSE, la
+visibilidad del botón para ese rol y el render de las columnas en el listado.
+`tests/test_beneficiarios_service_unit.py` cubre el formateo de la fecha y los
+campos calculados del listado.

--- a/static/custom/js/listSort.js
+++ b/static/custom/js/listSort.js
@@ -4,6 +4,31 @@
  * Reutilizable para todos los listados
  */
 
+function parseDateForSort(value) {
+  const match = /^(\d{1,2})\/(\d{1,2})\/(\d{4})$/.exec(String(value).trim());
+  if (!match) return null;
+
+  const day = Number(match[1]);
+  const month = Number(match[2]);
+  const year = Number(match[3]);
+  const timestamp = Date.UTC(year, month - 1, day);
+  const parsed = new Date(timestamp);
+
+  if (
+    parsed.getUTCFullYear() !== year ||
+    parsed.getUTCMonth() !== month - 1 ||
+    parsed.getUTCDate() !== day
+  ) {
+    return null;
+  }
+
+  return timestamp;
+}
+
+if (typeof module !== "undefined") {
+  module.exports = { parseDateForSort };
+}
+
 document.addEventListener("DOMContentLoaded", function () {
   // Buscar tabla - priorizar .table-comedor-moderno, luego .table, luego .projects
   const table = document.querySelector(".table-comedor-moderno, .table, .projects");
@@ -109,11 +134,18 @@ document.addEventListener("DOMContentLoaded", function () {
 
       // Detectar tipo de valor
       let isNumber = false;
-      let aNum = parseFloat(aValue);
-      let bNum = parseFloat(bValue);
+      let aNum = parseDateForSort(aValue);
+      let bNum = parseDateForSort(bValue);
 
-      if (!isNaN(aNum) && !isNaN(bNum) && aValue !== "" && bValue !== "") {
+      if (aNum !== null && bNum !== null) {
         isNumber = true;
+      } else {
+        aNum = parseFloat(aValue);
+        bNum = parseFloat(bValue);
+
+        if (!isNaN(aNum) && !isNaN(bNum) && aValue !== "" && bValue !== "") {
+          isNumber = true;
+        }
       }
 
       // Normalizar strings para comparación (minúsculas, sin acentos)

--- a/tests/js/test_list_sort_dates.js
+++ b/tests/js/test_list_sort_dates.js
@@ -1,0 +1,19 @@
+const assert = require('assert');
+
+global.document = {
+  addEventListener() {},
+};
+
+const { parseDateForSort } = require('../../static/custom/js/listSort.js');
+
+assert.strictEqual(
+  parseDateForSort('04/12/2013'),
+  Date.UTC(2013, 11, 4),
+);
+assert.ok(
+  parseDateForSort('04/12/2013') > parseDateForSort('10/01/2012'),
+  'El orden debe comparar año, mes y día, no solamente el día visible.',
+);
+assert.strictEqual(parseDateForSort('sin fecha'), null);
+
+console.log('listSort ordena fechas dd/mm/aaaa cronológicamente');

--- a/tests/test_beneficiarios_service_unit.py
+++ b/tests/test_beneficiarios_service_unit.py
@@ -3,6 +3,7 @@
 import contextlib
 import json
 
+from datetime import date
 from types import SimpleNamespace
 
 import pytest
@@ -242,7 +243,8 @@ def test_prepare_helpers_agregan_campos_display():
     beneficiario = SimpleNamespace(
         apellido="Perez",
         nombre="Ana",
-        responsable=SimpleNamespace(apellido="Lopez", nombre="Mario"),
+        fecha_nacimiento=date(2012, 3, 4),
+        responsable=SimpleNamespace(apellido="Lopez", nombre="Mario", cuil=20285551113),
         get_genero_display=lambda: "Femenino",
     )
     responsable = SimpleNamespace(
@@ -257,7 +259,22 @@ def test_prepare_helpers_agregan_campos_display():
 
     assert beneficiario.apellido_nombre == "Perez, Ana"
     assert beneficiario.responsable_nombre == "Lopez, Mario"
+    assert beneficiario.fecha_nacimiento_display == "04/03/2012"
+    assert beneficiario.responsable_cuil == 20285551113
     assert responsable.vinculo_display == "Padre"
+
+
+@pytest.mark.parametrize(
+    "fecha,vacio,esperado",
+    [
+        (date(2012, 3, 4), "-", "04/03/2012"),
+        (None, "-", "-"),
+        (None, "", ""),
+    ],
+)
+def test_formatear_fecha_nacimiento(fecha, vacio, esperado):
+    """Formatea dd/mm/aaaa y respeta el placeholder de fecha vacía."""
+    assert service.formatear_fecha_nacimiento(fecha, vacio=vacio) == esperado
 
 
 def test_filtered_wrappers_delegan_a_motor_avanzado(mocker):


### PR DESCRIPTION
## Contexto

En el listado de preinscriptos de Centro de Familia (`/beneficiarios/beneficiarios/`) faltaban dos datos en la tabla y el rol **CDF SSE** no veía el botón `Descargar CSV`, aunque tiene que poder exportar.

## Cambios

**Columnas nuevas en el listado**
- `Fecha de nacimiento` del beneficiario (formato `dd/mm/aaaa`), después de DNI.
- `CUIL del responsable`, después de Responsable.
- Ambas ordenables; se recalcularon los `width` para seguir sumando 100%.
- Los valores se calculan en `prepare_beneficiarios_for_display`; el queryset ya traía `select_related("responsable")`, así que no agrega consultas.

**Exportación CSV**
- Las dos columnas también se exportan, para que el CSV siga reflejando el listado visible.
- Se agregaron sus entradas en `SORT_FIELDS` (`fecha_nacimiento`, `responsable__cuil`) para que el orden elegido en la tabla se replique en la base.

**Botón de exportar para CDF SSE**
- Causa: el gate era el permiso único `auth.role_exportar_a_csv` (rol transversal) y CDF SSE solo tiene `centrodefamilia.view_centro` + `auth.role_cdf_sse`.
- Ahora `BeneficiariosExportView.export_permission_codes = ("auth.role_exportar_a_csv", "auth.role_cdf_sse")` y `check_export_permission` acepta cualquiera de los dos (mismo patrón que `ComedorExportView`).
- El listado reutiliza esa misma lista para decidir la visibilidad del botón, así vista y template no pueden divergir.
- No se tocó `core/permissions/registry.py` ni los grupos: el alcance queda acotado a este listado, sin habilitar exportación a CSV en otros módulos.

## Validación

- `black`, `djlint` y `pylint` sin hallazgos nuevos (pylint solo emite los `E0611`/`W0404` preexistentes por el alias de `sys.modules` en esos paquetes).
- Tests nuevos en `centrodefamilia/tests/test_beneficiarios_export.py`: columnas nuevas en el CSV, orden por CUIL del responsable, descarga con rol CDF SSE, visibilidad del botón para ese rol y render de las columnas en el listado. En `tests/test_beneficiarios_service_unit.py`: formateo de fecha y campos calculados.
- Aviso sobre el entorno local: con Python 3.14 + Django 4.2 todo test que renderice un template vía test client falla con `AttributeError: 'super' object has no attribute 'dicts'` (`django/template/context.py`). Es preexistente: la misma selección da 15 fallas en `development` y 17 con esta rama (las 2 nuevas son tests de render del mismo tipo). Los tests de CSV pasan localmente, y el render se verificó aparte con `RequestFactory`. Queda para CI/Docker la corrida completa.

## Nota operativa

El listado usa preferencias de columnas por usuario y las guardadas mandan sobre los defaults: quien ya guardó una configuración debe habilitar las dos columnas nuevas desde "Configurar columnas". Documentado en `docs/registro/cambios/2026-07-31-cdf-beneficiarios-columnas-y-export-sse.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
