### PR TITLE
docs(spec): completar trazabilidad de PRs y guías canónicas

### DIFF
--- a/docs/contexto/features/pr-2222-feat-comedores-agregar-etiqueta-caritas.md
+++ b/docs/contexto/features/pr-2222-feat-comedores-agregar-etiqueta-caritas.md
@@ -1,0 +1,59 @@
+# Contexto de feature PR #2222 - feat(comedores): agregar etiqueta CARITAS
+
+## Resumen
+
+- PR: https://github.com/dsocial118/SISOC/pull/2222
+- Base: `development`
+- Rama origen: `codex/issue-2216-caritas`
+- Autor: `juanikitro`
+
+## Contexto funcional
+
+- No informado explícitamente; inferir desde el título del PR y el diff.
+
+## Arquitectura tocada
+
+- Hay cambios en capa API/DRF y conviene revisar contratos de request/response.
+- Se modifican templates, con posible impacto visual o de composición UI.
+- Existen cambios de persistencia o migraciones que requieren revisión de datos.
+
+## Decisiones y supuestos detectados
+
+- Tipo de cambio declarado: No informado
+- Área principal declarada: No informada
+- Impacto usuario declarado: No informado
+- Riesgos / rollback: No informado
+
+## Design system y UI
+
+- El PR toca piezas de UI y conviene revisar consistencia visual con el patrón existente.
+- Archivos visuales relevantes: comedores/templates/comedor/comedor_detail.html, comedores/templates/comedor/comedor_form.html, organizaciones/templates/organizacion_detail.html, static/custom/css/comedor_detail.css
+
+## Memoria operativa para agentes
+
+- Empezar por `docs/registro/prs/PR-2222.md` para contexto resumido del PR.
+- Revisar primero estos archivos del diff:
+- `comedores/api_serializers.py`
+- `comedores/forms/comedor_form.py`
+- `comedores/migrations/0053_issue_2216_es_caritas.py`
+- `comedores/models.py`
+- `comedores/templates/comedor/comedor_detail.html`
+- `comedores/templates/comedor/comedor_form.html`
+- `docs/registro/cambios/2026-08-04-etiqueta-caritas-comedores.md`
+- `organizaciones/templates/organizacion_detail.html`
+- `requirements/lint.txt`
+- `static/custom/css/comedor_detail.css`
+- `tests/test_comedor_form_unit.py`
+- `tests/test_issue_2163_categoria_espacio.py`
+- `tests/test_pwa_comedores_api.py`
+- Documentación sugerida para ampliar contexto:
+- `docs/indice.md`
+- `docs/ia/CONTEXT_HYGIENE.md`
+- `docs/ia/ARCHITECTURE.md`
+- `docs/ia/TESTING.md`
+- `docs/registro/cambios/2026-08-04-etiqueta-caritas-comedores.md`
+
+## Trazabilidad
+
+- Documento generado automáticamente desde el evento de `pull_request`.
+- Si este PR cambia de título, el archivo se renombrará para mantener el slug alineado.

--- a/docs/contexto/features/pr-2227-chore-deps-migrar-django-4-2-a-5-2-lts.md
+++ b/docs/contexto/features/pr-2227-chore-deps-migrar-django-4-2-a-5-2-lts.md
@@ -1,0 +1,49 @@
+# Contexto de feature PR #2227 - chore(deps): migrar Django 4.2 a 5.2 LTS
+
+## Resumen
+
+- PR: https://github.com/dsocial118/SISOC/pull/2227
+- Base: `development`
+- Rama origen: `codex/issue-1776-django-52`
+- Autor: `juanikitro`
+
+## Contexto funcional
+
+- No informado explícitamente; inferir desde el título del PR y el diff.
+
+## Arquitectura tocada
+
+- Existen cambios de persistencia o migraciones que requieren revisión de datos.
+
+## Decisiones y supuestos detectados
+
+- Tipo de cambio declarado: No informado
+- Área principal declarada: No informada
+- Impacto usuario declarado: No informado
+- Riesgos / rollback: No informado
+
+## Design system y UI
+
+- Sin cambios visibles de UI o design system detectados en el diff.
+
+## Memoria operativa para agentes
+
+- Empezar por `docs/registro/prs/PR-2227.md` para contexto resumido del PR.
+- Revisar primero estos archivos del diff:
+- `core/models.py`
+- `dashboard/apps.py`
+- `dashboard/tests.py`
+- `docs/registro/cambios/2026-08-04-django-52-lts.md`
+- `requirements/base.txt`
+- `users/models.py`
+- Documentación sugerida para ampliar contexto:
+- `docs/indice.md`
+- `docs/ia/CONTEXT_HYGIENE.md`
+- `docs/ia/ARCHITECTURE.md`
+- `docs/ia/TESTING.md`
+- `docs/registro/cambios/2026-08-04-django-52-lts.md`
+
+## Trazabilidad
+
+- Documento generado automáticamente desde el evento de `pull_request`.
+- Si este PR cambia de título, el archivo se renombrará para mantener el slug alineado.

--- a/docs/contexto/features/pr-2228-fix-iam-restringe-accesos-de-ciudadanos-y-acompanamiento.md
+++ b/docs/contexto/features/pr-2228-fix-iam-restringe-accesos-de-ciudadanos-y-acompanamiento.md
@@ -1,0 +1,59 @@
+# Contexto de feature PR #2228 - fix(iam): restringe accesos de ciudadanos y acompanamiento
+
+## Resumen
+
+- PR: https://github.com/dsocial118/SISOC/pull/2228
+- Base: `development`
+- Rama origen: `codex/issue-2225-grupos-permisos`
+- Autor: `juanikitro`
+
+## Contexto funcional
+
+- No informado explícitamente; inferir desde el título del PR y el diff.
+
+## Arquitectura tocada
+
+- Hay cambios en vistas web y puede existir impacto en permisos o renderizado.
+- Se modifican templates, con posible impacto visual o de composición UI.
+- Existen cambios de persistencia o migraciones que requieren revisión de datos.
+
+## Decisiones y supuestos detectados
+
+- Tipo de cambio declarado: No informado
+- Área principal declarada: No informada
+- Impacto usuario declarado: No informado
+- Riesgos / rollback: No informado
+
+## Design system y UI
+
+- El PR toca piezas de UI y conviene revisar consistencia visual con el patrón existente.
+- Archivos visuales relevantes: comedores/templates/comedor/nomina_detail.html
+
+## Memoria operativa para agentes
+
+- Empezar por `docs/registro/prs/PR-2228.md` para contexto resumido del PR.
+- Revisar primero estos archivos del diff:
+- `acompanamientos/urls.py`
+- `acompanamientos/views.py`
+- `ciudadanos/urls.py`
+- `ciudadanos/views.py`
+- `ciudadanos/views_export.py`
+- `comedores/templates/comedor/nomina_detail.html`
+- `docs/registro/cambios/2026-08-04-issue-2225-permisos-grupos.md`
+- `tests/test_acompanamientos_views_unit.py`
+- `tests/test_ciudadanos_views_unit.py`
+- `tests/test_issue_2225_permissions.py`
+- `users/bootstrap/groups_seed.py`
+- `users/migrations/0042_revoke_acompanamiento_from_comedores_groups.py`
+- `users/migrations/0043_merge_issue_2225_profile_datos_identificatorios.py`
+- Documentación sugerida para ampliar contexto:
+- `docs/indice.md`
+- `docs/ia/CONTEXT_HYGIENE.md`
+- `docs/ia/ARCHITECTURE.md`
+- `docs/ia/TESTING.md`
+- `docs/registro/cambios/2026-08-04-issue-2225-permisos-grupos.md`
+
+## Trazabilidad
+
+- Documento generado automáticamente desde el evento de `pull_request`.
+- Si este PR cambia de título, el archivo se renombrará para mantener el slug alineado.

--- a/docs/contexto/features/pr-2230-comedores-cambios-en-filtros-ordenamiento-columnas.md
+++ b/docs/contexto/features/pr-2230-comedores-cambios-en-filtros-ordenamiento-columnas.md
@@ -1,0 +1,67 @@
+# Contexto de feature PR #2230 - Comedores: cambios-en-Filtros-Ordenamiento-Columnas
+
+## Resumen
+
+- PR: https://github.com/dsocial118/SISOC/pull/2230
+- Base: `development`
+- Rama origen: `task/mejoras-filtros-comedores`
+- Autor: `Esteban-Royo`
+
+## Contexto funcional
+
+- Listados y filtros de Comedores, Admisiones y Acompañamiento.
+
+## Arquitectura tocada
+
+- El PR toca lógica en `services/`, por lo que impacta reglas de negocio u orquestación.
+- Hay cambios en vistas web y puede existir impacto en permisos o renderizado.
+- Se modifican templates, con posible impacto visual o de composición UI.
+
+## Decisiones y supuestos detectados
+
+- Tipo de cambio declarado: Mejora funcional.
+- Área principal declarada: Comedores.
+- Impacto usuario declarado: Mejora la búsqueda, navegación y lectura de los listados.
+- Riesgos / rollback: Riesgo bajo; rollback mediante reversión del código, sin cambios de base.
+
+## Design system y UI
+
+- El PR toca piezas de UI y conviene revisar consistencia visual con el patrón existente.
+- Archivos visuales relevantes: acompanamientos/templates/lista_comedores.html, admisiones/templates/admisiones/admisiones_legales_list.html, admisiones/templates/admisiones/admisiones_tecnicos_list.html, templates/components/comedor_table.html, templates/components/data_table.html
+
+## Memoria operativa para agentes
+
+- Empezar por `docs/registro/prs/PR-2230.md` para contexto resumido del PR.
+- Revisar primero estos archivos del diff:
+- `.importlinter`
+- `AGENT_REPO_MAP.md`
+- `acompanamientos/acompanamiento_service.py`
+- `acompanamientos/services/__init__.py`
+- `acompanamientos/services/filter_config.py`
+- `acompanamientos/templates/lista_comedores.html`
+- `acompanamientos/views.py`
+- `acompanamientos/views_export.py`
+- `admisiones/services/admisiones_service/impl.py`
+- `admisiones/services/legales_service/impl.py`
+- `admisiones/templates/admisiones/admisiones_legales_list.html`
+- `admisiones/templates/admisiones/admisiones_tecnicos_list.html`
+- `admisiones/views/web_views.py`
+- `comedores/services/comedor_service/impl.py`
+- `comedores/services/filter_config/impl.py`
+- `core/services/favorite_filters/config.py`
+- `core/services/list_ordering.py`
+- `docs/registro/cambios/2026-08-03-filtros-ordenamiento-listados-comedores.md`
+- `templates/components/comedor_table.html`
+- `templates/components/data_table.html`
+- ... y 7 archivo(s) adicional(es) relacionados.
+- Documentación sugerida para ampliar contexto:
+- `docs/indice.md`
+- `docs/ia/CONTEXT_HYGIENE.md`
+- `docs/ia/ARCHITECTURE.md`
+- `docs/ia/TESTING.md`
+- `docs/registro/cambios/2026-08-03-filtros-ordenamiento-listados-comedores.md`
+
+## Trazabilidad
+
+- Documento generado automáticamente desde el evento de `pull_request`.
+- Si este PR cambia de título, el archivo se renombrará para mantener el slug alineado.

