### PR TITLE
fix(admisiones): autorizar transferencias issue 2272

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+<!-- AUTO-GENERATED RELEASE START: 2026-08-19 -->
+# Versión SISOC 19.08.2026
+
+## Actualizaciones
+
+- [sin-area] fix(admisiones): autorizar transferencias issue 2272. (PR #2296)
+<!-- AUTO-GENERATED RELEASE END: 2026-08-19 -->
+
 <!-- AUTO-GENERATED RELEASE START: 2026-08-13 -->
 # Versión SISOC 13.08.2026
 

--- a/admisiones/management/commands/corregir_expedientes_issue_2272.py
+++ b/admisiones/management/commands/corregir_expedientes_issue_2272.py
@@ -35,6 +35,7 @@ class ResultadoPreflight:
     """Resultado sin efectos de validar el manifiesto y la base objetivo."""
 
     correcciones: dict[int, CorreccionExpediente] = field(default_factory=dict)
+    liberaciones: dict[int, str] = field(default_factory=dict)
     errores: list[str] = field(default_factory=list)
     advertencias: list[str] = field(default_factory=list)
 
@@ -46,6 +47,12 @@ class Command(BaseCommand):
     )
 
     manifest_sha256 = "CF9899747608D668B7B17FF41791E77E5D473B56D62EE1FD71CFDAF854387403"
+    transferencias_autorizadas = {
+        2072: 1627,
+        2469: 1490,
+        2052: 1218,
+        802: 842,
+    }
 
     def add_arguments(self, parser):
         modo = parser.add_mutually_exclusive_group()
@@ -80,6 +87,9 @@ class Command(BaseCommand):
 
         if verificar:
             errores = self._verificar_correcciones(resultado.correcciones, database)
+            errores.extend(
+                self._verificar_liberaciones(resultado.correcciones, database)
+            )
             if errores:
                 for error in errores:
                     self.stderr.write(self.style.ERROR(error))
@@ -108,7 +118,7 @@ class Command(BaseCommand):
             resultado = self._preflight(database=database, bloquear_filas=True)
             self._detener_si_hay_errores(resultado)
             actualizadas, historial_creado = self._aplicar_correcciones(
-                resultado.correcciones, database
+                resultado.correcciones, resultado.liberaciones, database
             )
 
         self.stdout.write(
@@ -140,13 +150,17 @@ class Command(BaseCommand):
             return resultado
 
         propietarios_actuales = self._obtener_propietarios_actuales(
-            resultado.correcciones, database
+            resultado.correcciones, database, bloquear_filas=bloquear_filas
         )
+        self._validar_propietarios_actuales(resultado, propietarios_actuales)
+
+        return resultado
+
+    def _validar_propietarios_actuales(self, resultado, propietarios_actuales):
         propietarios_esperados = {
             correccion.numero_expediente.upper(): correccion.admision_id
             for correccion in resultado.correcciones.values()
         }
-        ids_objetivo = set(resultado.correcciones)
         for numero_expediente, propietarios in propietarios_actuales.items():
             propietario_esperado = propietarios_esperados[numero_expediente]
             propietarios_en_conflicto = []
@@ -155,10 +169,20 @@ class Command(BaseCommand):
                     continue
                 correccion_del_propietario = resultado.correcciones.get(propietario)
                 if (
-                    propietario in ids_objetivo
+                    correccion_del_propietario
                     and correccion_del_propietario.numero_expediente.upper()
                     != numero_expediente
                 ):
+                    continue
+                if (
+                    self.transferencias_autorizadas.get(propietario_esperado)
+                    == propietario
+                ):
+                    resultado.liberaciones[propietario] = numero_expediente
+                    resultado.advertencias.append(
+                        "Se liberará el expediente autorizado de la admisión "
+                        f"{propietario} para asignarlo a {propietario_esperado}."
+                    )
                     continue
                 propietarios_en_conflicto.append(propietario)
             if propietarios_en_conflicto:
@@ -168,8 +192,6 @@ class Command(BaseCommand):
                     "asociado actualmente a "
                     f"{propietarios_en_conflicto})."
                 )
-
-        return resultado
 
     def _cargar_y_validar_manifiesto(self):
         resultado = ResultadoPreflight()
@@ -264,7 +286,7 @@ class Command(BaseCommand):
         return hashlib.sha256(contenido_normalizado).hexdigest().upper()
 
     @staticmethod
-    def _obtener_propietarios_actuales(correcciones, database):
+    def _obtener_propietarios_actuales(correcciones, database, *, bloquear_filas):
         expedientes = {
             correccion.numero_expediente.upper() for correccion in correcciones.values()
         }
