### PR TITLE
cdi nomina restriccion

### DIFF
--- a/centrodeinfancia/admin.py
+++ b/centrodeinfancia/admin.py
@@ -1,5 +1,6 @@
 from django.contrib import admin
 
+from centrodeinfancia.forms import NominaCentroInfanciaAdminForm
 from centrodeinfancia.models import (
     AccesoCDI,
     AsistenciaNominaCentroInfancia,
@@ -52,6 +53,7 @@ class DepartamentoIpiAdmin(admin.ModelAdmin):
 
 @admin.register(NominaCentroInfancia)
 class NominaCentroInfanciaAdmin(admin.ModelAdmin):
+    form = NominaCentroInfanciaAdminForm
     list_display = ("id", "centro", "ciudadano", "estado", "fecha")
     list_filter = ("estado",)
     search_fields = ("centro__nombre", "ciudadano__apellido", "ciudadano__nombre")

--- a/centrodeinfancia/forms.py
+++ b/centrodeinfancia/forms.py
@@ -49,6 +49,11 @@ from centrodeinfancia.models import (
     NominaPais,
     NominaNacionalidad,
 )
+from centrodeinfancia.services import (
+    ESTADOS_NOMINA_CDI_VIGENTE,
+    MENSAJE_NOMINA_VIGENTE_EN_OTRO_CENTRO,
+    tiene_nomina_cdi_vigente_en_otro_centro,
+)
 from centrodeinfancia.forms_observacion import ObservacionCentroInfanciaForm
 from centrodeinfancia.forms_formulario_cdi import (
     FormularioCDIForm,
@@ -993,6 +998,29 @@ class NominaCentroInfanciaBaseForm(forms.ModelForm):
         for field_name in ["estado", "dni", "apellido", "nombre", "fecha_nacimiento"]:
             self.fields[field_name].required = True
 
+    def _validar_vigencia_unica_cdi(self, cleaned_data):
+        """Impide reactivar una ficha si la persona ya está vigente en otro CDI.
+
+        Sólo se valida la transición hacia un estado vigente: una ficha que ya
+        estaba Activa o Pendiente puede seguir editándose, porque los duplicados
+        históricos están fuera de alcance y no deben volverse ineditables.
+        """
+        instancia = self.instance
+        if not instancia.pk or not instancia.ciudadano_id:
+            return
+        if cleaned_data.get("estado") not in ESTADOS_NOMINA_CDI_VIGENTE:
+            return
+        # `self.instance` todavía tiene el estado persistido: `_post_clean` corre
+        # después de `clean()`.
+        if instancia.estado in ESTADOS_NOMINA_CDI_VIGENTE:
+            return
+        if tiene_nomina_cdi_vigente_en_otro_centro(
+            instancia.ciudadano_id,
+            instancia.centro_id,
+            excluir_nomina_id=instancia.pk,
+        ):
+            raise ValidationError(MENSAJE_NOMINA_VIGENTE_EN_OTRO_CENTRO)
+
     def clean(self):
         cleaned_data = super().clean()
         fecha_nacimiento = cleaned_data.get("fecha_nacimiento")
@@ -1000,6 +1028,7 @@ class NominaCentroInfanciaBaseForm(forms.ModelForm):
             cleaned_data["edad_calculada"] = NominaCentroInfancia(
                 fecha_nacimiento=fecha_nacimiento
             ).edad
+        self._validar_vigencia_unica_cdi(cleaned_data)
         return cleaned_data
 
 

--- a/centrodeinfancia/forms.py
+++ b/centrodeinfancia/forms.py
@@ -1050,17 +1050,15 @@ class NominaCentroInfanciaAdminForm(forms.ModelForm):
         estado = cleaned_data.get("estado")
         instancia = self.instance
 
-        if (
-            not ciudadano
-            or not centro
-            or estado not in ESTADOS_NOMINA_CDI_VIGENTE
-        ):
+        if not ciudadano or not centro or estado not in ESTADOS_NOMINA_CDI_VIGENTE:
             return cleaned_data
 
         if instancia.pk:
-            datos_persistidos = NominaCentroInfancia.objects.filter(
-                pk=instancia.pk
-            ).values("estado", "centro_id", "ciudadano_id").first()
+            datos_persistidos = (
+                NominaCentroInfancia.objects.filter(pk=instancia.pk)
+                .values("estado", "centro_id", "ciudadano_id")
+                .first()
+            )
             if (
                 datos_persistidos
                 and datos_persistidos["estado"] in ESTADOS_NOMINA_CDI_VIGENTE

--- a/centrodeinfancia/forms.py
+++ b/centrodeinfancia/forms.py
@@ -1036,6 +1036,49 @@ class NominaCentroInfanciaForm(NominaCentroInfanciaBaseForm):
     pass
 
 
+class NominaCentroInfanciaAdminForm(forms.ModelForm):
+    """Aplica la regla de vigencia única también en el admin de Django."""
+
+    class Meta:
+        model = NominaCentroInfancia
+        fields = "__all__"
+
+    def clean(self):
+        cleaned_data = super().clean()
+        ciudadano = cleaned_data.get("ciudadano")
+        centro = cleaned_data.get("centro")
+        estado = cleaned_data.get("estado")
+        instancia = self.instance
+
+        if (
+            not ciudadano
+            or not centro
+            or estado not in ESTADOS_NOMINA_CDI_VIGENTE
+        ):
+            return cleaned_data
+
+        if instancia.pk:
+            datos_persistidos = NominaCentroInfancia.objects.filter(
+                pk=instancia.pk
+            ).values("estado", "centro_id", "ciudadano_id").first()
+            if (
+                datos_persistidos
+                and datos_persistidos["estado"] in ESTADOS_NOMINA_CDI_VIGENTE
+                and datos_persistidos["centro_id"] == centro.pk
+                and datos_persistidos["ciudadano_id"] == ciudadano.pk
+            ):
+                return cleaned_data
+
+        if tiene_nomina_cdi_vigente_en_otro_centro(
+            ciudadano.pk,
+            centro.pk,
+            excluir_nomina_id=instancia.pk,
+        ):
+            raise ValidationError(MENSAJE_NOMINA_VIGENTE_EN_OTRO_CENTRO)
+
+        return cleaned_data
+
+
 class NominaCentroInfanciaCreateForm(NominaCentroInfanciaBaseForm):
     pass
 

--- a/centrodeinfancia/forms.py
+++ b/centrodeinfancia/forms.py
@@ -1067,6 +1067,16 @@ class NominaCentroInfanciaAdminForm(forms.ModelForm):
             ):
                 return cleaned_data
 
+        if (
+            NominaCentroInfancia.objects.filter(
+                ciudadano=ciudadano,
+                centro=centro,
+            )
+            .exclude(pk=instancia.pk)
+            .exists()
+        ):
+            raise ValidationError(MENSAJE_NOMINA_VIGENTE_EN_OTRO_CENTRO)
+
         if tiene_nomina_cdi_vigente_en_otro_centro(
             ciudadano.pk,
             centro.pk,

--- a/centrodeinfancia/models.py
+++ b/centrodeinfancia/models.py
@@ -1294,6 +1294,10 @@ class NominaNacionalidad(models.Model):
 
 
 class NominaCentroInfancia(SoftDeleteModelMixin, models.Model):
+    SOFT_RESTORE_VALIDATOR = (
+        "centrodeinfancia.services.validar_restauracion_nomina_cdi"
+    )
+
     class RespuestaSiNoNsNc(models.TextChoices):
         SI = "si", "Si"
         NO = "no", "No"
@@ -1460,27 +1464,6 @@ class NominaCentroInfancia(SoftDeleteModelMixin, models.Model):
         max_length=255, blank=True, null=True
     )
     observaciones = models.TextField(blank=True, null=True)
-
-    def validar_restauracion_soft(self) -> None:
-        """Evita restaurar una ficha vigente si ya existe otra en otro CDI."""
-        if self.estado not in (self.ESTADO_ACTIVO, self.ESTADO_PENDIENTE):
-            return
-
-        # La importación diferida evita el ciclo modelo -> servicio -> modelo.
-        from centrodeinfancia.services import (
-            MENSAJE_NOMINA_VIGENTE_EN_OTRO_CENTRO,
-            bloquear_ciudadano_para_nomina_cdi,
-            tiene_nomina_cdi_vigente_en_otro_centro,
-        )
-
-        bloquear_ciudadano_para_nomina_cdi(self.ciudadano_id)
-        if tiene_nomina_cdi_vigente_en_otro_centro(
-            self.ciudadano_id,
-            self.centro_id,
-            excluir_nomina_id=self.pk,
-            bloquear=True,
-        ):
-            raise ValidationError(MENSAJE_NOMINA_VIGENTE_EN_OTRO_CENTRO)
 
     # ── Sección 3: Registro ──────────────────────────────────────────────────
     tipo_registro = models.CharField(

--- a/centrodeinfancia/models.py
+++ b/centrodeinfancia/models.py
@@ -1461,6 +1461,27 @@ class NominaCentroInfancia(SoftDeleteModelMixin, models.Model):
     )
     observaciones = models.TextField(blank=True, null=True)
 
+    def validar_restauracion_soft(self) -> None:
+        """Evita restaurar una ficha vigente si ya existe otra en otro CDI."""
+        if self.estado not in (self.ESTADO_ACTIVO, self.ESTADO_PENDIENTE):
+            return
+
+        # La importación diferida evita el ciclo modelo -> servicio -> modelo.
+        from centrodeinfancia.services import (
+            MENSAJE_NOMINA_VIGENTE_EN_OTRO_CENTRO,
+            bloquear_ciudadano_para_nomina_cdi,
+            tiene_nomina_cdi_vigente_en_otro_centro,
+        )
+
+        bloquear_ciudadano_para_nomina_cdi(self.ciudadano_id)
+        if tiene_nomina_cdi_vigente_en_otro_centro(
+            self.ciudadano_id,
+            self.centro_id,
+            excluir_nomina_id=self.pk,
+            bloquear=True,
+        ):
+            raise ValidationError(MENSAJE_NOMINA_VIGENTE_EN_OTRO_CENTRO)
+
     # ── Sección 3: Registro ──────────────────────────────────────────────────
     tipo_registro = models.CharField(
         max_length=16,

--- a/centrodeinfancia/models.py
+++ b/centrodeinfancia/models.py
@@ -1294,9 +1294,7 @@ class NominaNacionalidad(models.Model):
 
 
 class NominaCentroInfancia(SoftDeleteModelMixin, models.Model):
-    SOFT_RESTORE_VALIDATOR = (
-        "centrodeinfancia.services.validar_restauracion_nomina_cdi"
-    )
+    SOFT_RESTORE_VALIDATOR = "centrodeinfancia.services.validar_restauracion_nomina_cdi"
 
     class RespuestaSiNoNsNc(models.TextChoices):
         SI = "si", "Si"

--- a/centrodeinfancia/services.py
+++ b/centrodeinfancia/services.py
@@ -37,8 +37,11 @@ MOTIVO_NOMINA_VIGENTE_OTRO_CENTRO = "vigente_otro_centro"
 
 
 def tiene_nomina_cdi_vigente_en_otro_centro(
-    ciudadano_id, centro_id, excluir_nomina_id=None, bloquear=False
-):
+    ciudadano_id: int | None,
+    centro_id: int | None,
+    excluir_nomina_id: int | None = None,
+    bloquear: bool = False,
+) -> bool:
     """Indica si la persona ya tiene una nómina CDI vigente fuera de ``centro_id``.
 
     Devuelve sólo un booleano a propósito: quien llama no debe poder informar
@@ -72,7 +75,7 @@ def tiene_nomina_cdi_vigente_en_otro_centro(
     return queryset.exists()
 
 
-def bloquear_ciudadano_para_nomina_cdi(ciudadano_id):
+def bloquear_ciudadano_para_nomina_cdi(ciudadano_id: int | None) -> None:
     """Toma el lock de fila del ciudadano dentro de la transacción en curso.
 
     Serializa altas/derivaciones simultáneas del mismo destinatario en centros
@@ -84,6 +87,37 @@ def bloquear_ciudadano_para_nomina_cdi(ciudadano_id):
     if not ciudadano_id:
         return
     Ciudadano.objects.select_for_update().filter(pk=ciudadano_id).exists()
+
+
+def puede_reactivar_nomina_cdi_bajo_bloqueo(
+    nomina: NominaCentroInfancia,
+) -> bool:
+    """Revalida una reactivación mientras serializa por ciudadano.
+
+    Debe invocarse dentro de ``transaction.atomic()`` inmediatamente antes de
+    guardar. Complementa la validación temprana del formulario y evita que dos
+    reactivaciones concurrentes de fichas en baja creen dos vigencias.
+    """
+    if (
+        not nomina.pk
+        or not nomina.ciudadano_id
+        or nomina.estado not in ESTADOS_NOMINA_CDI_VIGENTE
+    ):
+        return True
+
+    bloquear_ciudadano_para_nomina_cdi(nomina.ciudadano_id)
+    nomina_persistida = NominaCentroInfancia.objects.select_for_update().get(
+        pk=nomina.pk
+    )
+    if nomina_persistida.estado in ESTADOS_NOMINA_CDI_VIGENTE:
+        return True
+
+    return not tiene_nomina_cdi_vigente_en_otro_centro(
+        nomina_persistida.ciudadano_id,
+        nomina_persistida.centro_id,
+        excluir_nomina_id=nomina_persistida.pk,
+        bloquear=True,
+    )
 
 
 _CAMPOS_COPIABLES = [
@@ -255,8 +289,10 @@ class AsistenciaNominaCentroInfanciaService:
 class CentroDeInfanciaService:
     @staticmethod
     def _validar_vigencia_para_derivacion(
-        nomina_origen, centro_destino, bloquear=False
-    ):
+        nomina_origen: NominaCentroInfancia,
+        centro_destino: CentroDeInfancia,
+        bloquear: bool = False,
+    ) -> str | None:
         """Devuelve el mensaje de impedimento, o None si la derivación puede seguir.
 
         El origen no cuenta: pasa a baja dentro de la misma transacción.

--- a/centrodeinfancia/services.py
+++ b/centrodeinfancia/services.py
@@ -120,6 +120,21 @@ def puede_reactivar_nomina_cdi_bajo_bloqueo(
     )
 
 
+def validar_restauracion_nomina_cdi(nomina: NominaCentroInfancia) -> None:
+    """Impide restaurar una ficha vigente si existe otra en un CDI distinto."""
+    if nomina.estado not in ESTADOS_NOMINA_CDI_VIGENTE:
+        return
+
+    bloquear_ciudadano_para_nomina_cdi(nomina.ciudadano_id)
+    if tiene_nomina_cdi_vigente_en_otro_centro(
+        nomina.ciudadano_id,
+        nomina.centro_id,
+        excluir_nomina_id=nomina.pk,
+        bloquear=True,
+    ):
+        raise ValidationError(MENSAJE_NOMINA_VIGENTE_EN_OTRO_CENTRO)
+
+
 _CAMPOS_COPIABLES = [
     "dni",
     "apellido",

--- a/centrodeinfancia/services.py
+++ b/centrodeinfancia/services.py
@@ -14,8 +14,77 @@ from centrodeinfancia.models import (
     NominaCentroInfancia,
     NominaCentroInfanciaDerivacion,
 )
+from ciudadanos.models import Ciudadano
 
 logger = logging.getLogger(__name__)
+
+# Estados que cuentan como inscripción vigente en un CDI. Los registros en
+# "baja" (y los dados de baja lógicamente) no bloquean una nueva nominalización,
+# lo que permite sostener el flujo de derivación entre centros.
+ESTADOS_NOMINA_CDI_VIGENTE = (
+    NominaCentroInfancia.ESTADO_ACTIVO,
+    NominaCentroInfancia.ESTADO_PENDIENTE,
+)
+
+# Mensaje neutro: no debe permitir inferir en qué centro está la persona.
+MENSAJE_NOMINA_VIGENTE_EN_OTRO_CENTRO = (
+    "No se puede avanzar con el registro porque la persona ya se encuentra "
+    "registrada en otro Centro de Infancia."
+)
+
+MOTIVO_NOMINA_DUPLICADA_MISMO_CENTRO = "duplicada_mismo_centro"
+MOTIVO_NOMINA_VIGENTE_OTRO_CENTRO = "vigente_otro_centro"
+
+
+def tiene_nomina_cdi_vigente_en_otro_centro(
+    ciudadano_id, centro_id, excluir_nomina_id=None, bloquear=False
+):
+    """Indica si la persona ya tiene una nómina CDI vigente fuera de ``centro_id``.
+
+    Devuelve sólo un booleano a propósito: quien llama no debe poder informar
+    (ni inferir) de qué centro se trata.
+
+    El manager por defecto de ``NominaCentroInfancia`` ya excluye los registros
+    dados de baja lógicamente, así que ambos sentidos de "baja" (estado y soft
+    delete) quedan fuera del cálculo de vigencia.
+
+    ``bloquear=True`` convierte la consulta en una lectura con lock, y **sólo
+    puede usarse dentro de una transacción**. Es necesario en los caminos que
+    escriben: bajo REPEATABLE READ (default de InnoDB) una lectura común usa el
+    snapshot de la transacción, que pudo tomarse antes de obtener el lock del
+    ciudadano y no vería un alta concurrente ya commiteada. La lectura con lock
+    siempre ve la última versión commiteada y, al no haber filas, toma el gap
+    lock del índice de ``ciudadano_id``, que además frena el insert simultáneo.
+    """
+    if not ciudadano_id:
+        return False
+
+    queryset = NominaCentroInfancia.objects.filter(
+        ciudadano_id=ciudadano_id,
+        estado__in=ESTADOS_NOMINA_CDI_VIGENTE,
+    )
+    if centro_id:
+        queryset = queryset.exclude(centro_id=centro_id)
+    if excluir_nomina_id:
+        queryset = queryset.exclude(pk=excluir_nomina_id)
+    if bloquear:
+        queryset = queryset.select_for_update()
+    return queryset.exists()
+
+
+def bloquear_ciudadano_para_nomina_cdi(ciudadano_id):
+    """Toma el lock de fila del ciudadano dentro de la transacción en curso.
+
+    Serializa altas/derivaciones simultáneas del mismo destinatario en centros
+    distintos: bloquear el centro no alcanza porque los intentos concurrentes
+    ocurren justamente en centros diferentes. El lock se toma siempre sobre el
+    ciudadano primero para mantener un orden de adquisición único y evitar
+    deadlocks.
+    """
+    if not ciudadano_id:
+        return
+    Ciudadano.objects.select_for_update().filter(pk=ciudadano_id).exists()
+
 
 _CAMPOS_COPIABLES = [
     "dni",
@@ -185,6 +254,40 @@ class AsistenciaNominaCentroInfanciaService:
 
 class CentroDeInfanciaService:
     @staticmethod
+    def _validar_vigencia_para_derivacion(
+        nomina_origen, centro_destino, bloquear=False
+    ):
+        """Devuelve el mensaje de impedimento, o None si la derivación puede seguir.
+
+        El origen no cuenta: pasa a baja dentro de la misma transacción.
+        ``bloquear`` sólo se activa en la revalidación dentro de la transacción
+        (ver `tiene_nomina_cdi_vigente_en_otro_centro`).
+        """
+        queryset_destino = NominaCentroInfancia.objects.filter(
+            ciudadano_id=nomina_origen.ciudadano_id,
+            centro=centro_destino,
+            estado__in=ESTADOS_NOMINA_CDI_VIGENTE,
+        )
+        if bloquear:
+            queryset_destino = queryset_destino.select_for_update()
+        if queryset_destino.exists():
+            return (
+                "La persona ya tiene un registro activo o pendiente en "
+                f"«{centro_destino.nombre}»."
+            )
+
+        queryset_terceros = NominaCentroInfancia.objects.filter(
+            ciudadano_id=nomina_origen.ciudadano_id,
+            estado__in=ESTADOS_NOMINA_CDI_VIGENTE,
+        ).exclude(centro_id__in=[nomina_origen.centro_id, centro_destino.pk])
+        if bloquear:
+            queryset_terceros = queryset_terceros.select_for_update()
+        if queryset_terceros.exists():
+            return MENSAJE_NOMINA_VIGENTE_EN_OTRO_CENTRO
+
+        return None
+
+    @staticmethod
     def transferir_ciudadano_entre_centros(  # pylint: disable=too-many-return-statements
         nomina_pk, centro_destino_pk, usuario, motivo=""
     ):
@@ -209,23 +312,15 @@ class CentroDeInfanciaService:
         if centro_destino.pk == nomina_origen.centro_id:
             return False, "El centro destino debe ser diferente al centro de origen."
 
-        ya_existe = NominaCentroInfancia.objects.filter(
-            ciudadano_id=nomina_origen.ciudadano_id,
-            centro=centro_destino,
-            estado__in=[
-                NominaCentroInfancia.ESTADO_ACTIVO,
-                NominaCentroInfancia.ESTADO_PENDIENTE,
-            ],
-        ).exists()
-
-        if ya_existe:
-            return (
-                False,
-                f"La persona ya tiene un registro activo o pendiente en «{centro_destino.nombre}».",
-            )
+        impedimento = CentroDeInfanciaService._validar_vigencia_para_derivacion(
+            nomina_origen, centro_destino
+        )
+        if impedimento:
+            return False, impedimento
 
         try:
             with transaction.atomic():
+                bloquear_ciudadano_para_nomina_cdi(nomina_origen.ciudadano_id)
                 nomina_origen = NominaCentroInfancia.objects.select_for_update().get(
                     pk=nomina_pk
                 )
@@ -235,19 +330,11 @@ class CentroDeInfanciaService:
                         "El registro fue modificado antes de completar la derivación.",
                     )
 
-                ya_existe = NominaCentroInfancia.objects.filter(
-                    ciudadano_id=nomina_origen.ciudadano_id,
-                    centro=centro_destino,
-                    estado__in=[
-                        NominaCentroInfancia.ESTADO_ACTIVO,
-                        NominaCentroInfancia.ESTADO_PENDIENTE,
-                    ],
-                ).exists()
-                if ya_existe:
-                    return (
-                        False,
-                        f"La persona ya tiene un registro activo o pendiente en «{centro_destino.nombre}».",
-                    )
+                impedimento = CentroDeInfanciaService._validar_vigencia_para_derivacion(
+                    nomina_origen, centro_destino, bloquear=True
+                )
+                if impedimento:
+                    return False, impedimento
 
                 centro_origen_id = nomina_origen.centro_id
 

--- a/centrodeinfancia/tests/test_nomina_integridad.py
+++ b/centrodeinfancia/tests/test_nomina_integridad.py
@@ -15,6 +15,7 @@ from django.urls import reverse
 from ciudadanos.models import Ciudadano
 from centrodeinfancia.forms import NominaCentroInfanciaCreateForm
 from centrodeinfancia.models import CentroDeInfancia, NominaCentroInfancia
+from centrodeinfancia.services import MOTIVO_NOMINA_DUPLICADA_MISMO_CENTRO
 from centrodeinfancia.views import NominaCentroInfanciaCreateView
 from core.models import Localidad, Municipio, Provincia, Sexo
 
@@ -45,7 +46,7 @@ def test_crear_nomina_con_bloqueo_evitar_duplicados():
             return NominaCentroInfancia(**self._attrs)
 
     with transaction.atomic():
-        creado_1 = NominaCentroInfanciaCreateView._crear_nomina_con_bloqueo(
+        creado_1, motivo_1 = NominaCentroInfanciaCreateView._crear_nomina_con_bloqueo(
             centro=centro,
             ciudadano=ciudadano,
             form=_FormStub(
@@ -57,7 +58,7 @@ def test_crear_nomina_con_bloqueo_evitar_duplicados():
         )
 
     with transaction.atomic():
-        creado_2 = NominaCentroInfanciaCreateView._crear_nomina_con_bloqueo(
+        creado_2, motivo_2 = NominaCentroInfanciaCreateView._crear_nomina_con_bloqueo(
             centro=centro,
             ciudadano=ciudadano,
             form=_FormStub(
@@ -69,7 +70,9 @@ def test_crear_nomina_con_bloqueo_evitar_duplicados():
         )
 
     assert creado_1 is True
+    assert motivo_1 is None
     assert creado_2 is False
+    assert motivo_2 == MOTIVO_NOMINA_DUPLICADA_MISMO_CENTRO
     assert (
         NominaCentroInfancia.objects.filter(
             centro=centro,

--- a/centrodeinfancia/tests/test_nomina_vigencia_unica.py
+++ b/centrodeinfancia/tests/test_nomina_vigencia_unica.py
@@ -4,21 +4,28 @@ Vigente = estado Activo o Pendiente y registro no dado de baja. El impedimento
 nunca debe exponer cuál es el otro centro involucrado.
 """
 
+from concurrent.futures import ThreadPoolExecutor
 from datetime import date
+from threading import Barrier
 
 import pytest
 from django.contrib.auth.models import User
-from django.db import transaction
+from django.core.exceptions import ValidationError
+from django.db import close_old_connections, connection, transaction
 from django.urls import reverse
 
 from ciudadanos.models import Ciudadano
-from centrodeinfancia.forms import NominaCentroInfanciaForm
+from centrodeinfancia.forms import (
+    NominaCentroInfanciaAdminForm,
+    NominaCentroInfanciaForm,
+)
 from centrodeinfancia.models import CentroDeInfancia, NominaCentroInfancia
 from centrodeinfancia.services import (
     MENSAJE_NOMINA_VIGENTE_EN_OTRO_CENTRO,
     MOTIVO_NOMINA_DUPLICADA_MISMO_CENTRO,
     MOTIVO_NOMINA_VIGENTE_OTRO_CENTRO,
     CentroDeInfanciaService,
+    puede_reactivar_nomina_cdi_bajo_bloqueo,
     tiene_nomina_cdi_vigente_en_otro_centro,
 )
 from centrodeinfancia.tests.test_destinatario_form import datos_validos
@@ -196,8 +203,12 @@ def test_alta_toma_el_lock_de_fila_del_ciudadano(centro_destino, ciudadano, mock
 
 
 @pytest.mark.django_db(transaction=True)
-def test_altas_simultaneas_no_generan_dos_registros_vigentes(provincia):
-    """Dos altas del mismo destinatario en centros distintos: sólo una prospera."""
+@pytest.mark.mysql_compat
+def test_altas_concurrentes_en_mysql_no_generan_dos_registros_vigentes(provincia):
+    """Dos transacciones MySQL simultáneas quedan serializadas por ciudadano."""
+    if connection.vendor != "mysql":
+        pytest.skip("La contención real se verifica contra MySQL.")
+
     centro_1 = CentroDeInfancia.objects.create(nombre="CDI Race 1", provincia=provincia)
     centro_2 = CentroDeInfancia.objects.create(nombre="CDI Race 2", provincia=provincia)
     persona = Ciudadano.objects.create(
@@ -207,13 +218,27 @@ def test_altas_simultaneas_no_generan_dos_registros_vigentes(provincia):
         tipo_documento=Ciudadano.DOCUMENTO_DNI,
         documento=46999888,
     )
+    inicio = Barrier(2)
 
-    creado_1, _ = _intentar_alta(centro_1, persona)
-    creado_2, motivo_2 = _intentar_alta(centro_2, persona)
+    def alta_concurrente(centro_id):
+        close_old_connections()
+        try:
+            inicio.wait(timeout=10)
+            centro = CentroDeInfancia.objects.get(pk=centro_id)
+            ciudadano_actual = Ciudadano.objects.get(pk=persona.pk)
+            return _intentar_alta(centro, ciudadano_actual)
+        finally:
+            close_old_connections()
 
-    assert creado_1 is True
-    assert creado_2 is False
-    assert motivo_2 == MOTIVO_NOMINA_VIGENTE_OTRO_CENTRO
+    with ThreadPoolExecutor(max_workers=2) as executor:
+        resultados = list(
+            executor.map(alta_concurrente, (centro_1.pk, centro_2.pk), timeout=20)
+        )
+
+    assert sum(creado for creado, _ in resultados) == 1
+    assert sorted(motivo for creado, motivo in resultados if not creado) == [
+        MOTIVO_NOMINA_VIGENTE_OTRO_CENTRO
+    ]
     assert (
         NominaCentroInfancia.objects.filter(
             ciudadano=persona,
@@ -320,6 +345,76 @@ def test_edicion_permite_reactivar_si_no_hay_vigencia_en_otro_centro(
     )
 
     assert form.is_valid() is True, form.errors
+
+
+@pytest.mark.django_db
+def test_reactivacion_revalida_bajo_bloqueo_antes_de_guardar(
+    centro_origen, centro_destino, ciudadano
+):
+    _crear_nomina(centro_origen, ciudadano, NominaCentroInfancia.ESTADO_ACTIVO)
+    nomina_baja = _crear_nomina(
+        centro_destino, ciudadano, NominaCentroInfancia.ESTADO_BAJA
+    )
+    nomina_baja.estado = NominaCentroInfancia.ESTADO_ACTIVO
+
+    with transaction.atomic():
+        assert puede_reactivar_nomina_cdi_bajo_bloqueo(nomina_baja) is False
+
+
+@pytest.mark.django_db
+def test_admin_rechaza_alta_si_hay_vigencia_en_otro_centro(
+    centro_origen, centro_destino, ciudadano
+):
+    _crear_nomina(centro_origen, ciudadano, NominaCentroInfancia.ESTADO_ACTIVO)
+
+    form = NominaCentroInfanciaAdminForm(
+        data={
+            "centro": centro_destino.pk,
+            "ciudadano": ciudadano.pk,
+            "estado": NominaCentroInfancia.ESTADO_ACTIVO,
+        }
+    )
+
+    assert form.is_valid() is False
+    assert form.errors["__all__"] == [MENSAJE_NOMINA_VIGENTE_EN_OTRO_CENTRO]
+
+
+@pytest.mark.django_db
+def test_admin_rechaza_mover_ficha_vigente_a_otro_centro_con_vigencia(
+    centro_origen, centro_destino, ciudadano
+):
+    nomina_origen = _crear_nomina(
+        centro_origen, ciudadano, NominaCentroInfancia.ESTADO_ACTIVO
+    )
+    _crear_nomina(centro_destino, ciudadano, NominaCentroInfancia.ESTADO_ACTIVO)
+
+    form = NominaCentroInfanciaAdminForm(
+        data={
+            "centro": centro_destino.pk,
+            "ciudadano": ciudadano.pk,
+            "estado": NominaCentroInfancia.ESTADO_ACTIVO,
+        },
+        instance=nomina_origen,
+    )
+
+    assert form.is_valid() is False
+    assert form.errors["__all__"] == [MENSAJE_NOMINA_VIGENTE_EN_OTRO_CENTRO]
+
+
+@pytest.mark.django_db
+def test_restore_rechaza_ficha_vigente_si_hay_otro_centro_activo(
+    centro_origen, centro_destino, ciudadano
+):
+    nomina_eliminada = _crear_nomina(
+        centro_origen, ciudadano, NominaCentroInfancia.ESTADO_ACTIVO
+    )
+    nomina_eliminada.delete()
+    _crear_nomina(centro_destino, ciudadano, NominaCentroInfancia.ESTADO_ACTIVO)
+
+    with pytest.raises(ValidationError, match="No se puede avanzar"):
+        NominaCentroInfancia.all_objects.get(pk=nomina_eliminada.pk).restore()
+
+    assert NominaCentroInfancia.all_objects.get(pk=nomina_eliminada.pk).is_deleted
 
 
 @pytest.mark.django_db

--- a/centrodeinfancia/tests/test_nomina_vigencia_unica.py
+++ b/centrodeinfancia/tests/test_nomina_vigencia_unica.py
@@ -1,0 +1,432 @@
+"""Regla: una persona sólo puede tener una nómina CDI vigente a la vez.
+
+Vigente = estado Activo o Pendiente y registro no dado de baja. El impedimento
+nunca debe exponer cuál es el otro centro involucrado.
+"""
+
+from datetime import date
+
+import pytest
+from django.contrib.auth.models import User
+from django.db import transaction
+from django.urls import reverse
+
+from ciudadanos.models import Ciudadano
+from centrodeinfancia.forms import NominaCentroInfanciaForm
+from centrodeinfancia.models import CentroDeInfancia, NominaCentroInfancia
+from centrodeinfancia.services import (
+    MENSAJE_NOMINA_VIGENTE_EN_OTRO_CENTRO,
+    MOTIVO_NOMINA_DUPLICADA_MISMO_CENTRO,
+    MOTIVO_NOMINA_VIGENTE_OTRO_CENTRO,
+    CentroDeInfanciaService,
+    tiene_nomina_cdi_vigente_en_otro_centro,
+)
+from centrodeinfancia.tests.test_destinatario_form import datos_validos
+from centrodeinfancia.views import NominaCentroInfanciaCreateView
+from core.models import Provincia
+
+NOMBRE_CENTRO_A_OCULTAR = "CDI Confidencial Vigencia"
+
+
+@pytest.fixture
+def provincia():
+    return Provincia.objects.create(nombre="Santa Fe")
+
+
+@pytest.fixture
+def centro_destino(provincia):
+    return CentroDeInfancia.objects.create(
+        nombre="CDI Vigencia Destino", provincia=provincia
+    )
+
+
+@pytest.fixture
+def centro_origen(provincia):
+    return CentroDeInfancia.objects.create(
+        nombre=NOMBRE_CENTRO_A_OCULTAR, provincia=provincia
+    )
+
+
+@pytest.fixture
+def ciudadano():
+    return Ciudadano.objects.create(
+        apellido="Torres",
+        nombre="Luca",
+        fecha_nacimiento=date(2021, 7, 1),
+        tipo_documento=Ciudadano.DOCUMENTO_DNI,
+        documento=45123456,
+    )
+
+
+class _FormStub:
+    """Sustituto mínimo del ModelForm: sólo aporta `save(commit=False)`."""
+
+    def __init__(self, **attrs):
+        self._attrs = attrs
+
+    def save(self, commit=False):
+        assert commit is False
+        return NominaCentroInfancia(**self._attrs)
+
+
+def _crear_nomina(centro, ciudadano, estado):
+    return NominaCentroInfancia.objects.create(
+        centro=centro,
+        ciudadano=ciudadano,
+        estado=estado,
+        dni=ciudadano.documento,
+        apellido=ciudadano.apellido,
+        nombre=ciudadano.nombre,
+        fecha_nacimiento=ciudadano.fecha_nacimiento,
+    )
+
+
+def _intentar_alta(centro, ciudadano, estado=NominaCentroInfancia.ESTADO_ACTIVO):
+    with transaction.atomic():
+        return NominaCentroInfanciaCreateView._crear_nomina_con_bloqueo(  # pylint: disable=protected-access
+            centro=centro,
+            ciudadano=ciudadano,
+            form=_FormStub(estado=estado),
+        )
+
+
+# ─────────────────────────────────────────────────────────
+# Alta: helper de vigencia
+# ─────────────────────────────────────────────────────────
+
+
+@pytest.mark.django_db
+def test_permite_alta_sin_nomina_vigente(centro_destino, ciudadano):
+    creado, motivo = _intentar_alta(centro_destino, ciudadano)
+
+    assert creado is True
+    assert motivo is None
+    assert NominaCentroInfancia.objects.filter(centro=centro_destino).count() == 1
+
+
+@pytest.mark.django_db
+@pytest.mark.parametrize(
+    "estado_vigente",
+    [NominaCentroInfancia.ESTADO_ACTIVO, NominaCentroInfancia.ESTADO_PENDIENTE],
+)
+def test_bloquea_alta_si_hay_vigencia_en_otro_centro(
+    centro_origen, centro_destino, ciudadano, estado_vigente
+):
+    _crear_nomina(centro_origen, ciudadano, estado_vigente)
+
+    creado, motivo = _intentar_alta(centro_destino, ciudadano)
+
+    assert creado is False
+    assert motivo == MOTIVO_NOMINA_VIGENTE_OTRO_CENTRO
+    assert not NominaCentroInfancia.objects.filter(centro=centro_destino).exists()
+    # El registro de origen queda intacto.
+    assert NominaCentroInfancia.objects.get(centro=centro_origen).estado == (
+        estado_vigente
+    )
+
+
+@pytest.mark.django_db
+def test_permite_alta_si_los_registros_previos_estan_en_baja(
+    centro_origen, centro_destino, ciudadano
+):
+    _crear_nomina(centro_origen, ciudadano, NominaCentroInfancia.ESTADO_BAJA)
+
+    creado, motivo = _intentar_alta(centro_destino, ciudadano)
+
+    assert creado is True
+    assert motivo is None
+
+
+@pytest.mark.django_db
+def test_permite_alta_si_el_registro_previo_fue_dado_de_baja_logicamente(
+    centro_origen, centro_destino, ciudadano
+):
+    nomina = _crear_nomina(centro_origen, ciudadano, NominaCentroInfancia.ESTADO_ACTIVO)
+    nomina.delete()
+
+    creado, motivo = _intentar_alta(centro_destino, ciudadano)
+
+    assert creado is True
+    assert motivo is None
+
+
+@pytest.mark.django_db
+def test_conserva_el_bloqueo_de_duplicado_en_el_mismo_centro(centro_destino, ciudadano):
+    _crear_nomina(centro_destino, ciudadano, NominaCentroInfancia.ESTADO_BAJA)
+
+    creado, motivo = _intentar_alta(centro_destino, ciudadano)
+
+    assert creado is False
+    assert motivo == MOTIVO_NOMINA_DUPLICADA_MISMO_CENTRO
+
+
+@pytest.mark.django_db
+def test_helper_de_vigencia_ignora_el_propio_centro(centro_origen, ciudadano):
+    _crear_nomina(centro_origen, ciudadano, NominaCentroInfancia.ESTADO_ACTIVO)
+
+    assert (
+        tiene_nomina_cdi_vigente_en_otro_centro(ciudadano.pk, centro_origen.pk) is False
+    )
+
+
+# ─────────────────────────────────────────────────────────
+# Alta simultánea
+# ─────────────────────────────────────────────────────────
+
+
+@pytest.mark.django_db
+def test_alta_toma_el_lock_de_fila_del_ciudadano(centro_destino, ciudadano, mocker):
+    """El lock sobre el ciudadano es lo que serializa altas en centros distintos.
+
+    En SQLite `select_for_update` es un no-op, así que se verifica que el lock se
+    pida; el bloqueo efectivo lo aporta InnoDB en MySQL.
+    """
+    bloqueo = mocker.patch("centrodeinfancia.views.bloquear_ciudadano_para_nomina_cdi")
+    chequeo = mocker.patch(
+        "centrodeinfancia.views.tiene_nomina_cdi_vigente_en_otro_centro",
+        return_value=False,
+    )
+
+    _intentar_alta(centro_destino, ciudadano)
+
+    bloqueo.assert_called_once_with(ciudadano.pk)
+    # `bloquear=True`: bajo REPEATABLE READ una lectura común podría usar un
+    # snapshot anterior al lock y no ver un alta concurrente ya commiteada.
+    assert chequeo.call_args.kwargs["bloquear"] is True
+
+
+@pytest.mark.django_db(transaction=True)
+def test_altas_simultaneas_no_generan_dos_registros_vigentes(provincia):
+    """Dos altas del mismo destinatario en centros distintos: sólo una prospera."""
+    centro_1 = CentroDeInfancia.objects.create(nombre="CDI Race 1", provincia=provincia)
+    centro_2 = CentroDeInfancia.objects.create(nombre="CDI Race 2", provincia=provincia)
+    persona = Ciudadano.objects.create(
+        apellido="Race",
+        nombre="Roman",
+        fecha_nacimiento=date(2021, 1, 5),
+        tipo_documento=Ciudadano.DOCUMENTO_DNI,
+        documento=46999888,
+    )
+
+    creado_1, _ = _intentar_alta(centro_1, persona)
+    creado_2, motivo_2 = _intentar_alta(centro_2, persona)
+
+    assert creado_1 is True
+    assert creado_2 is False
+    assert motivo_2 == MOTIVO_NOMINA_VIGENTE_OTRO_CENTRO
+    assert (
+        NominaCentroInfancia.objects.filter(
+            ciudadano=persona,
+            estado__in=[
+                NominaCentroInfancia.ESTADO_ACTIVO,
+                NominaCentroInfancia.ESTADO_PENDIENTE,
+            ],
+        ).count()
+        == 1
+    )
+
+
+# ─────────────────────────────────────────────────────────
+# Alta vía vista: mensaje neutro
+# ─────────────────────────────────────────────────────────
+
+
+@pytest.mark.django_db
+def test_alta_via_vista_informa_sin_exponer_el_otro_centro(
+    client, centro_origen, centro_destino, ciudadano
+):
+    _crear_nomina(centro_origen, ciudadano, NominaCentroInfancia.ESTADO_ACTIVO)
+    user = User.objects.create_superuser(
+        username="super-cdi-vigencia",
+        email="super-cdi-vigencia@example.com",
+        password="test1234",
+    )
+    client.force_login(user)
+
+    response = client.post(
+        reverse("centrodeinfancia_nomina_crear", kwargs={"pk": centro_destino.pk}),
+        data=datos_validos(
+            centro_destino,
+            ciudadano_id=ciudadano.id,
+            estado=NominaCentroInfancia.ESTADO_ACTIVO,
+            dni=ciudadano.documento,
+            apellido=ciudadano.apellido,
+            nombre=ciudadano.nombre,
+            fecha_nacimiento="2021-07-01",
+            sexo="Masculino",
+        ),
+    )
+    contenido = response.content.decode()
+
+    assert response.status_code == 200
+    assert not NominaCentroInfancia.objects.filter(centro=centro_destino).exists()
+    assert MENSAJE_NOMINA_VIGENTE_EN_OTRO_CENTRO in contenido
+    assert NOMBRE_CENTRO_A_OCULTAR not in contenido
+    # Tampoco se filtra el identificador: ningún enlace apunta al centro de origen.
+    assert (
+        reverse("centrodeinfancia_nomina_ver", kwargs={"pk": centro_origen.pk})
+        not in contenido
+    )
+
+
+# ─────────────────────────────────────────────────────────
+# Edición: no se puede reactivar para saltear la regla
+# ─────────────────────────────────────────────────────────
+
+
+def _datos_edicion(nomina, estado):
+    return {
+        "estado": estado,
+        "dni": nomina.dni,
+        "apellido": nomina.apellido,
+        "nombre": nomina.nombre,
+        "fecha_nacimiento": "2021-07-01",
+    }
+
+
+@pytest.mark.django_db
+def test_edicion_no_permite_reactivar_si_hay_vigencia_en_otro_centro(
+    centro_origen, centro_destino, ciudadano
+):
+    _crear_nomina(centro_origen, ciudadano, NominaCentroInfancia.ESTADO_ACTIVO)
+    nomina_baja = _crear_nomina(
+        centro_destino, ciudadano, NominaCentroInfancia.ESTADO_BAJA
+    )
+
+    form = NominaCentroInfanciaForm(
+        data=_datos_edicion(nomina_baja, NominaCentroInfancia.ESTADO_ACTIVO),
+        instance=nomina_baja,
+    )
+
+    assert form.is_valid() is False
+    assert form.errors["__all__"] == [MENSAJE_NOMINA_VIGENTE_EN_OTRO_CENTRO]
+    assert NOMBRE_CENTRO_A_OCULTAR not in str(form.errors)
+    nomina_baja.refresh_from_db()
+    assert nomina_baja.estado == NominaCentroInfancia.ESTADO_BAJA
+
+
+@pytest.mark.django_db
+def test_edicion_permite_reactivar_si_no_hay_vigencia_en_otro_centro(
+    centro_origen, centro_destino, ciudadano
+):
+    _crear_nomina(centro_origen, ciudadano, NominaCentroInfancia.ESTADO_BAJA)
+    nomina_baja = _crear_nomina(
+        centro_destino, ciudadano, NominaCentroInfancia.ESTADO_BAJA
+    )
+
+    form = NominaCentroInfanciaForm(
+        data=_datos_edicion(nomina_baja, NominaCentroInfancia.ESTADO_ACTIVO),
+        instance=nomina_baja,
+    )
+
+    assert form.is_valid() is True, form.errors
+
+
+@pytest.mark.django_db
+def test_edicion_de_una_ficha_ya_vigente_no_queda_bloqueada(
+    centro_origen, centro_destino, ciudadano
+):
+    """Duplicados históricos: fuera de alcance, pero deben seguir siendo editables."""
+    _crear_nomina(centro_origen, ciudadano, NominaCentroInfancia.ESTADO_ACTIVO)
+    nomina_vigente = _crear_nomina(
+        centro_destino, ciudadano, NominaCentroInfancia.ESTADO_ACTIVO
+    )
+
+    form = NominaCentroInfanciaForm(
+        data=_datos_edicion(nomina_vigente, NominaCentroInfancia.ESTADO_PENDIENTE),
+        instance=nomina_vigente,
+    )
+
+    assert form.is_valid() is True, form.errors
+
+
+@pytest.mark.django_db
+def test_edicion_ajax_rechaza_la_reactivacion(
+    client, centro_origen, centro_destino, ciudadano
+):
+    _crear_nomina(centro_origen, ciudadano, NominaCentroInfancia.ESTADO_ACTIVO)
+    nomina_baja = _crear_nomina(
+        centro_destino, ciudadano, NominaCentroInfancia.ESTADO_BAJA
+    )
+    user = User.objects.create_superuser(
+        username="super-cdi-edicion",
+        email="super-cdi-edicion@example.com",
+        password="test1234",
+    )
+    client.force_login(user)
+
+    response = client.post(
+        reverse("centrodeinfancia_nomina_editar_ajax", kwargs={"pk": nomina_baja.pk}),
+        data=_datos_edicion(nomina_baja, NominaCentroInfancia.ESTADO_ACTIVO),
+    )
+    data = response.json()
+
+    assert data["success"] is False
+    assert data["errors"]["__all__"] == [MENSAJE_NOMINA_VIGENTE_EN_OTRO_CENTRO]
+    assert NOMBRE_CENTRO_A_OCULTAR not in response.content.decode()
+    nomina_baja.refresh_from_db()
+    assert nomina_baja.estado == NominaCentroInfancia.ESTADO_BAJA
+
+
+# ─────────────────────────────────────────────────────────
+# Derivación
+# ─────────────────────────────────────────────────────────
+
+
+@pytest.mark.django_db
+def test_derivacion_bloquea_si_hay_vigencia_en_un_tercer_centro(
+    provincia, centro_origen, centro_destino, ciudadano
+):
+    tercero = CentroDeInfancia.objects.create(
+        nombre="CDI Vigencia Tercero", provincia=provincia
+    )
+    nomina_origen = _crear_nomina(
+        centro_origen, ciudadano, NominaCentroInfancia.ESTADO_ACTIVO
+    )
+    _crear_nomina(tercero, ciudadano, NominaCentroInfancia.ESTADO_PENDIENTE)
+    usuario = User.objects.create_superuser(
+        username="super-cdi-derivacion",
+        email="super-cdi-derivacion@example.com",
+        password="test1234",
+    )
+
+    ok, msg = CentroDeInfanciaService.transferir_ciudadano_entre_centros(
+        nomina_pk=nomina_origen.pk,
+        centro_destino_pk=centro_destino.pk,
+        usuario=usuario,
+    )
+
+    assert ok is False
+    assert msg == MENSAJE_NOMINA_VIGENTE_EN_OTRO_CENTRO
+    assert "Tercero" not in msg
+    nomina_origen.refresh_from_db()
+    assert nomina_origen.estado == NominaCentroInfancia.ESTADO_ACTIVO
+    assert not NominaCentroInfancia.objects.filter(centro=centro_destino).exists()
+
+
+@pytest.mark.django_db
+def test_derivacion_permite_recrear_pendiente_en_destino(
+    centro_origen, centro_destino, ciudadano
+):
+    """El flujo de derivación sigue funcionando: origen a Baja, destino Pendiente."""
+    nomina_origen = _crear_nomina(
+        centro_origen, ciudadano, NominaCentroInfancia.ESTADO_ACTIVO
+    )
+    usuario = User.objects.create_superuser(
+        username="super-cdi-derivacion-ok",
+        email="super-cdi-derivacion-ok@example.com",
+        password="test1234",
+    )
+
+    ok, _ = CentroDeInfanciaService.transferir_ciudadano_entre_centros(
+        nomina_pk=nomina_origen.pk,
+        centro_destino_pk=centro_destino.pk,
+        usuario=usuario,
+    )
+
+    assert ok is True
+    nomina_origen.refresh_from_db()
+    assert nomina_origen.estado == NominaCentroInfancia.ESTADO_BAJA
+    assert NominaCentroInfancia.objects.get(centro=centro_destino).estado == (
+        NominaCentroInfancia.ESTADO_PENDIENTE
+    )

--- a/centrodeinfancia/views.py
+++ b/centrodeinfancia/views.py
@@ -70,8 +70,13 @@ from centrodeinfancia.models import (
     Trabajador,
 )
 from centrodeinfancia.services import (
+    MENSAJE_NOMINA_VIGENTE_EN_OTRO_CENTRO,
+    MOTIVO_NOMINA_DUPLICADA_MISMO_CENTRO,
+    MOTIVO_NOMINA_VIGENTE_OTRO_CENTRO,
     AsistenciaNominaCentroInfanciaService,
     CentroDeInfanciaService,
+    bloquear_ciudadano_para_nomina_cdi,
+    tiene_nomina_cdi_vigente_en_otro_centro,
 )
 from centrodeinfancia.services_user_provisioning import (
     crear_referente_cdi_automaticamente,
@@ -1383,21 +1388,37 @@ class NominaCentroInfanciaCreateView(
 
     @staticmethod
     def _crear_nomina_con_bloqueo(centro, ciudadano, form):
+        """Crea la nómina si la persona no tiene otra vigente.
+
+        Devuelve ``(creado, motivo)``: cuando ``creado`` es False, ``motivo`` es
+        una de las constantes ``MOTIVO_NOMINA_*`` para que la vista elija el
+        mensaje sin exponer datos del otro centro.
+        """
+        bloquear_ciudadano_para_nomina_cdi(ciudadano.pk)
         CentroDeInfancia.objects.select_for_update().filter(pk=centro.pk).exists()
-        existente = NominaCentroInfancia.objects.filter(
-            centro=centro,
-            ciudadano=ciudadano,
-            deleted_at__isnull=True,
-        ).exists()
+        existente = (
+            NominaCentroInfancia.objects.select_for_update()
+            .filter(
+                centro=centro,
+                ciudadano=ciudadano,
+                deleted_at__isnull=True,
+            )
+            .exists()
+        )
         if existente:
-            return False
+            return False, MOTIVO_NOMINA_DUPLICADA_MISMO_CENTRO
+
+        if tiene_nomina_cdi_vigente_en_otro_centro(
+            ciudadano.pk, centro.pk, bloquear=True
+        ):
+            return False, MOTIVO_NOMINA_VIGENTE_OTRO_CENTRO
 
         nomina = form.save(commit=False)
         nomina.centro = centro
         nomina.ciudadano = ciudadano
         nomina.clean()
         nomina.save()
-        return True
+        return True, None
 
     def get_queryset(self):
         return _nomina_cdi_queryset_scoped(self.request.user).filter(
@@ -1563,7 +1584,9 @@ class NominaCentroInfanciaCreateView(
             pieces.append(f'Departamento {cleaned_data["departamento_domicilio"]}')
         return " / ".join(pieces) or None
 
-    def post(self, request, *args, **kwargs):
+    def post(  # pylint: disable=too-many-return-statements
+        self, request, *args, **kwargs
+    ):
         self.object = None
         centro = self._get_centro()
         form = self.form_class(request.POST, centro=centro)
@@ -1635,7 +1658,7 @@ class NominaCentroInfanciaCreateView(
                             modificado_por=request.user,
                         )
 
-                creado = self._crear_nomina_con_bloqueo(
+                creado, motivo_rechazo = self._crear_nomina_con_bloqueo(
                     centro=centro,
                     ciudadano=ciudadano,
                     form=form,
@@ -1650,6 +1673,12 @@ class NominaCentroInfanciaCreateView(
                 },
             )
             messages.error(request, "No se pudo guardar la ficha en la nómina.")
+            context = self.get_context_data(form=form)
+            return self.render_to_response(context)
+
+        if motivo_rechazo == MOTIVO_NOMINA_VIGENTE_OTRO_CENTRO:
+            form.add_error(None, MENSAJE_NOMINA_VIGENTE_EN_OTRO_CENTRO)
+            messages.error(request, MENSAJE_NOMINA_VIGENTE_EN_OTRO_CENTRO)
             context = self.get_context_data(form=form)
             return self.render_to_response(context)
 

--- a/centrodeinfancia/views.py
+++ b/centrodeinfancia/views.py
@@ -76,6 +76,7 @@ from centrodeinfancia.services import (
     AsistenciaNominaCentroInfanciaService,
     CentroDeInfanciaService,
     bloquear_ciudadano_para_nomina_cdi,
+    puede_reactivar_nomina_cdi_bajo_bloqueo,
     tiene_nomina_cdi_vigente_en_otro_centro,
 )
 from centrodeinfancia.services_user_provisioning import (
@@ -1368,6 +1369,14 @@ class NominaCentroInfanciaEditView(
     def get_success_url(self):
         return reverse("centrodeinfancia_nomina_ver", kwargs={"pk": self.kwargs["pk"]})
 
+    def form_valid(self, form):
+        with transaction.atomic():
+            if not puede_reactivar_nomina_cdi_bajo_bloqueo(form.instance):
+                form.add_error(None, MENSAJE_NOMINA_VIGENTE_EN_OTRO_CENTRO)
+                return self.form_invalid(form)
+            self.object = form.save()
+        return redirect(self.get_success_url())
+
 
 class NominaCentroInfanciaCreateView(
     _AuditoriaSoloLecturaMixin,
@@ -1742,7 +1751,11 @@ def nomina_centrodeinfancia_editar_ajax(request, pk):
             raise PermissionDenied("El rol Auditoría tiene acceso de solo lectura.")
         form = NominaCentroInfanciaForm(request.POST, instance=nomina)
         if form.is_valid():
-            form.save()
+            with transaction.atomic():
+                if not puede_reactivar_nomina_cdi_bajo_bloqueo(form.instance):
+                    form.add_error(None, MENSAJE_NOMINA_VIGENTE_EN_OTRO_CENTRO)
+                    return JsonResponse({"success": False, "errors": form.errors})
+                form.save()
             return JsonResponse(
                 {"success": True, "message": "Datos modificados con éxito."}
             )

--- a/core/soft_delete/cascade.py
+++ b/core/soft_delete/cascade.py
@@ -498,6 +498,12 @@ def execute_restore_plan(plan: CascadePlan, *, user=None) -> tuple[int, dict]:
 
     with transaction.atomic():
         soft_nodes_by_model = _group_soft_nodes(plan)
+        for node in plan.iter_nodes_by_mode(MODE_SOFT):
+            validar_restauracion = getattr(
+                node.instance, "validar_restauracion_soft", None
+            )
+            if callable(validar_restauracion):
+                validar_restauracion()
         restore_updates_by_model = {
             model: build_soft_restore_operational_updates(model)
             for model in soft_nodes_by_model

--- a/core/soft_delete/cascade.py
+++ b/core/soft_delete/cascade.py
@@ -8,6 +8,7 @@ from functools import lru_cache
 
 from django.db import models, transaction
 from django.utils import timezone
+from django.utils.module_loading import import_string
 
 from .state_sync import (
     build_soft_delete_operational_updates,
@@ -499,11 +500,11 @@ def execute_restore_plan(plan: CascadePlan, *, user=None) -> tuple[int, dict]:
     with transaction.atomic():
         soft_nodes_by_model = _group_soft_nodes(plan)
         for node in plan.iter_nodes_by_mode(MODE_SOFT):
-            validar_restauracion = getattr(
-                node.instance, "validar_restauracion_soft", None
+            validator_path = getattr(
+                node.instance.__class__, "SOFT_RESTORE_VALIDATOR", None
             )
-            if callable(validar_restauracion):
-                validar_restauracion()
+            if validator_path:
+                import_string(validator_path)(node.instance)
         restore_updates_by_model = {
             model: build_soft_restore_operational_updates(model)
             for model in soft_nodes_by_model

--- a/core/trash_views.py
+++ b/core/trash_views.py
@@ -6,6 +6,7 @@ from urllib.parse import urlencode
 
 from django.contrib import messages
 from django.contrib.auth.mixins import LoginRequiredMixin
+from django.core.exceptions import ValidationError
 from django.core.paginator import Paginator
 from django.db.models import Q
 from django.db.utils import OperationalError
@@ -368,7 +369,23 @@ class TrashRestoreView(LoginRequiredMixin, SuperAdminRequiredMixin, View):
             )
             return redirect(_append_next(preview_url, _get_safe_next_url(request)))
 
-        restored_count, _ = instance.restore(user=request.user, cascade=True)
+        try:
+            restored_count, _ = instance.restore(user=request.user, cascade=True)
+        except ValidationError as exc:
+            messages.error(request, exc.messages[0])
+            return redirect(
+                _append_next(
+                    reverse(
+                        "papelera_preview_restore",
+                        kwargs={
+                            "app_label": app_label,
+                            "model_name": model._meta.model_name,
+                            "pk": pk,
+                        },
+                    ),
+                    _get_safe_next_url(request),
+                )
+            )
         messages.success(
             request,
             f"Restauración completada. Registros restaurados: {restored_count}.",

--- a/docs/registro/cambios/2026-08-07-cdi-nomina-vigente-en-un-solo-centro.md
+++ b/docs/registro/cambios/2026-08-07-cdi-nomina-vigente-en-un-solo-centro.md
@@ -49,8 +49,9 @@ crea Pendiente en la misma transacción).
 - **Sólo valida la transición hacia un estado vigente.** Una ficha que ya estaba vigente
   puede seguir editándose: los duplicados históricos están fuera de alcance y no deben
   volverse ineditables.
-- `NominaCentroInfanciaAdminForm`: aplica la misma validación al alta y a la reactivación
-  desde Django admin, sin revelar el otro centro.
+- `NominaCentroInfanciaAdminForm`: aplica la misma validación al alta, la reactivación y
+  el cambio de centro desde Django admin, sin revelar el otro centro ni permitir duplicar
+  el mismo centro.
 
 ### Restauración lógica
 

--- a/docs/registro/cambios/2026-08-07-cdi-nomina-vigente-en-un-solo-centro.md
+++ b/docs/registro/cambios/2026-08-07-cdi-nomina-vigente-en-un-solo-centro.md
@@ -1,0 +1,127 @@
+# 2026-08-07 - CDI: una única nómina vigente por persona
+
+## Contexto
+
+El alta de destinatario en un CDI (`/centrodeinfancia/<pk>/nomina/crear/`) impedía
+duplicar a una persona **dentro del mismo centro**, pero permitía que quedara registrada
+simultáneamente en varios Centros de Infancia. Se pide una única inscripción vigente por
+persona en todo el programa, sin revelar en qué centro está registrada.
+
+Regla funcional: **vigente = estado Activo o Pendiente**. Los registros en Baja no
+bloquean, lo que preserva el flujo de derivación (el origen pasa a Baja y el destino se
+crea Pendiente en la misma transacción).
+
+## Cambios aplicados
+
+### `centrodeinfancia/services.py`
+
+- `ESTADOS_NOMINA_CDI_VIGENTE` y `MENSAJE_NOMINA_VIGENTE_EN_OTRO_CENTRO` (mensaje neutro,
+  fuente única para todos los flujos).
+- `tiene_nomina_cdi_vigente_en_otro_centro(ciudadano_id, centro_id, excluir_nomina_id)`:
+  devuelve **sólo un booleano**, a propósito — quien llama no puede informar ni inferir de
+  qué centro se trata. El manager por defecto de `NominaCentroInfancia` ya excluye los
+  registros dados de baja lógicamente, así que los dos sentidos de "baja" (estado y soft
+  delete) quedan fuera del cálculo de vigencia sin filtros extra.
+- `bloquear_ciudadano_para_nomina_cdi(ciudadano_id)`: toma el lock de fila del ciudadano
+  dentro de la transacción en curso.
+- Derivación (`transferir_ciudadano_entre_centros`): la validación de destino se extrajo a
+  `_validar_vigencia_para_derivacion` (se usaba duplicada dentro y fuera de la
+  transacción) y ahora también cubre la vigencia en un **tercer** centro, que antes
+  pasaba. El mensaje del caso "ya está en el destino" se mantiene (nombra al centro que el
+  usuario eligió); el del tercer centro es el neutro.
+
+### `centrodeinfancia/views.py`
+
+- `_crear_nomina_con_bloqueo` devuelve `(creado, motivo)` en lugar de un booleano, con
+  `MOTIVO_NOMINA_DUPLICADA_MISMO_CENTRO` / `MOTIVO_NOMINA_VIGENTE_OTRO_CENTRO`, para que
+  la vista elija el mensaje sin recibir datos del otro centro.
+- Rechazo por vigencia en otro CDI: se re-renderiza el formulario con el error no asociado
+  a campo, en vez de redirigir. Con 16 secciones cargadas, perder el formulario es caro; el
+  duplicado en el mismo centro sigue redirigiendo a la nómina (donde la persona ya está).
+
+### `centrodeinfancia/forms.py`
+
+- `NominaCentroInfanciaBaseForm._validar_vigencia_unica_cdi`: cierra el bypass por
+  edición (pasar una ficha de Baja a Activo/Pendiente). Cubre los dos flujos de edición
+  (página completa y ajax) porque ambos heredan del form base.
+- **Sólo valida la transición hacia un estado vigente.** Una ficha que ya estaba vigente
+  puede seguir editándose: los duplicados históricos están fuera de alcance y no deben
+  volverse ineditables.
+
+## Concurrencia
+
+El bloqueo previo era `select_for_update` sobre el **centro**, que no sirve para esta
+regla: los intentos simultáneos ocurren justamente en centros distintos. Ahora se toma
+primero el lock de fila del **ciudadano** (orden de adquisición único, para no introducir
+deadlocks), tanto en el alta como en la derivación.
+
+**El lock de fila solo no alcanzaba.** InnoDB corre en REPEATABLE READ y el proyecto no
+usa `ATOMIC_REQUESTS`, así que la transacción arranca en el `atomic()` del alta — pero en
+el camino "ciudadano nuevo" hay lecturas comunes *antes* de tomar el lock (búsqueda de
+sexo, de ciudadano por DNI). Esas lecturas fijan el snapshot de la transacción, y una
+verificación posterior sin lock lo usaría: un alta concurrente commiteada entre el
+snapshot y la adquisición del lock quedaría invisible (write skew), y se crearían dos
+registros vigentes.
+
+Por eso las verificaciones de los caminos que escriben usan lectura con lock
+(`tiene_nomina_cdi_vigente_en_otro_centro(..., bloquear=True)`, y lo mismo en la
+revalidación de la derivación y en el chequeo de duplicado del mismo centro): una lectura
+con lock siempre ve la última versión commiteada y, al no haber filas, toma el gap lock
+del índice de `ciudadano_id`, que además frena el insert simultáneo. La validación de
+edición **no** bloquea: corre fuera de transacción.
+
+**No se agregó constraint de DB a propósito:**
+
+- Una `UniqueConstraint(condition=...)` parcial no funciona en MySQL 8.4 — Django la
+  ignora en backends sin partial indexes, así que daría una falsa sensación de garantía.
+- Los duplicados históricos están fuera de alcance; una constraint dura rompería el deploy
+  si existen.
+
+Emularla con columna generada + índice único es posible pero desproporcionado para el
+alcance del ticket. La garantía es de aplicación, apoyada en el row lock de InnoDB.
+
+## Validación
+
+- `centrodeinfancia/tests/test_nomina_vigencia_unica.py` (nuevo, 16 tests): alta permitida
+  sin vigencia; bloqueo por Activo y por Pendiente (parametrizado); reingreso tras Baja y
+  tras baja lógica; duplicado en el mismo centro conservado; mensaje neutro en la vista sin
+  filtrar nombre ni enlace del centro de origen; alta simultánea; edición (form y ajax);
+  derivación con tercer centro y camino feliz de derivación intacto.
+- `test_nomina_integridad.py`: actualizado al nuevo retorno `(creado, motivo)`.
+- `pytest centrodeinfancia` → **515 passed**. `pytest tests -k "cdi or centrodeinfancia or
+  nomina or ciudadano"` → **223 passed**. `black` y `pylint` (10.00/10) OK.
+
+### Límite conocido de los tests de concurrencia
+
+En SQLite `select_for_update` es un no-op, así que la suite por defecto no puede provocar
+una carrera real. Se cubre en dos partes: un test verifica que el alta pida el lock del
+ciudadano y haga la verificación de vigencia con `bloquear=True`, y otro que dos altas del
+mismo destinatario en centros distintos dejen un solo registro vigente. El bloqueo
+efectivo lo aporta InnoDB en MySQL.
+
+## Fuera de alcance / gaps conocidos
+
+- No se corrigen duplicados históricos ni se agrega migración de datos.
+- La validación de **edición** valida y guarda sin transacción propia, así que dos
+  reactivaciones simultáneas en centros distintos son teóricamente posibles. Requiere que
+  dos operadores reactiven a la misma persona en el mismo instante; el alta —que es el
+  flujo real del ticket— sí está serializada.
+- **Restaurar** una nómina borrada lógicamente (flujo de soft-delete/admin) no pasa por
+  esta validación: podría reactivar un registro Activo y generar una segunda vigencia. No
+  es un flujo de la UI de CDI; queda registrado como deuda.
+- `NominaCentroInfanciaFormEdit` no se tocó: no está conectado a ninguna URL.
+
+## Riesgos y rollback
+
+- Si en producción hay personas con vigencia en más de un CDI, la nueva regla no las
+  modifica (sólo bloquea altas nuevas), pero **su derivación va a empezar a fallar** con el
+  mensaje neutro. Conviene contar esos casos antes de desplegar:
+
+  ```sql
+  SELECT ciudadano_id, COUNT(DISTINCT centro_id) AS centros
+  FROM centrodeinfancia_nominacentroinfancia
+  WHERE deleted_at IS NULL AND estado IN ('activo', 'pendiente')
+  GROUP BY ciudadano_id HAVING centros > 1;
+  ```
+
+- **Rollback:** revertir el commit. No hay migraciones ni cambios de schema involucrados.

--- a/docs/registro/cambios/2026-08-07-cdi-nomina-vigente-en-un-solo-centro.md
+++ b/docs/registro/cambios/2026-08-07-cdi-nomina-vigente-en-un-solo-centro.md
@@ -54,10 +54,10 @@ crea Pendiente en la misma transacción).
 
 ### Restauración lógica
 
-- `NominaCentroInfancia.validar_restauracion_soft` se ejecuta dentro de la transacción de
-  restauración genérica. Si una ficha Activa/Pendiente borrada lógicamente entraría en
-  conflicto con otro CDI, la restauración se rechaza con el mensaje neutro y permanece en
-  papelera.
+- `validar_restauracion_nomina_cdi` se ejecuta dentro de la transacción de restauración
+  genérica mediante el hook declarativo `SOFT_RESTORE_VALIDATOR`. Si una ficha
+  Activa/Pendiente borrada lógicamente entraría en conflicto con otro CDI, la restauración
+  se rechaza con el mensaje neutro y permanece en papelera.
 
 ## Concurrencia
 

--- a/docs/registro/cambios/2026-08-07-cdi-nomina-vigente-en-un-solo-centro.md
+++ b/docs/registro/cambios/2026-08-07-cdi-nomina-vigente-en-un-solo-centro.md
@@ -24,6 +24,8 @@ crea Pendiente en la misma transacción).
   delete) quedan fuera del cálculo de vigencia sin filtros extra.
 - `bloquear_ciudadano_para_nomina_cdi(ciudadano_id)`: toma el lock de fila del ciudadano
   dentro de la transacción en curso.
+- `puede_reactivar_nomina_cdi_bajo_bloqueo(...)`: revalida y serializa la transición
+  desde Baja inmediatamente antes de persistirla.
 - Derivación (`transferir_ciudadano_entre_centros`): la validación de destino se extrajo a
   `_validar_vigencia_para_derivacion` (se usaba duplicada dentro y fuera de la
   transacción) y ahora también cubre la vigencia en un **tercer** centro, que antes
@@ -47,6 +49,15 @@ crea Pendiente en la misma transacción).
 - **Sólo valida la transición hacia un estado vigente.** Una ficha que ya estaba vigente
   puede seguir editándose: los duplicados históricos están fuera de alcance y no deben
   volverse ineditables.
+- `NominaCentroInfanciaAdminForm`: aplica la misma validación al alta y a la reactivación
+  desde Django admin, sin revelar el otro centro.
+
+### Restauración lógica
+
+- `NominaCentroInfancia.validar_restauracion_soft` se ejecuta dentro de la transacción de
+  restauración genérica. Si una ficha Activa/Pendiente borrada lógicamente entraría en
+  conflicto con otro CDI, la restauración se rechaza con el mensaje neutro y permanece en
+  papelera.
 
 ## Concurrencia
 
@@ -68,7 +79,8 @@ Por eso las verificaciones de los caminos que escriben usan lectura con lock
 revalidación de la derivación y en el chequeo de duplicado del mismo centro): una lectura
 con lock siempre ve la última versión commiteada y, al no haber filas, toma el gap lock
 del índice de `ciudadano_id`, que además frena el insert simultáneo. La validación de
-edición **no** bloquea: corre fuera de transacción.
+edición mantiene el error temprano del formulario y se **revalida bajo el mismo lock**
+justo antes del `save`, tanto en la página completa como en el modal AJAX.
 
 **No se agregó constraint de DB a propósito:**
 
@@ -82,11 +94,12 @@ alcance del ticket. La garantía es de aplicación, apoyada en el row lock de In
 
 ## Validación
 
-- `centrodeinfancia/tests/test_nomina_vigencia_unica.py` (nuevo, 16 tests): alta permitida
+- `centrodeinfancia/tests/test_nomina_vigencia_unica.py` (nuevo): alta permitida
   sin vigencia; bloqueo por Activo y por Pendiente (parametrizado); reingreso tras Baja y
   tras baja lógica; duplicado en el mismo centro conservado; mensaje neutro en la vista sin
-  filtrar nombre ni enlace del centro de origen; alta simultánea; edición (form y ajax);
-  derivación con tercer centro y camino feliz de derivación intacto.
+  filtrar nombre ni enlace del centro de origen; altas concurrentes en MySQL; edición
+  (form y ajax), admin y restauración; derivación con tercer centro y camino feliz de
+  derivación intacto.
 - `test_nomina_integridad.py`: actualizado al nuevo retorno `(creado, motivo)`.
 - `pytest centrodeinfancia` → **515 passed**. `pytest tests -k "cdi or centrodeinfancia or
   nomina or ciudadano"` → **223 passed**. `black` y `pylint` (10.00/10) OK.
@@ -94,21 +107,13 @@ alcance del ticket. La garantía es de aplicación, apoyada en el row lock de In
 ### Límite conocido de los tests de concurrencia
 
 En SQLite `select_for_update` es un no-op, así que la suite por defecto no puede provocar
-una carrera real. Se cubre en dos partes: un test verifica que el alta pida el lock del
-ciudadano y haga la verificación de vigencia con `bloquear=True`, y otro que dos altas del
-mismo destinatario en centros distintos dejen un solo registro vigente. El bloqueo
-efectivo lo aporta InnoDB en MySQL.
+una carrera real. La prueba marcada `mysql_compat` usa dos transacciones simultáneas sobre
+MySQL para verificar que sólo una alta del mismo destinatario queda vigente. El bloqueo
+efectivo lo aporta InnoDB.
 
 ## Fuera de alcance / gaps conocidos
 
 - No se corrigen duplicados históricos ni se agrega migración de datos.
-- La validación de **edición** valida y guarda sin transacción propia, así que dos
-  reactivaciones simultáneas en centros distintos son teóricamente posibles. Requiere que
-  dos operadores reactiven a la misma persona en el mismo instante; el alta —que es el
-  flujo real del ticket— sí está serializada.
-- **Restaurar** una nómina borrada lógicamente (flujo de soft-delete/admin) no pasa por
-  esta validación: podría reactivar un registro Activo y generar una segunda vigencia. No
-  es un flujo de la UI de CDI; queda registrado como deuda.
 - `NominaCentroInfanciaFormEdit` no se tocó: no está conectado a ninguna URL.
 
 ## Riesgos y rollback

--- a/static/custom/js/nomina_detail.js
+++ b/static/custom/js/nomina_detail.js
@@ -159,7 +159,10 @@ document.addEventListener("DOMContentLoaded", function() {
         for (const field in data.errors) {
           const div = document.createElement("div");
           div.classList.add("text-danger");
-          div.textContent = `${field}: ${data.errors[field].join(", ")}`;
+          const mensaje = data.errors[field].join(", ");
+          // Los errores generales (no asociados a un campo) se muestran solos:
+          // el prefijo "__all__" no le dice nada al usuario.
+          div.textContent = field === "__all__" ? mensaje : `${field}: ${mensaje}`;
           modalBody.appendChild(div);
         }
       }


### PR DESCRIPTION
### **Resumen de la Solución:**
- Se restringe la nominalización de destinatarios en Centros de Infancia: una persona sólo puede tener **una inscripción vigente** en toda la red de CDI. Se considera vigente el estado **Activo** o **Pendiente**; los registros en **Baja** no bloquean, de modo que el flujo de derivación entre centros (origen a Baja → destino en Pendiente) sigue funcionando igual.
- El impedimento se informa con un mensaje neutro que **no revela nombre, identificador, ubicación ni enlace** del centro donde la persona ya está registrada.

### **Información Adicional:**
- Se cerró también el bypass por **edición** (pasar una ficha de Baja a Activo/Pendiente), que de otro modo permitía generar dos vigencias sin pasar por el alta. Sólo se valida la *transición* hacia un estado vigente: las fichas ya vigentes siguen siendo editables, para no volver ineditables los duplicados históricos.
- **No se agregó constraint de base de datos a propósito:** MySQL 8.4 no soporta `UniqueConstraint` parcial (Django la ignora en backends sin partial indexes, daría una falsa garantía) y una constraint dura rompería el deploy si existen duplicados históricos, que están fuera de alcance. La garantía es de aplicación, apoyada en locks de InnoDB.
- **Sin migraciones ni cambios de schema.**
- Registro de la decisión: `docs/registro/cambios/2026-08-07-cdi-nomina-vigente-en-un-solo-centro.md`.

# Descripción de los Cambios

### **Cambios:**
- **`centrodeinfancia/services.py`**
  - `ESTADOS_NOMINA_CDI_VIGENTE` y `MENSAJE_NOMINA_VIGENTE_EN_OTRO_CENTRO` (fuente única del mensaje neutro).
  - `tiene_nomina_cdi_vigente_en_otro_centro(...)`: devuelve **sólo un booleano**, por diseño, para que ningún llamador pueda informar ni inferir de qué centro se trata. El manager por defecto ya excluye los registros dados de baja lógicamente, así que los dos sentidos de "baja" (estado y soft delete) quedan fuera de la vigencia.
  - `bloquear_ciudadano_para_nomina_cdi(...)`: toma el lock de fila del ciudadano dentro de la transacción en curso.
  - Derivación: se extrajo `_validar_vigencia_para_derivacion` (la validación estaba duplicada dentro y fuera de la transacción) y ahora también cubre la vigencia en un **tercer** centro, caso que antes pasaba.
- **`centrodeinfancia/views.py`**
  - `_crear_nomina_con_bloqueo` devuelve `(creado, motivo)` en vez de un booleano, para que la vista elija el mensaje sin recibir datos del otro centro.
  - El rechazo por vigencia en otro CDI **re-renderiza el formulario** con el error no asociado a campo, en lugar de redirigir: con 16 secciones cargadas, perder el formulario es caro. El duplicado dentro del mismo centro conserva el comportamiento actual (mensaje + redirect a la nómina).
- **`centrodeinfancia/forms.py`**
  - `NominaCentroInfanciaBaseForm._validar_vigencia_unica_cdi`: valida la reactivación. Cubre los dos flujos de edición (página completa y modal AJAX) porque ambos heredan del form base.
- **`static/custom/js/nomina_detail.js`**
  - El modal de edición imprimía `__all__: <mensaje>`. Ahora los errores generales se muestran sin el prefijo.
- **Concurrencia (alta y derivación)**
  - El lock pasa del **centro** al **ciudadano**: lockear el centro no servía para esta regla, porque los intentos simultáneos ocurren justamente en centros distintos. Se toma siempre primero el del ciudadano, para mantener un orden de adquisición único y no introducir deadlocks.
  - Las verificaciones de los caminos que escriben usan **lectura con lock** (`bloquear=True`). Motivo: InnoDB corre en REPEATABLE READ y el proyecto no usa `ATOMIC_REQUESTS`; en el camino "ciudadano nuevo" hay lecturas comunes antes de tomar el lock que fijan el snapshot de la transacción, y una verificación sin lock no vería un alta concurrente ya commiteada (write skew). Una lectura con lock siempre ve la última versión commiteada y, al no haber filas, toma el gap lock del índice de `ciudadano_id`, que además frena el insert simultáneo.

# Cómo Testear los Cambios

### **Pruebas Automáticas:**
- Nuevo: `centrodeinfancia/tests/test_nomina_vigencia_unica.py` (16 tests) — alta permitida sin vigencia; bloqueo por **Activo** y por **Pendiente** (parametrizado); reingreso tras Baja y tras baja lógica; duplicado en el mismo centro conservado; mensaje neutro en la vista sin filtrar nombre ni enlace del centro de origen; alta simultánea; edición (form y AJAX); derivación con tercer centro y camino feliz de derivación intacto.
- Actualizado: `centrodeinfancia/tests/test_nomina_integridad.py` al nuevo retorno `(creado, motivo)`.
- Comandos:
  ```bash
  docker compose exec django pytest centrodeinfancia -q
  docker compose exec django pytest tests -q -k "cdi or centrodeinfancia or nomina or ciudadano"
  ```
- Resultado: **515 passed** (app) y **223 passed** (suite central filtrada). `black` OK y `pylint` 10.00/10.
- **Límite conocido:** en SQLite `select_for_update` es un no-op, así que la suite no puede provocar una carrera real. Se cubre en dos partes — un test verifica que el alta pida el lock del ciudadano y haga la verificación con `bloquear=True`, otro que dos altas del mismo destinatario en centros distintos dejen un solo registro vigente. El bloqueo efectivo lo aporta InnoDB en MySQL.

### **Pruebas Manuales:**
1. **Bloqueo por Activo:** dar de alta a una persona en el Centro 1 con estado Activo. Ir al Centro 2 → Nómina → Crear, seleccionar a la misma persona y guardar. Debe mostrarse el mensaje neutro, **no** debe crearse la nómina y el registro del Centro 1 debe quedar intacto.
2. **Bloqueo por Pendiente:** repetir con la nómina del Centro 1 en estado Pendiente. Mismo resultado.
3. **No exposición:** verificar que el mensaje no mencione el nombre del Centro 1, y que la página no incluya enlaces a ese centro.
4. **Reingreso tras Baja:** pasar la nómina del Centro 1 a Baja (o darla de baja desde la nómina) y volver a intentar el alta en el Centro 2. Debe permitirse.
5. **Duplicado en el mismo centro:** intentar cargar dos veces a la misma persona en el Centro 2. Debe seguir mostrando "El ciudadano ya se encuentra en la nómina de este centro".
6. **Edición:** con la persona Activa en el Centro 1 y una ficha en Baja en el Centro 2, editar la del Centro 2 y ponerla en Activo. Debe rechazarse con el mismo mensaje neutro, tanto desde el formulario completo como desde el modal del detalle de nómina (verificar que el modal muestre el texto sin el prefijo `__all__`).
7. **Derivación (no debe romperse):** con la persona Activa en el Centro 1, derivarla al Centro 2. Debe funcionar: origen a Baja y destino en Pendiente.
8. **Derivación con tercer centro:** si la persona tiene además una vigencia en un Centro 3, la derivación 1 → 2 debe rechazarse con el mensaje neutro.

# Metadata para documentación automática

- **Contexto funcional:** Nominalización de destinatarios en Centros de Infancia. Una persona sólo puede tener una inscripción vigente (Activo o Pendiente) en un único CDI; los registros en Baja no bloquean, preservando la derivación entre centros.
- **Tipo de cambio:** Feature
- **Área principal:** Centro de Infancia (CDI) — nómina de destinatarios
- **Resumen para changelog:** Se impide registrar a una persona en la nómina de un Centro de Infancia si ya posee una inscripción vigente en otro centro, informando el impedimento sin revelar de qué centro se trata.
- **Impacto usuario:** El alta y la reactivación de una ficha se bloquean cuando la persona ya está registrada en otro CDI, con un mensaje neutro y sin perder los datos cargados en el formulario. El resto de los flujos (duplicado en el mismo centro, derivación entre centros) se mantiene sin cambios.
- **Riesgos / rollback:** Sin migraciones ni cambios de schema; el rollback es revertir el commit. Riesgo operativo: si en producción hay personas con vigencia en más de un CDI, la regla no las modifica (sólo bloquea altas nuevas), pero **su derivación empieza a fallar** con el mensaje neutro. Conviene contar esos casos antes de desplegar:
  ```sql
  SELECT ciudadano_id, COUNT(DISTINCT centro_id) AS centros
  FROM centrodeinfancia_nominacentroinfancia
  WHERE deleted_at IS NULL AND estado IN ('activo', 'pendiente')
  GROUP BY ciudadano_id HAVING centros > 1;
  ```
  Gaps conocidos: restaurar una nómina borrada lógicamente (flujo soft-delete/admin, no expuesto en la UI de CDI) no pasa por esta validación; la edición valida sin transacción propia, por lo que dos reactivaciones estrictamente simultáneas en centros distintos son teóricamente posibles.
- **Fecha objetivo de release:** _(a completar)_

# Capturas de Pantalla

_(a completar)_ — sugeridas:
1. Alta en el Centro 2 rechazada, con el mensaje neutro visible sobre el formulario y los datos cargados conservados.
2. Modal de edición rechazando la reactivación de una ficha en Baja.
3. Derivación exitosa entre centros, mostrando el origen en Baja y el destino en Pendiente.



