### PR TITLE
docs(spec): corregir trazabilidad y guías canónicas

### DIFF
--- a/.github/workflows/pr-docs.yml
+++ b/.github/workflows/pr-docs.yml
@@ -59,7 +59,9 @@ jobs:
 
     sync_pr_artifacts:
         needs: generate_pr_artifacts
-        if: always() && github.event.pull_request.head.ref != 'development' && github.event.pull_request.head.ref != 'homologacion' && github.event.pull_request.head.ref != 'main'
+        # Las ramas protegidas no se autoescriben, pero deben traer sus
+        # artefactos ya generados para que una promoción no saltee el gate.
+        if: always()
         runs-on: ubuntu-latest
 
         steps:
@@ -77,7 +79,7 @@ jobs:
                     git fetch --no-tags origin "+refs/pull/${{ github.event.pull_request.number }}/head:refs/remotes/origin/pr-head"
                   fi
 
-                  paths="$(git ls-tree -r --name-only refs/remotes/origin/pr-head -- docs/registro/prs docs/contexto/features)"
+                  paths="$(git ls-tree -r --name-only refs/remotes/origin/pr-head -- docs/registro/prs docs/contexto/features docs/registro/releases/pending CHANGELOG.md)"
                   record_path="docs/registro/prs/PR-${{ github.event.pull_request.number }}.md"
                   feature_pattern="^docs/contexto/features/pr-${{ github.event.pull_request.number }}-.*\\.md$"
                   missing=()
@@ -87,6 +89,15 @@ jobs:
                   fi
                   if ! grep -Eq "$feature_pattern" <<< "$paths"; then
                     missing+=("docs/contexto/features/pr-${{ github.event.pull_request.number }}-*.md")
+                  fi
+                  if [ "${{ github.event.pull_request.base.ref }}" = "main" ]; then
+                    release_pattern="^docs/registro/releases/pending/.*-pr-${{ github.event.pull_request.number }}\\.md$"
+                    if ! grep -Eq "$release_pattern" <<< "$paths"; then
+                      missing+=("docs/registro/releases/pending/*-pr-${{ github.event.pull_request.number }}.md")
+                    fi
+                    if ! grep -Fxq "CHANGELOG.md" <<< "$paths"; then
+                      missing+=("CHANGELOG.md")
+                    fi
                   fi
 
                   if [ "${#missing[@]}" -eq 0 ]; then

--- a/AGENT_REPO_MAP.md
+++ b/AGENT_REPO_MAP.md
@@ -13,7 +13,7 @@ Mapa practico del repositorio `SISOC` para futuros agentes de IA y desarrollador
 ### Hechos observados
 
 - Es un monolito Django grande, modularizado por apps de dominio, con backend renderizado por templates y APIs DRF convivientes.
-- El stack principal es Python 3.11 + Django 4.2 + MySQL 8 + Docker Compose.
+- El stack principal es Python 3.11 + Django 5.2 LTS + MySQL 8 + Docker Compose.
 - La operacion local y CI estan pensadas en modo Docker-first.
 - El repo mezcla backoffice web tradicional, APIs internas/server-to-server, flujos asincronos simples sin Celery, y una capa PWA/API para ciertos casos de uso.
 - La logica de negocio suele vivir en `services/` cuando la app la tiene, pero coexisten apps mas legacy con mas logica en `views.py`, `models.py` o `tasks.py`.
@@ -32,7 +32,7 @@ Mapa practico del repositorio `SISOC` para futuros agentes de IA y desarrollador
 | Item | Estado | Evidencia |
 | --- | --- | --- |
 | Python 3.11 | Hecho observado | `pyproject.toml`, workflows CI |
-| Django 4.2.27 | Hecho observado | `requirements/base.txt` |
+| Django 5.2.16 | Hecho observado | `requirements/base.txt` |
 | Django REST Framework | Hecho observado | `requirements/base.txt`, `config/settings.py` |
 | drf-spectacular | Hecho observado | `requirements/base.txt`, `config/urls.py` |
 | Gunicorn | Hecho observado | `requirements/base.txt`, `docker/django/entrypoint.py` |
@@ -489,6 +489,7 @@ La siguiente tabla mezcla hechos observados con inferencias explicitas cuando no
 - El Informe Tecnico Complementario se abre tanto desde Admision como desde el
   convenio seleccionado en `acompanamientos/views.py` y
   `acompanamientos/templates/acompañamiento_detail.html`.
+- Documentación canónica: `docs/implementaciones/admisiones_informes_tecnicos.md`.
 
 ### Si necesitas cambiar PWA
 
@@ -502,7 +503,9 @@ La siguiente tabla mezcla hechos observados con inferencias explicitas cuando no
   `pwa/services/nomina_queryset_service.py`
 - frontend: `mobile/src/api/` y `mobile/src/features/home/`
 - tests `tests/test_pwa_*`
-- docs: `docs/implementaciones/pwa_backend.md`, `docs/seguridad/security_baseline_pwa.md`
+- docs: `docs/implementaciones/pwa_backend.md`,
+  `docs/implementaciones/comedores_certificaciones_prestaciones.md`,
+  `docs/seguridad/security_baseline_pwa.md`
 
 ### Si necesitas cambiar documentos DOCX/PDF de prestaciones o nóminas
 
@@ -519,6 +522,7 @@ La siguiente tabla mezcla hechos observados con inferencias explicitas cuando no
 - listado y detalle del legajo: `organizaciones/views.py` y templates `organizacion_*`
 - proyectos editables: `OrganizacionForm.codigos_proyecto` mantiene el contrato CSV mediante un campo oculto
 - tests: `tests/test_rendicioncuentasmensual_services_unit.py` y `organizaciones/tests.py`
+- documentación canónica: `docs/flujos/rendiciones_mensuales_proyectos.md`
 
 ### Si necesitas cambiar OCR / procesamiento documental
 
@@ -806,8 +810,9 @@ Marcar esas zonas como `A inferir` hasta relevarlas cuando una tarea real las to
 - `.github/workflows/sync-main-downstream.yml`
 - `.github/workflows/pr-docs.yml`: genera los artefactos spec-as-source; usa
   `git status --porcelain --untracked-files=all` para incluir archivos nuevos.
-  Solo pushea en ramas internas no protegidas; para forks y ramas protegidas
-  falla `sync_pr_artifacts` con los paths pendientes para bloquear el merge.
+  Solo pushea en ramas internas no protegidas; `sync_pr_artifacts` verifica
+  también forks y ramas protegidas. Los PRs hacia `main` requieren además
+  release note pendiente y `CHANGELOG.md` ya versionados.
 - `.github/workflows/deploy.yml`
 - `scripts/ai/codex_run.ps1`
 - `scripts/ai/codex_task.ps1`

--- a/docs/contexto/aplicaciones.md
+++ b/docs/contexto/aplicaciones.md
@@ -2,11 +2,11 @@
 
 ## Aplicaciones instaladas
 - Apps Django/3ros: admin, auth, sessions, messages, staticfiles, admindocs, crispy_forms/bootstrap5, django_extensions, import_export, auditlog, DRF/rest_framework_api_key, drf_spectacular, corsheaders. Evidencia: config/settings.py:42-62.
-- Apps propias: users, core, dashboard, comedores, organizaciones, centrodeinfancia, ciudadanos, duplas, admisiones, intervenciones, historial, acompanamientos, expedientespagos, relevamientos, rendicioncuentasfinal, rendicioncuentasmensual, centrodefamilia, celiaquia, audittrail. Evidencia: config/settings.py:64-83.
+- Apps propias: users, core, dashboard, comedores, organizaciones, centrodeinfancia, ciudadanos, duplas, admisiones, intervenciones, historial, acompanamientos, expedientespagos, relevamientos, rendicioncuentasfinal, rendicioncuentasmensual, centrodefamilia, celiaquia, audittrail, pwa, comunicados, ticketera y VAT. Evidencia: config/settings.py.
 - Apps de debug/performance agregadas solo con `DEBUG=True`: debug_toolbar y silk. Evidencia: config/settings.py:359-366.
 
 ## URL principales
