### PR TITLE
fix(pwa): limitar nomina a la admision vigente

### DIFF
--- a/AGENT_REPO_MAP.md
+++ b/AGENT_REPO_MAP.md
@@ -498,6 +498,8 @@ La siguiente tabla mezcla hechos observados con inferencias explicitas cuando no
 - `pwa/api_urls.py`
 - `pwa/api_views.py`
 - `pwa/services/`
+- alcance de nómina por admisión vigente o comedor directo:
+  `pwa/services/nomina_queryset_service.py`
 - frontend: `mobile/src/api/` y `mobile/src/features/home/`
 - tests `tests/test_pwa_*`
 - docs: `docs/implementaciones/pwa_backend.md`, `docs/seguridad/security_baseline_pwa.md`

--- a/docs/contexto/features/pr-2287-fix-pwa-limitar-nomina-a-la-admision-vigente.md
+++ b/docs/contexto/features/pr-2287-fix-pwa-limitar-nomina-a-la-admision-vigente.md
@@ -1,0 +1,52 @@
+# Contexto de feature PR #2287 - fix(pwa): limitar nomina a la admision vigente
+
+## Resumen
+
+- PR: https://github.com/dsocial118/SISOC/pull/2287
+- Base: `development`
+- Rama origen: `Fixes-13-08-26`
+- Autor: `PabloCao1`
+
+## Contexto funcional
+
+- No informado explícitamente; inferir desde el título del PR y el diff.
+
+## Arquitectura tocada
+
+- El PR toca lógica en `services/`, por lo que impacta reglas de negocio u orquestación.
+- Hay cambios en capa API/DRF y conviene revisar contratos de request/response.
+- Hay cambios en vistas web y puede existir impacto en permisos o renderizado.
+
+## Decisiones y supuestos detectados
+
+- Tipo de cambio declarado: No informado
+- Área principal declarada: No informada
+- Impacto usuario declarado: No informado
+- Riesgos / rollback: No informado
+
+## Design system y UI
+
+- Sin cambios visibles de UI o design system detectados en el diff.
+
+## Memoria operativa para agentes
+
+- Empezar por `docs/registro/prs/PR-2287.md` para contexto resumido del PR.
+- Revisar primero estos archivos del diff:
+- `AGENT_REPO_MAP.md`
+- `docs/registro/cambios/2026-08-13-alcance-nomina-pwa-admision-vigente.md`
+- `pwa/api_views.py`
+- `pwa/services/nomina_destinatarios_pdf_service.py`
+- `pwa/services/nomina_queryset_service.py`
+- `pwa/services/nomina_service.py`
+- `tests/test_pwa_nomina_api.py`
+- Documentación sugerida para ampliar contexto:
+- `docs/indice.md`
+- `docs/ia/CONTEXT_HYGIENE.md`
+- `docs/ia/ARCHITECTURE.md`
+- `docs/ia/TESTING.md`
+- `docs/registro/cambios/2026-08-13-alcance-nomina-pwa-admision-vigente.md`
+
+## Trazabilidad
+
+- Documento generado automáticamente desde el evento de `pull_request`.
+- Si este PR cambia de título, el archivo se renombrará para mantener el slug alineado.

--- a/docs/registro/cambios/2026-08-13-alcance-nomina-pwa-admision-vigente.md
+++ b/docs/registro/cambios/2026-08-13-alcance-nomina-pwa-admision-vigente.md
@@ -1,0 +1,32 @@
+# Alcance de nómina PWA por admisión vigente
+
+## Fecha
+
+2026-08-13
+
+## Problema
+
+La nómina PWA consolidaba registros activos de todas las admisiones de un
+comedor. La marca `vigente_pwa` no limitaba el listado, por lo que personas que
+solo pertenecían a admisiones anteriores continuaban visibles.
+
+## Cambio
+
+- Los programas que organizan su nómina por admisión usan exclusivamente la
+  admisión resuelta por `ComedorService.get_admision_vigente_pwa`.
+- Los programas con nómina directa conservan los registros asociados al comedor
+  con `admision_id` nulo.
+- El mismo alcance se aplica al listado PWA, cupos y validaciones, asistencia y
+  generación del PDF mensual de destinatarios.
+
+## Compatibilidad
+
+Si no existe una marca `vigente_pwa`, se conserva el fallback existente del
+servicio: la admisión activa de mayor ID y, en última instancia, la admisión de
+mayor ID.
+
+## Validación
+
+- Se agregó una regresión con dos admisiones activas que verifica que el endpoint
+  exponga solamente la nómina de la admisión marcada como vigente.
+- `pwa/tests.py` y `tests/test_pwa_nomina_api.py`: 18 tests aprobados.