--- a/docs/contexto/features/pr-2231-style-templates-corrige-formato-para-promocion-a-homologacion.md
+++ b/docs/contexto/features/pr-2231-style-templates-corrige-formato-para-promocion-a-homologacion.md
@@ -1,0 +1,46 @@
+# Contexto de feature PR #2231 - style(templates): corrige formato para promocion a homologacion
+
+## Resumen
+
+- PR: https://github.com/dsocial118/SISOC/pull/2231
+- Base: `development`
+- Rama origen: `codex/fix-pr-2229-djlint`
+- Autor: `juanikitro`
+
+## Contexto funcional
+
+- No informado explícitamente; inferir desde el título del PR y el diff.
+
+## Arquitectura tocada
+
+- Se modifican templates, con posible impacto visual o de composición UI.
+
+## Decisiones y supuestos detectados
+
+- Tipo de cambio declarado: No informado
+- Área principal declarada: No informada
+- Impacto usuario declarado: No informado
+- Riesgos / rollback: No informado
+
+## Design system y UI
+
+- El PR toca piezas de UI y conviene revisar consistencia visual con el patrón existente.
+- Archivos visuales relevantes: admisiones/templates/admisiones/admisiones_tecnicos_form.html, templates/includes/base.html, templates/includes/sidebar/new_opciones.html
+
+## Memoria operativa para agentes
+
+- Empezar por `docs/registro/prs/PR-2231.md` para contexto resumido del PR.
+- Revisar primero estos archivos del diff:
+- `admisiones/templates/admisiones/admisiones_tecnicos_form.html`
+- `templates/includes/base.html`
+- `templates/includes/sidebar/new_opciones.html`
+- Documentación sugerida para ampliar contexto:
+- `docs/indice.md`
+- `docs/ia/CONTEXT_HYGIENE.md`
+- `docs/ia/ARCHITECTURE.md`
+- `docs/ia/TESTING.md`
+
+## Trazabilidad
+
+- Documento generado automáticamente desde el evento de `pull_request`.
+- Si este PR cambia de título, el archivo se renombrará para mantener el slug alineado.

--- a/docs/contexto/features/pr-2235-issues-1961-2005-2076-2079-y-2188.md
+++ b/docs/contexto/features/pr-2235-issues-1961-2005-2076-2079-y-2188.md
@@ -1,0 +1,70 @@
+# Contexto de feature PR #2235 - Issues 1961, 2005, 2076, 2079 y 2188
+
+## Resumen
+
+- PR: https://github.com/dsocial118/SISOC/pull/2235
+- Base: `development`
+- Rama origen: `Fixes-VS-Agosto`
+- Autor: `PabloCao1`
+
+## Contexto funcional
+
+- No informado explícitamente; inferir desde el título del PR y el diff.
+
+## Arquitectura tocada
+
+- El PR toca lógica en `services/`, por lo que impacta reglas de negocio u orquestación.
+- Hay cambios en capa API/DRF y conviene revisar contratos de request/response.
+- Hay cambios en vistas web y puede existir impacto en permisos o renderizado.
+- Se modifican templates, con posible impacto visual o de composición UI.
+- Existen cambios de persistencia o migraciones que requieren revisión de datos.
+
+## Decisiones y supuestos detectados
+
+- Tipo de cambio declarado: No informado
+- Área principal declarada: No informada
+- Impacto usuario declarado: No informado
+- Riesgos / rollback: No informado
+
+## Design system y UI
+
+- El PR toca piezas de UI y conviene revisar consistencia visual con el patrón existente.
+- Archivos visuales relevantes: admisiones/templates/admisiones/admisiones_legales_detalle.html, admisiones/templates/admisiones/admisiones_tecnicos_form.html, comedores/templates/comedor/comedor_convenio_pnud_form.html, comedores/templates/comedor/comedor_form.html, organizaciones/templates/organizacion_detail.html, organizaciones/templates/organizacion_form.html, organizaciones/templates/organizacion_rendicion_detail.html, rendicioncuentasmensual/templates/rendicioncuentasmensual_detail.html
+
+## Memoria operativa para agentes
+
+- Empezar por `docs/registro/prs/PR-2235.md` para contexto resumido del PR.
+- Revisar primero estos archivos del diff:
+- `AGENT_REPO_MAP.md`
+- `admisiones/forms/admisiones_forms.py`
+- `admisiones/migrations/0075_alter_admision_legales_num_if.py`
+- `admisiones/models/admisiones.py`
+- `admisiones/services/admisiones_service/impl.py`
+- `admisiones/templates/admisiones/admisiones_legales_detalle.html`
+- `admisiones/templates/admisiones/admisiones_tecnicos_form.html`
+- `comedores/api_serializers.py`
+- `comedores/api_views.py`
+- `comedores/forms/comedor_form.py`
+- `comedores/forms/convenio_pnud_form.py`
+- `comedores/migrations/0054_issue_1961_proyecto_organizacion.py`
+- `comedores/migrations/0055_issue_2188_personas_declaradas_siph.py`
+- `comedores/models.py`
+- `comedores/templates/comedor/comedor_convenio_pnud_form.html`
+- `comedores/templates/comedor/comedor_form.html`
+- `comedores/views/capacitaciones.py`
+- `comedores/views/comedor.py`
+- `docs/registro/cambios/2026-08-04-issue-2005-rendiciones-en-organizaciones.md`
+- `docs/registro/cambios/2026-08-04-issues-1961-2076-2079-2188.md`
+- ... y 23 archivo(s) adicional(es) relacionados.
+- Documentación sugerida para ampliar contexto:
+- `docs/indice.md`
+- `docs/ia/CONTEXT_HYGIENE.md`
+- `docs/ia/ARCHITECTURE.md`
+- `docs/ia/TESTING.md`
+- `docs/registro/cambios/2026-08-04-issue-2005-rendiciones-en-organizaciones.md`
+- `docs/registro/cambios/2026-08-04-issues-1961-2076-2079-2188.md`
+
+## Trazabilidad
+
+- Documento generado automáticamente desde el evento de `pull_request`.
+- Si este PR cambia de título, el archivo se renombrará para mantener el slug alineado.

--- a/docs/contexto/features/pr-2237-ui-buscadores.md
+++ b/docs/contexto/features/pr-2237-ui-buscadores.md
@@ -1,0 +1,66 @@
+# Contexto de feature PR #2237 - UI buscadores
+
+## Resumen
+
+- PR: https://github.com/dsocial118/SISOC/pull/2237
+- Base: `development`
+- Rama origen: `UI_buscadores`
+- Autor: `MariaNavarro90`
+
+## Contexto funcional
+
+- Buscadores y filtros de listados en toda la aplicación.
+
+## Arquitectura tocada
+
+- Hay cambios en vistas web y puede existir impacto en permisos o renderizado.
+- Se modifican templates, con posible impacto visual o de composición UI.
+
+## Decisiones y supuestos detectados
+
+- Tipo de cambio declarado: Feature + refactor de UI. Incluye corrección de bugs encontrados en el camino.
+- Área principal declarada: Componente compartido search_bar / listados transversales.
+- Impacto usuario declarado: Alto y visible. Cambia el aspecto y la interacción de todos los listados. Se pierden la búsqueda por campo vacío, por rango y por exclusión, la combinación con OR, y los filtros favoritos dejan de estar accesibles desde la UI.
+- Riesgos / rollback: No informado
+
+## Design system y UI
+
+- El PR toca piezas de UI y conviene revisar consistencia visual con el patrón existente.
+- Archivos visuales relevantes: VAT/templates/vat/centros/centro_list.html, celiaquia/templates/celiaquia/expediente_list.html, ciudadanos/templates/ciudadanos/ciudadano_list.html, comedores/templates/comedor/actividades_pnud_list.html, insumos/templates/insumos/insumos_list.html, static/custom/css/comedoresSearchBar.css, static/custom/css/hitos.css, static/custom/css/listModerno.css
+
+## Memoria operativa para agentes
+
+- Empezar por `docs/registro/prs/PR-2237.md` para contexto resumido del PR.
+- Revisar primero estos archivos del diff:
+- `VAT/templates/vat/centros/centro_list.html`
+- `celiaquia/templates/celiaquia/expediente_list.html`
+- `celiaquia/views/expediente.py`
+- `centrodefamilia/tests/test_beneficiarios_export.py`
+- `ciudadanos/ciudadanos_filter_config.py`
+- `ciudadanos/templates/ciudadanos/ciudadano_list.html`
+- `ciudadanos/views.py`
+- `comedores/templates/comedor/actividades_pnud_list.html`
+- `comunicados/views.py`
+- `docs/registro/cambios/2026-07-31-buscador-transversal-lupa-y-cta.md`
+- `insumos/templates/insumos/insumos_list.html`
+- `insumos/views.py`
+- `static/custom/css/comedoresSearchBar.css`
+- `static/custom/css/hitos.css`
+- `static/custom/css/listModerno.css`
+- `static/custom/css/poncho.css`
+- `static/custom/css/poncho_listados.css`
+- `static/custom/css/ver_para_ser_libre.css`
+- `static/custom/js/advanced_filters.js`
+- `static/custom/js/favorite_filters.js`
+- ... y 6 archivo(s) adicional(es) relacionados.
+- Documentación sugerida para ampliar contexto:
+- `docs/indice.md`
+- `docs/ia/CONTEXT_HYGIENE.md`
+- `docs/ia/ARCHITECTURE.md`
+- `docs/ia/TESTING.md`
+- `docs/registro/cambios/2026-07-31-buscador-transversal-lupa-y-cta.md`
+
+## Trazabilidad
+
+- Documento generado automáticamente desde el evento de `pull_request`.
+- Si este PR cambia de título, el archivo se renombrará para mantener el slug alineado.