@@ -277,6 +299,8 @@ class Command(BaseCommand):
             .filter(numero_normalizado__in=expedientes)
             .values_list("pk", "numero_normalizado")
         )
+        if bloquear_filas:
+            filas = filas.select_for_update()
         for admision_id, numero_expediente in filas:
             propietarios[numero_expediente].add(admision_id)
         return propietarios
@@ -315,18 +339,87 @@ class Command(BaseCommand):
             ]
         return []
 
+    def _verificar_liberaciones(self, correcciones, database):
+        ids_liberados = {
+            origen
+            for destino, origen in self.transferencias_autorizadas.items()
+            if destino in correcciones
+        }
+        valores_actuales = {
+            admision_id: (num_expediente, legales_num_if)
+            for admision_id, num_expediente, legales_num_if in (
+                Admision.objects.using(database)
+                .filter(pk__in=ids_liberados)
+                .values_list("pk", "num_expediente", "legales_num_if")
+            )
+        }
+        ids_faltantes = sorted(ids_liberados - set(valores_actuales))
+        if ids_faltantes:
+            return [
+                "La verificación no encontró todas las admisiones liberadas "
+                f"({len(ids_faltantes)} faltantes; ejemplo: {ids_faltantes[:5]})."
+            ]
+        pendientes = [
+            admision_id
+            for admision_id, (
+                num_expediente,
+                legales_num_if,
+            ) in valores_actuales.items()
+            if num_expediente is not None or legales_num_if is not None
+        ]
+        if pendientes:
+            return [
+                "La verificación encontró "
+                f"{len(pendientes)} admisiones con expedientes no liberados; "
+                f"ejemplos: {pendientes[:5]}."
+            ]
+        return []
+
     @staticmethod
-    def _aplicar_correcciones(correcciones, database):
+    def _aplicar_correcciones(correcciones, liberaciones, database):
         admisiones = list(
             Admision.objects.using(database)
             .select_for_update()
-            .filter(pk__in=correcciones)
+            .filter(pk__in=set(correcciones) | set(liberaciones))
             .order_by("pk")
         )
         historial = []
         actualizadas = []
 
         for admision in admisiones:
+            if admision.pk in liberaciones:
+                numero_liberado = liberaciones[admision.pk]
+                if (admision.num_expediente or "").upper() != numero_liberado:
+                    raise CommandError(
+                        "La admisión autorizada para liberar el expediente cambió "
+                        f"antes de aplicar la corrección ({admision.pk})."
+                    )
+                if admision.num_expediente is not None:
+                    historial.append(
+                        AdmisionHistorial(
+                            admision=admision,
+                            campo="Número de expediente",
+                            valor_anterior=admision.num_expediente,
+                            valor_nuevo=None,
+                            usuario=None,
+                        )
+                    )
+                if admision.legales_num_if is not None:
+                    historial.append(
+                        AdmisionHistorial(
+                            admision=admision,
+                            campo="Expediente en Legales",
+                            valor_anterior=admision.legales_num_if,
+                            valor_nuevo=None,
+                            usuario=None,
+                        )
+                    )
+                admision.num_expediente = None
+                admision.legales_num_if = None
+                admision.modificado = timezone.localdate()
+                actualizadas.append(admision)
+                continue
+
             numero_nuevo = correcciones[admision.pk].numero_expediente
             if admision.num_expediente != numero_nuevo:
                 historial.append(

--- a/admisiones/tests/test_corregir_expedientes_issue_2272.py
+++ b/admisiones/tests/test_corregir_expedientes_issue_2272.py
@@ -54,6 +54,53 @@ def test_preflight_rechaza_colision_con_admision_fuera_del_manifiesto(tmp_path):
     )
 
 
