### PR TITLE
refactor: enforce domain boundaries for phase 3

### DIFF
--- a/.importlinter
+++ b/.importlinter
@@ -222,3 +222,268 @@ forbidden_modules =
     pwa
     ticketera
 ignore_imports =
+
+[importlinter:contract:dispositivos-public-boundary]
+name = los dominios no importan internals de Dispositivos
+type = forbidden
+allow_indirect_imports = True
+source_modules =
+    core
+    users
+    ciudadanos
+    comedores
+    organizaciones
+    duplas
+    admisiones
+    audittrail
+    intervenciones
+    historial
+    acompanamientos
+    expedientespagos
+    relevamientos
+    rendicioncuentasfinal
+    rendicioncuentasmensual
+    centrodefamilia
+    VAT
+    celiaquia
+    importarexpediente
+    comunicados
+    centrodeinfancia
+    ver_para_ser_libre
+    pwa
+    ticketera
+    dashboard
+    healthcheck
+    iam
+    insumos
+    ocr
+forbidden_modules =
+    dispositivos.admin
+    dispositivos.apps
+    dispositivos.dispositivos_filter_config
+    dispositivos.favorite_filters
+    dispositivos.forms
+    dispositivos.management
+    dispositivos.models
+    dispositivos.services
+    dispositivos.urls
+    dispositivos.validators
+    dispositivos.views
+ignore_imports =
+
+[importlinter:contract:vat-public-boundary]
+name = los dominios no importan internals de VAT
+type = forbidden
+allow_indirect_imports = True
+source_modules =
+    core
+    users
+    ciudadanos
+    comedores
+    organizaciones
+    duplas
+    admisiones
+    audittrail
+    intervenciones
+    historial
+    acompanamientos
+    expedientespagos
+    relevamientos
+    rendicioncuentasfinal
+    rendicioncuentasmensual
+    centrodefamilia
+    celiaquia
+    importarexpediente
+    comunicados
+    centrodeinfancia
+    ver_para_ser_libre
+    dispositivos
+    pwa
+    ticketera
+    dashboard
+    healthcheck
+    iam
+    insumos
+    ocr
+forbidden_modules =
+    VAT.admin
+    VAT.api_views
+    VAT.api_web_views
+    VAT.apps
+    VAT.cache_utils
+    VAT.forms
+    VAT.global_urls
+    VAT.management
+    VAT.models
+    VAT.pagination
+    VAT.serializers
+    VAT.services
+    VAT.sidebar_access
+    VAT.urls
+    VAT.views
+ignore_imports =
+
+[importlinter:contract:vpsl-public-boundary]
+name = los dominios no importan internals de Ver para Ser Libre
+type = forbidden
+allow_indirect_imports = True
+source_modules =
+    core
+    users
+    ciudadanos
+    comedores
+    organizaciones
+    duplas
+    admisiones
+    audittrail
+    intervenciones
+    historial
+    acompanamientos
+    expedientespagos
+    relevamientos
+    rendicioncuentasfinal
+    rendicioncuentasmensual
+    centrodefamilia
+    VAT
+    celiaquia
+    importarexpediente
+    comunicados
+    centrodeinfancia
+    dispositivos
+    pwa
+    ticketera
+    dashboard
+    healthcheck
+    iam
+    insumos
+    ocr
+forbidden_modules =
+    ver_para_ser_libre.admin
+    ver_para_ser_libre.apps
+    ver_para_ser_libre.forms
+    ver_para_ser_libre.management
+    ver_para_ser_libre.models
+    ver_para_ser_libre.services
+    ver_para_ser_libre.urls
+    ver_para_ser_libre.views
+ignore_imports =
+
+[importlinter:contract:centrodefamilia-public-boundary]
+name = los dominios no importan internals de Centro de Familia
+type = forbidden
+allow_indirect_imports = True
+source_modules =
+    core
+    users
+    ciudadanos
+    comedores
+    organizaciones
+    duplas
+    admisiones
+    audittrail
+    intervenciones
+    historial
+    acompanamientos
+    expedientespagos
+    relevamientos
+    rendicioncuentasfinal
+    rendicioncuentasmensual
+    VAT
+    celiaquia
+    importarexpediente
+    comunicados
+    centrodeinfancia
+    ver_para_ser_libre
+    dispositivos
+    pwa
+    ticketera
+    dashboard
+    healthcheck
+    iam
+    insumos
+    ocr
+forbidden_modules =
+    centrodefamilia.access
+    centrodefamilia.admin
+    centrodefamilia.api_urls
+    centrodefamilia.api_views
+    centrodefamilia.apps
+    centrodefamilia.ciudadano_detail
+    centrodefamilia.forms
+    centrodefamilia.management
+    centrodefamilia.models
+    centrodefamilia.services
+    centrodefamilia.urls
+    centrodefamilia.views
+ignore_imports =
+
+[importlinter:contract:centrodeinfancia-public-boundary]
+name = los dominios no importan internals de Centro de Infancia
+type = forbidden
+allow_indirect_imports = True
+source_modules =
+    core
+    users
+    ciudadanos
+    comedores
+    organizaciones
+    duplas
+    admisiones
+    audittrail
+    intervenciones
+    historial
+    acompanamientos
+    expedientespagos
+    relevamientos
+    rendicioncuentasfinal
+    rendicioncuentasmensual
+    centrodefamilia
+    VAT
+    celiaquia
+    importarexpediente
+    comunicados
+    ver_para_ser_libre
+    dispositivos
+    pwa
+    ticketera
+    dashboard
+    healthcheck
+    iam
+    insumos
+    ocr
+forbidden_modules =
+    centrodeinfancia.access
+    centrodeinfancia.admin
+    centrodeinfancia.apps
+    centrodeinfancia.forms
+    centrodeinfancia.management
+    centrodeinfancia.models
+    centrodeinfancia.services
+    centrodeinfancia.signals
+    centrodeinfancia.urls
+    centrodeinfancia.views
+ignore_imports =
+
+[importlinter:contract:centrodeinfancia-consumes-intervenciones-api]
+name = Centro de Infancia consume el catálogo público de Intervenciones
+type = forbidden
+allow_indirect_imports = True
+source_modules =
+    centrodeinfancia
+forbidden_modules =
+    intervenciones.constants
+    intervenciones.forms
+    intervenciones.models
+    intervenciones.services_catalogo
+    intervenciones.views
+ignore_imports =
+
+[importlinter:contract:vpsl-no-comedores]
+name = Ver para Ser Libre no depende de Comedores
+type = forbidden
+allow_indirect_imports = True
+source_modules =
+    ver_para_ser_libre
+forbidden_modules =
+    comedores
+ignore_imports =

--- a/AGENT_REPO_MAP.md
+++ b/AGENT_REPO_MAP.md
@@ -315,6 +315,9 @@ La siguiente tabla mezcla hechos observados con inferencias explicitas cuando no
 - La arquitectura actual tiene boundaries monitoreados por `import-linter`, con baseline de excepciones a reducir por cortes. Los filtros favoritos se aportan desde cada app mediante `core.services.favorite_filters.registry`; `core` no debe volver a importar configuraciones de dominio para resolverlos.
 - Los paneles de Ciudadano 360 se aportan por dominio mediante `ciudadanos.detail_contributions`; las vistas de ciudadanos no deben consultar modelos de esos dominios directamente.
 - Las consultas RENAPER pasan por `core.services.renaper`, que delega el transporte compartido a `core.integrations.renaper`; ningún dominio debe tener su propio cliente ni importar otro dominio para consultarlo.
+- Los consumidores interdominio usan contratos Python acotados: `centrodefamilia.api` expone métricas para Dashboard, `ciudadanos.api` resuelve ciudadanos desde RENAPER y `intervenciones.api` provee el catálogo autorizado para CDI.
+- Los receivers de auditoría de Centro de Infancia viven en `centrodeinfancia.signals` y llaman `audittrail.api`; Audittrail no debe importar modelos CDI.
+- Dispositivos, VAT y Ver para Ser Libre no exponen internals a otros dominios. La composición de rutas de preview de VAT se realiza desde `VAT.global_urls`.
 - Los efectos de backfill de soft delete se registran desde cada dominio en `core.soft_delete.registry`; `core.soft_delete.state_sync` no debe importar handlers de dominio.
 - Las restricciones de navegacion aportadas por dominios se registran en `core.services.sidebar_access`; el template tag global no debe importar reglas VAT.
 - El endpoint Select2 de organizaciones vive en `organizaciones.views` y `organizaciones.urls`, aunque conserva la ruta global `ajax/load-organizaciones/`.