--- a/docs/contexto/features/pr-2253-refactor-architecture-completar-ratchet-de-fase-0.md
+++ b/docs/contexto/features/pr-2253-refactor-architecture-completar-ratchet-de-fase-0.md
@@ -1,0 +1,79 @@
+# Contexto de feature PR #2253 - refactor(architecture): completar ratchet de Fase 0
+
+## Resumen
+
+- PR: https://github.com/dsocial118/SISOC/pull/2253
+- Base: `development`
+- Rama origen: `codex/issue-2241-kernel-ratchet`
+- Autor: `juanikitro`
+
+## Contexto funcional
+
+- boundary arquitectónico del monolito modular.
+
+## Arquitectura tocada
+
+- El PR toca lógica en `services/`, por lo que impacta reglas de negocio u orquestación.
+- Hay cambios en capa API/DRF y conviene revisar contratos de request/response.
+- Hay cambios en vistas web y puede existir impacto en permisos o renderizado.
+
+## Decisiones y supuestos detectados
+
+- Tipo de cambio declarado: refactor sin migraciones.
+- Área principal declarada: core, ciudadanos y users.
+- Impacto usuario declarado: ninguno esperado; se preservan permisos, accesos PWA y flujos existentes.
+- Riesgos / rollback: bajo; revertir el commit restaura los imports directos. Los registros fallan explícitamente si falta un proveedor.
+
+## Design system y UI
+
+- Sin cambios visibles de UI o design system detectados en el diff.
+
+## Memoria operativa para agentes
+
+- Empezar por `docs/registro/prs/PR-2253.md` para contexto resumido del PR.
+- Revisar primero estos archivos del diff:
+- `.importlinter`
+- `AGENT_REPO_MAP.md`
+- `VAT/apps.py`
+- `VAT/ciudadano_detail.py`
+- `VAT/favorite_filters.py`
+- `VAT/sidebar_access.py`
+- `acompanamientos/apps.py`
+- `acompanamientos/favorite_filters.py`
+- `admisiones/apps.py`
+- `admisiones/favorite_filters.py`
+- `celiaquia/apps.py`
+- `celiaquia/ciudadano_detail.py`
+- `centrodefamilia/apps.py`
+- `centrodefamilia/ciudadano_detail.py`
+- `centrodefamilia/favorite_filters.py`
+- `ciudadanos/detail_contributions.py`
+- `ciudadanos/services_importacion_masiva.py`
+- `ciudadanos/test_territorial_scope.py`
+- `ciudadanos/views.py`
+- `comedores/apps.py`
+- ... y 79 archivo(s) adicional(es) relacionados.
+- Documentación sugerida para ampliar contexto:
+- `docs/indice.md`
+- `docs/ia/CONTEXT_HYGIENE.md`
+- `docs/ia/ARCHITECTURE.md`
+- `docs/ia/TESTING.md`
+- `docs/registro/decisiones/2026-08-06-capacidad-comedores-pwa-fase-0.md`
+- `docs/registro/decisiones/2026-08-06-catalogos-formularios-users-fase-0.md`
+- `docs/registro/decisiones/2026-08-06-cierre-ratchet-fase-0.md`
+- `docs/registro/decisiones/2026-08-06-contribuciones-ciudadano-360-fase-0.md`
+- `docs/registro/decisiones/2026-08-06-endpoint-organizaciones-fase-0.md`
+- `docs/registro/decisiones/2026-08-06-puerto-auditoria-auth-pwa-fase-0.md`
+- `docs/registro/decisiones/2026-08-06-puerto-renaper-fase-0.md`
+- `docs/registro/decisiones/2026-08-06-registro-filtros-favoritos-fase-0.md`
+- `docs/registro/decisiones/2026-08-06-registro-post-fixture-intervenciones-fase-0.md`
+- `docs/registro/decisiones/2026-08-06-registro-sidebar-vat-fase-0.md`
+- `docs/registro/decisiones/2026-08-06-registro-soft-delete-vat-fase-0.md`
+- `docs/registro/decisiones/2026-08-06-resolvedor-importacion-pwa-fase-0.md`
+- `docs/registro/decisiones/2026-08-06-senal-coordinador-duplas-fase-0.md`
+- `docs/registro/decisiones/2026-08-06-tests-alcance-territorial-ciudadanos-fase-0.md`
+
+## Trazabilidad
+
+- Documento generado automáticamente desde el evento de `pull_request`.
+- Si este PR cambia de título, el archivo se renombrará para mantener el slug alineado.

--- a/docs/contexto/features/pr-2255-fixes-post-revision-issues-1961-2076-2079-y-2188.md
+++ b/docs/contexto/features/pr-2255-fixes-post-revision-issues-1961-2076-2079-y-2188.md
@@ -1,0 +1,70 @@
+# Contexto de feature PR #2255 - Fixes post revisión: issues 1961, 2076, 2079 y 2188
+
+## Resumen
+
+- PR: https://github.com/dsocial118/SISOC/pull/2255
+- Base: `development`
+- Rama origen: `Fixex-Vs-Agosto2`
+- Autor: `PabloCao1`
+
+## Contexto funcional
+
+- No informado explícitamente; inferir desde el título del PR y el diff.
+
+## Arquitectura tocada
+
+- Hay cambios en capa API/DRF y conviene revisar contratos de request/response.
+- Hay cambios en vistas web y puede existir impacto en permisos o renderizado.
+- Se modifican templates, con posible impacto visual o de composición UI.
+
+## Decisiones y supuestos detectados
+
+- Tipo de cambio declarado: No informado
+- Área principal declarada: No informada
+- Impacto usuario declarado: No informado
+- Riesgos / rollback: No informado
+
+## Design system y UI
+
+- El PR toca piezas de UI y conviene revisar consistencia visual con el patrón existente.
+- Archivos visuales relevantes: admisiones/templates/admisiones/admisiones_legales_detalle.html, admisiones/templates/admisiones/admisiones_tecnicos_form.html, admisiones/templates/admisiones/partials/numero_expediente_estructurado.html, comedores/templates/comedor/comedor_form.html, organizaciones/templates/organizacion_detail.html, static/custom/css/numeroExpedienteModal.css
+
+## Memoria operativa para agentes
+
+- Empezar por `docs/registro/prs/PR-2255.md` para contexto resumido del PR.
+- Revisar primero estos archivos del diff:
+- `admisiones/forms/admisiones_forms.py`
+- `admisiones/templates/admisiones/admisiones_legales_detalle.html`
+- `admisiones/templates/admisiones/admisiones_tecnicos_form.html`
+- `admisiones/templates/admisiones/partials/numero_expediente_estructurado.html`
+- `admisiones/views/web_views.py`
+- `comedores/api_views.py`
+- `comedores/templates/comedor/comedor_form.html`
+- `comedores/views/comedor.py`
+- `docs/registro/cambios/2026-08-06-issue-1961-proyectos-alta-comedor.md`
+- `docs/registro/cambios/2026-08-06-issue-2076-edicion-expediente.md`
+- `docs/registro/cambios/2026-08-06-issue-2079-subsanacion-auditoria.md`
+- `docs/registro/cambios/2026-08-06-issue-2188-capacitaciones-actividades-pnud.md`
+- `organizaciones/templates/organizacion_detail.html`
+- `organizaciones/tests.py`
+- `organizaciones/urls.py`
+- `organizaciones/views.py`
+- `rendicioncuentasmensual/services.py`
+- `static/custom/css/numeroExpedienteModal.css`
+- `tests/test_admisiones_forms_unit.py`
+- `tests/test_admisiones_web_views_unit.py`
+- ... y 3 archivo(s) adicional(es) relacionados.
+- Documentación sugerida para ampliar contexto:
+- `docs/indice.md`
+- `docs/ia/CONTEXT_HYGIENE.md`
+- `docs/ia/ARCHITECTURE.md`
+- `docs/ia/TESTING.md`
+- `docs/registro/cambios/2026-08-06-issue-1961-proyectos-alta-comedor.md`
+- `docs/registro/cambios/2026-08-06-issue-2076-edicion-expediente.md`
+- `docs/registro/cambios/2026-08-06-issue-2079-subsanacion-auditoria.md`
+- `docs/registro/cambios/2026-08-06-issue-2188-capacitaciones-actividades-pnud.md`
+
+## Trazabilidad
+
+- Documento generado automáticamente desde el evento de `pull_request`.
+- Si este PR cambia de título, el archivo se renombrará para mantener el slug alineado.

--- a/docs/contexto/features/pr-2260-cdi-nomina-restriccion.md
+++ b/docs/contexto/features/pr-2260-cdi-nomina-restriccion.md
@@ -1,0 +1,56 @@
+# Contexto de feature PR #2260 - cdi nomina restriccion
+
+## Resumen
+
+- PR: https://github.com/dsocial118/SISOC/pull/2260
+- Base: `development`
+- Rama origen: `cdi_nomina_res`
+- Autor: `MariaNavarro90`
+
+## Contexto funcional
+
+- Nominalización de destinatarios en Centros de Infancia. Una persona sólo puede tener una inscripción vigente (Activo o Pendiente) en un único CDI; los registros en Baja no bloquean, preservando la derivación entre centros.
+
+## Arquitectura tocada
+
+- Hay cambios en vistas web y puede existir impacto en permisos o renderizado.
+- Existen cambios de persistencia o migraciones que requieren revisión de datos.
+
+## Decisiones y supuestos detectados
+
+- Tipo de cambio declarado: Feature
+- Área principal declarada: Centro de Infancia (CDI) — nómina de destinatarios
+- Impacto usuario declarado: El alta y la reactivación de una ficha se bloquean cuando la persona ya está registrada en otro CDI, con un mensaje neutro y sin perder los datos cargados en el formulario. El resto de los flujos (duplicado en el mismo centro, derivación entre centros) se mantiene sin cambios.
+- Riesgos / rollback: Sin migraciones ni cambios de schema; el rollback es revertir el commit. Riesgo operativo: si en producción hay personas con vigencia en más de un CDI, la regla no las modifica (sólo bloquea altas nuevas), pero su derivación empieza a fallar con el mensaje neutro. Conviene contar esos casos antes de desplegar:
+
+## Design system y UI
+
+- El PR toca piezas de UI y conviene revisar consistencia visual con el patrón existente.
+- Archivos visuales relevantes: static/custom/js/nomina_detail.js
+
+## Memoria operativa para agentes
+
+- Empezar por `docs/registro/prs/PR-2260.md` para contexto resumido del PR.
+- Revisar primero estos archivos del diff:
+- `centrodeinfancia/admin.py`
+- `centrodeinfancia/forms.py`
+- `centrodeinfancia/models.py`
+- `centrodeinfancia/services.py`
+- `centrodeinfancia/tests/test_nomina_integridad.py`
+- `centrodeinfancia/tests/test_nomina_vigencia_unica.py`
+- `centrodeinfancia/views.py`
+- `core/soft_delete/cascade.py`
+- `core/trash_views.py`
+- `docs/registro/cambios/2026-08-07-cdi-nomina-vigente-en-un-solo-centro.md`
+- `static/custom/js/nomina_detail.js`
+- Documentación sugerida para ampliar contexto:
+- `docs/indice.md`
+- `docs/ia/CONTEXT_HYGIENE.md`
+- `docs/ia/ARCHITECTURE.md`
+- `docs/ia/TESTING.md`
+- `docs/registro/cambios/2026-08-07-cdi-nomina-vigente-en-un-solo-centro.md`
+
+## Trazabilidad
+
+- Documento generado automáticamente desde el evento de `pull_request`.
+- Si este PR cambia de título, el archivo se renombrará para mantener el slug alineado.