--- a/docs/registro/prs/PR-2287.md
+++ b/docs/registro/prs/PR-2287.md
@@ -1,0 +1,55 @@
+# PR #2287 - fix(pwa): limitar nomina a la admision vigente
+
+## Metadata
+
+- PR: https://github.com/dsocial118/SISOC/pull/2287
+- Base: `development`
+- Rama origen: `Fixes-13-08-26`
+- Autor: `PabloCao1`
+
+## Resumen operativo
+
+- Tipo de cambio: No informado
+- Área principal: No informada
+- Contexto funcional: No informado explícitamente; revisar título, diff y documentación relacionada.
+- Resumen para changelog: No informado
+- Impacto usuario: No informado
+
+## Áreas afectadas
+
+- `AGENT_REPO_MAP.md`
+- `docs/registro`
+- `pwa`
+- `tests`
+
+## Archivos relevantes del diff
+
+- `AGENT_REPO_MAP.md`
+- `docs/registro/cambios/2026-08-13-alcance-nomina-pwa-admision-vigente.md`
+- `pwa/api_views.py`
+- `pwa/services/nomina_destinatarios_pdf_service.py`
+- `pwa/services/nomina_queryset_service.py`
+- `pwa/services/nomina_service.py`
+- `tests/test_pwa_nomina_api.py`
+
+## Validación declarada
+
+- Pruebas automáticas: No informado en el PR.
+- Pruebas manuales: No informado en el PR.
+
+## Riesgos y rollback
+
+- No informado explícitamente en el PR.
+
+## Documentación sugerida para lectura
+
+- `docs/indice.md`
+- `docs/ia/CONTEXT_HYGIENE.md`
+- `docs/ia/ARCHITECTURE.md`
+- `docs/ia/TESTING.md`
+- `docs/registro/cambios/2026-08-13-alcance-nomina-pwa-admision-vigente.md`
+
+## Notas para continuidad
+
+- Este documento es generado automáticamente desde el contexto del PR y sirve como índice rápido para revisión y futuras sesiones de agentes.
+- Si la metadata del body del PR está incompleta, varias secciones usarán fallbacks derivados del título o del diff.

--- a/pwa/api_views.py
+++ b/pwa/api_views.py
@@ -72,6 +72,7 @@ from pwa.services.nomina_destinatarios_pdf_service import (
     get_latest_nomina_destinatarios_documents_by_period,
     serialize_nomina_destinatarios_documento,
 )