-- Router raíz incluye auth, users, core, dashboard, comedores, organizaciones, centrodeinfancia, duplas, audittrail, ciudadanos, admisiones, centrodefamilia, healthcheck, acompanamientos (prefijo), expedientespagos (prefijo), rendicioncuentasfinal, relevamientos, rendicioncuentasmensual (prefijo), celiaquia y APIs de `users`, `comedores` y `centrodefamilia`; expone Swagger/Redoc en `/api/docs` y `/api/redoc`. Evidencia: config/urls.py:12-47.
+- Router raíz incluye auth, users, core, dashboard, comedores, organizaciones, centrodeinfancia, duplas, audittrail, ciudadanos, admisiones, centrodefamilia, healthcheck, acompanamientos (prefijo), expedientespagos (prefijo), rendicioncuentasfinal, relevamientos, rendicioncuentasmensual (prefijo), celiaquia y las APIs de `users`, `comedores`, `centrodefamilia`, `vat`, `comunicados`, `renaper`, `pwa` y `ticketera`; expone Swagger/Redoc en `/api/docs` y `/api/redoc`. Evidencia: config/urls.py.
 - Endpoint de salud `/health/` responde `OK`. Evidencia: healthcheck/urls.py:1-5 y healthcheck/views.py:1-4.
 
 ## API PWA (estado actual)

--- a/docs/contexto/features/pr-2258-feat-celiaquia-contrato-publico-de-integracion.md
+++ b/docs/contexto/features/pr-2258-feat-celiaquia-contrato-publico-de-integracion.md
@@ -1,0 +1,66 @@
+# Contexto de feature PR #2258 - feat(celiaquia): contrato público de integración
+
+## Resumen
+
+- PR: https://github.com/dsocial118/SISOC/pull/2258
+- Base: `development`
+- Rama origen: `codex/issue-2242-celiaquia-public-contract`
+- Autor: `juanikitro`
+
+## Contexto funcional
+
+- No informado explícitamente; inferir desde el título del PR y el diff.
+
+## Arquitectura tocada
+
+- El PR toca lógica en `services/`, por lo que impacta reglas de negocio u orquestación.
+- Hay cambios en vistas web y puede existir impacto en permisos o renderizado.
+- Se modifican templates, con posible impacto visual o de composición UI.
+- El alcance incluye automatización o tooling de CI/CD.
+
+## Decisiones y supuestos detectados
+
+- Tipo de cambio declarado: No informado
+- Área principal declarada: No informada
+- Impacto usuario declarado: No informado
+- Riesgos / rollback: No informado
+
+## Design system y UI
+
+- El PR toca piezas de UI y conviene revisar consistencia visual con el patrón existente.
+- Archivos visuales relevantes: ciudadanos/templates/ciudadanos/ciudadano_detail.html
+
+## Memoria operativa para agentes
+
+- Empezar por `docs/registro/prs/PR-2258.md` para contexto resumido del PR.
+- Revisar primero estos archivos del diff:
+- `.github/workflows/architecture.yml`
+- `.importlinter`
+- `.importlinter_celiaquia_config`
+- `AGENT_REPO_MAP.md`
+- `celiaquia/api.py`
+- `celiaquia/apps.py`
+- `celiaquia/ciudadano_detail.py`
+- `celiaquia/global_urls.py`
+- `celiaquia/services/ciudadano_resumen_service/__init__.py`
+- `celiaquia/services/ciudadano_resumen_service/impl.py`
+- `celiaquia/tests/test_public_api.py`
+- `ciudadanos/templates/ciudadanos/ciudadano_detail.html`
+- `ciudadanos/views.py`
+- `config/urls.py`
+- `docs/ia/MODULAR_BOUNDARIES.md`
+- `docs/registro/decisiones/2026-08-07-contrato-publico-celiaquia.md`
+- `tests/test_ciudadanos_templates_unit.py`
+- `tests/test_ciudadanos_views_unit.py`
+- Documentación sugerida para ampliar contexto:
+- `docs/indice.md`
+- `docs/ia/CONTEXT_HYGIENE.md`
+- `docs/ia/ARCHITECTURE.md`
+- `docs/ia/TESTING.md`
+- `docs/ia/MODULAR_BOUNDARIES.md`
+- `docs/registro/decisiones/2026-08-07-contrato-publico-celiaquia.md`
+
+## Trazabilidad
+
+- Documento generado automáticamente desde el evento de `pull_request`.
+- Si este PR cambia de título, el archivo se renombrará para mantener el slug alineado.

--- a/docs/contexto/features/pr-2263-docs-spec-completar-trazabilidad-de-prs-y-guias-canonicas.md
+++ b/docs/contexto/features/pr-2263-docs-spec-completar-trazabilidad-de-prs-y-guias-canonicas.md
@@ -1,0 +1,88 @@
+# Contexto de feature PR #2263 - docs(spec): completar trazabilidad de PRs y guías canónicas
+
+## Resumen
+
+- PR: https://github.com/dsocial118/SISOC/pull/2263
+- Base: `development`
+- Rama origen: `codex/spec-as-source-backfill-20260810`
+- Autor: `juanikitro`
+
+## Contexto funcional
+
+- No informado explícitamente; inferir desde el título del PR y el diff.
+
+## Arquitectura tocada
+
+- No se detectó un patrón arquitectónico dominante más allá del diff observado.
+
+## Decisiones y supuestos detectados
+
+- Tipo de cambio declarado: No informado
+- Área principal declarada: No informada
+- Impacto usuario declarado: No informado
+- Riesgos / rollback: No informado
+
+## Design system y UI
+
+- Sin cambios visibles de UI o design system detectados en el diff.
+
+## Memoria operativa para agentes
+
+- Empezar por `docs/registro/prs/PR-2263.md` para contexto resumido del PR.
+- Revisar primero estos archivos del diff:
+- `docs/contexto/features/pr-2222-feat-comedores-agregar-etiqueta-caritas.md`
+- `docs/contexto/features/pr-2227-chore-deps-migrar-django-4-2-a-5-2-lts.md`
+- `docs/contexto/features/pr-2228-fix-iam-restringe-accesos-de-ciudadanos-y-acompanamiento.md`
+- `docs/contexto/features/pr-2230-comedores-cambios-en-filtros-ordenamiento-columnas.md`
+- `docs/contexto/features/pr-2231-style-templates-corrige-formato-para-promocion-a-homologacion.md`
+- `docs/contexto/features/pr-2235-issues-1961-2005-2076-2079-y-2188.md`
+- `docs/contexto/features/pr-2237-ui-buscadores.md`
+- `docs/contexto/features/pr-2253-refactor-architecture-completar-ratchet-de-fase-0.md`
+- `docs/contexto/features/pr-2255-fixes-post-revision-issues-1961-2076-2079-y-2188.md`
+- `docs/contexto/features/pr-2260-cdi-nomina-restriccion.md`
+- `docs/contexto/features/pr-2261-mi-cuenta.md`
+- `docs/flujos/derivar_nomina_centros.md`
+- `docs/implementaciones/centrodeinfancia_nomina_renaper.md`
+- `docs/implementaciones/usuarios_perfil_iam.md`
+- `docs/registro/prs/PR-2222.md`
+- `docs/registro/prs/PR-2227.md`
+- `docs/registro/prs/PR-2228.md`
+- `docs/registro/prs/PR-2230.md`
+- `docs/registro/prs/PR-2231.md`
+- `docs/registro/prs/PR-2235.md`
+- ... y 5 archivo(s) adicional(es) relacionados.
+- Documentación sugerida para ampliar contexto:
+- `docs/indice.md`
+- `docs/ia/CONTEXT_HYGIENE.md`
+- `docs/ia/ARCHITECTURE.md`
+- `docs/ia/TESTING.md`
+- `docs/contexto/features/pr-2222-feat-comedores-agregar-etiqueta-caritas.md`
+- `docs/contexto/features/pr-2227-chore-deps-migrar-django-4-2-a-5-2-lts.md`
+- `docs/contexto/features/pr-2228-fix-iam-restringe-accesos-de-ciudadanos-y-acompanamiento.md`
+- `docs/contexto/features/pr-2230-comedores-cambios-en-filtros-ordenamiento-columnas.md`
+- `docs/contexto/features/pr-2231-style-templates-corrige-formato-para-promocion-a-homologacion.md`
+- `docs/contexto/features/pr-2235-issues-1961-2005-2076-2079-y-2188.md`
+- `docs/contexto/features/pr-2237-ui-buscadores.md`
+- `docs/contexto/features/pr-2253-refactor-architecture-completar-ratchet-de-fase-0.md`
+- `docs/contexto/features/pr-2255-fixes-post-revision-issues-1961-2076-2079-y-2188.md`
+- `docs/contexto/features/pr-2260-cdi-nomina-restriccion.md`
+- `docs/contexto/features/pr-2261-mi-cuenta.md`
+- `docs/flujos/derivar_nomina_centros.md`
+- `docs/implementaciones/centrodeinfancia_nomina_renaper.md`
+- `docs/implementaciones/usuarios_perfil_iam.md`
+- `docs/registro/prs/PR-2222.md`
+- `docs/registro/prs/PR-2227.md`
+- `docs/registro/prs/PR-2228.md`
+- `docs/registro/prs/PR-2230.md`
+- `docs/registro/prs/PR-2231.md`
+- `docs/registro/prs/PR-2235.md`
+- `docs/registro/prs/PR-2237.md`
+- `docs/registro/prs/PR-2253.md`
+- `docs/registro/prs/PR-2255.md`
+- `docs/registro/prs/PR-2260.md`
+- `docs/registro/prs/PR-2261.md`
+
+## Trazabilidad
+
+- Documento generado automáticamente desde el evento de `pull_request`.
+- Si este PR cambia de título, el archivo se renombrará para mantener el slug alineado.