--- a/docs/contexto/features/pr-2261-mi-cuenta.md
+++ b/docs/contexto/features/pr-2261-mi-cuenta.md
@@ -1,0 +1,65 @@
+# Contexto de feature PR #2261 - Mi cuenta
+
+## Resumen
+
+- PR: https://github.com/dsocial118/SISOC/pull/2261
+- Base: `development`
+- Rama origen: `MiCuenta`
+- Autor: `MariaNavarro90`
+
+## Contexto funcional
+
+- Forzar una actualización masiva de datos personales por única vez y dejar una sección permanente de autogestión. Hasta ahora los datos identificatorios de los usuarios solo se editaban desde el ABM, con perfiles incompletos o desactualizados.
+
+## Arquitectura tocada
+
+- Hay cambios en vistas web y puede existir impacto en permisos o renderizado.
+- Se modifican templates, con posible impacto visual o de composición UI.
+- Existen cambios de persistencia o migraciones que requieren revisión de datos.
+
+## Decisiones y supuestos detectados
+
+- Tipo de cambio declarado: Nuevas Funcionalidades
+- Área principal declarada: users
+- Impacto usuario declarado: Alto y visible desde el primer login. Todos los usuarios activos verán una pantalla de confirmación bloqueante en su próximo ingreso web y no podrán operar hasta completar DNI, CUIL, nombre, apellido, mail y aceptar la declaración. Los usuarios que solo operan la PWA no la ven: el middleware exime /api/.
+- Riesgos / rollback: El riesgo principal es de soporte, no técnico: exigir DNI y CUIL válidos a todo el padrón activo es un gate duro, y un usuario con el CUIL mal cargado no puede seguir usando el sistema hasta corregirlo. Conviene avisar a soporte antes del deploy. Para desactivar el flujo sin revertir código alcanza con quitar users.middleware.ProfileConfirmationMiddleware de MIDDLEWARE, o bajar el flag en masa con Profile.objects.update(needs_profile_confirmation=False). La 0044 es reversible: su RunPython tiene función inversa. Los campos agregados son aditivos y no rompen lecturas previas.
+
+## Design system y UI
+
+- El PR toca piezas de UI y conviene revisar consistencia visual con el patrón existente.
+- Archivos visuales relevantes: static/custom/css/poncho_formularios.css, templates/includes/sidebar/opciones.html, users/templates/user/_mi_cuenta_campos.html, users/templates/user/_mi_cuenta_submit_js.html, users/templates/user/confirmar_datos.html, users/templates/user/mi_cuenta.html
+
+## Memoria operativa para agentes
+
+- Empezar por `docs/registro/prs/PR-2261.md` para contexto resumido del PR.
+- Revisar primero estos archivos del diff:
+- `AGENT_REPO_MAP.md`
+- `config/settings.py`
+- `docs/registro/cambios/2026-08-06-mi-cuenta-confirmacion-datos.md`
+- `static/custom/css/poncho_formularios.css`
+- `templates/includes/sidebar/opciones.html`
+- `tests/test_users_mi_cuenta.py`
+- `tests/urls_vat_comision_horarios.py`
+- `users/forms.py`
+- `users/middleware.py`
+- `users/migrations/0044_profile_confirmacion_datos.py`
+- `users/migrations/0045_profile_correo_institucional_declaracion.py`
+- `users/models.py`
+- `users/profile_utils.py`
+- `users/templates/user/_mi_cuenta_campos.html`
+- `users/templates/user/_mi_cuenta_submit_js.html`
+- `users/templates/user/confirmar_datos.html`
+- `users/templates/user/mi_cuenta.html`
+- `users/urls.py`
+- `users/views.py`
+- Documentación sugerida para ampliar contexto:
+- `docs/indice.md`
+- `docs/ia/CONTEXT_HYGIENE.md`
+- `docs/ia/ARCHITECTURE.md`
+- `docs/ia/TESTING.md`
+- `docs/registro/cambios/2026-08-06-mi-cuenta-confirmacion-datos.md`
+
+## Trazabilidad
+
+- Documento generado automáticamente desde el evento de `pull_request`.
+- Si este PR cambia de título, el archivo se renombrará para mantener el slug alineado.

--- a/docs/flujos/derivar_nomina_centros.md
+++ b/docs/flujos/derivar_nomina_centros.md
@@ -32,9 +32,12 @@ pendiente de validación en destino. Aplica tanto a `comedores.Nomina` como a
 5. Si el comedor destino usa admisión, busca la última admisión activa; si no
    hay, rechaza con mensaje claro.
 6. Verifica que la persona no tenga ya un registro `Activo`/`Espera` o
-   `Activo`/`Pendiente` en destino.
+   `Activo`/`Pendiente` en destino. Para CDI también rechaza una ficha vigente
+   en cualquier **tercer** centro, sin revelar cuál es.
 7. Abre una transacción atómica:
-   - Bloquea origen con `select_for_update()` y revalida estado y duplicado.
+   - En CDI bloquea primero la fila de la persona y luego la nómina origen;
+     revalida estado y vigencia bajo lock. En Comedores bloquea el origen y
+     revalida el duplicado según su contrato actual.
    - Marca origen como `BAJA`.
    - Crea destino con estado `ESPERA`/`PENDIENTE`. En CDI copia campos ricos
      desde el origen (`_CAMPOS_COPIABLES`: identidad, salud, domicilio,
@@ -48,6 +51,9 @@ pendiente de validación en destino. Aplica tanto a `comedores.Nomina` como a
 - El usuario debe tener scope tanto sobre origen como sobre destino.
 - Comedor destino con `programa.usa_admision_para_nomina=True` exige al menos
   una `Admision.activa=True`.
+- En CDI, una ficha `Activo` o `Pendiente` en otro centro bloquea el alta y la
+  derivación. `Baja` y la baja lógica no bloquean, para permitir que el origen
+  de la derivación se cierre y el destino quede pendiente.
 - Permisos requeridos en URL (ambos a la vez, `permissions_all_required`):
   - Comedores: `comedores.change_nomina` + `comedores.add_nomina`.
   - CDI: `centrodeinfancia.change_nominacentroinfancia` +
@@ -55,7 +61,8 @@ pendiente de validación en destino. Aplica tanto a `comedores.Nomina` como a
 
 ## Side effects
 - Cambio de estado del origen y creación del registro destino, todo bajo
-  `transaction.atomic` con bloqueo de fila origen.
+  `transaction.atomic`. CDI serializa además por fila de ciudadano para que
+  intentos concurrentes desde centros distintos no creen dos vigencias.
 - Registro de auditoría inmutable (admin define `has_add_permission=False` y
   `has_change_permission=False`).
 - FKs `comedor_origen`/`comedor_destino` con `on_delete=PROTECT` para impedir
@@ -69,6 +76,8 @@ pendiente de validación en destino. Aplica tanto a `comedores.Nomina` como a
 - `La persona ya tiene un registro activo o en espera en «X»`: hay duplicado.
 - `El registro fue modificado antes de completar la derivación`: TOCTOU
   detectado por la revalidación bajo lock.
+- En CDI, el conflicto con un tercer centro vigente devuelve el mensaje neutro
+  de nómina vigente; no informa el nombre ni el enlace del centro ajeno.
 
 ## Selector del modal
 - `comedores_para_derivar` se construye con `get_scoped_comedor_queryset(user)`
@@ -96,4 +105,5 @@ pendiente de validación en destino. Aplica tanto a `comedores.Nomina` como a
   con admisión, fallas por estado/duplicado/admisión inexistente) + vistas
   AJAX (405 sin POST, 302/403 sin auth, 400 entrada inválida, 200 OK).
 - `centrodeinfancia/tests/test_derivar_service.py`: análogos para CDI,
-  incluyendo verificación de copia de campos ricos (incluye FK a Provincia).
+  incluyendo verificación de copia de campos ricos (incluye FK a Provincia),
+  conflicto con un tercer CDI y revalidación concurrente en MySQL.

--- a/docs/implementaciones/centrodeinfancia_nomina_renaper.md
+++ b/docs/implementaciones/centrodeinfancia_nomina_renaper.md
@@ -28,6 +28,30 @@ referentes por `AccesoCDI` activo, trabajadores por `Trabajador.usuario` y los
 roles nacionales por alcance nacional. El rol Auditoría no puede mutar CDI,
 trabajadores, nóminas ni formularios.
 
+## Integridad de la nómina vigente
+
+Una persona puede tener, como máximo, una ficha de nómina **vigente** entre
+todos los CDI. Para esta regla, vigente significa estado `Activo` o `Pendiente`.
+Las fichas en `Baja` y las dadas de baja lógicamente no bloquean un alta ni una
+derivación posterior.
+
+- El alta, la reactivación por edición, el Django admin y la restauración desde
+  la papelera aplican la misma regla y devuelven un mensaje neutro. No exponen
+  el CDI en el que existe la ficha que provoca el conflicto.
+- La derivación conserva el histórico: primero deja el origen en `Baja` y crea
+  el destino en `Pendiente`, dentro de la misma transacción. También rechaza el
+  flujo si la persona tiene una ficha vigente en un **tercer** CDI.
+- Antes de persistir una operación que puede crear o reactivar vigencia, el
+  servicio bloquea la fila de la persona y revalida bajo lock. Esto serializa
+  intentos concurrentes desde CDI diferentes y evita que dos altas simultáneas
+  dejen fichas vigentes.
+
+La garantía es de aplicación sobre MySQL/InnoDB; no hay una constraint parcial
+en base de datos porque MySQL no la implementa para este caso y los duplicados
+históricos no se corrigen automáticamente. Antes de desplegar un cambio de
+esta regla conviene revisar los duplicados vigentes existentes, ya que no se
+modifican pero pueden bloquear derivaciones posteriores.
+
 ## Precarga y bloqueo RENAPER de trabajadores
 
 - La búsqueda consulta RENAPER solo cuando no encuentra ciudadanos locales,
