### PR TITLE
fix(ci): permitir promociones entre ramas protegidas

### DIFF
--- a/.github/workflows/pr-docs.yml
+++ b/.github/workflows/pr-docs.yml
@@ -59,7 +59,7 @@ jobs:
 
     sync_pr_artifacts:
         needs: generate_pr_artifacts
-        if: always()
+        if: always() && github.event.pull_request.head.ref != 'development' && github.event.pull_request.head.ref != 'homologacion' && github.event.pull_request.head.ref != 'main'
         runs-on: ubuntu-latest
 
         steps:

--- a/docs/contexto/features/pr-2270-fix-ci-permitir-promociones-entre-ramas-protegidas.md
+++ b/docs/contexto/features/pr-2270-fix-ci-permitir-promociones-entre-ramas-protegidas.md
@@ -31,12 +31,16 @@
 - Empezar por `docs/registro/prs/PR-2270.md` para contexto resumido del PR.
 - Revisar primero estos archivos del diff:
 - `.github/workflows/pr-docs.yml`
+- `docs/contexto/features/pr-2270-fix-ci-permitir-promociones-entre-ramas-protegidas.md`
+- `docs/registro/prs/PR-2270.md`
 - `tests/test_pr_doc_automation_unit.py`
 - Documentación sugerida para ampliar contexto:
 - `docs/indice.md`
 - `docs/ia/CONTEXT_HYGIENE.md`
 - `docs/ia/ARCHITECTURE.md`
 - `docs/ia/TESTING.md`
+- `docs/contexto/features/pr-2270-fix-ci-permitir-promociones-entre-ramas-protegidas.md`
+- `docs/registro/prs/PR-2270.md`
 
 ## Trazabilidad
 

--- a/docs/contexto/features/pr-2270-fix-ci-permitir-promociones-entre-ramas-protegidas.md
+++ b/docs/contexto/features/pr-2270-fix-ci-permitir-promociones-entre-ramas-protegidas.md
@@ -1,0 +1,44 @@
+# Contexto de feature PR #2270 - fix(ci): permitir promociones entre ramas protegidas
+
+## Resumen
+
+- PR: https://github.com/dsocial118/SISOC/pull/2270
+- Base: `development`
+- Rama origen: `codex/fix-pr-docs-promotions`
+- Autor: `juanikitro`
+
+## Contexto funcional
+
+- No informado explícitamente; inferir desde el título del PR y el diff.
+
+## Arquitectura tocada
+
+- El alcance incluye automatización o tooling de CI/CD.
+
+## Decisiones y supuestos detectados
+
+- Tipo de cambio declarado: No informado
+- Área principal declarada: No informada
+- Impacto usuario declarado: No informado
+- Riesgos / rollback: No informado
+
+## Design system y UI
+
+- Sin cambios visibles de UI o design system detectados en el diff.
+
+## Memoria operativa para agentes
+
+- Empezar por `docs/registro/prs/PR-2270.md` para contexto resumido del PR.
+- Revisar primero estos archivos del diff:
+- `.github/workflows/pr-docs.yml`
+- `tests/test_pr_doc_automation_unit.py`
+- Documentación sugerida para ampliar contexto:
+- `docs/indice.md`
+- `docs/ia/CONTEXT_HYGIENE.md`
+- `docs/ia/ARCHITECTURE.md`
+- `docs/ia/TESTING.md`
+
+## Trazabilidad
+
+- Documento generado automáticamente desde el evento de `pull_request`.
+- Si este PR cambia de título, el archivo se renombrará para mantener el slug alineado.