--- a/docs/contexto/features/pr-2265-fixs.md
+++ b/docs/contexto/features/pr-2265-fixs.md
@@ -1,0 +1,48 @@
+# Contexto de feature PR #2265 - Fixs
+
+## Resumen
+
+- PR: https://github.com/dsocial118/SISOC/pull/2265
+- Base: `development`
+- Rama origen: `Bug-visual-2226`
+- Autor: `nehuen871`
+
+## Contexto funcional
+
+- No informado explícitamente; inferir desde el título del PR y el diff.
+
+## Arquitectura tocada
+
+- No se detectó un patrón arquitectónico dominante más allá del diff observado.
+
+## Decisiones y supuestos detectados
+
+- Tipo de cambio declarado: No informado
+- Área principal declarada: No informada
+- Impacto usuario declarado: No informado
+- Riesgos / rollback: No informado
+
+## Design system y UI
+
+- El PR toca piezas de UI y conviene revisar consistencia visual con el patrón existente.
+- Archivos visuales relevantes: static/custom/css/comedorFormModerno.css, static/custom/js/comedorFormModerno.js
+
+## Memoria operativa para agentes
+
+- Empezar por `docs/registro/prs/PR-2265.md` para contexto resumido del PR.
+- Revisar primero estos archivos del diff:
+- `comedores/test_comedor_form_select2_layout.py`
+- `docs/registro/cambios/2026-08-10-select2-formulario-comedores.md`
+- `static/custom/css/comedorFormModerno.css`
+- `static/custom/js/comedorFormModerno.js`
+- Documentación sugerida para ampliar contexto:
+- `docs/indice.md`
+- `docs/ia/CONTEXT_HYGIENE.md`
+- `docs/ia/ARCHITECTURE.md`
+- `docs/ia/TESTING.md`
+- `docs/registro/cambios/2026-08-10-select2-formulario-comedores.md`
+
+## Trazabilidad
+
+- Documento generado automáticamente desde el evento de `pull_request`.
+- Si este PR cambia de título, el archivo se renombrará para mantener el slug alineado.

--- a/docs/contexto/features/pr-2266-refactor-core-centralizar-integracion-renaper.md
+++ b/docs/contexto/features/pr-2266-refactor-core-centralizar-integracion-renaper.md
@@ -1,0 +1,71 @@
+# Contexto de feature PR #2266 - refactor(core): centralizar integración RENAPER
+
+## Resumen
+
+- PR: https://github.com/dsocial118/SISOC/pull/2266
+- Base: `development`
+- Rama origen: `codex/issue-2243-shared-renaper`
+- Autor: `juanikitro`
+
+## Contexto funcional
+
+- No informado explícitamente; inferir desde el título del PR y el diff.
+
+## Arquitectura tocada
+
+- El PR toca lógica en `services/`, por lo que impacta reglas de negocio u orquestación.
+- Hay cambios en capa API/DRF y conviene revisar contratos de request/response.
+- Hay cambios en vistas web y puede existir impacto en permisos o renderizado.
+
+## Decisiones y supuestos detectados
+
+- Tipo de cambio declarado: No informado
+- Área principal declarada: No informada
+- Impacto usuario declarado: No informado
+- Riesgos / rollback: No informado
+
+## Design system y UI
+
+- Sin cambios visibles de UI o design system detectados en el diff.
+
+## Memoria operativa para agentes
+
+- Empezar por `docs/registro/prs/PR-2266.md` para contexto resumido del PR.
+- Revisar primero estos archivos del diff:
+- `.env.example`
+- `.importlinter`
+- `AGENT_REPO_MAP.md`
+- `VAT/services/consulta_renaper/__init__.py`
+- `VAT/services/consulta_renaper/impl.py`
+- `celiaquia/views/validacion_renaper.py`
+- `centrodefamilia/apps.py`
+- `centrodefamilia/services/beneficiarios_service/impl.py`
+- `centrodefamilia/services/consulta_renaper/__init__.py`
+- `centrodefamilia/services/consulta_renaper/impl.py`
+- `comedores/services/comedor_service/impl.py`
+- `config/settings.py`
+- `core/api_views.py`
+- `core/integrations/__init__.py`
+- `core/integrations/renaper.py`
+- `core/services/renaper.py`
+- `docs/contexto/arquitectura.md`
+- `docs/contexto/panorama.md`
+- `docs/flujos/consulta_renaper.md`
+- `docs/ia/MODULAR_BOUNDARIES.md`
+- ... y 8 archivo(s) adicional(es) relacionados.
+- Documentación sugerida para ampliar contexto:
+- `docs/indice.md`
+- `docs/ia/CONTEXT_HYGIENE.md`
+- `docs/ia/ARCHITECTURE.md`
+- `docs/ia/TESTING.md`
+- `docs/contexto/arquitectura.md`
+- `docs/contexto/panorama.md`
+- `docs/flujos/consulta_renaper.md`
+- `docs/ia/MODULAR_BOUNDARIES.md`
+- `docs/operacion/integraciones.md`
+- `docs/registro/decisiones/2026-08-10-integracion-renaper-compartida.md`
+
+## Trazabilidad
+
+- Documento generado automáticamente desde el evento de `pull_request`.
+- Si este PR cambia de título, el archivo se renombrará para mantener el slug alineado.