@@ -53,6 +77,8 @@ trabajadores, nóminas ni formularios.
 ## Referencias de implementación y validación
 
 - `centrodeinfancia/services.py`: `AsistenciaNominaCentroInfanciaService`.
+- `centrodeinfancia/services.py`: validación y serialización de nómina vigente
+  por persona (`tiene_nomina_cdi_vigente_en_otro_centro`).
 - `centrodeinfancia/views.py`: `AsistenciaNominaCentroView`, calendario y
   `TrabajadorCentroInfanciaCreateView`.
 - `centrodeinfancia/urls.py`: protección de rutas y redirección histórica.
@@ -65,4 +91,6 @@ trabajadores, nóminas ni formularios.
   negocio y compatibilidad de asistencia.
 - `docs/registro/cambios/2026-07-15-cdi-enforcement-alcances.md`: alcance por
   rol y restricción de Auditoría.
+- `docs/registro/cambios/2026-08-07-cdi-nomina-vigente-en-un-solo-centro.md`:
+  alcance, concurrencia, límites y rollback de la exclusividad de vigencia.
 - `docs/qa/2038-roles-simepi-cdi-guia-testeo.md`: guía funcional de roles.

--- a/docs/implementaciones/usuarios_perfil_iam.md
+++ b/docs/implementaciones/usuarios_perfil_iam.md
@@ -96,6 +96,24 @@ Reglas actuales para usuarios con acceso PWA creados desde web:
   - `must_change_password` pasa a `False`;
   - se limpia `temporary_password_plaintext`.
 
+### Mi cuenta y confirmación de datos personales
+
+- La autogestión de datos vive en `/mi-cuenta/`; el usuario solo puede editar
+  su propio nombre, apellido, DNI, CUIL, mail y correo institucional.
+- `/mi-cuenta/confirmar/` es un gate de confirmación de una sola vez para los
+  perfiles históricos activos. DNI, CUIL y la declaración de confidencialidad
+  son obligatorios; el correo institucional es opcional.
+- `ProfileConfirmationMiddleware` se ejecuta después de
+  `FirstLoginPasswordChangeMiddleware`: primero se exige el cambio de
+  contraseña, si corresponde, y luego la confirmación de datos. Las rutas API
+  están exentas para no bloquear clientes PWA/mobile.
+- El servidor valida y guarda con `MiCuentaForm`; el botón deshabilitado en la
+  interfaz solo es una ayuda de UX y no reemplaza la validación del formulario.
+- `Profile.needs_profile_confirmation` y `datos_confirmados_at` registran el
+  estado de la confirmación. Las migraciones también crean perfiles faltantes
+  para usuarios activos históricos; los nuevos perfiles conservan el default
+  de no requerir confirmación.
+
 ### Historial de acceso PWA
 
 - Los accesos mobile del usuario no se borran físicamente al quitar permisos.
@@ -132,6 +150,8 @@ Reglas actuales para usuarios con acceso PWA creados desde web:
 - `users/migrations/0013_profile_password_security_fields.py`
 - `users/migrations/0014_bootstrap_group_permissions.py`
 - `users/migrations/0015_assign_bootstrap_group_permissions.py`
+- `users/migrations/0044_profile_confirmacion_datos.py`
+- `users/migrations/0045_profile_correo_institucional_declaracion.py`
 
 ## 5) Operación post-deploy
 
@@ -145,6 +165,10 @@ Validaciones mínimas:
 - Un usuario con permiso puede ver/entrar al módulo.
 - Un usuario sin permiso no ve el ítem de sidebar y recibe `403` por URL directa.
 - Reset de contraseña web y API funcionan de punta a punta.
+- Tras desplegar las migraciones 0044/0045, un usuario web activo sin
+  confirmación debe ser redirigido a `/mi-cuenta/confirmar/`; completar el
+  formulario debe quitar el bloqueo. Verificar también que una llamada `/api/`
+  autenticada no sea redirigida.
 
 ## Guía para nuevas features
 

--- a/docs/registro/prs/PR-2222.md
+++ b/docs/registro/prs/PR-2222.md
@@ -1,0 +1,64 @@
+# PR #2222 - feat(comedores): agregar etiqueta CARITAS
+
+## Metadata
+
+- PR: https://github.com/dsocial118/SISOC/pull/2222
+- Base: `development`
+- Rama origen: `codex/issue-2216-caritas`
+- Autor: `juanikitro`
+- Última actualización: `2026-08-04T15:05:21Z`
+
+## Resumen operativo
+
+- Tipo de cambio: No informado
+- Área principal: No informada
+- Contexto funcional: No informado explícitamente; revisar título, diff y documentación relacionada.
+- Resumen para changelog: No informado
+- Impacto usuario: No informado
+
+## Áreas afectadas
+
+- `comedores`
+- `docs/registro`
+- `organizaciones`
+- `requirements`
+- `static`
+- `tests`
+
+## Archivos relevantes del diff
+
+- `comedores/api_serializers.py`
+- `comedores/forms/comedor_form.py`
+- `comedores/migrations/0053_issue_2216_es_caritas.py`
+- `comedores/models.py`
+- `comedores/templates/comedor/comedor_detail.html`
+- `comedores/templates/comedor/comedor_form.html`
+- `docs/registro/cambios/2026-08-04-etiqueta-caritas-comedores.md`
+- `organizaciones/templates/organizacion_detail.html`
+- `requirements/lint.txt`
+- `static/custom/css/comedor_detail.css`
+- `tests/test_comedor_form_unit.py`
+- `tests/test_issue_2163_categoria_espacio.py`
+- `tests/test_pwa_comedores_api.py`
+
+## Validación declarada
+
+- Pruebas automáticas: No informado en el PR.
+- Pruebas manuales: No informado en el PR.
+
+## Riesgos y rollback
+
+- No informado explícitamente en el PR.
+
+## Documentación sugerida para lectura
+
+- `docs/indice.md`
+- `docs/ia/CONTEXT_HYGIENE.md`
+- `docs/ia/ARCHITECTURE.md`
+- `docs/ia/TESTING.md`
+- `docs/registro/cambios/2026-08-04-etiqueta-caritas-comedores.md`
+
+## Notas para continuidad
+
+- Este documento es generado automáticamente desde el contexto del PR y sirve como índice rápido para revisión y futuras sesiones de agentes.
+- Si la metadata del body del PR está incompleta, varias secciones usarán fallbacks derivados del título o del diff.

--- a/docs/registro/prs/PR-2227.md
+++ b/docs/registro/prs/PR-2227.md
@@ -1,0 +1,56 @@
+# PR #2227 - chore(deps): migrar Django 4.2 a 5.2 LTS
+
+## Metadata
+
+- PR: https://github.com/dsocial118/SISOC/pull/2227
+- Base: `development`
+- Rama origen: `codex/issue-1776-django-52`
+- Autor: `juanikitro`
+- Última actualización: `2026-08-04T16:18:52Z`
+
+## Resumen operativo
+
+- Tipo de cambio: No informado
+- Área principal: No informada
+- Contexto funcional: No informado explícitamente; revisar título, diff y documentación relacionada.
+- Resumen para changelog: No informado
+- Impacto usuario: No informado
+
+## Áreas afectadas
+
+- `core`
+- `dashboard`
+- `docs/registro`
+- `requirements`
+- `users`
+
+## Archivos relevantes del diff
+
+- `core/models.py`
+- `dashboard/apps.py`
+- `dashboard/tests.py`
+- `docs/registro/cambios/2026-08-04-django-52-lts.md`
+- `requirements/base.txt`
+- `users/models.py`
+
+## Validación declarada
+
+- Pruebas automáticas: No informado en el PR.
+- Pruebas manuales: No informado en el PR.
+
+## Riesgos y rollback
+
+- No informado explícitamente en el PR.
+
+## Documentación sugerida para lectura
+
+- `docs/indice.md`
+- `docs/ia/CONTEXT_HYGIENE.md`
+- `docs/ia/ARCHITECTURE.md`
+- `docs/ia/TESTING.md`
+- `docs/registro/cambios/2026-08-04-django-52-lts.md`
+
+## Notas para continuidad
+
+- Este documento es generado automáticamente desde el contexto del PR y sirve como índice rápido para revisión y futuras sesiones de agentes.
+- Si la metadata del body del PR está incompleta, varias secciones usarán fallbacks derivados del título o del diff.

--- a/docs/registro/prs/PR-2228.md
+++ b/docs/registro/prs/PR-2228.md
@@ -1,0 +1,64 @@
+# PR #2228 - fix(iam): restringe accesos de ciudadanos y acompanamiento
+
+## Metadata
+
+- PR: https://github.com/dsocial118/SISOC/pull/2228
+- Base: `development`
+- Rama origen: `codex/issue-2225-grupos-permisos`
+- Autor: `juanikitro`
+- Última actualización: `2026-08-04T16:46:19Z`
+
+## Resumen operativo
+
+- Tipo de cambio: No informado
+- Área principal: No informada
+- Contexto funcional: No informado explícitamente; revisar título, diff y documentación relacionada.
+- Resumen para changelog: No informado
+- Impacto usuario: No informado
+
+## Áreas afectadas
+
+- `acompanamientos`
+- `ciudadanos`
+- `comedores`
+- `docs/registro`
+- `tests`
+- `users`
+
+## Archivos relevantes del diff
+
+- `acompanamientos/urls.py`
+- `acompanamientos/views.py`
+- `ciudadanos/urls.py`
+- `ciudadanos/views.py`
+- `ciudadanos/views_export.py`
+- `comedores/templates/comedor/nomina_detail.html`
+- `docs/registro/cambios/2026-08-04-issue-2225-permisos-grupos.md`
+- `tests/test_acompanamientos_views_unit.py`
+- `tests/test_ciudadanos_views_unit.py`
+- `tests/test_issue_2225_permissions.py`
+- `users/bootstrap/groups_seed.py`
+- `users/migrations/0042_revoke_acompanamiento_from_comedores_groups.py`
+- `users/migrations/0043_merge_issue_2225_profile_datos_identificatorios.py`
+
+## Validación declarada
+
+- Pruebas automáticas: No informado en el PR.
+- Pruebas manuales: No informado en el PR.
+
+## Riesgos y rollback
+
+- No informado explícitamente en el PR.
+
+## Documentación sugerida para lectura
+
+- `docs/indice.md`
+- `docs/ia/CONTEXT_HYGIENE.md`
+- `docs/ia/ARCHITECTURE.md`
+- `docs/ia/TESTING.md`
+- `docs/registro/cambios/2026-08-04-issue-2225-permisos-grupos.md`
+
+## Notas para continuidad
+
+- Este documento es generado automáticamente desde el contexto del PR y sirve como índice rápido para revisión y futuras sesiones de agentes.
+- Si la metadata del body del PR está incompleta, varias secciones usarán fallbacks derivados del título o del diff.