--- a/docs/registro/prs/PR-2270.md
+++ b/docs/registro/prs/PR-2270.md
@@ -1,0 +1,47 @@
+# PR #2270 - fix(ci): permitir promociones entre ramas protegidas
+
+## Metadata
+
+- PR: https://github.com/dsocial118/SISOC/pull/2270
+- Base: `development`
+- Rama origen: `codex/fix-pr-docs-promotions`
+- Autor: `juanikitro`
+
+## Resumen operativo
+
+- Tipo de cambio: No informado
+- Área principal: No informada
+- Contexto funcional: No informado explícitamente; revisar título, diff y documentación relacionada.
+- Resumen para changelog: No informado
+- Impacto usuario: No informado
+
+## Áreas afectadas
+
+- `.github/workflows`
+- `tests`
+
+## Archivos relevantes del diff
+
+- `.github/workflows/pr-docs.yml`
+- `tests/test_pr_doc_automation_unit.py`
+
+## Validación declarada
+
+- Pruebas automáticas: No informado en el PR.
+- Pruebas manuales: No informado en el PR.
+
+## Riesgos y rollback
+
+- No informado explícitamente en el PR.
+
+## Documentación sugerida para lectura
+
+- `docs/indice.md`
+- `docs/ia/CONTEXT_HYGIENE.md`
+- `docs/ia/ARCHITECTURE.md`
+- `docs/ia/TESTING.md`
+
+## Notas para continuidad
+
+- Este documento es generado automáticamente desde el contexto del PR y sirve como índice rápido para revisión y futuras sesiones de agentes.
+- Si la metadata del body del PR está incompleta, varias secciones usarán fallbacks derivados del título o del diff.

--- a/docs/registro/prs/PR-2270.md
+++ b/docs/registro/prs/PR-2270.md
@@ -18,11 +18,15 @@
 ## Áreas afectadas
 
 - `.github/workflows`
+- `docs/contexto`
+- `docs/registro`
 - `tests`
 
 ## Archivos relevantes del diff
 
 - `.github/workflows/pr-docs.yml`
+- `docs/contexto/features/pr-2270-fix-ci-permitir-promociones-entre-ramas-protegidas.md`
+- `docs/registro/prs/PR-2270.md`
 - `tests/test_pr_doc_automation_unit.py`
 
 ## Validación declarada
@@ -40,6 +44,8 @@
 - `docs/ia/CONTEXT_HYGIENE.md`
 - `docs/ia/ARCHITECTURE.md`
 - `docs/ia/TESTING.md`
+- `docs/contexto/features/pr-2270-fix-ci-permitir-promociones-entre-ramas-protegidas.md`
+- `docs/registro/prs/PR-2270.md`
 
 ## Notas para continuidad
 

--- a/tests/test_pr_doc_automation_unit.py
+++ b/tests/test_pr_doc_automation_unit.py
@@ -39,6 +39,10 @@ def test_pr_docs_workflow_detecta_artefactos_nuevos_no_trackeados():
     assert "ref: ${{ github.event.pull_request.base.sha }}" in workflow
     assert "needs: generate_pr_artifacts" in workflow
     assert "if: always()" in workflow
+    assert (
+        "if: always() && github.event.pull_request.head.ref != 'development'"
+        in workflow
+    )
     assert "refs/pull/${{ github.event.pull_request.number }}/head" in workflow
     assert "git ls-tree -r --name-only refs/remotes/origin/pr-head" in workflow
     assert "Faltan artefactos spec-as-source requeridos para mergear." in workflow

--- a/tests/test_pr_doc_automation_unit.py
+++ b/tests/test_pr_doc_automation_unit.py
@@ -31,6 +31,7 @@ def test_pr_docs_workflow_detecta_artefactos_nuevos_no_trackeados():
     )
     assert "generate_pr_artifacts:" in workflow
     assert "contents: write" in workflow
+    assert "github.event.sender.login != 'github-actions[bot]'" in workflow
     assert (
         "head.repo.full_name == github.repository && "
         "github.event.pull_request.head.ref != 'development'"


### PR DESCRIPTION
Corrige el gate de artefactos spec-as-source para que los PR de promoción entre development, homologacion y main no exijan documentos con número de PR que esas ramas protegidas no pueden generar automáticamente. Mantiene la validación para ramas de trabajo.