--- a/docs/contexto/features/pr-2303-docs-spec-corregir-trazabilidad-y-guias-canonicas.md
+++ b/docs/contexto/features/pr-2303-docs-spec-corregir-trazabilidad-y-guias-canonicas.md
@@ -1,0 +1,82 @@
+# Contexto de feature PR #2303 - docs(spec): corregir trazabilidad y guías canónicas
+
+## Resumen
+
+- PR: https://github.com/dsocial118/SISOC/pull/2303
+- Base: `development`
+- Rama origen: `codex/spec-as-source-fix-20260818`
+- Autor: `juanikitro`
+
+## Contexto funcional
+
+- No informado explícitamente; inferir desde el título del PR y el diff.
+
+## Arquitectura tocada
+
+- El alcance incluye automatización o tooling de CI/CD.
+
+## Decisiones y supuestos detectados
+
+- Tipo de cambio declarado: No informado
+- Área principal declarada: No informada
+- Impacto usuario declarado: No informado
+- Riesgos / rollback: No informado
+
+## Design system y UI
+
+- Sin cambios visibles de UI o design system detectados en el diff.
+
+## Memoria operativa para agentes
+
+- Empezar por `docs/registro/prs/PR-2303.md` para contexto resumido del PR.
+- Revisar primero estos archivos del diff:
+- `.github/workflows/pr-docs.yml`
+- `AGENT_REPO_MAP.md`
+- `docs/contexto/aplicaciones.md`
+- `docs/contexto/features/pr-2258-feat-celiaquia-contrato-publico-de-integracion.md`
+- `docs/contexto/features/pr-2263-docs-spec-completar-trazabilidad-de-prs-y-guias-canonicas.md`
+- `docs/contexto/features/pr-2265-fixs.md`
+- `docs/contexto/features/pr-2266-refactor-core-centralizar-integracion-renaper.md`
+- `docs/flujos/rendiciones_mensuales_proyectos.md`
+- `docs/implementaciones/admisiones_informes_tecnicos.md`
+- `docs/implementaciones/comedores_certificaciones_prestaciones.md`
+- `docs/implementaciones/pwa_backend.md`
+- `docs/implementaciones/usuarios_perfil_iam.md`
+- `docs/indice.md`
+- `docs/operacion/infraestructura.md`
+- `docs/operacion/integraciones.md`
+- `docs/registro/README.md`
+- `docs/registro/cambios/2026-08-18-gate-spec-as-source-promociones.md`
+- `docs/registro/prs/PR-2258.md`
+- `docs/registro/prs/PR-2263.md`
+- `docs/registro/prs/PR-2265.md`
+- ... y 3 archivo(s) adicional(es) relacionados.
+- Documentación sugerida para ampliar contexto:
+- `docs/indice.md`
+- `docs/ia/CONTEXT_HYGIENE.md`
+- `docs/ia/ARCHITECTURE.md`
+- `docs/ia/TESTING.md`
+- `docs/contexto/aplicaciones.md`
+- `docs/contexto/features/pr-2258-feat-celiaquia-contrato-publico-de-integracion.md`
+- `docs/contexto/features/pr-2263-docs-spec-completar-trazabilidad-de-prs-y-guias-canonicas.md`
+- `docs/contexto/features/pr-2265-fixs.md`
+- `docs/contexto/features/pr-2266-refactor-core-centralizar-integracion-renaper.md`
+- `docs/flujos/rendiciones_mensuales_proyectos.md`
+- `docs/implementaciones/admisiones_informes_tecnicos.md`
+- `docs/implementaciones/comedores_certificaciones_prestaciones.md`
+- `docs/implementaciones/pwa_backend.md`
+- `docs/implementaciones/usuarios_perfil_iam.md`
+- `docs/operacion/infraestructura.md`
+- `docs/operacion/integraciones.md`
+- `docs/registro/README.md`
+- `docs/registro/cambios/2026-08-18-gate-spec-as-source-promociones.md`
+- `docs/registro/prs/PR-2258.md`
+- `docs/registro/prs/PR-2263.md`
+- `docs/registro/prs/PR-2265.md`
+- `docs/registro/prs/PR-2266.md`
+- `docs/seguridad/security_baseline.md`
+
+## Trazabilidad
+
+- Documento generado automáticamente desde el evento de `pull_request`.
+- Si este PR cambia de título, el archivo se renombrará para mantener el slug alineado.

--- a/docs/flujos/rendiciones_mensuales_proyectos.md
+++ b/docs/flujos/rendiciones_mensuales_proyectos.md
@@ -1,0 +1,37 @@
+# Rendiciones mensuales y proyectos de organizaciones
+
+## Asociación de proyecto
+
+`RendicionCuentaMensual.proyecto` es la relación principal con
+`ProyectoOrganizacion`. Para registros históricos se conserva el fallback por
+`comedor.codigo_de_proyecto`; los listados, notificaciones y el detalle no
+deben excluir datos legados cuando esa relación nueva todavía sea nula.
+
+La PWA ofrece los proyectos activos de la organización y persiste el proyecto
+seleccionado en la rendición. La publicación de SISOC y SISOC-Mobile debe ser
+coordinada cuando cambie este contrato.
+
+## Revisión y subsanaciones
+
+- Validar u observar documentos no cambia por sí solo el estado global: la
+  etapa se resuelve al finalizar la revisión.
+- Territorial mantiene la rendición `En revisión` al derivarla a Auditoría.
+  Solo el cierre satisfactorio de Auditoría finaliza la presentación.
+- Una subsanación conserva la etapa que la originó. Al reanudar Auditoría se
+  preservan documentos ya validados; solo el primer inicio restablece los
+  documentos heredados desde Territorial.
+- El cierre administrativo de Auditoría usa un único formulario con monto,
+  acta, resultado y observaciones condicionales.
+
+## Despliegue y validación
+
+Aplicar `rendicioncuentasmensual.0016` antes de usar la asociación directa.
+Validar una rendición nueva con proyecto, una histórica con fallback, una
+subsanación de Territorial y otra de Auditoría antes de promover a producción.
+
+## Referencias
+
+- `rendicioncuentasmensual/services.py`
+- `organizaciones/views.py`
+- `docs/registro/cambios/2026-08-10-fixes-admisiones-pwa-rendiciones.md`
+- `docs/registro/cambios/2026-08-12-correcciones-issues-reabiertos.md`

--- a/docs/implementaciones/admisiones_informes_tecnicos.md
+++ b/docs/implementaciones/admisiones_informes_tecnicos.md
@@ -1,0 +1,38 @@
+# Informes Técnicos de Admisiones
+
+## Alcance
+
+El Informe Técnico concentra los datos de admisión usados por las plantillas
+DOCX. Los formularios validan las condiciones del dominio antes de renderizar y
+conservan errores de unicidad como errores de formulario, sin responder 500.
+
+## Renovaciones y prestaciones
+
+Las renovaciones pueden requerir un Informe Técnico Complementario cuando se
+modifican prestaciones. Esa condición se persiste en Admisiones y se expone
+como variable documental para la plantilla; no debe resolverse solo en el
+template ni inferirse después de guardar.
+
+## Templates dinámicos
+
+Las combinaciones de condiciones se resuelven mediante versiones publicadas de
+templates dinámicos. Solo personal autorizado publica una versión y únicamente
+las variables documentales activas quedan disponibles. Antes de habilitar una
+combinación nueva en un ambiente, debe existir su template publicado: no se
+crea ni publica automáticamente durante el alta de una admisión.
+
+## Despliegue y compatibilidad
+
+Aplicar las migraciones `admisiones.0076`, `0077` y `0078` antes de operar los
+nuevos campos. Luego verificar una renovación sin modificación de prestaciones
+y otra que requiera informe complementario, incluyendo la resolución de la
+plantilla publicada. El rollback de aplicación conserva los datos agregados;
+no borrar templates ni valores ya persistidos.
+
+## Referencias
+
+- `admisiones/forms/admisiones_forms.py`
+- `admisiones/services/docx_service/impl.py`
+- `admisiones/services/templates_informe_tecnico_service/impl.py`
+- `docs/registro/cambios/2026-08-10-fixes-admisiones-pwa-rendiciones.md`
+- `docs/registro/cambios/2026-08-12-correcciones-issues-reabiertos.md`