--- a/docs/registro/prs/PR-2230.md
+++ b/docs/registro/prs/PR-2230.md
@@ -1,0 +1,81 @@
+# PR #2230 - Comedores: cambios-en-Filtros-Ordenamiento-Columnas
+
+## Metadata
+
+- PR: https://github.com/dsocial118/SISOC/pull/2230
+- Base: `development`
+- Rama origen: `task/mejoras-filtros-comedores`
+- Autor: `Esteban-Royo`
+- Última actualización: `2026-08-07T13:46:42Z`
+
+## Resumen operativo
+
+- Tipo de cambio: Mejora funcional.
+- Área principal: Comedores.
+- Contexto funcional: Listados y filtros de Comedores, Admisiones y Acompañamiento.
+- Resumen para changelog: Nuevos filtros, ordenamiento paginado y nombres legibles de estados.
+- Impacto usuario: Mejora la búsqueda, navegación y lectura de los listados.
+
+## Áreas afectadas
+
+- `.importlinter`
+- `AGENT_REPO_MAP.md`
+- `acompanamientos`
+- `admisiones`
+- `comedores`
+- `core`
+- `docs/registro`
+- `templates`
+- `tests`
+
+## Archivos relevantes del diff
+
+- `.importlinter`
+- `AGENT_REPO_MAP.md`
+- `acompanamientos/acompanamiento_service.py`
+- `acompanamientos/services/__init__.py`
+- `acompanamientos/services/filter_config.py`
+- `acompanamientos/templates/lista_comedores.html`
+- `acompanamientos/views.py`
+- `acompanamientos/views_export.py`
+- `admisiones/services/admisiones_service/impl.py`
+- `admisiones/services/legales_service/impl.py`
+- `admisiones/templates/admisiones/admisiones_legales_list.html`
+- `admisiones/templates/admisiones/admisiones_tecnicos_list.html`
+- `admisiones/views/web_views.py`
+- `comedores/services/comedor_service/impl.py`
+- `comedores/services/filter_config/impl.py`
+- `core/services/favorite_filters/config.py`
+- `core/services/list_ordering.py`
+- `docs/registro/cambios/2026-08-03-filtros-ordenamiento-listados-comedores.md`
+- `templates/components/comedor_table.html`
+- `templates/components/data_table.html`
+- `tests/test_acompanamientos_filter_config_unit.py`
+- `tests/test_acompanamientos_list_filters_db.py`
+- `tests/test_admisiones_service_helpers_unit.py`
+- `tests/test_comedores_filter_config_unit.py`
+- `tests/test_comedores_list_values_unit.py`
+- `tests/test_legales_service_unit.py`
+- `tests/test_list_ordering_unit.py`
+
+## Validación declarada
+
+- Pruebas automáticas: No informado en el PR.
+- Pruebas manuales: No informado en el PR.
+
+## Riesgos y rollback
+
+- Riesgo bajo; rollback mediante reversión del código, sin cambios de base.
+
+## Documentación sugerida para lectura
+
+- `docs/indice.md`
+- `docs/ia/CONTEXT_HYGIENE.md`
+- `docs/ia/ARCHITECTURE.md`
+- `docs/ia/TESTING.md`
+- `docs/registro/cambios/2026-08-03-filtros-ordenamiento-listados-comedores.md`
+
+## Notas para continuidad
+
+- Este documento es generado automáticamente desde el contexto del PR y sirve como índice rápido para revisión y futuras sesiones de agentes.
+- Si la metadata del body del PR está incompleta, varias secciones usarán fallbacks derivados del título o del diff.

--- a/docs/registro/prs/PR-2231.md
+++ b/docs/registro/prs/PR-2231.md
@@ -1,0 +1,49 @@
+# PR #2231 - style(templates): corrige formato para promocion a homologacion
+
+## Metadata
+
+- PR: https://github.com/dsocial118/SISOC/pull/2231
+- Base: `development`
+- Rama origen: `codex/fix-pr-2229-djlint`
+- Autor: `juanikitro`
+- Última actualización: `2026-08-04T17:11:54Z`
+
+## Resumen operativo
+
+- Tipo de cambio: No informado
+- Área principal: No informada
+- Contexto funcional: No informado explícitamente; revisar título, diff y documentación relacionada.
+- Resumen para changelog: No informado
+- Impacto usuario: No informado
+
+## Áreas afectadas
+
+- `admisiones`
+- `templates`
+
+## Archivos relevantes del diff
+
+- `admisiones/templates/admisiones/admisiones_tecnicos_form.html`
+- `templates/includes/base.html`
+- `templates/includes/sidebar/new_opciones.html`
+
+## Validación declarada
+
+- Pruebas automáticas: No informado en el PR.
+- Pruebas manuales: No informado en el PR.
+
+## Riesgos y rollback
+
+- No informado explícitamente en el PR.
+
+## Documentación sugerida para lectura
+
+- `docs/indice.md`
+- `docs/ia/CONTEXT_HYGIENE.md`
+- `docs/ia/ARCHITECTURE.md`
+- `docs/ia/TESTING.md`
+
+## Notas para continuidad
+
+- Este documento es generado automáticamente desde el contexto del PR y sirve como índice rápido para revisión y futuras sesiones de agentes.
+- Si la metadata del body del PR está incompleta, varias secciones usarán fallbacks derivados del título o del diff.

--- a/docs/registro/prs/PR-2235.md
+++ b/docs/registro/prs/PR-2235.md
@@ -1,0 +1,95 @@
+# PR #2235 - Issues 1961, 2005, 2076, 2079 y 2188
+
+## Metadata
+
+- PR: https://github.com/dsocial118/SISOC/pull/2235
+- Base: `development`
+- Rama origen: `Fixes-VS-Agosto`
+- Autor: `PabloCao1`
+- Última actualización: `2026-08-05T15:54:00Z`
+
+## Resumen operativo
+
+- Tipo de cambio: No informado
+- Área principal: No informada
+- Contexto funcional: No informado explícitamente; revisar título, diff y documentación relacionada.
+- Resumen para changelog: No informado
+- Impacto usuario: No informado
+
+## Áreas afectadas
+
+- `AGENT_REPO_MAP.md`
+- `admisiones`
+- `comedores`
+- `docs/registro`
+- `organizaciones`
+- `rendicioncuentasmensual`
+- `static`
+- `tests`
+
+## Archivos relevantes del diff
+
+- `AGENT_REPO_MAP.md`
+- `admisiones/forms/admisiones_forms.py`
+- `admisiones/migrations/0075_alter_admision_legales_num_if.py`
+- `admisiones/models/admisiones.py`
+- `admisiones/services/admisiones_service/impl.py`
+- `admisiones/templates/admisiones/admisiones_legales_detalle.html`
+- `admisiones/templates/admisiones/admisiones_tecnicos_form.html`
+- `comedores/api_serializers.py`
+- `comedores/api_views.py`
+- `comedores/forms/comedor_form.py`
+- `comedores/forms/convenio_pnud_form.py`
+- `comedores/migrations/0054_issue_1961_proyecto_organizacion.py`
+- `comedores/migrations/0055_issue_2188_personas_declaradas_siph.py`
+- `comedores/models.py`
+- `comedores/templates/comedor/comedor_convenio_pnud_form.html`
+- `comedores/templates/comedor/comedor_form.html`
+- `comedores/views/capacitaciones.py`
+- `comedores/views/comedor.py`
+- `docs/registro/cambios/2026-08-04-issue-2005-rendiciones-en-organizaciones.md`
+- `docs/registro/cambios/2026-08-04-issues-1961-2076-2079-2188.md`
+- `organizaciones/admin.py`
+- `organizaciones/forms.py`
+- `organizaciones/migrations/0020_proyecto_organizacion.py`
+- `organizaciones/migrations/0021_issue_2188_vencimiento_firmante_programa.py`
+- `organizaciones/models.py`
+- `organizaciones/templates/organizacion_detail.html`
+- `organizaciones/templates/organizacion_form.html`
+- `organizaciones/templates/organizacion_rendicion_detail.html`
+- `organizaciones/tests.py`
+- `organizaciones/urls.py`
+- `organizaciones/views.py`
+- `rendicioncuentasmensual/forms.py`
+- `rendicioncuentasmensual/migrations/0014_issue_2005_datos_auditoria.py`
+- `rendicioncuentasmensual/migrations/0015_issue_2079_grupos_revision.py`
+- `rendicioncuentasmensual/models.py`
+- `rendicioncuentasmensual/services.py`
+- `rendicioncuentasmensual/templates/rendicioncuentasmensual_detail.html`
+- `rendicioncuentasmensual/templates/rendicioncuentasmensual_global_list.html`
+- `rendicioncuentasmensual/views.py`
+- `static/custom/js/admisionesactualizarestado.js`
+- ... y 3 archivo(s) adicional(es) en el diff.
+
+## Validación declarada
+
+- Pruebas automáticas: No informado en el PR.
+- Pruebas manuales: No informado en el PR.
+
+## Riesgos y rollback
+
+- No informado explícitamente en el PR.
+
+## Documentación sugerida para lectura
+
+- `docs/indice.md`
+- `docs/ia/CONTEXT_HYGIENE.md`
+- `docs/ia/ARCHITECTURE.md`
+- `docs/ia/TESTING.md`
+- `docs/registro/cambios/2026-08-04-issue-2005-rendiciones-en-organizaciones.md`
+- `docs/registro/cambios/2026-08-04-issues-1961-2076-2079-2188.md`
+
+## Notas para continuidad
+
+- Este documento es generado automáticamente desde el contexto del PR y sirve como índice rápido para revisión y futuras sesiones de agentes.
+- Si la metadata del body del PR está incompleta, varias secciones usarán fallbacks derivados del título o del diff.