--- a/VAT/global_urls.py
+++ b/VAT/global_urls.py
@@ -1,0 +1,14 @@
+"""Rutas globales de VAT que puede incluir la composición del proyecto."""
+
+from django.urls import path
+
+from VAT.views.reporte import ReporteInscriptosAsistenciasView
+
+
+urlpatterns = [
+    path(
+        "vat/reportes/inscripciones-asistencias/",
+        ReporteInscriptosAsistenciasView.as_view(),
+        name="vat_reporte_inscripciones_asistencias",
+    ),
+]

--- a/audittrail/api.py
+++ b/audittrail/api.py
@@ -1,0 +1,62 @@
+"""Contrato público para registrar eventos de auditoría de dominios."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from django.db import transaction
+
+from auditlog.models import LogEntry
+
+from audittrail.context import get_audit_context
+from config.middlewares.threadlocals import get_current_user
+
+
+ACTION_CREATE = LogEntry.Action.CREATE
+
+
+def _actor_actual():
+    context = get_audit_context()
+    actor = context.get("actor") if isinstance(context, dict) else None
+    if actor and getattr(actor, "is_authenticated", False):
+        return actor
+    actor = get_current_user()
+    return actor if actor and getattr(actor, "is_authenticated", False) else None
+
+
+def _additional_data() -> dict[str, Any] | None:
+    context = get_audit_context()
+    if not isinstance(context, dict):
+        return None
+
+    payload: dict[str, Any] = {}
+    source = str(context.get("source") or "").strip()
+    if source:
+        payload["audittrail_source"] = source
+    batch_key = context.get("batch_key")
+    if batch_key not in (None, ""):
+        payload["audittrail_batch_key"] = str(batch_key)
+    extra = context.get("extra")
+    if isinstance(extra, dict) and extra:
+        payload["audittrail_context"] = extra
+    return payload or None
+
+
+def registrar_evento(
+    objeto, cambios: dict[str, Any], accion: int = ACTION_CREATE
+) -> None:
+    """Registra un evento después del commit sin conocer el modelo del dominio."""
+
+    if not objeto or not cambios:
+        return
+
+    actor = _actor_actual()
+    additional_data = _additional_data()
+
+    def _create_log():
+        kwargs = {"action": accion, "changes": cambios, "actor": actor}
+        if additional_data and hasattr(LogEntry, "additional_data"):
+            kwargs["additional_data"] = additional_data
+        LogEntry.objects.log_create(objeto, **kwargs)
+
+    transaction.on_commit(_create_log)

--- a/audittrail/signals.py
+++ b/audittrail/signals.py
@@ -11,12 +11,6 @@ from django.dispatch import receiver
 
 from auditlog.models import LogEntry
 from admisiones.models.admisiones import Admision
-from centrodeinfancia.models import (
-    CentroDeInfancia,
-    FormularioCDI,
-    IntervencionCentroInfancia,
-    NominaCentroInfancia,
-)
 from comedores.models import Comedor, ImagenComedor, Referente
 from audittrail.context import get_audit_context
 from audittrail.models import AuditEntryMeta
@@ -220,33 +214,6 @@ def _log_comedor_event(comedor: Comedor, changes: dict, action: int):
     transaction.on_commit(_create_log)
 
 
-def _log_centro_infancia_event(
-    centro: CentroDeInfancia,
-    changes: dict,
-    action: int,
-):
-    """
-    Genera una entrada de auditoría para un centro de infancia con los cambios provistos.
-    """
-    if not centro or not changes:
-        return
-
-    actor = _get_actor()
-    additional_data = _build_custom_signal_additional_data()
-
-    def _create_log():
-        kwargs = {
-            "action": action,
-            "changes": changes,
-            "actor": actor,
-        }
-        if additional_data and hasattr(LogEntry, "additional_data"):
-            kwargs["additional_data"] = additional_data
-        LogEntry.objects.log_create(centro, **kwargs)
-
-    transaction.on_commit(_create_log)
-
-
 def _log_organizacion_event(organizacion: Organizacion, changes: dict, action: int):
     """
     Genera una entrada de auditoría para una organización con los cambios provistos.