--- a/docs/implementaciones/comedores_certificaciones_prestaciones.md
+++ b/docs/implementaciones/comedores_certificaciones_prestaciones.md
@@ -1,0 +1,31 @@
+# Certificaciones mensuales de prestaciones
+
+## Flujo
+
+La conformidad mensual genera un PDF de certificación para afirmaciones y no
+conformidades, usando una de cuatro plantillas según el resultado y si opera el
+usuario principal o un subusuario. El historial web y la PWA muestran el estado
+y permiten descargar el archivo generado.
+
+## Fallback sin fuente
+
+Si falta informe técnico o convenio, se usa una fuente explícita con
+prestaciones en cero. El PDF incluye la leyenda **“Datos de prestaciones no
+disponibles.”**; no inventa prestaciones ni atribuye datos inexistentes.
+
+Los registros históricos sin archivo se mantienen visibles como no disponibles
+para descarga. Para altas nuevas, una falla al generar o guardar el PDF revierte
+la conformidad: no queda una certificación parcial.
+
+## Operación y rollback
+
+Verificar en cada ambiente las cuatro plantillas versionadas bajo
+`pwa/files/varios/` y una descarga con fuente y otra con fallback. Revertir la
+aplicación restaura el comportamiento previo para altas nuevas; no modifica los
+archivos ni registros ya creados.
+
+## Referencias
+
+- `comedores/services/certificacion_prestaciones_service.py`
+- `comedores/api_views.py`
+- `docs/registro/cambios/2026-08-13-certificaciones-prestaciones-sin-fuente.md`

--- a/docs/implementaciones/pwa_backend.md
+++ b/docs/implementaciones/pwa_backend.md
@@ -86,6 +86,8 @@ Servicios de dominio: `users/services_pwa.py`
     - `organizaciones_ids`
     - `must_change_password`
 - `POST /api/users/logout/`
+- `POST /api/users/password-reset/request/`
+- `POST /api/users/password-reset/confirm/`
   - invalida token actual.
 
 ### 2) Comedores / perfil de espacio
@@ -108,6 +110,30 @@ Fuentes de documentos consolidadas: foto legajo, imágenes de comedor, documenta
 - `GET /api/comedores/{id}/nomina/`
 - `POST /api/comedores/{id}/nomina/`
 - `PATCH /api/comedores/nomina/{nomina_id}/`
+
+Para programas cuya nómina se organiza por admisión, todos los flujos PWA usan
+exclusivamente la admisión resuelta por
+`ComedorService.get_admision_vigente_pwa`: listado, cupos, validaciones,
+asistencia y PDF mensual. Si no hay marca `vigente_pwa`, el servicio mantiene
+el fallback compatible a la admisión activa de mayor ID y luego a la admisión
+de mayor ID. Los programas de nómina directa consultan solo registros del
+comedor con `admision_id` nulo; no mezclan registros de admisiones históricas.
+
+### Recuperación de contraseña PWA
+
+- `POST /api/users/password-reset/request/` requiere `username` y `email`.
+  Responde de manera genérica y limita intentos por IP e identidad para no
+  revelar cuentas.
+- Solo se envía el enlace cuando ambos datos corresponden a un usuario PWA
+  activo. El enlace apunta a
+  `<PWA_BASE_URL>/password-reset-confirm?uid=...&token=...`.
+- `POST /api/users/password-reset/confirm/` recibe `uid`, `token` y
+  `new_password`; un reset exitoso elimina el requisito de cambiar la
+  contraseña inicial.
+
+`PWA_BASE_URL` debe configurarse con la URL pública de Mobile en cada ambiente.
+No se debe depender del `Origin` recibido en producción para construir enlaces
+de recuperación.
 
 ### 5) Prestación alimentaria
 

--- a/docs/implementaciones/usuarios_perfil_iam.md
+++ b/docs/implementaciones/usuarios_perfil_iam.md
@@ -96,6 +96,16 @@ Reglas actuales para usuarios con acceso PWA creados desde web:
   - `must_change_password` pasa a `False`;
   - se limpia `temporary_password_plaintext`.
 
+### Recuperación PWA
+
+El reseteo PWA reemplaza el reseteo administrativo con contraseña temporal. La
+solicitud API requiere el par `username` + `email`; si identifica a un usuario
+PWA activo, envía un enlace de recuperación a la URL pública configurada en
+`PWA_BASE_URL`. La respuesta no confirma si la cuenta existe y el endpoint
+aplica rate limit por IP e identidad. Ver también
+`docs/implementaciones/pwa_backend.md` para el contrato de request/confirmación
+y `docs/operacion/integraciones.md` para la configuración por ambiente.
+
 ### Mi cuenta y confirmación de datos personales
 
 - La autogestión de datos vive en `/mi-cuenta/`; el usuario solo puede editar

--- a/docs/indice.md
+++ b/docs/indice.md
@@ -45,6 +45,8 @@
 - `docs/implementaciones/filtros_avanzados.md`: comportamiento y consideraciones de filtros avanzados.
 - `docs/implementaciones/preferencias_columnas.md`: preferencias de columnas en listados.
 - `docs/implementaciones/pwa_backend.md`: implementación backend de funcionalidades PWA.
+- `docs/implementaciones/admisiones_informes_tecnicos.md`: contrato de campos, templates dinámicos y publicación de Informes Técnicos.
+- `docs/implementaciones/comedores_certificaciones_prestaciones.md`: generación, fallback y descarga de certificaciones de prestaciones.
 - `docs/implementaciones/usuarios_perfil_iam.md`: implementación de Usuarios/Perfil + IAM por permisos Django y guía para extender nuevas features.
 - `docs/implementaciones/centrodeinfancia_nomina_renaper.md`: contrato de asistencia de nómina CDI, alcance y precarga RENAPER de trabajadores.
 - `docs/implementaciones/centrodefamilia_preinscriptos.md`: contrato del listado y exportación CSV de preinscriptos CDF, incluyendo columnas, ordenamiento y permisos.
@@ -56,6 +58,7 @@
 - `docs/flujos/consulta_renaper.md`: integración con RENAPER para la consulta de datos ciudadanos.
 - `docs/flujos/cambio_programa_comedor.md`: procedimiento para cambiar programas asignados a comedores.
 - `docs/flujos/derivar_nomina_centros.md`: flujo y reglas para derivar beneficiarios entre centros (comedores y CDI).
+- `docs/flujos/rendiciones_mensuales_proyectos.md`: estados de revisión, subsanaciones y asociación de rendiciones a proyectos.
 - `docs/integraciones/ticketera_api.md`: contrato server-to-server de la API Ticketera (5 endpoints, dirigido al desarrollador de la Ticketera).
 
 ### 6. IA, planes y registro spec-as-source

--- a/docs/operacion/infraestructura.md
+++ b/docs/operacion/infraestructura.md
@@ -76,7 +76,7 @@
 
 - App runtime:
   - Python 3.11.9.
-  - Django 4.2.x + DRF.
+  - Django 5.2.16 + DRF 3.16.1.
   - Gunicorn en qa/homologacion/prd; runserver en dev.
 
 - Process model:

--- a/docs/operacion/integraciones.md
+++ b/docs/operacion/integraciones.md
@@ -17,3 +17,8 @@
 - RENAPER: cliente HTTP compartido en `core/integrations/renaper.py`, con autenticación efímera por consulta y fachada compatible en `core/services/renaper.py`; credenciales `RENAPER_API_*`, timeout y retries/backoff configurables. No persiste tokens en cache ni registra DNI, tokens o payloads remotos.
 - Google Maps: clave opcional `GOOGLE_MAPS_API_KEY`. Evidencia: config/settings.py:241.
 - Correo saliente: Django usa `send_mail` y puede operar con backend SMTP. Para Resend, la configuración recomendada es `EMAIL_BACKEND=django.core.mail.backends.smtp.EmailBackend`, `EMAIL_HOST=smtp.resend.com`, `EMAIL_PORT=587`, `EMAIL_HOST_USER=resend`, `EMAIL_HOST_PASSWORD=<API_KEY>`, `EMAIL_USE_TLS=true`, `EMAIL_USE_SSL=false` y un `DEFAULT_FROM_EMAIL` verificado en el proveedor. Si falta alguno de los datos críticos del SMTP, SISOC vuelve al backend de consola para no romper entornos locales. Evidencia: config/settings.py:189-242; users/services_auth.py:45-81.
