### PR TITLE
fix(deploy): recuperar checkout movil de HML

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -146,9 +146,15 @@ jobs:
                       echo "[deploy] Actualizando el helper local de HML antes del deploy versionado."
                       git -C "$APP_ROOT" merge --ff-only origin/homologacion
                   fi
-                  git -C /sisoc/SISOC-Mobile update-index --refresh
+                  MOBILE_ROOT=/sisoc/SISOC-Mobile
+                  if ! git -C "$MOBILE_ROOT" fetch origin --prune; then
+                      echo "::warning::El checkout movil no puede actualizarse; reparando permisos de su metadata git."
+                      sudo -n chown -R "$(id -u):$(id -g)" "$MOBILE_ROOT/.git"
+                      git -C "$MOBILE_ROOT" fetch origin --prune
+                  fi
+                  git -C "$MOBILE_ROOT" update-index --refresh
                   echo "Commit previo al deploy para rollback: $(git rev-parse HEAD)"
-                  ./scripts/operacion/deploy_refresh.sh --yes --expected-revision "$EXPECTED_SHA" --with-mobile --mobile-dir /sisoc/SISOC-Mobile
+                  ./scripts/operacion/deploy_refresh.sh --yes --expected-revision "$EXPECTED_SHA" --with-mobile --mobile-dir "$MOBILE_ROOT"
                   wait_for() {
                       local description="$1"
                       local attempts="$2"

--- a/docs/contexto/features/pr-2280-fix-deploy-recuperar-checkout-movil-de-hml.md
+++ b/docs/contexto/features/pr-2280-fix-deploy-recuperar-checkout-movil-de-hml.md
@@ -1,0 +1,43 @@
+# Contexto de feature PR #2280 - fix(deploy): recuperar checkout movil de HML
+
+## Resumen
+
+- PR: https://github.com/dsocial118/SISOC/pull/2280
+- Base: `homologacion`
+- Rama origen: `codex/fix-hml-mobile-checkout-permissions-20260812`
+- Autor: `juanikitro`
+
+## Contexto funcional
+
+- No informado explícitamente; inferir desde el título del PR y el diff.
+
+## Arquitectura tocada
+
+- El alcance incluye automatización o tooling de CI/CD.
+
+## Decisiones y supuestos detectados
+
+- Tipo de cambio declarado: No informado
+- Área principal declarada: No informada
+- Impacto usuario declarado: No informado
+- Riesgos / rollback: No informado
+
+## Design system y UI
+
+- Sin cambios visibles de UI o design system detectados en el diff.
+
+## Memoria operativa para agentes
+
+- Empezar por `docs/registro/prs/PR-2280.md` para contexto resumido del PR.
+- Revisar primero estos archivos del diff:
+- `.github/workflows/deploy.yml`
+- Documentación sugerida para ampliar contexto:
+- `docs/indice.md`
+- `docs/ia/CONTEXT_HYGIENE.md`
+- `docs/ia/ARCHITECTURE.md`
+- `docs/ia/TESTING.md`
+
+## Trazabilidad
+
+- Documento generado automáticamente desde el evento de `pull_request`.
+- Si este PR cambia de título, el archivo se renombrará para mantener el slug alineado.

--- a/docs/registro/prs/PR-2280.md
+++ b/docs/registro/prs/PR-2280.md
@@ -1,0 +1,45 @@
+# PR #2280 - fix(deploy): recuperar checkout movil de HML
+
+## Metadata
+
+- PR: https://github.com/dsocial118/SISOC/pull/2280
+- Base: `homologacion`
+- Rama origen: `codex/fix-hml-mobile-checkout-permissions-20260812`
+- Autor: `juanikitro`
+
+## Resumen operativo
+
+- Tipo de cambio: No informado
+- Área principal: No informada
+- Contexto funcional: No informado explícitamente; revisar título, diff y documentación relacionada.
+- Resumen para changelog: No informado
+- Impacto usuario: No informado
+
+## Áreas afectadas
+
+- `.github/workflows`
+
+## Archivos relevantes del diff
+
+- `.github/workflows/deploy.yml`
+
+## Validación declarada
+
+- Pruebas automáticas: No informado en el PR.
+- Pruebas manuales: No informado en el PR.
+
+## Riesgos y rollback
+
+- No informado explícitamente en el PR.
+
+## Documentación sugerida para lectura
+
+- `docs/indice.md`
+- `docs/ia/CONTEXT_HYGIENE.md`
+- `docs/ia/ARCHITECTURE.md`
+- `docs/ia/TESTING.md`
+
+## Notas para continuidad
+
+- Este documento es generado automáticamente desde el contexto del PR y sirve como índice rápido para revisión y futuras sesiones de agentes.
+- Si la metadata del body del PR está incompleta, varias secciones usarán fallbacks derivados del título o del diff.


### PR DESCRIPTION
## Motivo\n\nEl deploy de HML falla antes de publicar SISOC-Mobile porque el runner no puede escribir en \.git/objects\ del checkout persistente.\n\n## Cambio\n\n- verifica que el checkout movil pueda hacer \etch\ antes de bajar el stack;\n- ante el error, repara exclusivamente la propiedad de \/sisoc/SISOC-Mobile/.git\ con \sudo -n\ y reintenta;\n- reutiliza la ruta validada en el deploy movil.\n\n## Validacion\n\n- \git diff --check\\n\nLa proxima ejecucion de HML verifica el permiso real y la compilacion PWA.