### PR TITLE
fix(deploy): reparar metadata git movil con Docker

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -149,7 +149,10 @@ jobs:
                   MOBILE_ROOT=/sisoc/SISOC-Mobile
                   if ! git -C "$MOBILE_ROOT" fetch origin --prune; then
                       echo "::warning::El checkout movil no puede actualizarse; reparando permisos de su metadata git."
-                      sudo -n chown -R "$(id -u):$(id -g)" "$MOBILE_ROOT/.git"
+                      docker run --rm --user 0:0 \
+                          -v "$MOBILE_ROOT/.git:/target" \
+                          --entrypoint chown sisoc-django \
+                          -R "$(id -u):$(id -g)" /target
                       git -C "$MOBILE_ROOT" fetch origin --prune
                   fi
                   git -C "$MOBILE_ROOT" update-index --refresh

--- a/docs/contexto/features/pr-2281-fix-deploy-reparar-metadata-git-movil-con-docker.md
+++ b/docs/contexto/features/pr-2281-fix-deploy-reparar-metadata-git-movil-con-docker.md
@@ -1,0 +1,43 @@
+# Contexto de feature PR #2281 - fix(deploy): reparar metadata git movil con Docker
+
+## Resumen
+
+- PR: https://github.com/dsocial118/SISOC/pull/2281
+- Base: `homologacion`
+- Rama origen: `codex/fix-hml-mobile-git-ownership-20260812`
+- Autor: `juanikitro`
+
+## Contexto funcional
+
+- No informado explícitamente; inferir desde el título del PR y el diff.
+
+## Arquitectura tocada
+
+- El alcance incluye automatización o tooling de CI/CD.
+
+## Decisiones y supuestos detectados
+
+- Tipo de cambio declarado: No informado
+- Área principal declarada: No informada
+- Impacto usuario declarado: No informado
+- Riesgos / rollback: No informado
+
+## Design system y UI
+
+- Sin cambios visibles de UI o design system detectados en el diff.
+
+## Memoria operativa para agentes
+
+- Empezar por `docs/registro/prs/PR-2281.md` para contexto resumido del PR.
+- Revisar primero estos archivos del diff:
+- `.github/workflows/deploy.yml`
+- Documentación sugerida para ampliar contexto:
+- `docs/indice.md`
+- `docs/ia/CONTEXT_HYGIENE.md`
+- `docs/ia/ARCHITECTURE.md`
+- `docs/ia/TESTING.md`
+
+## Trazabilidad
+
+- Documento generado automáticamente desde el evento de `pull_request`.
+- Si este PR cambia de título, el archivo se renombrará para mantener el slug alineado.

--- a/docs/registro/prs/PR-2281.md
+++ b/docs/registro/prs/PR-2281.md
@@ -1,0 +1,45 @@
+# PR #2281 - fix(deploy): reparar metadata git movil con Docker
+
+## Metadata
+
+- PR: https://github.com/dsocial118/SISOC/pull/2281
+- Base: `homologacion`
+- Rama origen: `codex/fix-hml-mobile-git-ownership-20260812`
+- Autor: `juanikitro`
+
+## Resumen operativo
+
+- Tipo de cambio: No informado
+- Área principal: No informada
+- Contexto funcional: No informado explícitamente; revisar título, diff y documentación relacionada.
+- Resumen para changelog: No informado
+- Impacto usuario: No informado
+
+## Áreas afectadas
+
+- `.github/workflows`
+
+## Archivos relevantes del diff
+
+- `.github/workflows/deploy.yml`
+
+## Validación declarada
+
+- Pruebas automáticas: No informado en el PR.
+- Pruebas manuales: No informado en el PR.
+
+## Riesgos y rollback
+
+- No informado explícitamente en el PR.
+
+## Documentación sugerida para lectura
+
+- `docs/indice.md`
+- `docs/ia/CONTEXT_HYGIENE.md`
+- `docs/ia/ARCHITECTURE.md`
+- `docs/ia/TESTING.md`
+
+## Notas para continuidad
+
+- Este documento es generado automáticamente desde el contexto del PR y sirve como índice rápido para revisión y futuras sesiones de agentes.
+- Si la metadata del body del PR está incompleta, varias secciones usarán fallbacks derivados del título o del diff.


### PR DESCRIPTION
## Motivo\n\nEl runner de HML detecta correctamente el checkout movil no escribible, pero no tiene \sudo\ sin contraseña.\n\n## Cambio\n\nReemplaza la corrección privilegiada interactiva por un contenedor Docker local (el mismo daemon ya requerido por el deploy), montado únicamente sobre \/sisoc/SISOC-Mobile/.git\ y ejecutando sólo \chown\. Luego repite el \etch\ antes de reiniciar el stack.\n\n## Validación\n\n- \git diff --check\\n- La ejecución HML posterior valida permisos reales y el build de SISOC-Mobile.