+- Recuperación PWA: `PWA_BASE_URL` debe ser la URL pública del frontend Mobile
+  del ambiente, sin slash final. Se usa para construir enlaces de recuperación
+  con `uid` y `token`; en HML/PRD configurarla explícitamente antes de habilitar
+  el flujo y verificar que llegue al frontend esperado. Evidencia:
+  `users/services_auth.py` y `config/settings.py`.

--- a/docs/registro/README.md
+++ b/docs/registro/README.md
@@ -25,6 +25,34 @@ Ampliar solo si el cambio toca reglas funcionales, permisos, seguridad o comport
 - `docs/registro/decisiones/`
 - `YYYY-MM-DD-<tema>.md`
 
+## Artefactos obligatorios de pull request
+
+Cada PR debe conservar en su rama origen:
+
+- `docs/registro/prs/PR-<numero>.md`;
+- `docs/contexto/features/pr-<numero>-<slug>.md`.
+
+Cuando el destino es `main`, también debe incluir una nota en
+`docs/registro/releases/pending/` y el bloque correspondiente en
+`CHANGELOG.md`.
+
+Para ramas internas no protegidas, `.github/workflows/pr-docs.yml` genera y
+pushea estos archivos. Las ramas protegidas (`development`, `homologacion` y
+`main`) no se autoescriben: el mismo workflow verifica los artefactos ya
+versionados y bloquea el merge si faltan.
+
+En una promoción o cuando el bot no puede escribir la rama, generar de forma
+explícita antes de abrir o actualizar el PR:
+
+```powershell
+$env:GITHUB_TOKEN = gh auth token
+python scripts/ci/pr_doc_automation.py --repository dsocial118/SISOC --pr <numero>
+```
+
+Revisar y commitear únicamente los paths generados. Para una promoción a
+`main`, confirmar además que la release note y el bloque de `CHANGELOG.md`
+describen la fecha objetivo correcta.
+
 ## Cuando registrar
 
 - cambios funcionales visibles,

--- a/docs/registro/cambios/2026-08-18-gate-spec-as-source-promociones.md
+++ b/docs/registro/cambios/2026-08-18-gate-spec-as-source-promociones.md
@@ -1,0 +1,18 @@
+# Gate spec-as-source para promociones protegidas
+
+## Cambio
+
+`pr-docs.yml` mantiene la generación automática solo para ramas internas no
+protegidas. Su verificación ahora se ejecuta también para promociones desde
+`development`, `homologacion` o `main`: exige el registro de PR y el contexto
+de feature ya versionados.
+
+Cuando el destino es `main`, además exige la release note pendiente y
+`CHANGELOG.md`. De ese modo una promoción no puede omitir trazabilidad porque
+el bot no tenga permiso para escribir la rama protegida.
+
+## Operación
+
+El responsable de la promoción debe ejecutar el generador versionado, revisar
+los archivos resultantes y commitearlos antes de actualizar el PR. La guía
+completa está en `docs/registro/README.md`.

--- a/docs/registro/prs/PR-2258.md
+++ b/docs/registro/prs/PR-2258.md
@@ -1,0 +1,73 @@
+# PR #2258 - feat(celiaquia): contrato público de integración
+
+## Metadata
+
+- PR: https://github.com/dsocial118/SISOC/pull/2258
+- Base: `development`
+- Rama origen: `codex/issue-2242-celiaquia-public-contract`
+- Autor: `juanikitro`
+
+## Resumen operativo
+
+- Tipo de cambio: No informado
+- Área principal: No informada
+- Contexto funcional: No informado explícitamente; revisar título, diff y documentación relacionada.
+- Resumen para changelog: No informado
+- Impacto usuario: No informado
+
+## Áreas afectadas
+
+- `.github/workflows`
+- `.importlinter`
+- `.importlinter_celiaquia_config`
+- `AGENT_REPO_MAP.md`
+- `celiaquia`
+- `ciudadanos`
+- `config`
+- `docs/ia`
+- `docs/registro`
+- `tests`
+
+## Archivos relevantes del diff
+
+- `.github/workflows/architecture.yml`
+- `.importlinter`
+- `.importlinter_celiaquia_config`
+- `AGENT_REPO_MAP.md`
+- `celiaquia/api.py`
+- `celiaquia/apps.py`
+- `celiaquia/ciudadano_detail.py`
+- `celiaquia/global_urls.py`
+- `celiaquia/services/ciudadano_resumen_service/__init__.py`
+- `celiaquia/services/ciudadano_resumen_service/impl.py`
+- `celiaquia/tests/test_public_api.py`
+- `ciudadanos/templates/ciudadanos/ciudadano_detail.html`
+- `ciudadanos/views.py`
+- `config/urls.py`
+- `docs/ia/MODULAR_BOUNDARIES.md`
+- `docs/registro/decisiones/2026-08-07-contrato-publico-celiaquia.md`
+- `tests/test_ciudadanos_templates_unit.py`
+- `tests/test_ciudadanos_views_unit.py`
+
+## Validación declarada
+
+- Pruebas automáticas: No informado en el PR.
+- Pruebas manuales: No informado en el PR.
+
+## Riesgos y rollback
+
+- No informado explícitamente en el PR.
+
+## Documentación sugerida para lectura
+
+- `docs/indice.md`
+- `docs/ia/CONTEXT_HYGIENE.md`
+- `docs/ia/ARCHITECTURE.md`
+- `docs/ia/TESTING.md`
+- `docs/ia/MODULAR_BOUNDARIES.md`
+- `docs/registro/decisiones/2026-08-07-contrato-publico-celiaquia.md`
+
+## Notas para continuidad
+
+- Este documento es generado automáticamente desde el contexto del PR y sirve como índice rápido para revisión y futuras sesiones de agentes.
+- Si la metadata del body del PR está incompleta, varias secciones usarán fallbacks derivados del título o del diff.