@@ -350,80 +317,6 @@ def log_intervencion_creation(sender, instance: Intervencion, created: bool, **k
     _log_comedor_event(
         instance.comedor,
         {"Intervención": [None, description]},
-        LogEntry.Action.CREATE,
-    )
-
-
-@receiver(post_save, sender=NominaCentroInfancia)
-def log_nomina_centro_infancia_creation(
-    sender,
-    instance: NominaCentroInfancia,
-    created: bool,
-    **kwargs,
-):
-    """
-    Registra altas de nómina vinculadas a un centro de infancia.
-    """
-    if not created or not instance.centro:
-        return
-
-    description = f"Nómina #{instance.pk}"
-    if instance.ciudadano_id:
-        description = f"{description} - {instance.ciudadano}"
-
-    _log_centro_infancia_event(
-        instance.centro,
-        {"Nómina": [None, description]},
-        LogEntry.Action.CREATE,
-    )
-
-
-@receiver(post_save, sender=IntervencionCentroInfancia)
-def log_intervencion_centro_infancia_creation(
-    sender,
-    instance: IntervencionCentroInfancia,
-    created: bool,
-    **kwargs,
-):
-    """
-    Registra altas de intervenciones vinculadas a un centro de infancia.
-    """
-    if not created or not instance.centro:
-        return
-
-    tipo = getattr(instance, "tipo_intervencion", None)
-    description = f"Intervención #{instance.pk}"
-    if tipo:
-        description = f"{description} - {tipo}"
-
-    _log_centro_infancia_event(
-        instance.centro,
-        {"Intervención": [None, description]},
-        LogEntry.Action.CREATE,
-    )
-
-
-@receiver(post_save, sender=FormularioCDI)
-def log_formulario_cdi_creation(
-    sender, instance: FormularioCDI, created: bool, **kwargs
-):
-    """
-    Registra altas de formularios CDI vinculadas a un centro de infancia.
-    """
-    if not created or not instance.centro:
-        return
-
-    fecha = None
-    if getattr(instance, "fecha_relevamiento", None):
-        fecha = instance.fecha_relevamiento.strftime("%Y-%m-%d")
-
-    description = f"Formulario CDI #{instance.pk}"
-    if fecha:
-        description = f"{description} - {fecha}"
-
-    _log_centro_infancia_event(
-        instance.centro,
-        {"Formulario CDI": [None, description]},
         LogEntry.Action.CREATE,
     )
 

--- a/centrodefamilia/api.py
+++ b/centrodefamilia/api.py
@@ -1,0 +1,30 @@
+"""Contrato Python público de Centro de Familia."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from centrodefamilia.models import ActividadCentro, Centro, ParticipanteActividad
+
+
+@dataclass(frozen=True)
+class MetricasDashboardCentroFamilia:
+    """Indicadores agregados que otros módulos pueden mostrar."""
+
+    participantes_total: int
+    centros_adheridos_totales: int
+    centros_faro_totales: int
+    actividades_totales: int
+
+
+def obtener_metricas_dashboard() -> MetricasDashboardCentroFamilia:
+    """Devuelve los indicadores públicos de Centro de Familia para Dashboard."""
+
+    return MetricasDashboardCentroFamilia(
+        participantes_total=ParticipanteActividad.objects.filter(
+            estado="inscrito"
+        ).count(),
+        centros_adheridos_totales=Centro.objects.filter(tipo="adherido").count(),
+        centros_faro_totales=Centro.objects.filter(tipo="faro").count(),
+        actividades_totales=ActividadCentro.objects.count(),
+    )

--- a/centrodefamilia/tests/test_centrodefamilia_public_api.py
+++ b/centrodefamilia/tests/test_centrodefamilia_public_api.py
@@ -1,0 +1,38 @@
+import pytest
+
+from centrodefamilia.api import (
+    MetricasDashboardCentroFamilia,
+    obtener_metricas_dashboard,
+)
+from centrodefamilia.models import ActividadCentro, Centro, ParticipanteActividad
+
+
+@pytest.mark.django_db
+def test_obtener_metricas_dashboard_expone_valores_agregados(mocker):
+    mocker.patch.object(
+        ParticipanteActividad.objects,
+        "filter",
+        return_value=mocker.Mock(count=mocker.Mock(return_value=7)),
+    )
+    mocker.patch.object(
+        Centro.objects,
+        "filter",
+        side_effect=[
+            mocker.Mock(count=mocker.Mock(return_value=3)),
+            mocker.Mock(count=mocker.Mock(return_value=2)),
+        ],
+    )
+    mocker.patch.object(
+        ActividadCentro.objects,
+        "count",
+        return_value=11,
+    )
+
+    metricas = obtener_metricas_dashboard()
+
+    assert metricas == MetricasDashboardCentroFamilia(
+        participantes_total=7,
+        centros_adheridos_totales=3,
+        centros_faro_totales=2,
+        actividades_totales=11,
+    )

--- a/centrodeinfancia/apps.py
+++ b/centrodeinfancia/apps.py
@@ -5,3 +5,6 @@ class CentrodeinfanciaConfig(AppConfig):
     default_auto_field = "django.db.models.BigAutoField"
     name = "centrodeinfancia"
     verbose_name = "Centro de Desarrollo Infantil"
+
+    def ready(self):
+        import centrodeinfancia.signals  # pylint: disable=unused-import,import-outside-toplevel

--- a/centrodeinfancia/forms.py
+++ b/centrodeinfancia/forms.py
@@ -16,12 +16,7 @@ from core.validators import (
     validate_telefono_ar,
     validate_unicode_email,
 )
-from intervenciones.constants import PROGRAMA_ALIASES_CENTRO_INFANCIA
-from intervenciones.models.intervenciones import (
-    SubIntervencion,
-    TipoDestinatario,
-    TipoIntervencion,
-)
+from intervenciones.api import obtener_configuracion_formulario_cdi
 from users.models import Profile
 from users.territorial_scope import (
     get_single_full_province_scope_id,
@@ -2026,29 +2021,26 @@ class IntervencionCentroInfanciaForm(forms.ModelForm):
             selected_subtipo_id = self._parse_selected_id(
                 self.data.get(self.add_prefix("subintervencion"))
             )
-        self.fields["tipo_intervencion"].queryset = TipoIntervencion.para_programas(
-            *PROGRAMA_ALIASES_CENTRO_INFANCIA,
-            include_ids=[selected_tipo_id] if selected_tipo_id else None,
-        )
-        self.fields["subintervencion"].queryset = SubIntervencion.para_tipo(
+        configuracion_catalogo = obtener_configuracion_formulario_cdi(
             selected_tipo_id,
-            include_ids=[selected_subtipo_id] if selected_subtipo_id else None,
+            selected_subtipo_id,
+            destinatario_fijo_nombre,
         )
+        self.fields["tipo_intervencion"].queryset = configuracion_catalogo.tipos
+        self.fields["subintervencion"].queryset = configuracion_catalogo.subtipos
 
         self.destinatario_fijo_instance = None
         self.destinatario_fijo_missing = False
         self.destinatario_fijo_nombre = destinatario_fijo_nombre
         if destinatario_fijo_nombre:
-            destinatario_fijo = TipoDestinatario.objects.filter(
-                nombre__iexact=destinatario_fijo_nombre
-            ).first()
+            destinatario_fijo = configuracion_catalogo.destinatario_fijo
             if destinatario_fijo:
                 self.destinatario_fijo_instance = destinatario_fijo
                 self.fields["destinatario"].required = False
                 self.fields["destinatario"].initial = destinatario_fijo.pk
-                self.fields["destinatario"].queryset = TipoDestinatario.objects.filter(
-                    pk=destinatario_fijo.pk
-                )
+                self.fields["destinatario"].queryset = self.fields[
+                    "destinatario"
+                ].queryset.filter(pk=destinatario_fijo.pk)
             else:
                 self.destinatario_fijo_missing = True
                 self.fields["destinatario"].required = False

--- a/centrodeinfancia/signals.py
+++ b/centrodeinfancia/signals.py
@@ -1,0 +1,52 @@
+"""Eventos de auditoría que pertenecen al dominio Centro de Infancia."""
+
+from django.db.models.signals import post_save
+from django.dispatch import receiver
+
+from audittrail.api import ACTION_CREATE, registrar_evento
+from centrodeinfancia.models import (
+    FormularioCDI,
+    IntervencionCentroInfancia,
+    NominaCentroInfancia,
+)
+
+
+@receiver(post_save, sender=NominaCentroInfancia)
+def registrar_alta_nomina(sender, instance, created: bool, **kwargs):
+    if not created or not instance.centro:
+        return
+
+    descripcion = f"Nómina #{instance.pk}"
+    if instance.ciudadano_id:
+        descripcion = f"{descripcion} - {instance.ciudadano}"
+    registrar_evento(instance.centro, {"Nómina": [None, descripcion]}, ACTION_CREATE)
+
+
+@receiver(post_save, sender=IntervencionCentroInfancia)
+def registrar_alta_intervencion(sender, instance, created: bool, **kwargs):
+    if not created or not instance.centro:
+        return
+
+    descripcion = f"Intervención #{instance.pk}"
+    if instance.tipo_intervencion:
+        descripcion = f"{descripcion} - {instance.tipo_intervencion}"
+    registrar_evento(
+        instance.centro,
+        {"Intervención": [None, descripcion]},
+        ACTION_CREATE,
+    )
+
+
+@receiver(post_save, sender=FormularioCDI)
+def registrar_alta_formulario(sender, instance, created: bool, **kwargs):
+    if not created or not instance.centro:
+        return
+
+    descripcion = f"Formulario CDI #{instance.pk}"
+    if instance.fecha_relevamiento:
+        descripcion = f"{descripcion} - {instance.fecha_relevamiento:%Y-%m-%d}"
+    registrar_evento(
+        instance.centro,
+        {"Formulario CDI": [None, descripcion]},
+        ACTION_CREATE,
+    )

--- a/centrodeinfancia/tests/test_audit_signals.py
+++ b/centrodeinfancia/tests/test_audit_signals.py
@@ -1,0 +1,36 @@
+from datetime import date
+from types import SimpleNamespace
+
+from centrodeinfancia import signals
+
+
+def test_registrar_alta_nomina_delega_evento_al_contrato_publico(mocker):
+    registrar_evento = mocker.patch("centrodeinfancia.signals.registrar_evento")
+    centro = SimpleNamespace()
+    instancia = SimpleNamespace(pk=10, centro=centro, ciudadano_id=None)
+
+    signals.registrar_alta_nomina(None, instancia, created=True)
+
+    registrar_evento.assert_called_once_with(
+        centro,
+        {"Nómina": [None, "Nómina #10"]},
+        signals.ACTION_CREATE,
+    )
+
+
+def test_registrar_alta_formulario_conserva_fecha(mocker):
+    registrar_evento = mocker.patch("centrodeinfancia.signals.registrar_evento")
+    centro = SimpleNamespace()
+    instancia = SimpleNamespace(
+        pk=4,
+        centro=centro,
+        fecha_relevamiento=date(2026, 8, 11),
+    )
+
+    signals.registrar_alta_formulario(None, instancia, created=True)
+
+    registrar_evento.assert_called_once_with(
+        centro,
+        {"Formulario CDI": [None, "Formulario CDI #4 - 2026-08-11"]},
+        signals.ACTION_CREATE,
+    )

--- a/centrodeinfancia/views.py
+++ b/centrodeinfancia/views.py
@@ -86,7 +86,7 @@ from centrodeinfancia.services_user_provisioning import (
     sincronizar_email_trabajador,
 )
 from centrodeinfancia.views_formulario_cdi import construir_resumenes_formularios
-from intervenciones.constants import PROGRAMA_ALIASES_CENTRO_INFANCIA
+from intervenciones.api import programa_aliases_cdi
 
 
 CDI_LIST_HEADERS = [
@@ -712,7 +712,7 @@ class CentroDeInfanciaDetailView(LoginRequiredMixin, DetailView):
                 str(tipo.pk): (tipo.programa or "").strip()
                 for tipo in tipo_intervencion_queryset
             }
-            alias_list = list(PROGRAMA_ALIASES_CENTRO_INFANCIA)
+            alias_list = list(programa_aliases_cdi())
             context["tipo_intervencion_programas"] = tipo_programas_map
             context["tipo_intervencion_programa_aliases"] = alias_list
             context["tipo_intervencion_programas_json"] = json.dumps(tipo_programas_map)

--- a/ciudadanos/api.py
+++ b/ciudadanos/api.py
@@ -1,0 +1,311 @@
+"""Contrato Python público para resolver ciudadanos desde RENAPER."""
+
+from __future__ import annotations
+
+import logging
+import unicodedata
+from datetime import date, datetime
+from typing import Any
+
+from django.db import IntegrityError
+
+from ciudadanos.models import Ciudadano
+from core.models import Localidad, Municipio, Nacionalidad, Provincia
+from core.services.renaper import consultar_datos_renaper
+
+
+logger = logging.getLogger("django")
+
+_GEO_ALIASES = {
+    "ciudad de buenos aires": "ciudad autonoma de buenos aires",
+    "ciudad autonoma de buenos aires": "ciudad autonoma de buenos aires",
+    "caba": "ciudad autonoma de buenos aires",
+    "capital federal": "ciudad autonoma de buenos aires",
+}
+_NUMEROS_INICIALES = {
+    "uno": "1",
+    "una": "1",
+    "dos": "2",
+    "tres": "3",
+    "cuatro": "4",
+    "cinco": "5",
+    "seis": "6",
+    "siete": "7",
+    "ocho": "8",
+    "nueve": "9",
+    "diez": "10",
+    "once": "11",
+    "doce": "12",
+    "trece": "13",
+    "catorce": "14",
+    "quince": "15",
+    "dieciseis": "16",
+    "diecisiete": "17",
+    "dieciocho": "18",
+    "diecinueve": "19",
+    "veinte": "20",
+    "veintiuno": "21",
+    "veintidos": "22",
+    "veintitres": "23",
+    "veinticuatro": "24",
+    "veinticinco": "25",
+    "veintiseis": "26",
+    "veintisiete": "27",
+    "veintiocho": "28",
+    "veintinueve": "29",
+    "treinta": "30",
+}
+
+
+def _normalizar(valor: object) -> str:
+    if not valor:
+        return ""
+    texto = str(valor).replace("_", " ").replace("-", " ").lower()
+    texto = " ".join(texto.split())
+    texto = _GEO_ALIASES.get(texto, texto)
+    texto = " ".join(
+        unicodedata.normalize("NFKD", texto)
+        .encode("ascii", "ignore")
+        .decode("utf-8")
+        .split()
+    )
+    partes = texto.split()
+    if partes and partes[0] in _NUMEROS_INICIALES:
+        partes[0] = _NUMEROS_INICIALES[partes[0]]
+    return " ".join(partes)
+
+
+def _buscar_por_nombre(queryset, valor: object):
+    objetivo = _normalizar(valor)
+    if not objetivo:
+        return None
+    return next(
+        (
+            item
+            for item in queryset
+            if _normalizar(getattr(item, "nombre", "")) == objetivo
+        ),
+        None,
+    )
+
+
+def _resolver_ubicacion(datos: dict[str, Any]) -> dict[str, object | None]:
+    provincia = _buscar_por_nombre(Provincia.objects.all(), datos.get("provincia_api"))
+    municipios = Municipio.objects.all()
+    if provincia:
+        municipios = municipios.filter(provincia=provincia)
+    municipio = _buscar_por_nombre(municipios, datos.get("municipio_api"))
+    localidades = Localidad.objects.all()
+    if municipio:
+        localidades = localidades.filter(municipio=municipio)
+    elif provincia:
+        localidades = localidades.filter(municipio__provincia=provincia)
+    return {
+        "provincia": provincia,
+        "municipio": municipio,
+        "localidad": _buscar_por_nombre(localidades, datos.get("localidad_api")),
+    }
+
+
+def _resolver_nacionalidad(nombre: object):
+    objetivo = _normalizar(nombre)
+    if not objetivo:
+        return None
+    return next(
+        (
+            nacionalidad
+            for nacionalidad in Nacionalidad.objects.all()
+            if _normalizar(nacionalidad.nacionalidad) == objetivo
+        ),
+        None,
+    )
+
+
+def _parse_fecha(valor: object):
+    if isinstance(valor, date):
+        return valor
+    if not valor:
+        return None
+    for formato in ("%Y-%m-%d", "%d/%m/%Y", "%Y/%m/%d"):
+        try:
+            return datetime.strptime(str(valor), formato).date()
+        except ValueError:
+            continue
+    return None
+
+
+def _consultar_por_dni(dni: str, sexo: str | None) -> dict[str, Any]:
+    sexos = (
+        (sexo.upper(),)
+        if sexo and sexo.upper() in {"M", "F", "X"}
+        else (
+            "M",
+            "F",
+            "X",
+        )
+    )
+    ultimo_error = "No se encontraron datos en RENAPER."
+    for sexo_consulta in sexos:
+        resultado = consultar_datos_renaper(dni, sexo_consulta)
+        if resultado.get("success"):
+            return resultado
+        ultimo_error = resultado.get("error") or ultimo_error
+        if resultado.get("error_type") != "no_match":
+            break
+    return {"success": False, "error": ultimo_error}
+
+
+def _datos_para_ciudadano(datos: dict[str, Any], dni: str) -> dict[str, Any] | None:
+    apellido = " ".join(str(datos.get("apellido") or "").split()).title()
+    nombre = " ".join(str(datos.get("nombre") or "").split()).title()
+    fecha_nacimiento = _parse_fecha(datos.get("fecha_nacimiento"))
+    if not apellido or not nombre or not fecha_nacimiento:
+        return None
+
+    ubicacion = _resolver_ubicacion(datos)
+    ciudadano_data: dict[str, Any] = {
+        "apellido": apellido,
+        "nombre": nombre,
+        "documento": int(datos.get("dni") or dni),
+        "tipo_documento": datos.get("tipo_documento") or Ciudadano.DOCUMENTO_DNI,
+        "fecha_nacimiento": fecha_nacimiento,
+        "origen_dato": "renaper",
+        "cuil_cuit": str(datos.get("cuil")) if datos.get("cuil") else None,
+        "calle": datos.get("calle") or None,
+        "altura": str(datos.get("altura")) if datos.get("altura") else None,
+        "piso_departamento": datos.get("piso_vivienda")
+        or datos.get("departamento_vivienda"),
+        "barrio": datos.get("barrio") or None,
+        "codigo_postal": (
+            str(datos.get("codigo_postal")) if datos.get("codigo_postal") else None
+        ),
+    }
+    if datos.get("sexo"):
+        ciudadano_data["sexo_id"] = datos["sexo"]
+    for campo, objeto in ubicacion.items():
+        if objeto:
+            ciudadano_data[f"{campo}_id"] = objeto.pk
+    nacionalidad = _resolver_nacionalidad(datos.get("nacionalidad_api"))
+    if nacionalidad:
+        ciudadano_data["nacionalidad_id"] = nacionalidad.pk
+    return ciudadano_data
+
+
+def _buscar_ciudadano_verificado(dni: str):
+    ciudadano = Ciudadano.objects.filter(documento_unico_key=f"DNI_{dni}").first()
+    if ciudadano:
+        return ciudadano
+    return Ciudadano.objects.filter(
+        tipo_documento=Ciudadano.DOCUMENTO_DNI,
+        documento=int(dni),
+        tipo_registro_identidad=Ciudadano.TIPO_REGISTRO_ESTANDAR,
+    ).first()
+
+
+def _resumen_ciudadano(ciudadano) -> dict[str, Any]:
+    sexo = str(ciudadano.sexo or "")
+    sexo_normalizado = {"masculino": "M", "femenino": "F", "x": "X"}.get(
+        sexo.lower(), sexo[:1].upper()
+    )
+    return {
+        "dni": str(ciudadano.documento or ""),
+        "nombre": ciudadano.nombre or "",
+        "apellido": ciudadano.apellido or "",
+        "genero": sexo,
+        "sexo": sexo_normalizado,
+        "fecha_nacimiento": (
+            ciudadano.fecha_nacimiento.isoformat() if ciudadano.fecha_nacimiento else ""
+        ),
+        "edad": ciudadano.edad,
+        "telefono": ciudadano.telefono or "",
+        "ciudadano_id": ciudadano.pk,
+    }
+
+
+def consultar_ciudadano_renaper(dni: object, sexo: str | None = None) -> dict[str, Any]:
+    """Consulta RENAPER sin inspeccionar ni crear ciudadanos locales."""
+
+    dni_texto = str(dni or "").strip()
+    if not dni_texto.isdigit() or len(dni_texto) < 7:
+        return {"success": False, "message": "Debe ingresar un DNI válido."}
+    resultado = _consultar_por_dni(dni_texto, sexo)
+    if not resultado.get("success"):
+        return {"success": False, "message": resultado.get("error")}
+    return {
+        "success": True,
+        "message": "Datos obtenidos desde RENAPER.",
+        "data": resultado.get("data") or {},
+        "datos_api": resultado.get("datos_api"),
+    }
+
+
+def prevalidar_ciudadano_renaper(
+    dni: object, sexo: str | None = None
+) -> dict[str, Any]:
+    """Consulta o recupera un ciudadano sin crear registros nuevos."""
+
+    dni_texto = str(dni or "").strip()
+    if not dni_texto.isdigit() or len(dni_texto) < 7:
+        return {"success": False, "message": "Debe ingresar un DNI válido."}
+    existente = _buscar_ciudadano_verificado(dni_texto)
+    if existente:
+        return {
+            "success": True,
+            "message": "Ciudadano existente validado.",
+            "data": _resumen_ciudadano(existente),
+            "datos_api": None,
+            "created": False,
+            "pending_creation": False,
+        }
+    resultado = consultar_ciudadano_renaper(dni_texto, sexo)
+    if not resultado.get("success"):
+        return resultado
+    return {
+        **resultado,
+        "created": False,
+        "pending_creation": True,
+    }
+
+
+def resolver_ciudadano_renaper(
+    dni: object, usuario=None, sexo: str | None = None
+) -> dict[str, Any]:
+    """Resuelve un ciudadano validado; crea uno sólo si RENAPER lo permite."""
+
+    resultado = prevalidar_ciudadano_renaper(dni, sexo)
+    if not resultado.get("success") or not resultado.get("pending_creation"):
+        return resultado
+    ciudadano_data = _datos_para_ciudadano(
+        resultado.get("data") or {}, str(dni).strip()
+    )
+    if not ciudadano_data:
+        return {
+            "success": False,
+            "message": "RENAPER no devolvió datos mínimos para crear el ciudadano.",
+        }
+    if usuario and getattr(usuario, "is_authenticated", False):
+        ciudadano_data.update({"creado_por": usuario, "modificado_por": usuario})
+    try:
+        ciudadano = Ciudadano.objects.create(**ciudadano_data)
+    except IntegrityError:
+        ciudadano = _buscar_ciudadano_verificado(str(dni).strip())
+        if not ciudadano:
+            logger.exception("ciudadanos.renaper.create_conflict")
+            return {
+                "success": False,
+                "message": "No se pudo crear el ciudadano con los datos de RENAPER.",
+            }
+        return {
+            "success": True,
+            "message": "El ciudadano ya existe en la base.",
+            "data": _resumen_ciudadano(ciudadano),
+            "datos_api": None,
+            "created": False,
+        }
+    return {
+        "success": True,
+        "message": "Ciudadano creado automáticamente con datos de RENAPER.",
+        "data": _resumen_ciudadano(ciudadano),
+        "datos_api": resultado.get("datos_api"),
+        "created": True,
+    }

--- a/ciudadanos/api.py
+++ b/ciudadanos/api.py
@@ -155,18 +155,25 @@ def _consultar_por_dni(dni: str, sexo: str | None) -> dict[str, Any]:
     return {"success": False, "error": ultimo_error}
 
 
-def _datos_para_ciudadano(datos: dict[str, Any], dni: str) -> dict[str, Any] | None:
+def _datos_para_ciudadano(
+    datos: dict[str, Any], dni: str
+) -> tuple[dict[str, Any] | None, str | None]:
     apellido = " ".join(str(datos.get("apellido") or "").split()).title()
     nombre = " ".join(str(datos.get("nombre") or "").split()).title()
     fecha_nacimiento = _parse_fecha(datos.get("fecha_nacimiento"))
     if not apellido or not nombre or not fecha_nacimiento:
-        return None
+        return None, "RENAPER no devolvió datos mínimos para crear el ciudadano."
+
+    try:
+        documento = int(datos.get("dni") or dni)
+    except (TypeError, ValueError):
+        return None, "RENAPER devolvió un DNI inválido."
 
     ubicacion = _resolver_ubicacion(datos)
     ciudadano_data: dict[str, Any] = {
         "apellido": apellido,
         "nombre": nombre,
-        "documento": int(datos.get("dni") or dni),
+        "documento": documento,
         "tipo_documento": datos.get("tipo_documento") or Ciudadano.DOCUMENTO_DNI,
         "fecha_nacimiento": fecha_nacimiento,
         "origen_dato": "renaper",
@@ -188,7 +195,7 @@ def _datos_para_ciudadano(datos: dict[str, Any], dni: str) -> dict[str, Any] | N
     nacionalidad = _resolver_nacionalidad(datos.get("nacionalidad_api"))
     if nacionalidad:
         ciudadano_data["nacionalidad_id"] = nacionalidad.pk
-    return ciudadano_data
+    return ciudadano_data, None
 
 
 def _buscar_ciudadano_verificado(dni: str):
@@ -275,13 +282,13 @@ def resolver_ciudadano_renaper(
     resultado = prevalidar_ciudadano_renaper(dni, sexo)
     if not resultado.get("success") or not resultado.get("pending_creation"):
         return resultado
-    ciudadano_data = _datos_para_ciudadano(
+    ciudadano_data, error = _datos_para_ciudadano(
         resultado.get("data") or {}, str(dni).strip()
     )
     if not ciudadano_data:
         return {
             "success": False,
-            "message": "RENAPER no devolvió datos mínimos para crear el ciudadano.",
+            "message": error,
         }
     if usuario and getattr(usuario, "is_authenticated", False):
         ciudadano_data.update({"creado_por": usuario, "modificado_por": usuario})

--- a/config/urls_preview.py
+++ b/config/urls_preview.py
@@ -2,8 +2,6 @@ from django.contrib import admin
 from django.shortcuts import redirect
 from django.urls import include, path
 
-from VAT.views.reporte import ReporteInscriptosAsistenciasView
-
 
 def _root_redirect(_request):
     return redirect("vat_reporte_inscripciones_asistencias")
@@ -18,9 +16,5 @@ urlpatterns = [
     path("admin/", admin.site.urls),
     path("__debug__/", include("debug_toolbar.urls")),
     path("", _root_redirect),
-    path(
-        "vat/reportes/inscripciones-asistencias/",
-        ReporteInscriptosAsistenciasView.as_view(),
-        name="vat_reporte_inscripciones_asistencias",
-    ),
+    path("", include("VAT.global_urls")),
 ]

--- a/dashboard/views.py
+++ b/dashboard/views.py
@@ -1,7 +1,7 @@
 from django.contrib.auth.mixins import LoginRequiredMixin, UserPassesTestMixin
 from django.views.generic import DetailView, TemplateView
 
-from centrodefamilia.models import Centro, ActividadCentro, ParticipanteActividad
+from centrodefamilia.api import obtener_metricas_dashboard
 from dashboard.models import Dashboard, Tablero
 
 
@@ -16,17 +16,8 @@ class DashboardView(LoginRequiredMixin, TemplateView):
         context.update({item.llave: item.cantidad for item in dashboard_data})
 
         # 2) Indicadores dinámicos
-        context["participantes_total"] = ParticipanteActividad.objects.filter(
-            estado="inscrito"
-        ).count()
-
-        context["centros_adheridos_totales"] = Centro.objects.filter(
-            tipo="adherido"
-        ).count()
-
-        context["centros_faro_totales"] = Centro.objects.filter(tipo="faro").count()
-
-        context["actividades_totales"] = ActividadCentro.objects.count()
+        metricas_cdf = obtener_metricas_dashboard()
+        context.update(metricas_cdf.__dict__)
 
         return context
 

--- a/docs/contexto/features/pr-2271-refactor-enforce-domain-boundaries-for-phase-3.md
+++ b/docs/contexto/features/pr-2271-refactor-enforce-domain-boundaries-for-phase-3.md
@@ -45,18 +45,20 @@
 - `ciudadanos/api.py`
 - `config/urls_preview.py`
 - `dashboard/views.py`
+- `docs/contexto/features/pr-2271-refactor-enforce-domain-boundaries-for-phase-3.md`
 - `docs/registro/decisiones/2026-08-11-boundaries-fase-3.md`
+- `docs/registro/prs/PR-2271.md`
 - `intervenciones/api.py`
 - `intervenciones/tests/test_intervenciones_public_api.py`
-- `tests/test_ciudadanos_renaper_api_unit.py`
-- `ver_para_ser_libre/tests/test_boundary_api.py`
-- ... y 2 archivo(s) adicional(es) relacionados.
+- ... y 4 archivo(s) adicional(es) relacionados.
 - Documentación sugerida para ampliar contexto:
 - `docs/indice.md`
 - `docs/ia/CONTEXT_HYGIENE.md`
 - `docs/ia/ARCHITECTURE.md`
 - `docs/ia/TESTING.md`
+- `docs/contexto/features/pr-2271-refactor-enforce-domain-boundaries-for-phase-3.md`
 - `docs/registro/decisiones/2026-08-11-boundaries-fase-3.md`
+- `docs/registro/prs/PR-2271.md`
 
 ## Trazabilidad
 

--- a/docs/contexto/features/pr-2271-refactor-enforce-domain-boundaries-for-phase-3.md
+++ b/docs/contexto/features/pr-2271-refactor-enforce-domain-boundaries-for-phase-3.md
@@ -1,0 +1,64 @@
+# Contexto de feature PR #2271 - refactor: enforce domain boundaries for phase 3
+
+## Resumen
+
+- PR: https://github.com/dsocial118/SISOC/pull/2271
+- Base: `development`
+- Rama origen: `codex/issue-2244-2248-boundaries`
+- Autor: `juanikitro`
+
+## Contexto funcional
+
+- No informado explícitamente; inferir desde el título del PR y el diff.
+
+## Arquitectura tocada
+
+- Hay cambios en vistas web y puede existir impacto en permisos o renderizado.
+
+## Decisiones y supuestos detectados
+
+- Tipo de cambio declarado: No informado
+- Área principal declarada: No informada
+- Impacto usuario declarado: No informado
+- Riesgos / rollback: No informado
+
+## Design system y UI
+
+- Sin cambios visibles de UI o design system detectados en el diff.
+
+## Memoria operativa para agentes
+
+- Empezar por `docs/registro/prs/PR-2271.md` para contexto resumido del PR.
+- Revisar primero estos archivos del diff:
+- `.importlinter`
+- `AGENT_REPO_MAP.md`
+- `VAT/global_urls.py`
+- `audittrail/api.py`
+- `audittrail/signals.py`
+- `centrodefamilia/api.py`
+- `centrodefamilia/tests/test_centrodefamilia_public_api.py`
+- `centrodeinfancia/apps.py`
+- `centrodeinfancia/forms.py`
+- `centrodeinfancia/signals.py`
+- `centrodeinfancia/tests/test_audit_signals.py`
+- `centrodeinfancia/views.py`
+- `ciudadanos/api.py`
+- `config/urls_preview.py`
+- `dashboard/views.py`
+- `docs/registro/decisiones/2026-08-11-boundaries-fase-3.md`
+- `intervenciones/api.py`
+- `intervenciones/tests/test_intervenciones_public_api.py`
+- `tests/test_ciudadanos_renaper_api_unit.py`
+- `ver_para_ser_libre/tests/test_boundary_api.py`
+- ... y 2 archivo(s) adicional(es) relacionados.
+- Documentación sugerida para ampliar contexto:
+- `docs/indice.md`
+- `docs/ia/CONTEXT_HYGIENE.md`
+- `docs/ia/ARCHITECTURE.md`
+- `docs/ia/TESTING.md`
+- `docs/registro/decisiones/2026-08-11-boundaries-fase-3.md`
+
+## Trazabilidad
+
+- Documento generado automáticamente desde el evento de `pull_request`.
+- Si este PR cambia de título, el archivo se renombrará para mantener el slug alineado.

--- a/docs/registro/decisiones/2026-08-11-boundaries-fase-3.md
+++ b/docs/registro/decisiones/2026-08-11-boundaries-fase-3.md
@@ -1,0 +1,35 @@
+# Boundaries públicos de Fase 3
+
+## Decisión
+
+Los dominios `dispositivos`, `VAT`, `ver_para_ser_libre`, `centrodefamilia` y
+`centrodeinfancia` permanecen dentro del monolito modular. No se crean
+deployables, APIs HTTP internas ni migraciones de datos.
+
+- Dispositivos y VAT no tenían consumidores Python de negocio: sus internals
+  quedan prohibidos para los demás dominios. La ruta de preview de VAT se
+  compone desde `VAT.global_urls`, no desde una view interna.
+- Ver para Ser Libre es independiente de Comedores: no hay FKs ni transacciones
+  compartidas. Su resolución de ciudadanos usa `ciudadanos.api` y la fachada
+  RENAPER compartida.
+- Dashboard consume el agregado `centrodefamilia.api.obtener_metricas_dashboard`
+  en vez de consultar modelos CDF.
+- Centro de Infancia conserva sus registros e invariantes. Intervenciones es el
+  dueño del catálogo que CDI consume mediante `intervenciones.api`; las FKs de
+  catálogo existentes no cambian de ownership.
+- Los receivers de auditoría de CDI viven en el dominio y utilizan
+  `audittrail.api`, de modo que Audittrail ya no importa modelos CDI.
+
+## Protección
+
+`.importlinter` prohíbe imports externos a los internals de los cinco dominios,
+impide que VPSL vuelva a depender de Comedores y fuerza a CDI a consumir el
+catálogo público de Intervenciones.
+
+## Consecuencias
+
+Los contratos son Python internos al monolito. El adaptador de formularios de
+CDI conserva querysets de catálogo para mantener el contrato de los campos
+Django; no constituye una API de transporte ni un límite de extracción. La
+extracción futura sigue requiriendo evaluación separada de ownership de datos,
+consistencia transaccional y operación.

--- a/docs/registro/prs/PR-2271.md
+++ b/docs/registro/prs/PR-2271.md
@@ -26,6 +26,7 @@
 - `ciudadanos`
 - `config`
 - `dashboard`
+- `docs/contexto`
 - `docs/registro`
 - `intervenciones`
 - `tests`
@@ -48,7 +49,9 @@
 - `ciudadanos/api.py`
 - `config/urls_preview.py`
 - `dashboard/views.py`
+- `docs/contexto/features/pr-2271-refactor-enforce-domain-boundaries-for-phase-3.md`
 - `docs/registro/decisiones/2026-08-11-boundaries-fase-3.md`
+- `docs/registro/prs/PR-2271.md`
 - `intervenciones/api.py`
 - `intervenciones/tests/test_intervenciones_public_api.py`
 - `tests/test_ciudadanos_renaper_api_unit.py`
@@ -71,7 +74,9 @@
 - `docs/ia/CONTEXT_HYGIENE.md`
 - `docs/ia/ARCHITECTURE.md`
 - `docs/ia/TESTING.md`
+- `docs/contexto/features/pr-2271-refactor-enforce-domain-boundaries-for-phase-3.md`
 - `docs/registro/decisiones/2026-08-11-boundaries-fase-3.md`
+- `docs/registro/prs/PR-2271.md`
 
 ## Notas para continuidad
 

--- a/docs/registro/prs/PR-2271.md
+++ b/docs/registro/prs/PR-2271.md
@@ -1,0 +1,79 @@
+# PR #2271 - refactor: enforce domain boundaries for phase 3
+
+## Metadata
+
+- PR: https://github.com/dsocial118/SISOC/pull/2271
+- Base: `development`
+- Rama origen: `codex/issue-2244-2248-boundaries`
+- Autor: `juanikitro`
+
+## Resumen operativo
+
+- Tipo de cambio: No informado
+- Área principal: No informada
+- Contexto funcional: No informado explícitamente; revisar título, diff y documentación relacionada.
+- Resumen para changelog: No informado
+- Impacto usuario: No informado
+
+## Áreas afectadas
+
+- `.importlinter`
+- `AGENT_REPO_MAP.md`
+- `VAT`
+- `audittrail`
+- `centrodefamilia`
+- `centrodeinfancia`
+- `ciudadanos`
+- `config`
+- `dashboard`
+- `docs/registro`
+- `intervenciones`
+- `tests`
+- `ver_para_ser_libre`
+
+## Archivos relevantes del diff
+
+- `.importlinter`
+- `AGENT_REPO_MAP.md`
+- `VAT/global_urls.py`
+- `audittrail/api.py`
+- `audittrail/signals.py`
+- `centrodefamilia/api.py`
+- `centrodefamilia/tests/test_centrodefamilia_public_api.py`
+- `centrodeinfancia/apps.py`
+- `centrodeinfancia/forms.py`
+- `centrodeinfancia/signals.py`
+- `centrodeinfancia/tests/test_audit_signals.py`
+- `centrodeinfancia/views.py`
+- `ciudadanos/api.py`
+- `config/urls_preview.py`
+- `dashboard/views.py`
+- `docs/registro/decisiones/2026-08-11-boundaries-fase-3.md`
+- `intervenciones/api.py`
+- `intervenciones/tests/test_intervenciones_public_api.py`
+- `tests/test_ciudadanos_renaper_api_unit.py`
+- `ver_para_ser_libre/tests/test_boundary_api.py`
+- `ver_para_ser_libre/tests/test_workflow.py`
+- `ver_para_ser_libre/views.py`
+
+## Validación declarada
+
+- Pruebas automáticas: No informado en el PR.
+- Pruebas manuales: No informado en el PR.
+
+## Riesgos y rollback
+
+- No informado explícitamente en el PR.
+
+## Documentación sugerida para lectura
+
+- `docs/indice.md`
+- `docs/ia/CONTEXT_HYGIENE.md`
+- `docs/ia/ARCHITECTURE.md`
+- `docs/ia/TESTING.md`
+- `docs/registro/decisiones/2026-08-11-boundaries-fase-3.md`
+
+## Notas para continuidad
+
+- Este documento es generado automáticamente desde el contexto del PR y sirve como índice rápido para revisión y futuras sesiones de agentes.
+- Si la metadata del body del PR está incompleta, varias secciones usarán fallbacks derivados del título o del diff.

--- a/intervenciones/api.py
+++ b/intervenciones/api.py
@@ -1,0 +1,52 @@
+"""Contrato Python público para los catálogos de Intervenciones."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from intervenciones.constants import PROGRAMA_ALIASES_CENTRO_INFANCIA
+from intervenciones.models.intervenciones import (
+    SubIntervencion,
+    TipoDestinatario,
+    TipoIntervencion,
+)
+
+
+@dataclass(frozen=True)
+class ConfiguracionFormularioCDI:
+    """Opciones autorizadas para un formulario de intervención de CDI."""
+
+    tipos: object
+    subtipos: object
+    destinatario_fijo: object | None
+
+
+def programa_aliases_cdi() -> tuple[str, ...]:
+    """Devuelve los alias del catálogo que corresponden a Centro de Infancia."""
+
+    return tuple(PROGRAMA_ALIASES_CENTRO_INFANCIA)
+
+
+def obtener_configuracion_formulario_cdi(
+    tipo_seleccionado_id: int | None,
+    subtipo_seleccionado_id: int | None,
+    destinatario_fijo_nombre: str | None = None,
+) -> ConfiguracionFormularioCDI:
+    """Resuelve catálogos de CDI sin exponer imports a los consumidores."""
+
+    destinatario_fijo = None
+    if destinatario_fijo_nombre:
+        destinatario_fijo = TipoDestinatario.objects.filter(
+            nombre__iexact=destinatario_fijo_nombre
+        ).first()
+    return ConfiguracionFormularioCDI(
+        tipos=TipoIntervencion.para_programas(
+            *PROGRAMA_ALIASES_CENTRO_INFANCIA,
+            include_ids=[tipo_seleccionado_id] if tipo_seleccionado_id else None,
+        ),
+        subtipos=SubIntervencion.para_tipo(
+            tipo_seleccionado_id,
+            include_ids=[subtipo_seleccionado_id] if subtipo_seleccionado_id else None,
+        ),
+        destinatario_fijo=destinatario_fijo,
+    )

--- a/intervenciones/tests/test_intervenciones_public_api.py
+++ b/intervenciones/tests/test_intervenciones_public_api.py
@@ -1,0 +1,21 @@
+import pytest
+
+from intervenciones.api import obtener_configuracion_formulario_cdi
+from intervenciones.models.intervenciones import SubIntervencion, TipoIntervencion
+
+
+@pytest.mark.django_db
+def test_catalogo_cdi_expone_solo_tipos_permitidos_y_subtipo_seleccionado():
+    tipo_cdi = TipoIntervencion.objects.create(nombre="CDI", programa="cdi")
+    tipo_comedor = TipoIntervencion.objects.create(
+        nombre="Comedor", programa="comedores"
+    )
+    subtipo = SubIntervencion.objects.create(
+        nombre="Seguimiento", tipo_intervencion=tipo_cdi
+    )
+
+    configuracion = obtener_configuracion_formulario_cdi(tipo_cdi.pk, subtipo.pk)
+
+    assert tipo_cdi in configuracion.tipos
+    assert tipo_comedor not in configuracion.tipos
+    assert list(configuracion.subtipos) == [subtipo]

--- a/tests/test_ciudadanos_renaper_api_unit.py
+++ b/tests/test_ciudadanos_renaper_api_unit.py
@@ -35,7 +35,7 @@ def test_resolver_ciudadano_crea_y_expone_resumen(mocker):
     )
     mocker.patch(
         "ciudadanos.api._datos_para_ciudadano",
-        return_value={"nombre": "Ana"},
+        return_value=({"nombre": "Ana"}, None),
     )
     ciudadano = SimpleNamespace(
         documento=12345678,
@@ -56,3 +56,26 @@ def test_resolver_ciudadano_crea_y_expone_resumen(mocker):
     crear.assert_called_once_with(nombre="Ana")
     assert resultado["success"] is True
     assert resultado["data"]["ciudadano_id"] == 12
+
+
+def test_resolver_ciudadano_rechaza_dni_invalido_de_renaper(mocker):
+    mocker.patch(
+        "ciudadanos.api.prevalidar_ciudadano_renaper",
+        return_value={
+            "success": True,
+            "pending_creation": True,
+            "data": {
+                "dni": "no-es-un-dni",
+                "nombre": "Ana",
+                "apellido": "Pérez",
+                "fecha_nacimiento": "2000-01-01",
+            },
+        },
+    )
+
+    resultado = api.resolver_ciudadano_renaper("12345678")
+
+    assert resultado == {
+        "success": False,
+        "message": "RENAPER devolvió un DNI inválido.",
+    }

--- a/tests/test_ciudadanos_renaper_api_unit.py
+++ b/tests/test_ciudadanos_renaper_api_unit.py
@@ -1,0 +1,58 @@
+from types import SimpleNamespace
+
+from ciudadanos import api
+
+
+def test_prevalidar_ciudadano_existente_expone_datos_sin_modelo(mocker):
+    ciudadano = SimpleNamespace(
+        documento=12345678,
+        nombre="Ana",
+        apellido="Pérez",
+        sexo="Femenino",
+        fecha_nacimiento=None,
+        edad=30,
+        telefono="",
+        pk=11,
+    )
+    mocker.patch("ciudadanos.api._buscar_ciudadano_verificado", return_value=ciudadano)
+
+    resultado = api.prevalidar_ciudadano_renaper("12345678")
+
+    assert resultado["success"] is True
+    assert resultado["data"]["ciudadano_id"] == 11
+    assert "ciudadano" not in resultado
+
+
+def test_resolver_ciudadano_crea_y_expone_resumen(mocker):
+    mocker.patch(
+        "ciudadanos.api.prevalidar_ciudadano_renaper",
+        return_value={
+            "success": True,
+            "pending_creation": True,
+            "data": {"dni": 12345678},
+            "datos_api": {"origen": "fake"},
+        },
+    )
+    mocker.patch(
+        "ciudadanos.api._datos_para_ciudadano",
+        return_value={"nombre": "Ana"},
+    )
+    ciudadano = SimpleNamespace(
+        documento=12345678,
+        nombre="Ana",
+        apellido="Pérez",
+        sexo="Femenino",
+        fecha_nacimiento=None,
+        edad=30,
+        telefono="",
+        pk=12,
+    )
+    crear = mocker.patch(
+        "ciudadanos.api.Ciudadano.objects.create", return_value=ciudadano
+    )
+
+    resultado = api.resolver_ciudadano_renaper("12345678")
+
+    crear.assert_called_once_with(nombre="Ana")
+    assert resultado["success"] is True
+    assert resultado["data"]["ciudadano_id"] == 12

--- a/ver_para_ser_libre/tests/test_boundary_api.py
+++ b/ver_para_ser_libre/tests/test_boundary_api.py
@@ -1,0 +1,24 @@
+from ver_para_ser_libre import views
+
+
+def test_resolver_ciudadano_registro_usa_la_fachada_de_ciudadanos(mocker):
+    resultado = {"success": True, "ciudadano_id": 42}
+    resolver = mocker.patch(
+        "ver_para_ser_libre.views.resolver_ciudadano_renaper",
+        return_value=resultado,
+    )
+    usuario = object()
+
+    assert views._resolver_ciudadano_registro_vpsl(12345678, "F", usuario) == resultado
+    resolver.assert_called_once_with(12345678, usuario=usuario, sexo="F")
+
+
+def test_prevalidar_ciudadano_usa_la_fachada_de_ciudadanos(mocker):
+    resultado = {"success": True, "data": {"dni": "12345678"}}
+    prevalidar = mocker.patch(
+        "ver_para_ser_libre.views.prevalidar_ciudadano_renaper",
+        return_value=resultado,
+    )
+
+    assert views._prevalidar_ciudadano_registro_vpsl(12345678, "M") == resultado
+    prevalidar.assert_called_once_with(12345678, sexo="M")

--- a/ver_para_ser_libre/tests/test_workflow.py
+++ b/ver_para_ser_libre/tests/test_workflow.py
@@ -1477,7 +1477,7 @@ def test_consultar_renaper_vpsl_devuelve_datos_normalizados(client, mocker):
     )
     client.force_login(user)
     renaper = mocker.patch(
-        "ver_para_ser_libre.views.ComedorService.obtener_datos_ciudadano_desde_renaper",
+        "ver_para_ser_libre.views.consultar_ciudadano_renaper",
         return_value={
             "success": True,
             "message": "Datos obtenidos desde RENAPER.",
@@ -1516,7 +1516,7 @@ def test_consultar_renaper_vpsl_normaliza_sexo_display_si_viene_codigo(client, m
     )
     client.force_login(user)
     mocker.patch(
-        "ver_para_ser_libre.views.ComedorService.obtener_datos_ciudadano_desde_renaper",
+        "ver_para_ser_libre.views.consultar_ciudadano_renaper",
         return_value={
             "success": True,
             "data": {
@@ -1564,7 +1564,7 @@ def test_consultar_renaper_vpsl_normaliza_codigos_numericos_de_sexo(
     )
     client.force_login(user)
     mocker.patch(
-        "ver_para_ser_libre.views.ComedorService.obtener_datos_ciudadano_desde_renaper",
+        "ver_para_ser_libre.views.consultar_ciudadano_renaper",
         return_value={
             "success": True,
             "data": {
@@ -1597,9 +1597,7 @@ def test_consultar_renaper_vpsl_registro_usa_ciudadano_existente_sin_renaper(
         password="testpass123",
     )
     ciudadano = crear_ciudadano_validado(documento=12345678)
-    renaper = mocker.patch(
-        "comedores.services.comedor_service.impl.ComedorService.obtener_datos_ciudadano_desde_renaper"
-    )
+    renaper = mocker.patch("ciudadanos.api.consultar_ciudadano_renaper")
     client.force_login(user)
 
     response = client.get(
@@ -1625,7 +1623,7 @@ def test_consultar_renaper_vpsl_registro_consulta_renaper_sin_crear_ciudadano(
         password="testpass123",
     )
     renaper = mocker.patch(
-        "comedores.services.comedor_service.impl.ComedorService.obtener_datos_ciudadano_desde_renaper",
+        "ver_para_ser_libre.views.prevalidar_ciudadano_renaper",
         return_value={
             "success": True,
             "message": "Datos obtenidos desde RENAPER.",
@@ -1639,6 +1637,7 @@ def test_consultar_renaper_vpsl_registro_consulta_renaper_sin_crear_ciudadano(
                 "origen_dato": "renaper",
             },
             "datos_api": {"origen": "renaper"},
+            "pending_creation": True,
         },
     )
     client.force_login(user)
@@ -1888,18 +1887,15 @@ def test_registro_create_crea_ciudadano_al_guardar_si_no_existe(client, mocker):
     jornada = crear_jornada(estado=EstadoJornada.HABILITADA)
     sexo = Sexo.objects.create(sexo="Masculino")
     renaper = mocker.patch(
-        "comedores.services.comedor_service.impl.ComedorService.obtener_datos_ciudadano_desde_renaper",
+        "ciudadanos.api.consultar_datos_renaper",
         return_value={
             "success": True,
-            "message": "Datos obtenidos desde RENAPER.",
             "data": {
-                "apellido": "Gomez",
                 "nombre": "Juan",
-                "fecha_nacimiento": date(2010, 1, 10),
-                "documento": 22333444,
-                "tipo_documento": Ciudadano.DOCUMENTO_DNI,
+                "apellido": "Gomez",
+                "dni": 22333444,
                 "sexo": sexo.pk,
-                "origen_dato": "renaper",
+                "fecha_nacimiento": date(2010, 1, 10),
             },
             "datos_api": {"origen": "renaper"},
         },
@@ -1935,7 +1931,7 @@ def test_registro_create_crea_ciudadano_al_guardar_si_no_existe(client, mocker):
     assert registro.datos_renaper["ciudadano_id"] == ciudadano.pk
     assert registro.datos_renaper["ciudadano_created"] is True
     assert registro.datos_renaper["origen_validacion"] == "renaper"
-    renaper.assert_called_once_with("22333444", sexo="M")
+    renaper.assert_called_once_with("22333444", "M")
 
 
 def test_registro_create_precarga_fecha_de_jornada(client):

--- a/ver_para_ser_libre/views.py
+++ b/ver_para_ser_libre/views.py
@@ -1,5 +1,4 @@
-# Modulo extenso de vistas del programa; orquesta helpers internos de
-# ComedorService y del modulo workflow (acceso protegido intencional).
+# Modulo extenso de vistas del programa y del modulo workflow.
 # pylint: disable=too-many-lines,protected-access
 import unicodedata
 from urllib.parse import quote_plus
@@ -22,7 +21,11 @@ from django.views.generic import (
     UpdateView,
 )
 
-from comedores.services.comedor_service import ComedorService
+from ciudadanos.api import (
+    consultar_ciudadano_renaper,
+    prevalidar_ciudadano_renaper,
+    resolver_ciudadano_renaper,
+)
 from core.mixins import CSVExportMixin
 from core.models import Provincia
 from core.soft_delete.view_helpers import SoftDeleteDeleteViewMixin
@@ -171,72 +174,12 @@ def _puede_exportar(user):
     return user_has_permission_code(user, "auth.role_exportar_a_csv")
 
 
-def _extraer_persona_ciudadano(ciudadano):
-    sexo_raw = str(ciudadano.sexo or "")
-    sexo_normalizado = _normalizar_sexo_renaper(sexo_raw)
-    fecha_nacimiento = ciudadano.fecha_nacimiento
-    return {
-        "dni": str(ciudadano.documento or ""),
-        "nombre": ciudadano.nombre or "",
-        "apellido": ciudadano.apellido or "",
-        "genero": _display_sexo_renaper(sexo_raw, sexo_normalizado),
-        "sexo": sexo_normalizado,
-        "fecha_nacimiento": (fecha_nacimiento.isoformat() if fecha_nacimiento else ""),
-        "edad": ciudadano.edad,
-        "telefono": ciudadano.telefono or "",
-        "ciudadano_id": ciudadano.pk,
-    }
-
-
 def _resolver_ciudadano_registro_vpsl(dni, sexo, user):
-    resultado = ComedorService.crear_ciudadano_desde_renaper(dni, user=user, sexo=sexo)
-    if not resultado.get("success"):
-        return {
-            "success": False,
-            "message": resultado.get("message", "No se pudo validar el ciudadano."),
-        }
-    ciudadano = resultado.get("ciudadano")
-    if not ciudadano:
-        return {
-            "success": False,
-            "message": "No se obtuvo el legajo ciudadano validado.",
-        }
-    return {
-        "success": True,
-        "message": resultado.get("message", "Ciudadano validado correctamente."),
-        "data": _extraer_persona_ciudadano(ciudadano),
-        "datos_api": resultado.get("datos_api"),
-        "ciudadano": ciudadano,
-        "created": bool(resultado.get("created")),
-    }
+    return resolver_ciudadano_renaper(dni, usuario=user, sexo=sexo)
 
 
 def _prevalidar_ciudadano_registro_vpsl(dni, sexo):
-    existente = ComedorService._buscar_ciudadano_existente_por_dni_renaper(dni)
-    if existente:
-        return {
-            "success": True,
-            "message": "Ciudadano existente validado.",
-            "data": _extraer_persona_ciudadano(existente),
-            "datos_api": None,
-            "created": False,
-            "pending_creation": False,
-        }
-
-    resultado = ComedorService.obtener_datos_ciudadano_desde_renaper(dni, sexo=sexo)
-    if not resultado.get("success"):
-        return {
-            "success": False,
-            "message": resultado.get("message", "No se encontraron datos en RENAPER."),
-        }
-    return {
-        "success": True,
-        "message": resultado.get("message", "Datos obtenidos desde RENAPER."),
-        "data": _extraer_persona_renaper(resultado.get("data") or {}),
-        "datos_api": resultado.get("datos_api"),
-        "created": False,
-        "pending_creation": True,
-    }
+    return prevalidar_ciudadano_renaper(dni, sexo=sexo)
 
 
 def _buscar_registro_duplicado_en_itinerario(jornada, dni, exclude_pk=None):
@@ -343,7 +286,7 @@ def consultar_renaper_vpsl(request):
             }
         )
 
-    resultado = ComedorService.obtener_datos_ciudadano_desde_renaper(dni, sexo=sexo)
+    resultado = consultar_ciudadano_renaper(dni, sexo=sexo)
     if not resultado.get("success"):
         return JsonResponse(
             {


### PR DESCRIPTION
## Resumen

Implementa los límites de arquitectura de los issues #2244, #2245, #2246, #2247 y #2248.

- Aísla la composición de preview de VAT.
- Elimina la dependencia VPSL hacia Comedores para RENAPER mediante ciudadanos.api.
- Expone métricas CDF para Dashboard y desacopla CDI de Audittrail e Intervenciones mediante contratos Python acotados.
- Agrega contratos import-linter y documentación de la decisión.

## Validación

- 89 passed en la suite focalizada Docker.
- 666 passed en el smoke Docker.
- black --check sobre el código modificado.
- pylint focalizado: 10.00/10.
- makemigrations --check --dry-run: sin cambios.
- lint-imports: 12 contratos y el contrato aislado de Celiaquía, todos OK.

## Nota

El chequeo de migraciones se ejecutó sin el servicio MySQL (--no-deps), por lo que Django emitió un warning de conectividad de ese servicio.

Closes #2244
Closes #2245
Closes #2246
Closes #2247
Closes #2248