### PR TITLE
fix(users): quitar declaración de confirmación de datos

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 ## Actualizaciones
 
 - [sin-area] fix(admisiones): autorizar transferencias issue 2272. (PR #2296)
+- [sin-area] fix(users): quitar declaración de confirmación de datos. (PR #2300)
 <!-- AUTO-GENERATED RELEASE END: 2026-08-19 -->
 
 <!-- AUTO-GENERATED RELEASE START: 2026-08-13 -->

--- a/docs/contexto/features/pr-2300-fix-users-quitar-declaracion-de-confirmacion-de-datos.md
+++ b/docs/contexto/features/pr-2300-fix-users-quitar-declaracion-de-confirmacion-de-datos.md
@@ -1,0 +1,50 @@
+# Contexto de feature PR #2300 - fix(users): quitar declaración de confirmación de datos
+
+## Resumen
+
+- PR: https://github.com/dsocial118/SISOC/pull/2300
+- Base: `main`
+- Rama origen: `hotfix/main-local`
+- Autor: `PabloCao1`
+
+## Contexto funcional
+
+- No informado explícitamente; inferir desde el título del PR y el diff.
+
+## Arquitectura tocada
+
+- Se modifican templates, con posible impacto visual o de composición UI.
+
+## Decisiones y supuestos detectados
+
+- Tipo de cambio declarado: No informado
+- Área principal declarada: No informada
+- Impacto usuario declarado: No informado
+- Riesgos / rollback: No informado
+
+## Design system y UI
+
+- El PR toca piezas de UI y conviene revisar consistencia visual con el patrón existente.
+- Archivos visuales relevantes: users/templates/user/_mi_cuenta_campos.html, users/templates/user/confirmar_datos.html, users/templates/user/mi_cuenta.html
+
+## Memoria operativa para agentes
+
+- Empezar por `docs/registro/prs/PR-2300.md` para contexto resumido del PR.
+- Revisar primero estos archivos del diff:
+- `docs/registro/cambios/2026-08-14-confirmacion-datos-sin-declaracion.md`
+- `tests/test_users_mi_cuenta.py`
+- `users/forms.py`
+- `users/templates/user/_mi_cuenta_campos.html`
+- `users/templates/user/confirmar_datos.html`
+- `users/templates/user/mi_cuenta.html`
+- Documentación sugerida para ampliar contexto:
+- `docs/indice.md`
+- `docs/ia/CONTEXT_HYGIENE.md`
+- `docs/ia/ARCHITECTURE.md`
+- `docs/ia/TESTING.md`
+- `docs/registro/cambios/2026-08-14-confirmacion-datos-sin-declaracion.md`
+
+## Trazabilidad
+
+- Documento generado automáticamente desde el evento de `pull_request`.
+- Si este PR cambia de título, el archivo se renombrará para mantener el slug alineado.

--- a/docs/contexto/features/pr-2300-fix-users-quitar-declaracion-de-confirmacion-de-datos.md
+++ b/docs/contexto/features/pr-2300-fix-users-quitar-declaracion-de-confirmacion-de-datos.md
@@ -31,7 +31,11 @@
 
 - Empezar por `docs/registro/prs/PR-2300.md` para contexto resumido del PR.
 - Revisar primero estos archivos del diff:
+- `CHANGELOG.md`
+- `docs/contexto/features/pr-2300-fix-users-quitar-declaracion-de-confirmacion-de-datos.md`
 - `docs/registro/cambios/2026-08-14-confirmacion-datos-sin-declaracion.md`
+- `docs/registro/prs/PR-2300.md`
+- `docs/registro/releases/pending/2026-08-19-pr-2300.md`
 - `tests/test_users_mi_cuenta.py`
 - `users/forms.py`
 - `users/templates/user/_mi_cuenta_campos.html`
@@ -42,7 +46,10 @@
 - `docs/ia/CONTEXT_HYGIENE.md`
 - `docs/ia/ARCHITECTURE.md`
 - `docs/ia/TESTING.md`
+- `docs/contexto/features/pr-2300-fix-users-quitar-declaracion-de-confirmacion-de-datos.md`
 - `docs/registro/cambios/2026-08-14-confirmacion-datos-sin-declaracion.md`
+- `docs/registro/prs/PR-2300.md`
+- `docs/registro/releases/pending/2026-08-19-pr-2300.md`
 
 ## Trazabilidad
 

--- a/docs/registro/cambios/2026-08-14-confirmacion-datos-sin-declaracion.md
+++ b/docs/registro/cambios/2026-08-14-confirmacion-datos-sin-declaracion.md
@@ -1,0 +1,19 @@
+# Confirmación de datos sin declaración
+
+Fecha: 2026-08-14
+
+## Cambio
+
+El modal obligatorio de confirmación de datos personales y la pantalla
+persistente **Mi cuenta** dejan de mostrar y exigir la declaración de
+confidencialidad. También se retira de ambas vistas el texto sobre identificación
+y auditoría interna.
+
+El campo histórico se conserva en la base de datos, sin escrituras nuevas desde
+este formulario, para mantener compatibilidad y evitar una migración destructiva
+en el hotfix.
+
+## Validación
+
+- `pytest tests/test_users_mi_cuenta.py -q`
+- `djlint users/templates/user/confirmar_datos.html users/templates/user/_mi_cuenta_campos.html --check`

--- a/docs/registro/prs/PR-2300.md
+++ b/docs/registro/prs/PR-2300.md
@@ -17,13 +17,19 @@
 
 ## Áreas afectadas
 
+- `CHANGELOG.md`
+- `docs/contexto`
 - `docs/registro`
 - `tests`
 - `users`
 
 ## Archivos relevantes del diff
 
+- `CHANGELOG.md`
+- `docs/contexto/features/pr-2300-fix-users-quitar-declaracion-de-confirmacion-de-datos.md`
 - `docs/registro/cambios/2026-08-14-confirmacion-datos-sin-declaracion.md`
+- `docs/registro/prs/PR-2300.md`
+- `docs/registro/releases/pending/2026-08-19-pr-2300.md`
 - `tests/test_users_mi_cuenta.py`
 - `users/forms.py`
 - `users/templates/user/_mi_cuenta_campos.html`
@@ -45,7 +51,10 @@
 - `docs/ia/CONTEXT_HYGIENE.md`
 - `docs/ia/ARCHITECTURE.md`
 - `docs/ia/TESTING.md`
+- `docs/contexto/features/pr-2300-fix-users-quitar-declaracion-de-confirmacion-de-datos.md`
 - `docs/registro/cambios/2026-08-14-confirmacion-datos-sin-declaracion.md`
+- `docs/registro/prs/PR-2300.md`
+- `docs/registro/releases/pending/2026-08-19-pr-2300.md`
 
 ## Notas para continuidad
 

--- a/docs/registro/prs/PR-2300.md
+++ b/docs/registro/prs/PR-2300.md
@@ -1,0 +1,53 @@
+# PR #2300 - fix(users): quitar declaración de confirmación de datos
+
+## Metadata
+
+- PR: https://github.com/dsocial118/SISOC/pull/2300
+- Base: `main`
+- Rama origen: `hotfix/main-local`
+- Autor: `PabloCao1`
+
+## Resumen operativo
+
+- Tipo de cambio: No informado
+- Área principal: No informada
+- Contexto funcional: No informado explícitamente; revisar título, diff y documentación relacionada.
+- Resumen para changelog: No informado
+- Impacto usuario: No informado
+
+## Áreas afectadas
+
+- `docs/registro`
+- `tests`
+- `users`
+
+## Archivos relevantes del diff
+
+- `docs/registro/cambios/2026-08-14-confirmacion-datos-sin-declaracion.md`
+- `tests/test_users_mi_cuenta.py`
+- `users/forms.py`
+- `users/templates/user/_mi_cuenta_campos.html`
+- `users/templates/user/confirmar_datos.html`
+- `users/templates/user/mi_cuenta.html`
+
+## Validación declarada
+
+- Pruebas automáticas: No informado en el PR.
+- Pruebas manuales: No informado en el PR.
+
+## Riesgos y rollback
+
+- No informado explícitamente en el PR.
+
+## Documentación sugerida para lectura
+
+- `docs/indice.md`
+- `docs/ia/CONTEXT_HYGIENE.md`
+- `docs/ia/ARCHITECTURE.md`
+- `docs/ia/TESTING.md`
+- `docs/registro/cambios/2026-08-14-confirmacion-datos-sin-declaracion.md`
+
+## Notas para continuidad
+
+- Este documento es generado automáticamente desde el contexto del PR y sirve como índice rápido para revisión y futuras sesiones de agentes.
+- Si la metadata del body del PR está incompleta, varias secciones usarán fallbacks derivados del título o del diff.

--- a/docs/registro/releases/pending/2026-08-19-pr-2300.md
+++ b/docs/registro/releases/pending/2026-08-19-pr-2300.md
@@ -1,0 +1,19 @@
+---
+pr: 2300
+release_date: 2026-08-19
+category: Actualizaciones
+area: sin-area
+title: fix(users): quitar declaración de confirmación de datos
+summary: fix(users): quitar declaración de confirmación de datos
+impact: No informado
+source_url: https://github.com/dsocial118/SISOC/pull/2300
+---
+# Release note preliminar PR #2300
+
+- Fecha objetivo de release: 2026-08-19
+- Categoría: Actualizaciones
+- Área: sin-area
+- Título del PR: fix(users): quitar declaración de confirmación de datos
+- Resumen: fix(users): quitar declaración de confirmación de datos
+- Impacto usuario: No informado
+- Fuente: https://github.com/dsocial118/SISOC/pull/2300

--- a/tests/test_users_mi_cuenta.py
+++ b/tests/test_users_mi_cuenta.py
@@ -23,7 +23,6 @@ def _form_data(**overrides):
         "dni": "12345678",
         "cuil": CUIL_VALIDO,
         "correo_institucional": "",
-        "declaracion_aceptada": "on",
     }
     data.update(overrides)
     return data
@@ -81,16 +80,6 @@ def test_form_acepta_correo_institucional_vacio():
 
 
 @pytest.mark.django_db
-def test_form_falla_sin_declaracion_aceptada():
-    user = _crear_usuario("ut2b")
-
-    form = MiCuentaForm(data=_form_data(declaracion_aceptada=""), instance=user)
-
-    assert form.is_valid() is False
-    assert "declaracion_aceptada" in form.errors
-
-
-@pytest.mark.django_db
 def test_form_rechaza_cuil_con_digito_verificador_invalido():
     user = _crear_usuario("ut2d")
 
@@ -118,7 +107,7 @@ def test_form_guarda_user_y_profile_y_limpia_flag():
     assert user.profile.dni == "12345678"
     assert user.profile.cuil == "20123456786"
     assert user.profile.correo_institucional == "ana@desarrollosocial.gob.ar"
-    assert user.profile.declaracion_aceptada is True
+    assert user.profile.declaracion_aceptada is False
     assert user.profile.needs_profile_confirmation is False
     assert user.profile.datos_confirmados_at is not None
 
@@ -133,13 +122,11 @@ def test_form_precarga_datos_del_perfil():
     user.profile.dni = "12345678"
     user.profile.cuil = "20123456786"
     user.profile.correo_institucional = "ana@desarrollosocial.gob.ar"
-    user.profile.declaracion_aceptada = True
     user.profile.save(
         update_fields=[
             "dni",
             "cuil",
             "correo_institucional",
-            "declaracion_aceptada",
         ]
     )
 
@@ -149,7 +136,7 @@ def test_form_precarga_datos_del_perfil():
     assert form.fields["dni"].initial == "12345678"
     assert form.fields["cuil"].initial == "20123456786"
     assert form.fields["correo_institucional"].initial == "ana@desarrollosocial.gob.ar"
-    assert form.fields["declaracion_aceptada"].initial is True
+    assert "declaracion_aceptada" not in form.fields
 
 
 # --- Middleware -------------------------------------------------------------
@@ -317,20 +304,37 @@ def test_boton_guardar_se_habilita_por_js_en_ambas_vistas(client, url_name):
 
 
 @pytest.mark.django_db
-def test_confirmacion_rechaza_guardado_sin_declaracion(client):
-    """El gate de JS no alcanza: el servidor también rechaza."""
-
+def test_confirmacion_no_muestra_declaracion(client):
     user = _crear_usuario("sin_declaracion", needs_profile_confirmation=True)
     client.force_login(user)
 
+    response = client.get(reverse("confirmar_datos_personales"))
+    html = response.content.decode()
+
+    assert "declaracion_aceptada" not in html
+    assert "Acepto que la información contenida" not in html
+    assert "Estos datos se usan para identificación y auditoría interna." not in html
+
     response = client.post(
         reverse("confirmar_datos_personales"),
-        data=_form_data(declaracion_aceptada=""),
+        data=_form_data(),
     )
 
-    assert response.status_code == 200
+    assert response.status_code in {302, 303}
     user.refresh_from_db()
-    assert user.profile.needs_profile_confirmation is True
+    assert user.profile.needs_profile_confirmation is False
+
+
+@pytest.mark.django_db
+def test_mi_cuenta_no_muestra_declaracion(client):
+    user = _crear_usuario("mi_cuenta_sin_declaracion")
+    client.force_login(user)
+
+    html = client.get(reverse("mi_cuenta")).content.decode()
+
+    assert "declaracion_aceptada" not in html
+    assert "Acepto que la información contenida" not in html
+    assert "Estos datos se usan para identificación y auditoría interna." not in html
 
 
 def test_sidebar_expone_mi_cuenta():

--- a/users/forms.py
+++ b/users/forms.py
@@ -1208,18 +1208,6 @@ class UserImportForm(forms.Form):
 #
 # El texto original de UX estaba redactado como aviso en segunda persona
 # ("comprometiéndote a..."), que no funciona como leyenda de un checkbox: al
-# tildarlo el usuario tiene que estar declarando algo en primera persona. Se
-# reformuló la persona gramatical sin tocar el alcance normativo, y la parte
-# instructiva ("revisá y completá tus datos") se movió al encabezado del modal,
-# que es donde corresponde: eso se lee, no se acepta.
-TEXTO_DECLARACION = (
-    "Acepto que la información contenida en el sistema será utilizada "
-    "exclusivamente para el cumplimiento de las funciones autorizadas y me "
-    "comprometo a preservar su confidencialidad, de conformidad con la "
-    "normativa vigente."
-)
-
-
 class MiCuentaForm(forms.ModelForm):
     """Edición de los datos personales del propio usuario.
 
@@ -1253,12 +1241,6 @@ class MiCuentaForm(forms.ModelForm):
         label="Correo institucional",
         help_text="Opcional.",
     )
-    declaracion_aceptada = forms.BooleanField(
-        required=True,
-        label=TEXTO_DECLARACION,
-        error_messages={"required": "Debe aceptar la declaración para continuar."},
-    )
-
     class Meta:
         model = User
         fields = ["first_name", "last_name", "email"]
@@ -1278,7 +1260,6 @@ class MiCuentaForm(forms.ModelForm):
             self.fields["dni"].initial = profile.dni
             self.fields["cuil"].initial = profile.cuil
             self.fields["correo_institucional"].initial = profile.correo_institucional
-            self.fields["declaracion_aceptada"].initial = profile.declaracion_aceptada
 
     def clean_dni(self):
         dni = solo_digitos(self.cleaned_data.get("dni"))
@@ -1303,7 +1284,6 @@ class MiCuentaForm(forms.ModelForm):
             profile.dni = self.cleaned_data["dni"]
             profile.cuil = self.cleaned_data["cuil"]
             profile.correo_institucional = self.cleaned_data["correo_institucional"]
-            profile.declaracion_aceptada = self.cleaned_data["declaracion_aceptada"]
             profile.needs_profile_confirmation = False
             profile.datos_confirmados_at = timezone.now()
             profile.save(
@@ -1311,7 +1291,6 @@ class MiCuentaForm(forms.ModelForm):
                     "dni",
                     "cuil",
                     "correo_institucional",
-                    "declaracion_aceptada",
                     "needs_profile_confirmation",
                     "datos_confirmados_at",
                 ]

--- a/users/forms.py
+++ b/users/forms.py
@@ -1241,6 +1241,7 @@ class MiCuentaForm(forms.ModelForm):
         label="Correo institucional",
         help_text="Opcional.",
     )
+
     class Meta:
         model = User
         fields = ["first_name", "last_name", "email"]

--- a/users/templates/user/_mi_cuenta_campos.html
+++ b/users/templates/user/_mi_cuenta_campos.html
@@ -20,6 +20,4 @@
         <div class="col-md-6">{{ form.email|as_crispy_field }}</div>
         <div class="col-md-6">{{ form.correo_institucional|as_crispy_field }}</div>
     </div>
-    <hr />
-    {{ form.declaracion_aceptada|as_crispy_field }}
 </div>

--- a/users/templates/user/confirmar_datos.html
+++ b/users/templates/user/confirmar_datos.html
@@ -43,7 +43,6 @@
                             Vas a poder modificar estos datos luego desde <strong>Mi cuenta</strong>.
                         </p>
                         {% include "user/_mi_cuenta_campos.html" %}
-                        <p class="text-muted small mb-0">Estos datos se usan para identificación y auditoría interna.</p>
                     </div>
                     <div class="modal-footer justify-content-end">
                         <button type="submit"

--- a/users/templates/user/mi_cuenta.html
+++ b/users/templates/user/mi_cuenta.html
@@ -15,7 +15,6 @@
                     <form method="post" novalidate>
                         {% csrf_token %}
                         {% include "user/_mi_cuenta_campos.html" %}
-                        <p class="text-muted small mb-3">Estos datos se usan para identificación y auditoría interna.</p>
                         <button class="poncho-btn poncho-btn--cta"
                                 type="submit"
                                 data-mi-cuenta-submit>Guardar datos</button>


### PR DESCRIPTION
## Resumen
- elimina el checkbox y la declaración de confidencialidad del modal de confirmación
- elimina la misma declaración y el texto de auditoría de Mi cuenta
- conserva el campo histórico en base de datos para evitar una migración destructiva

## Validación
- pytest tests/test_users_mi_cuenta.py -q (28 passed)
- djlint users/templates/user/confirmar_datos.html users/templates/user/mi_cuenta.html users/templates/user/_mi_cuenta_campos.html --check
- git diff --check