--- a/docs/registro/prs/PR-2263.md
+++ b/docs/registro/prs/PR-2263.md
@@ -1,0 +1,97 @@
+# PR #2263 - docs(spec): completar trazabilidad de PRs y guías canónicas
+
+## Metadata
+
+- PR: https://github.com/dsocial118/SISOC/pull/2263
+- Base: `development`
+- Rama origen: `codex/spec-as-source-backfill-20260810`
+- Autor: `juanikitro`
+
+## Resumen operativo
+
+- Tipo de cambio: No informado
+- Área principal: No informada
+- Contexto funcional: No informado explícitamente; revisar título, diff y documentación relacionada.
+- Resumen para changelog: No informado
+- Impacto usuario: No informado
+
+## Áreas afectadas
+
+- `docs/contexto`
+- `docs/flujos`
+- `docs/implementaciones`
+- `docs/registro`
+
+## Archivos relevantes del diff
+
+- `docs/contexto/features/pr-2222-feat-comedores-agregar-etiqueta-caritas.md`
+- `docs/contexto/features/pr-2227-chore-deps-migrar-django-4-2-a-5-2-lts.md`
+- `docs/contexto/features/pr-2228-fix-iam-restringe-accesos-de-ciudadanos-y-acompanamiento.md`
+- `docs/contexto/features/pr-2230-comedores-cambios-en-filtros-ordenamiento-columnas.md`
+- `docs/contexto/features/pr-2231-style-templates-corrige-formato-para-promocion-a-homologacion.md`
+- `docs/contexto/features/pr-2235-issues-1961-2005-2076-2079-y-2188.md`
+- `docs/contexto/features/pr-2237-ui-buscadores.md`
+- `docs/contexto/features/pr-2253-refactor-architecture-completar-ratchet-de-fase-0.md`
+- `docs/contexto/features/pr-2255-fixes-post-revision-issues-1961-2076-2079-y-2188.md`
+- `docs/contexto/features/pr-2260-cdi-nomina-restriccion.md`
+- `docs/contexto/features/pr-2261-mi-cuenta.md`
+- `docs/flujos/derivar_nomina_centros.md`
+- `docs/implementaciones/centrodeinfancia_nomina_renaper.md`
+- `docs/implementaciones/usuarios_perfil_iam.md`
+- `docs/registro/prs/PR-2222.md`
+- `docs/registro/prs/PR-2227.md`
+- `docs/registro/prs/PR-2228.md`
+- `docs/registro/prs/PR-2230.md`
+- `docs/registro/prs/PR-2231.md`
+- `docs/registro/prs/PR-2235.md`
+- `docs/registro/prs/PR-2237.md`
+- `docs/registro/prs/PR-2253.md`
+- `docs/registro/prs/PR-2255.md`
+- `docs/registro/prs/PR-2260.md`
+- `docs/registro/prs/PR-2261.md`
+
+## Validación declarada
+
+- Pruebas automáticas: No informado en el PR.
+- Pruebas manuales: No informado en el PR.
+
+## Riesgos y rollback
+
+- No informado explícitamente en el PR.
+
+## Documentación sugerida para lectura
+
+- `docs/indice.md`
+- `docs/ia/CONTEXT_HYGIENE.md`
+- `docs/ia/ARCHITECTURE.md`
+- `docs/ia/TESTING.md`
+- `docs/contexto/features/pr-2222-feat-comedores-agregar-etiqueta-caritas.md`
+- `docs/contexto/features/pr-2227-chore-deps-migrar-django-4-2-a-5-2-lts.md`
+- `docs/contexto/features/pr-2228-fix-iam-restringe-accesos-de-ciudadanos-y-acompanamiento.md`
+- `docs/contexto/features/pr-2230-comedores-cambios-en-filtros-ordenamiento-columnas.md`
+- `docs/contexto/features/pr-2231-style-templates-corrige-formato-para-promocion-a-homologacion.md`
+- `docs/contexto/features/pr-2235-issues-1961-2005-2076-2079-y-2188.md`
+- `docs/contexto/features/pr-2237-ui-buscadores.md`
+- `docs/contexto/features/pr-2253-refactor-architecture-completar-ratchet-de-fase-0.md`
+- `docs/contexto/features/pr-2255-fixes-post-revision-issues-1961-2076-2079-y-2188.md`
+- `docs/contexto/features/pr-2260-cdi-nomina-restriccion.md`
+- `docs/contexto/features/pr-2261-mi-cuenta.md`
+- `docs/flujos/derivar_nomina_centros.md`
+- `docs/implementaciones/centrodeinfancia_nomina_renaper.md`
+- `docs/implementaciones/usuarios_perfil_iam.md`
+- `docs/registro/prs/PR-2222.md`
+- `docs/registro/prs/PR-2227.md`
+- `docs/registro/prs/PR-2228.md`
+- `docs/registro/prs/PR-2230.md`
+- `docs/registro/prs/PR-2231.md`
+- `docs/registro/prs/PR-2235.md`
+- `docs/registro/prs/PR-2237.md`
+- `docs/registro/prs/PR-2253.md`
+- `docs/registro/prs/PR-2255.md`
+- `docs/registro/prs/PR-2260.md`
+- `docs/registro/prs/PR-2261.md`
+
+## Notas para continuidad
+
+- Este documento es generado automáticamente desde el contexto del PR y sirve como índice rápido para revisión y futuras sesiones de agentes.
+- Si la metadata del body del PR está incompleta, varias secciones usarán fallbacks derivados del título o del diff.

--- a/docs/registro/prs/PR-2265.md
+++ b/docs/registro/prs/PR-2265.md
@@ -1,0 +1,51 @@
+# PR #2265 - Fixs
+
+## Metadata
+
+- PR: https://github.com/dsocial118/SISOC/pull/2265
+- Base: `development`
+- Rama origen: `Bug-visual-2226`
+- Autor: `nehuen871`
+
+## Resumen operativo
+
+- Tipo de cambio: No informado
+- Área principal: No informada
+- Contexto funcional: No informado explícitamente; revisar título, diff y documentación relacionada.
+- Resumen para changelog: No informado
+- Impacto usuario: No informado
+
+## Áreas afectadas
+
+- `comedores`
+- `docs/registro`
+- `static`
+
+## Archivos relevantes del diff
+
+- `comedores/test_comedor_form_select2_layout.py`
+- `docs/registro/cambios/2026-08-10-select2-formulario-comedores.md`
+- `static/custom/css/comedorFormModerno.css`
+- `static/custom/js/comedorFormModerno.js`
+
+## Validación declarada
+
+- Pruebas automáticas: No informado en el PR.
+- Pruebas manuales: No informado en el PR.
+
+## Riesgos y rollback
+
+- No informado explícitamente en el PR.
+
+## Documentación sugerida para lectura
+
+- `docs/indice.md`
+- `docs/ia/CONTEXT_HYGIENE.md`
+- `docs/ia/ARCHITECTURE.md`
+- `docs/ia/TESTING.md`
+- `docs/registro/cambios/2026-08-10-select2-formulario-comedores.md`
+
+## Notas para continuidad
+
+- Este documento es generado automáticamente desde el contexto del PR y sirve como índice rápido para revisión y futuras sesiones de agentes.
+- Si la metadata del body del PR está incompleta, varias secciones usarán fallbacks derivados del título o del diff.

--- a/docs/registro/prs/PR-2266.md
+++ b/docs/registro/prs/PR-2266.md
@@ -1,0 +1,93 @@
+# PR #2266 - refactor(core): centralizar integración RENAPER
+
+## Metadata
+
+- PR: https://github.com/dsocial118/SISOC/pull/2266
+- Base: `development`
+- Rama origen: `codex/issue-2243-shared-renaper`
+- Autor: `juanikitro`
+
+## Resumen operativo
+
+- Tipo de cambio: No informado
+- Área principal: No informada
+- Contexto funcional: No informado explícitamente; revisar título, diff y documentación relacionada.
+- Resumen para changelog: No informado
+- Impacto usuario: No informado
+
+## Áreas afectadas
+
+- `.env.example`
+- `.importlinter`
+- `AGENT_REPO_MAP.md`
+- `VAT`
+- `celiaquia`
+- `centrodefamilia`
+- `comedores`
+- `config`
+- `core`
+- `docs/contexto`
+- `docs/flujos`
+- `docs/ia`
+- `docs/indice.md`
+- `docs/operacion`
+- `docs/registro`
+- `tests`
+
+## Archivos relevantes del diff
+
+- `.env.example`
+- `.importlinter`
+- `AGENT_REPO_MAP.md`
+- `VAT/services/consulta_renaper/__init__.py`
+- `VAT/services/consulta_renaper/impl.py`
+- `celiaquia/views/validacion_renaper.py`
+- `centrodefamilia/apps.py`
+- `centrodefamilia/services/beneficiarios_service/impl.py`
+- `centrodefamilia/services/consulta_renaper/__init__.py`
+- `centrodefamilia/services/consulta_renaper/impl.py`
+- `comedores/services/comedor_service/impl.py`
+- `config/settings.py`
+- `core/api_views.py`
+- `core/integrations/__init__.py`
+- `core/integrations/renaper.py`
+- `core/services/renaper.py`
+- `docs/contexto/arquitectura.md`
+- `docs/contexto/panorama.md`
+- `docs/flujos/consulta_renaper.md`
+- `docs/ia/MODULAR_BOUNDARIES.md`
+- `docs/indice.md`
+- `docs/operacion/integraciones.md`
+- `docs/registro/decisiones/2026-08-10-integracion-renaper-compartida.md`
+- `tests/test_comedor_service_renaper_helpers_unit.py`
+- `tests/test_consulta_renaper_unit.py`
+- `tests/test_core_renaper_api_unit.py`
+- `tests/test_settings_unit.py`
+- `tests/test_validacion_renaper_view_unit.py`
+
+## Validación declarada
+
+- Pruebas automáticas: No informado en el PR.
+- Pruebas manuales: No informado en el PR.
+
+## Riesgos y rollback
+
+- No informado explícitamente en el PR.
+
+## Documentación sugerida para lectura
+
+- `docs/indice.md`
+- `docs/ia/CONTEXT_HYGIENE.md`
+- `docs/ia/ARCHITECTURE.md`
+- `docs/ia/TESTING.md`
+- `docs/contexto/arquitectura.md`
+- `docs/contexto/panorama.md`
+- `docs/flujos/consulta_renaper.md`
+- `docs/ia/MODULAR_BOUNDARIES.md`
+- `docs/operacion/integraciones.md`
+- `docs/registro/decisiones/2026-08-10-integracion-renaper-compartida.md`
+
+## Notas para continuidad
+
+- Este documento es generado automáticamente desde el contexto del PR y sirve como índice rápido para revisión y futuras sesiones de agentes.
+- Si la metadata del body del PR está incompleta, varias secciones usarán fallbacks derivados del título o del diff.