+from pwa.services.nomina_queryset_service import get_nomina_queryset_for_comedor
 from pwa.utils import parse_periodo_referencia
 from pwa.view_helpers import (
     build_mensaje_espacio_summary,
@@ -735,9 +736,8 @@ class NominaEspacioPWAViewSet(viewsets.ViewSet):
         comedor_id = self.kwargs["comedor_id"]
         periodo_actual = get_periodo_mensual_actual()
         queryset = (
-            Nomina.objects.filter(
-                Q(admision__comedor_id=comedor_id)
-                | Q(comedor_id=comedor_id, admision__isnull=True),
+            get_nomina_queryset_for_comedor(comedor_id)
+            .filter(
                 deleted_at__isnull=True,
                 estado=Nomina.ESTADO_ACTIVO,
             )
@@ -811,10 +811,10 @@ class NominaEspacioPWAViewSet(viewsets.ViewSet):
     def _attendance_queryset(self, tab: str):
         comedor_id = self.kwargs["comedor_id"]
         tab = (tab or "consolidada").strip().lower()
+        nomina_ids = get_nomina_queryset_for_comedor(comedor_id).values("id")
         queryset = (
             RegistroAsistenciaNominaPWA.objects.filter(
-                Q(nomina__admision__comedor_id=comedor_id)
-                | Q(nomina__comedor_id=comedor_id, nomina__admision__isnull=True),
+                nomina_id__in=nomina_ids,
                 periodicidad=RegistroAsistenciaNominaPWA.PERIODICIDAD_MENSUAL,
                 nomina__deleted_at__isnull=True,
             )

--- a/pwa/services/nomina_destinatarios_pdf_service.py
+++ b/pwa/services/nomina_destinatarios_pdf_service.py
@@ -19,6 +19,7 @@ from lxml import etree
 
 from comedores.models import Nomina
 from pwa.models import NominaDestinatariosDocumentoPWA
+from pwa.services.nomina_queryset_service import get_nomina_queryset_for_comedor
 
 
 DDJJ_TEXTO_PROVISORIO = (
@@ -70,11 +71,8 @@ def _full_name(user):
 
 def _nomina_alimentaria_activa_queryset(comedor_id):
     queryset = (
-        Nomina.objects.filter(
-            (
-                Q(admision__comedor_id=comedor_id)
-                | Q(comedor_id=comedor_id, admision__isnull=True)
-            ),
+        get_nomina_queryset_for_comedor(comedor_id)
+        .filter(
             deleted_at__isnull=True,
             estado=Nomina.ESTADO_ACTIVO,
         )

--- a/pwa/services/nomina_queryset_service.py
+++ b/pwa/services/nomina_queryset_service.py
@@ -1,0 +1,19 @@
+from comedores.models import Comedor, Nomina
+from comedores.services.comedor_service.impl import ComedorService
+from comedores.utils import comedor_usa_admision_para_nomina
+
+
+def get_nomina_queryset_for_comedor(comedor_id):
+    """Devuelve la nomina que corresponde al contexto PWA del comedor."""
+
+    comedor = Comedor.objects.select_related("programa").filter(pk=comedor_id).first()
+    if not comedor:
+        return Nomina.objects.none()
+
+    if comedor_usa_admision_para_nomina(comedor):
+        admision = ComedorService.get_admision_vigente_pwa(comedor_id)
+        if not admision:
+            return Nomina.objects.none()
+        return Nomina.objects.filter(admision_id=admision.id)
+
+    return Nomina.objects.filter(comedor_id=comedor_id, admision__isnull=True)

--- a/pwa/services/nomina_service.py
+++ b/pwa/services/nomina_service.py
@@ -25,6 +25,7 @@ from pwa.services.auditoria_operacion_service import registrar_evento_operacion
 from pwa.services.nomina_destinatarios_pdf_service import (
     generar_nomina_destinatarios_pdf,
 )
+from pwa.services.nomina_queryset_service import get_nomina_queryset_for_comedor
 
 DNI_REGEX = re.compile(r"^\d{7,8}$")
 logger = logging.getLogger("django")
@@ -90,13 +91,13 @@ def _snapshot_registro_asistencia(
 
 
 def _active_nomina_queryset(*, comedor_id: int):
-    return Nomina.objects.filter(
-        (
-            Q(admision__comedor_id=comedor_id)
-            | Q(comedor_id=comedor_id, admision__isnull=True)
-        ),
-        deleted_at__isnull=True,
-    ).exclude(estado=Nomina.ESTADO_BAJA)
+    return (
+        get_nomina_queryset_for_comedor(comedor_id)
+        .filter(
+            deleted_at__isnull=True,
+        )
+        .exclude(estado=Nomina.ESTADO_BAJA)
+    )
 
 
 def _programa_nombre_normalizado(comedor: Comedor | None) -> str:

--- a/tests/test_pwa_nomina_api.py
+++ b/tests/test_pwa_nomina_api.py
@@ -105,6 +105,52 @@ def fecha_fija_en_ventana(mocker):
 
 
 @pytest.mark.django_db
+def test_nomina_list_usa_solo_admision_vigente_pwa(comedor, admision, sexo_f):
+    representante = _create_representante(
+        comedor=comedor,
+        username="rep_nomina_admision_vigente",
+    )
+    client = _auth_client_for_user(representante)
+    admision_vigente = Admision.objects.create(
+        comedor=comedor,
+        activa=True,
+        vigente_pwa=True,
+    )
+    ciudadano_anterior = Ciudadano.objects.create(
+        nombre="Persona",
+        apellido="Anterior",
+        documento=20111222,
+        sexo=sexo_f,
+    )
+    ciudadano_vigente = Ciudadano.objects.create(
+        nombre="Persona",
+        apellido="Vigente",
+        documento=30111222,
+        sexo=sexo_f,
+    )
+    nomina_anterior = Nomina.objects.create(
+        admision=admision,
+        ciudadano=ciudadano_anterior,
+        estado=Nomina.ESTADO_ACTIVO,
+    )
+    nomina_vigente = Nomina.objects.create(
+        admision=admision_vigente,
+        ciudadano=ciudadano_vigente,
+        estado=Nomina.ESTADO_ACTIVO,
+    )
+
+    response = client.get(
+        f"/api/pwa/espacios/{comedor.id}/nomina/",
+        {"tab": "alimentaria"},
+    )
+
+    assert response.status_code == 200
+    assert response.data["stats"]["total_nomina"] == 1
+    assert [row["id"] for row in response.data["results"]] == [nomina_vigente.id]
+    assert nomina_anterior.id not in {row["id"] for row in response.data["results"]}
+
+
+@pytest.mark.django_db
 def test_nomina_list_stats_and_tabs(comedor, admision, sexo_f, sexo_m, dia):
     representante = _create_representante(comedor=comedor, username="rep_nomina_tabs")
     client = _auth_client_for_user(representante)


### PR DESCRIPTION
Resumen: limita la nomina PWA a la admision vigente en programas con admisiones; conserva nomina directa para programas sin admision como PNUD; aplica el alcance a listado, cupos, asistencia y PDF mensual; agrega test de regresion. Caso verificado: comedor 1620 mostraba 353 ciudadanos al combinar las admisiones 2137 y 1501. Validacion: 18 tests focalizados aprobados, Black y git diff check correctos.