--- a/docs/registro/prs/PR-2237.md
+++ b/docs/registro/prs/PR-2237.md
@@ -1,0 +1,83 @@
+# PR #2237 - UI buscadores
+
+## Metadata
+
+- PR: https://github.com/dsocial118/SISOC/pull/2237
+- Base: `development`
+- Rama origen: `UI_buscadores`
+- Autor: `MariaNavarro90`
+- Última actualización: `2026-08-07T13:47:28Z`
+
+## Resumen operativo
+
+- Tipo de cambio: Feature + refactor de UI. Incluye corrección de bugs encontrados en el camino.
+- Área principal: Componente compartido search_bar / listados transversales.
+- Contexto funcional: Buscadores y filtros de listados en toda la aplicación.
+- Resumen para changelog: Se rediseñó el buscador de listados según el prototipo de UX/UI y se unificó en los 46 listados de la aplicación: la lupa reemplaza al botón "Filtrar", cada filtro es una barra completa, y se unificaron tabla, botones y paleta.
+- Impacto usuario: Alto y visible. Cambia el aspecto y la interacción de todos los listados. Se pierden la búsqueda por campo vacío, por rango y por exclusión, la combinación con OR, y los filtros favoritos dejan de estar accesibles desde la UI.
+
+## Áreas afectadas
+
+- `VAT`
+- `celiaquia`
+- `centrodefamilia`
+- `ciudadanos`
+- `comedores`
+- `comunicados`
+- `docs/registro`
+- `insumos`
+- `static`
+- `templates`
+- `tests`
+- `ver_para_ser_libre`
+
+## Archivos relevantes del diff
+
+- `VAT/templates/vat/centros/centro_list.html`
+- `celiaquia/templates/celiaquia/expediente_list.html`
+- `celiaquia/views/expediente.py`
+- `centrodefamilia/tests/test_beneficiarios_export.py`
+- `ciudadanos/ciudadanos_filter_config.py`
+- `ciudadanos/templates/ciudadanos/ciudadano_list.html`
+- `ciudadanos/views.py`
+- `comedores/templates/comedor/actividades_pnud_list.html`
+- `comunicados/views.py`
+- `docs/registro/cambios/2026-07-31-buscador-transversal-lupa-y-cta.md`
+- `insumos/templates/insumos/insumos_list.html`
+- `insumos/views.py`
+- `static/custom/css/comedoresSearchBar.css`
+- `static/custom/css/hitos.css`
+- `static/custom/css/listModerno.css`
+- `static/custom/css/poncho.css`
+- `static/custom/css/poncho_listados.css`
+- `static/custom/css/ver_para_ser_libre.css`
+- `static/custom/js/advanced_filters.js`
+- `static/custom/js/favorite_filters.js`
+- `templates/components/search_bar.html`
+- `templates/comunicados/comunicado_gestion_list.html`
+- `templates/comunicados/comunicado_list.html`
+- `templates/includes/base.html`
+- `tests/test_ciudadanos_views_unit.py`
+- `ver_para_ser_libre/templates/ver_para_ser_libre/itinerario_list.html`
+
+## Validación declarada
+
+- Pruebas automáticas: No informado en el PR.
+- Pruebas manuales: No informado en el PR.
+
+## Riesgos y rollback
+
+- No informado explícitamente en el PR.
+
+## Documentación sugerida para lectura
+
+- `docs/indice.md`
+- `docs/ia/CONTEXT_HYGIENE.md`
+- `docs/ia/ARCHITECTURE.md`
+- `docs/ia/TESTING.md`
+- `docs/registro/cambios/2026-07-31-buscador-transversal-lupa-y-cta.md`
+
+## Notas para continuidad
+
+- Este documento es generado automáticamente desde el contexto del PR y sirve como índice rápido para revisión y futuras sesiones de agentes.
+- Si la metadata del body del PR está incompleta, varias secciones usarán fallbacks derivados del título o del diff.

--- a/docs/registro/prs/PR-2253.md
+++ b/docs/registro/prs/PR-2253.md
@@ -1,0 +1,118 @@
+# PR #2253 - refactor(architecture): completar ratchet de Fase 0
+
+## Metadata
+
+- PR: https://github.com/dsocial118/SISOC/pull/2253
+- Base: `development`
+- Rama origen: `codex/issue-2241-kernel-ratchet`
+- Autor: `juanikitro`
+- Última actualización: `2026-08-07T14:10:01Z`
+
+## Resumen operativo
+
+- Tipo de cambio: refactor sin migraciones.
+- Área principal: core, ciudadanos y users.
+- Contexto funcional: boundary arquitectónico del monolito modular.
+- Resumen para changelog: desacopla el kernel de implementaciones de dominio en Fase 0.
+- Impacto usuario: ninguno esperado; se preservan permisos, accesos PWA y flujos existentes.
+
+## Áreas afectadas
+
+- `.importlinter`
+- `AGENT_REPO_MAP.md`
+- `VAT`
+- `acompanamientos`
+- `admisiones`
+- `celiaquia`
+- `centrodefamilia`
+- `ciudadanos`
+- `comedores`
+- `core`
+- `dispositivos`
+- `docs/registro`
+- `duplas`
+- `intervenciones`
+- `organizaciones`
+- `pwa`
+- `rendicioncuentasmensual`
+- `tests`
+- `users`
+
+## Archivos relevantes del diff
+
+- `.importlinter`
+- `AGENT_REPO_MAP.md`
+- `VAT/apps.py`
+- `VAT/ciudadano_detail.py`
+- `VAT/favorite_filters.py`
+- `VAT/sidebar_access.py`
+- `acompanamientos/apps.py`
+- `acompanamientos/favorite_filters.py`
+- `admisiones/apps.py`
+- `admisiones/favorite_filters.py`
+- `celiaquia/apps.py`
+- `celiaquia/ciudadano_detail.py`
+- `centrodefamilia/apps.py`
+- `centrodefamilia/ciudadano_detail.py`
+- `centrodefamilia/favorite_filters.py`
+- `ciudadanos/detail_contributions.py`
+- `ciudadanos/services_importacion_masiva.py`
+- `ciudadanos/test_territorial_scope.py`
+- `ciudadanos/views.py`
+- `comedores/apps.py`
+- `comedores/ciudadano_detail.py`
+- `comedores/favorite_filters.py`
+- `comedores/pwa_capabilities.py`
+- `comedores/pwa_user_import.py`
+- `comedores/test_pwa_capabilities.py`
+- `comedores/user_form_catalog.py`
+- `core/api_views.py`
+- `core/management/commands/load_fixtures.py`
+- `core/services/favorite_filters/__init__.py`
+- `core/services/favorite_filters/config.py`
+- `core/services/favorite_filters/registry.py`
+- `core/services/fixture_post_load.py`
+- `core/services/renaper.py`
+- `core/services/sidebar_access.py`
+- `core/soft_delete/registry.py`
+- `core/soft_delete/state_sync.py`
+- `core/templatetags/custom_filters.py`
+- `core/tests/test_renaper_api.py`
+- `core/urls.py`
+- `core/views.py`
+- ... y 59 archivo(s) adicional(es) en el diff.
+
+## Validación declarada
+
+- Pruebas automáticas: No informado en el PR.
+- Pruebas manuales: No informado en el PR.
+
+## Riesgos y rollback
+
+- bajo; revertir el commit restaura los imports directos. Los registros fallan explícitamente si falta un proveedor.
+
+## Documentación sugerida para lectura
+
+- `docs/indice.md`
+- `docs/ia/CONTEXT_HYGIENE.md`
+- `docs/ia/ARCHITECTURE.md`
+- `docs/ia/TESTING.md`
+- `docs/registro/decisiones/2026-08-06-capacidad-comedores-pwa-fase-0.md`
+- `docs/registro/decisiones/2026-08-06-catalogos-formularios-users-fase-0.md`
+- `docs/registro/decisiones/2026-08-06-cierre-ratchet-fase-0.md`
+- `docs/registro/decisiones/2026-08-06-contribuciones-ciudadano-360-fase-0.md`
+- `docs/registro/decisiones/2026-08-06-endpoint-organizaciones-fase-0.md`
+- `docs/registro/decisiones/2026-08-06-puerto-auditoria-auth-pwa-fase-0.md`
+- `docs/registro/decisiones/2026-08-06-puerto-renaper-fase-0.md`
+- `docs/registro/decisiones/2026-08-06-registro-filtros-favoritos-fase-0.md`
+- `docs/registro/decisiones/2026-08-06-registro-post-fixture-intervenciones-fase-0.md`
+- `docs/registro/decisiones/2026-08-06-registro-sidebar-vat-fase-0.md`
+- `docs/registro/decisiones/2026-08-06-registro-soft-delete-vat-fase-0.md`
+- `docs/registro/decisiones/2026-08-06-resolvedor-importacion-pwa-fase-0.md`
+- `docs/registro/decisiones/2026-08-06-senal-coordinador-duplas-fase-0.md`
+- `docs/registro/decisiones/2026-08-06-tests-alcance-territorial-ciudadanos-fase-0.md`
+
+## Notas para continuidad
+
+- Este documento es generado automáticamente desde el contexto del PR y sirve como índice rápido para revisión y futuras sesiones de agentes.
+- Si la metadata del body del PR está incompleta, varias secciones usarán fallbacks derivados del título o del diff.