--- a/docs/registro/prs/PR-2303.md
+++ b/docs/registro/prs/PR-2303.md
@@ -1,0 +1,95 @@
+# PR #2303 - docs(spec): corregir trazabilidad y guías canónicas
+
+## Metadata
+
+- PR: https://github.com/dsocial118/SISOC/pull/2303
+- Base: `development`
+- Rama origen: `codex/spec-as-source-fix-20260818`
+- Autor: `juanikitro`
+
+## Resumen operativo
+
+- Tipo de cambio: No informado
+- Área principal: No informada
+- Contexto funcional: No informado explícitamente; revisar título, diff y documentación relacionada.
+- Resumen para changelog: No informado
+- Impacto usuario: No informado
+
+## Áreas afectadas
+
+- `.github/workflows`
+- `AGENT_REPO_MAP.md`
+- `docs/contexto`
+- `docs/flujos`
+- `docs/implementaciones`
+- `docs/indice.md`
+- `docs/operacion`
+- `docs/registro`
+- `docs/seguridad`
+- `tests`
+
+## Archivos relevantes del diff
+
+- `.github/workflows/pr-docs.yml`
+- `AGENT_REPO_MAP.md`
+- `docs/contexto/aplicaciones.md`
+- `docs/contexto/features/pr-2258-feat-celiaquia-contrato-publico-de-integracion.md`
+- `docs/contexto/features/pr-2263-docs-spec-completar-trazabilidad-de-prs-y-guias-canonicas.md`
+- `docs/contexto/features/pr-2265-fixs.md`
+- `docs/contexto/features/pr-2266-refactor-core-centralizar-integracion-renaper.md`
+- `docs/flujos/rendiciones_mensuales_proyectos.md`
+- `docs/implementaciones/admisiones_informes_tecnicos.md`
+- `docs/implementaciones/comedores_certificaciones_prestaciones.md`
+- `docs/implementaciones/pwa_backend.md`
+- `docs/implementaciones/usuarios_perfil_iam.md`
+- `docs/indice.md`
+- `docs/operacion/infraestructura.md`
+- `docs/operacion/integraciones.md`
+- `docs/registro/README.md`
+- `docs/registro/cambios/2026-08-18-gate-spec-as-source-promociones.md`
+- `docs/registro/prs/PR-2258.md`
+- `docs/registro/prs/PR-2263.md`
+- `docs/registro/prs/PR-2265.md`
+- `docs/registro/prs/PR-2266.md`
+- `docs/seguridad/security_baseline.md`
+- `tests/test_pr_doc_automation_unit.py`
+
+## Validación declarada
+
+- Pruebas automáticas: No informado en el PR.
+- Pruebas manuales: No informado en el PR.
+
+## Riesgos y rollback
+
+- No informado explícitamente en el PR.
+
+## Documentación sugerida para lectura
+
+- `docs/indice.md`
+- `docs/ia/CONTEXT_HYGIENE.md`
+- `docs/ia/ARCHITECTURE.md`
+- `docs/ia/TESTING.md`
+- `docs/contexto/aplicaciones.md`
+- `docs/contexto/features/pr-2258-feat-celiaquia-contrato-publico-de-integracion.md`
+- `docs/contexto/features/pr-2263-docs-spec-completar-trazabilidad-de-prs-y-guias-canonicas.md`
+- `docs/contexto/features/pr-2265-fixs.md`
+- `docs/contexto/features/pr-2266-refactor-core-centralizar-integracion-renaper.md`
+- `docs/flujos/rendiciones_mensuales_proyectos.md`
+- `docs/implementaciones/admisiones_informes_tecnicos.md`
+- `docs/implementaciones/comedores_certificaciones_prestaciones.md`
+- `docs/implementaciones/pwa_backend.md`
+- `docs/implementaciones/usuarios_perfil_iam.md`
+- `docs/operacion/infraestructura.md`
+- `docs/operacion/integraciones.md`
+- `docs/registro/README.md`
+- `docs/registro/cambios/2026-08-18-gate-spec-as-source-promociones.md`
+- `docs/registro/prs/PR-2258.md`
+- `docs/registro/prs/PR-2263.md`
+- `docs/registro/prs/PR-2265.md`
+- `docs/registro/prs/PR-2266.md`
+- `docs/seguridad/security_baseline.md`
+
+## Notas para continuidad
+
+- Este documento es generado automáticamente desde el contexto del PR y sirve como índice rápido para revisión y futuras sesiones de agentes.
+- Si la metadata del body del PR está incompleta, varias secciones usarán fallbacks derivados del título o del diff.

--- a/docs/seguridad/security_baseline.md
+++ b/docs/seguridad/security_baseline.md
@@ -1,7 +1,7 @@
 # Security Baseline - BACKOFFICE (Django/DRF)
 
 ## Alcance
-- Backend: Django 4.2.27 + DRF 3.15.2 (ver `requirements.txt`)
+- Backend: Django 5.2.16 + DRF 3.16.1 (ver `requirements/base.txt`)
 - Autenticacion API: API Keys via `djangorestframework-api-key==3.0.0`
 - Autenticacion web: sesiones Django (`SessionAuthentication`)
 - DB: MySQL 8.0 (Docker Compose)

--- a/tests/test_pr_doc_automation_unit.py
+++ b/tests/test_pr_doc_automation_unit.py
@@ -40,12 +40,11 @@ def test_pr_docs_workflow_detecta_artefactos_nuevos_no_trackeados():
     assert "ref: ${{ github.event.pull_request.base.sha }}" in workflow
     assert "needs: generate_pr_artifacts" in workflow
     assert "if: always()" in workflow
-    assert (
-        "if: always() && github.event.pull_request.head.ref != 'development'"
-        in workflow
-    )
+    assert "Las ramas protegidas no se autoescriben" in workflow
     assert "refs/pull/${{ github.event.pull_request.number }}/head" in workflow
     assert "git ls-tree -r --name-only refs/remotes/origin/pr-head" in workflow
+    assert "docs/registro/releases/pending" in workflow
+    assert "github.event.pull_request.base.ref" in workflow
     assert "Faltan artefactos spec-as-source requeridos para mergear." in workflow
     assert "exit 1" in workflow
 


### PR DESCRIPTION
## Qué cambia

- Backfill de los artefactos spec-as-source para los PR #2258, #2263, #2265 y #2266.
- Guías canónicas e índices para PWA, Informes Técnicos, rendiciones y certificaciones de prestaciones.
- Corrección de referencias operativas a Django 5.2.16 y la configuración de recuperación PWA.
- `pr-docs.yml` verifica promociones desde ramas protegidas y exige release note más changelog para PRs hacia `main`, sin autoescribir esas ramas.

## Motivo

La auditoría detectó cambios funcionales documentados solo en registros, huecos de trazabilidad y una excepción no controlada en promociones protegidas.

## Validación

- Generación exitosa de los cuatro pares PR/feature con `scripts/ci/pr_doc_automation.py`.
- `git diff --check` y compilación Python de los archivos de automatización/tests.
- Comprobación estática del contrato nuevo en `pr-docs.yml`.
- El test focalizado no pudo ejecutarse: Docker no está disponible y la `.venv` local no incluye `pytest`.