+def test_apply_libera_un_conflicto_autorizado_del_csv(tmp_path):
+    numero_corregido = "EX-2026-987654321- -APN-DDNAYF#MCH"
+    origen = Admision.objects.create(
+        pk=1627,
+        num_expediente=numero_corregido,
+        legales_num_if="EX-2025-111111111- -APN-DDNAYF#MCH",
+    )
+    destino = Admision.objects.create(
+        pk=2072,
+        num_expediente="EX-2025-222222222- -APN-DDNAYF#MCH",
+        legales_num_if="EX-2025-333333333- -APN-DDNAYF#MCH",
+    )
+    command = Command()
+    _configurar_manifiesto(
+        command,
+        tmp_path,
+        "ID ADMISION,Expediente Correcto\n" f"2072,{numero_corregido}\n",
+    )
+
+    command.handle(apply=True, database="default")
+
+    origen.refresh_from_db()
+    destino.refresh_from_db()
+    assert (origen.num_expediente, origen.legales_num_if) == (None, None)
+    assert (destino.num_expediente, destino.legales_num_if) == (
+        numero_corregido,
+        numero_corregido,
+    )
+    assert AdmisionHistorial.objects.filter(admision=origen).count() == 2
+    command.handle(apply=False, database="default", verify=True)
+
+
+def test_preflight_rechaza_un_conflicto_distinto_al_autorizado(tmp_path):
+    numero_corregido = "EX-2026-987654321- -APN-DDNAYF#MCH"
+    Admision.objects.create(pk=999, num_expediente=numero_corregido)
+    Admision.objects.create(pk=2072)
+    command = Command()
+    _configurar_manifiesto(
+        command,
+        tmp_path,
+        "ID ADMISION,Expediente Correcto\n" f"2072,{numero_corregido}\n",
+    )
+
+    with pytest.raises(CommandError):
+        command.handle(apply=False, database="default")
+
+
 def test_preflight_conserva_todos_los_propietarios_de_un_expediente(tmp_path):
     numero_compartido = "EX-2026-987654321- -APN-DDNAYF#MCH"
     Admision.objects.create(pk=100, num_expediente=numero_compartido)

--- a/docs/contexto/features/pr-2296-fix-admisiones-autorizar-transferencias-issue-2272.md
+++ b/docs/contexto/features/pr-2296-fix-admisiones-autorizar-transferencias-issue-2272.md
@@ -1,0 +1,48 @@
+# Contexto de feature PR #2296 - fix(admisiones): autorizar transferencias issue 2272
+
+## Resumen
+
+- PR: https://github.com/dsocial118/SISOC/pull/2296
+- Base: `main`
+- Rama origen: `codex/issue-2272-authorized-transfers`
+- Autor: `juanikitro`
+
+## Contexto funcional
+
+- No informado explícitamente; inferir desde el título del PR y el diff.
+
+## Arquitectura tocada
+
+- No se detectó un patrón arquitectónico dominante más allá del diff observado.
+
+## Decisiones y supuestos detectados
+
+- Tipo de cambio declarado: No informado
+- Área principal declarada: No informada
+- Impacto usuario declarado: No informado
+- Riesgos / rollback: No informado
+
+## Design system y UI
+
+- Sin cambios visibles de UI o design system detectados en el diff.
+
+## Memoria operativa para agentes
+
+- Empezar por `docs/registro/prs/PR-2296.md` para contexto resumido del PR.
+- Revisar primero estos archivos del diff:
+- `admisiones/management/commands/corregir_expedientes_issue_2272.py`
+- `admisiones/tests/test_corregir_expedientes_issue_2272.py`
+- `docs/operacion/correccion_expedientes_issue_2272.md`
+- `docs/registro/cambios/2026-08-12-issue-2272-correccion-expedientes.md`
+- Documentación sugerida para ampliar contexto:
+- `docs/indice.md`
+- `docs/ia/CONTEXT_HYGIENE.md`
+- `docs/ia/ARCHITECTURE.md`
+- `docs/ia/TESTING.md`
+- `docs/operacion/correccion_expedientes_issue_2272.md`
+- `docs/registro/cambios/2026-08-12-issue-2272-correccion-expedientes.md`
+
+## Trazabilidad
+
+- Documento generado automáticamente desde el evento de `pull_request`.
+- Si este PR cambia de título, el archivo se renombrará para mantener el slug alineado.

--- a/docs/operacion/correccion_expedientes_issue_2272.md
+++ b/docs/operacion/correccion_expedientes_issue_2272.md
@@ -14,6 +14,12 @@ hasta nueve dígitos. La fuente contiene 470 admisiones únicas. No existe una
 regla especial de exclusión: como las admisiones 1448, 1794, 2314 y 2462 no
 figuran en el manifiesto, el comando simplemente las deja intactas.
 
+El CSV prevalece, con autorización operativa, sobre cuatro ocupaciones
+históricas detectadas en PRD: el comando libera ambos campos de 1627, 1490,
+1218 y 842 para asignar los expedientes a 2072, 2469, 2052 y 802. Cualquier
+otra colisión continúa bloqueando el preflight. La aplicación y `--verify`
+registran y comprueban esas liberaciones.
+
 No existe ni debe improvisarse una opción `--manifest` en el host. Cualquier
 nueva fuente requiere un cambio revisado que actualice el CSV y
 `manifest_sha256` antes de desplegarse.

--- a/docs/registro/cambios/2026-08-12-issue-2272-correccion-expedientes.md
+++ b/docs/registro/cambios/2026-08-12-issue-2272-correccion-expedientes.md
@@ -32,6 +32,12 @@ fuente anterior, no aparecen en la fuente nueva. No existe una regla especial
 de exclusión: el comando actualiza solamente los IDs presentes en el manifiesto
 y deja intactas las demás admisiones.
 