--- a/docs/registro/prs/PR-2255.md
+++ b/docs/registro/prs/PR-2255.md
@@ -1,0 +1,78 @@
+# PR #2255 - Fixes post revisión: issues 1961, 2076, 2079 y 2188
+
+## Metadata
+
+- PR: https://github.com/dsocial118/SISOC/pull/2255
+- Base: `development`
+- Rama origen: `Fixex-Vs-Agosto2`
+- Autor: `PabloCao1`
+- Última actualización: `2026-08-07T14:01:50Z`
+
+## Resumen operativo
+
+- Tipo de cambio: No informado
+- Área principal: No informada
+- Contexto funcional: No informado explícitamente; revisar título, diff y documentación relacionada.
+- Resumen para changelog: No informado
+- Impacto usuario: No informado
+
+## Áreas afectadas
+
+- `admisiones`
+- `comedores`
+- `docs/registro`
+- `organizaciones`
+- `rendicioncuentasmensual`
+- `static`
+- `tests`
+
+## Archivos relevantes del diff
+
+- `admisiones/forms/admisiones_forms.py`
+- `admisiones/templates/admisiones/admisiones_legales_detalle.html`
+- `admisiones/templates/admisiones/admisiones_tecnicos_form.html`
+- `admisiones/templates/admisiones/partials/numero_expediente_estructurado.html`
+- `admisiones/views/web_views.py`
+- `comedores/api_views.py`
+- `comedores/templates/comedor/comedor_form.html`
+- `comedores/views/comedor.py`
+- `docs/registro/cambios/2026-08-06-issue-1961-proyectos-alta-comedor.md`
+- `docs/registro/cambios/2026-08-06-issue-2076-edicion-expediente.md`
+- `docs/registro/cambios/2026-08-06-issue-2079-subsanacion-auditoria.md`
+- `docs/registro/cambios/2026-08-06-issue-2188-capacitaciones-actividades-pnud.md`
+- `organizaciones/templates/organizacion_detail.html`
+- `organizaciones/tests.py`
+- `organizaciones/urls.py`
+- `organizaciones/views.py`
+- `rendicioncuentasmensual/services.py`
+- `static/custom/css/numeroExpedienteModal.css`
+- `tests/test_admisiones_forms_unit.py`
+- `tests/test_admisiones_web_views_unit.py`
+- `tests/test_comedor_views_unit.py`
+- `tests/test_comedores_api_views_unit.py`
+- `tests/test_rendicioncuentasmensual_services_unit.py`
+
+## Validación declarada
+
+- Pruebas automáticas: No informado en el PR.
+- Pruebas manuales: No informado en el PR.
+
+## Riesgos y rollback
+
+- No informado explícitamente en el PR.
+
+## Documentación sugerida para lectura
+
+- `docs/indice.md`
+- `docs/ia/CONTEXT_HYGIENE.md`
+- `docs/ia/ARCHITECTURE.md`
+- `docs/ia/TESTING.md`
+- `docs/registro/cambios/2026-08-06-issue-1961-proyectos-alta-comedor.md`
+- `docs/registro/cambios/2026-08-06-issue-2076-edicion-expediente.md`
+- `docs/registro/cambios/2026-08-06-issue-2079-subsanacion-auditoria.md`
+- `docs/registro/cambios/2026-08-06-issue-2188-capacitaciones-actividades-pnud.md`
+
+## Notas para continuidad
+
+- Este documento es generado automáticamente desde el contexto del PR y sirve como índice rápido para revisión y futuras sesiones de agentes.
+- Si la metadata del body del PR está incompleta, varias secciones usarán fallbacks derivados del título o del diff.

--- a/docs/registro/prs/PR-2260.md
+++ b/docs/registro/prs/PR-2260.md
@@ -1,0 +1,60 @@
+# PR #2260 - cdi nomina restriccion
+
+## Metadata
+
+- PR: https://github.com/dsocial118/SISOC/pull/2260
+- Base: `development`
+- Rama origen: `cdi_nomina_res`
+- Autor: `MariaNavarro90`
+- Última actualización: `2026-08-10T13:13:41Z`
+
+## Resumen operativo
+
+- Tipo de cambio: Feature
+- Área principal: Centro de Infancia (CDI) — nómina de destinatarios
+- Contexto funcional: Nominalización de destinatarios en Centros de Infancia. Una persona sólo puede tener una inscripción vigente (Activo o Pendiente) en un único CDI; los registros en Baja no bloquean, preservando la derivación entre centros.
+- Resumen para changelog: Se impide registrar a una persona en la nómina de un Centro de Infancia si ya posee una inscripción vigente en otro centro, informando el impedimento sin revelar de qué centro se trata.
+- Impacto usuario: El alta y la reactivación de una ficha se bloquean cuando la persona ya está registrada en otro CDI, con un mensaje neutro y sin perder los datos cargados en el formulario. El resto de los flujos (duplicado en el mismo centro, derivación entre centros) se mantiene sin cambios.
+
+## Áreas afectadas
+
+- `centrodeinfancia`
+- `core`
+- `docs/registro`
+- `static`
+
+## Archivos relevantes del diff
+
+- `centrodeinfancia/admin.py`
+- `centrodeinfancia/forms.py`
+- `centrodeinfancia/models.py`
+- `centrodeinfancia/services.py`
+- `centrodeinfancia/tests/test_nomina_integridad.py`
+- `centrodeinfancia/tests/test_nomina_vigencia_unica.py`
+- `centrodeinfancia/views.py`
+- `core/soft_delete/cascade.py`
+- `core/trash_views.py`
+- `docs/registro/cambios/2026-08-07-cdi-nomina-vigente-en-un-solo-centro.md`
+- `static/custom/js/nomina_detail.js`
+
+## Validación declarada
+
+- Pruebas automáticas: No informado en el PR.
+- Pruebas manuales: No informado en el PR.
+
+## Riesgos y rollback
+
+- Sin migraciones ni cambios de schema; el rollback es revertir el commit. Riesgo operativo: si en producción hay personas con vigencia en más de un CDI, la regla no las modifica (sólo bloquea altas nuevas), pero su derivación empieza a fallar con el mensaje neutro. Conviene contar esos casos antes de desplegar:
+
+## Documentación sugerida para lectura
+
+- `docs/indice.md`
+- `docs/ia/CONTEXT_HYGIENE.md`
+- `docs/ia/ARCHITECTURE.md`
+- `docs/ia/TESTING.md`
+- `docs/registro/cambios/2026-08-07-cdi-nomina-vigente-en-un-solo-centro.md`
+
+## Notas para continuidad
+
+- Este documento es generado automáticamente desde el contexto del PR y sirve como índice rápido para revisión y futuras sesiones de agentes.
+- Si la metadata del body del PR está incompleta, varias secciones usarán fallbacks derivados del título o del diff.

--- a/docs/registro/prs/PR-2261.md
+++ b/docs/registro/prs/PR-2261.md
@@ -1,0 +1,71 @@
+# PR #2261 - Mi cuenta
+
+## Metadata
+
+- PR: https://github.com/dsocial118/SISOC/pull/2261
+- Base: `development`
+- Rama origen: `MiCuenta`
+- Autor: `MariaNavarro90`
+- Última actualización: `2026-08-10T12:49:12Z`
+
+## Resumen operativo
+
+- Tipo de cambio: Nuevas Funcionalidades
+- Área principal: users
+- Contexto funcional: Forzar una actualización masiva de datos personales por única vez y dejar una sección permanente de autogestión. Hasta ahora los datos identificatorios de los usuarios solo se editaban desde el ABM, con perfiles incompletos o desactualizados.
+- Resumen para changelog: Nueva sección "Mi cuenta" para que cada usuario gestione sus datos personales, con una confirmación obligatoria por única vez en el primer ingreso posterior al despliegue.
+- Impacto usuario: Alto y visible desde el primer login. Todos los usuarios activos verán una pantalla de confirmación bloqueante en su próximo ingreso web y no podrán operar hasta completar DNI, CUIL, nombre, apellido, mail y aceptar la declaración. Los usuarios que solo operan la PWA no la ven: el middleware exime /api/.
+
+## Áreas afectadas
+
+- `AGENT_REPO_MAP.md`
+- `config`
+- `docs/registro`
+- `static`
+- `templates`
+- `tests`
+- `users`
+
+## Archivos relevantes del diff
+
+- `AGENT_REPO_MAP.md`
+- `config/settings.py`
+- `docs/registro/cambios/2026-08-06-mi-cuenta-confirmacion-datos.md`
+- `static/custom/css/poncho_formularios.css`
+- `templates/includes/sidebar/opciones.html`
+- `tests/test_users_mi_cuenta.py`
+- `tests/urls_vat_comision_horarios.py`
+- `users/forms.py`
+- `users/middleware.py`
+- `users/migrations/0044_profile_confirmacion_datos.py`
+- `users/migrations/0045_profile_correo_institucional_declaracion.py`
+- `users/models.py`
+- `users/profile_utils.py`
+- `users/templates/user/_mi_cuenta_campos.html`
+- `users/templates/user/_mi_cuenta_submit_js.html`
+- `users/templates/user/confirmar_datos.html`
+- `users/templates/user/mi_cuenta.html`
+- `users/urls.py`
+- `users/views.py`
+
+## Validación declarada
+
+- Pruebas automáticas: No informado en el PR.
+- Pruebas manuales: No informado en el PR.
+
+## Riesgos y rollback
+
+- El riesgo principal es de soporte, no técnico: exigir DNI y CUIL válidos a todo el padrón activo es un gate duro, y un usuario con el CUIL mal cargado no puede seguir usando el sistema hasta corregirlo. Conviene avisar a soporte antes del deploy. Para desactivar el flujo sin revertir código alcanza con quitar users.middleware.ProfileConfirmationMiddleware de MIDDLEWARE, o bajar el flag en masa con Profile.objects.update(needs_profile_confirmation=False). La 0044 es reversible: su RunPython tiene función inversa. Los campos agregados son aditivos y no rompen lecturas previas.
+
+## Documentación sugerida para lectura
+
+- `docs/indice.md`
+- `docs/ia/CONTEXT_HYGIENE.md`
+- `docs/ia/ARCHITECTURE.md`
+- `docs/ia/TESTING.md`
+- `docs/registro/cambios/2026-08-06-mi-cuenta-confirmacion-datos.md`
+
+## Notas para continuidad
+
+- Este documento es generado automáticamente desde el contexto del PR y sirve como índice rápido para revisión y futuras sesiones de agentes.
+- Si la metadata del body del PR está incompleta, varias secciones usarán fallbacks derivados del título o del diff.


### PR DESCRIPTION
## Resumen
- reconstruye los artefactos spec-as-source de los PR #2222, #2227, #2228, #2230, #2231, #2235, #2237, #2253, #2255, #2260 y #2261;
- documenta la exclusividad de nómina vigente CDI y su impacto en derivaciones;
- incorpora Mi Cuenta y la confirmación obligatoria a la guía IAM.

## Validación
- generación idempotente del artefacto de PR #2260;
- 11/11 PRs con registro y contexto de feature;
- Markdown con newline final;
- git diff --cached --check antes del commit.

## Alcance
Solo documentación; no cambia comportamiento de la aplicación.