+Con autorización explícita, el comando libera ambos campos de expediente en
+las admisiones 1627, 1490, 1218 y 842 antes de asignar esos números a 2072,
+2469, 2052 y 802, respectivamente. La liberación sólo se permite si la
+ocupación observada coincide exactamente con uno de esos cuatro pares, queda en
+historial y `--verify` confirma que los campos liberados quedaron vacíos.
+
 ## Siguiente paso operativo
 
 La fuente aprobada queda versionada junto con su checksum. No se acepta un

--- a/docs/registro/prs/PR-2296.md
+++ b/docs/registro/prs/PR-2296.md
@@ -1,0 +1,52 @@
+# PR #2296 - fix(admisiones): autorizar transferencias issue 2272
+
+## Metadata
+
+- PR: https://github.com/dsocial118/SISOC/pull/2296
+- Base: `main`
+- Rama origen: `codex/issue-2272-authorized-transfers`
+- Autor: `juanikitro`
+
+## Resumen operativo
+
+- Tipo de cambio: No informado
+- Área principal: No informada
+- Contexto funcional: No informado explícitamente; revisar título, diff y documentación relacionada.
+- Resumen para changelog: No informado
+- Impacto usuario: No informado
+
+## Áreas afectadas
+
+- `admisiones`
+- `docs/operacion`
+- `docs/registro`
+
+## Archivos relevantes del diff
+
+- `admisiones/management/commands/corregir_expedientes_issue_2272.py`
+- `admisiones/tests/test_corregir_expedientes_issue_2272.py`
+- `docs/operacion/correccion_expedientes_issue_2272.md`
+- `docs/registro/cambios/2026-08-12-issue-2272-correccion-expedientes.md`
+
+## Validación declarada
+
+- Pruebas automáticas: No informado en el PR.
+- Pruebas manuales: No informado en el PR.
+
+## Riesgos y rollback
+
+- No informado explícitamente en el PR.
+
+## Documentación sugerida para lectura
+
+- `docs/indice.md`
+- `docs/ia/CONTEXT_HYGIENE.md`
+- `docs/ia/ARCHITECTURE.md`
+- `docs/ia/TESTING.md`
+- `docs/operacion/correccion_expedientes_issue_2272.md`
+- `docs/registro/cambios/2026-08-12-issue-2272-correccion-expedientes.md`
+
+## Notas para continuidad
+
+- Este documento es generado automáticamente desde el contexto del PR y sirve como índice rápido para revisión y futuras sesiones de agentes.
+- Si la metadata del body del PR está incompleta, varias secciones usarán fallbacks derivados del título o del diff.

--- a/docs/registro/releases/pending/2026-08-19-pr-2296.md
+++ b/docs/registro/releases/pending/2026-08-19-pr-2296.md
@@ -1,0 +1,19 @@
+---
+pr: 2296
+release_date: 2026-08-19
+category: Actualizaciones
+area: sin-area
+title: fix(admisiones): autorizar transferencias issue 2272
+summary: fix(admisiones): autorizar transferencias issue 2272
+impact: No informado
+source_url: https://github.com/dsocial118/SISOC/pull/2296
+---
+# Release note preliminar PR #2296
+
+- Fecha objetivo de release: 2026-08-19
+- Categoría: Actualizaciones
+- Área: sin-area
+- Título del PR: fix(admisiones): autorizar transferencias issue 2272
+- Resumen: fix(admisiones): autorizar transferencias issue 2272
+- Impacto usuario: No informado
+- Fuente: https://github.com/dsocial118/SISOC/pull/2296


### PR DESCRIPTION
## Resumen

Autoriza de forma acotada las cuatro transferencias detectadas por el preflight de #2272 cuando el CSV prevalece:

- 1627 → 2072
- 1490 → 2469
- 1218 → 2052
- 842 → 802

Antes de asignar el expediente destino, limpia `num_expediente` y `legales_num_if` del origen, genera historial y verifica posteriormente que ambos campos quedaron vacíos. Cualquier otra colisión sigue bloqueando la ejecución.

## Validación

- `scripts/ai/codex_run.ps1 test admisiones/tests/test_corregir_expedientes_issue_2272.py -q` — 12 passed
- `scripts/ai/codex_run.ps1 black-check admisiones/management/commands/corregir_expedientes_issue_2272.py admisiones/tests/test_corregir_expedientes_issue_2272.py`
- `git diff --check`

## Operación

No ejecuta datos en este PR. Tras merge y despliegue, ejecutar el preflight en PRD y, sólo si confirma estas cuatro liberaciones autorizadas, `--apply` seguido de `--verify` según el runbook.