### PR TITLE
feat(centrodeinfancia): descargar nómina provincial de niños [HML]

### DIFF
--- a/AGENT_REPO_MAP.md
+++ b/AGENT_REPO_MAP.md
@@ -283,7 +283,7 @@ La siguiente tabla mezcla hechos observados con inferencias explicitas cuando no
 | `ticketera/` | API server-to-server con kill-switch | `api_urls.py`, `api_views.py`, `api_serializers.py` | Medio |
 | `comunicados/` | mensajes/comunicados y API asociada | `models.py`, `views.py`, `api_views.py`, forms | Medio |
 | `organizaciones/` | entidades/organizaciones vinculadas; edición modal de proyectos y detalle con rendiciones por relación directa o legado | `models.py`, `forms.py`, `views.py`, templates de organización | Alto |
-| `centrodeinfancia/` | dominio de centros de infancia, personal y asistencia | `models.py`, `services.py`, `views.py`, `tests/`, urls | Alto |
+| `centrodeinfancia/` | dominio de centros de infancia, personal, asistencia y descargables provinciales | `models.py`, `services.py`, `services_nomina_ninos_pdf.py`, `views.py`, `tests/`, urls | Alto |
 | `acompanamientos/` | seguimiento/acompanamientos | `views.py`, `acompanamiento_service.py`, `services/filter_config.py`, templates | Medio |
 | `expedientespagos/` | expedientes de pagos | `models.py`, `views.py`, urls | Bajo |
 | `rendicioncuentasfinal/` | rendicion final | `models.py`, `views.py`, urls | Bajo |
@@ -509,6 +509,11 @@ La siguiente tabla mezcla hechos observados con inferencias explicitas cuando no
 - plantillas versionadas: `pwa/files/varios/PROGRAMA.ALIMENTAR.COMUNIDAD.docx` y `pwa/files/varios/NOMINA.DE.DESTINATARIOS.docx`
 - certificación de prestaciones: `comedores/services/certificacion_prestaciones_service.py`
 - nómina de destinatarios: `pwa/services/nomina_destinatarios_pdf_service.py`
+- descarga provincial de niños SIMEPI: endpoint
+  `centrodeinfancia_nomina_ninos_pdf`, servicio
+  `centrodeinfancia/services_nomina_ninos_pdf.py` y pruebas
+  `centrodeinfancia/tests/test_nomina_ninos_pdf.py`; exige grupo `SIMEPI - EGP`
+  y un único alcance provincial completo, y entrega un JPEG por página
 - conversión e incrustación de Office en rendiciones: `rendicioncuentasmensual/service_helpers.py`
 - el runtime Django requiere LibreOffice Writer/Calc para convertir DOCX/XLSX a PDF
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 
 - [sin-area] fix(admisiones): autorizar transferencias issue 2272. (PR #2296)
 - [sin-area] fix(users): quitar declaración de confirmación de datos. (PR #2300)
+- [sin-area] feat(centrodeinfancia): descargar nómina provincial de niños. (PR #2308)
 <!-- AUTO-GENERATED RELEASE END: 2026-08-19 -->
 
 <!-- AUTO-GENERATED RELEASE START: 2026-08-13 -->

--- a/centrodeinfancia/access.py
+++ b/centrodeinfancia/access.py
@@ -7,12 +7,30 @@ from users.models import Profile
 from users.services_delegation import effective_delegatable_groups_qs
 from users.territorial_scope import (
     apply_territorial_scope,
+    get_effective_scopes,
     get_single_full_province_scope_id,
     is_territorial_user,
     user_can_access_territory,
 )
 
 GRUPO_CDI_REFERENTE_CENTRO = UserGroups.CDI_REFERENTE_CENTRO
+
+
+def es_egp_simepi(user):
+    """Indica si el usuario tiene el rol provincial habilitado para la descarga."""
+    if not user or not getattr(user, "is_authenticated", False):
+        return False
+    return user.groups.filter(name=UserGroups.SIMEPI_EGP).exists()
+
+
+def get_provincia_completa_unica_egp_id(user):
+    """Devuelve la provincia sólo para un EGP con un único alcance completo."""
+    if not es_egp_simepi(user):
+        return None
+    scopes = get_effective_scopes(user)
+    if len(scopes) != 1 or not scopes[0].is_full_province:
+        return None
+    return scopes[0].provincia_id
 
 
 def actor_puede_delegar_grupo_nombre(user, grupo_nombre):

--- a/centrodeinfancia/services_nomina_ninos_pdf.py
+++ b/centrodeinfancia/services_nomina_ninos_pdf.py
@@ -110,13 +110,9 @@ def _date_text(value):
 
 def _normalize(value):
     normalized = unicodedata.normalize("NFKD", str(value or ""))
-    return (
-        " ".join(
-            "".join(
-                char for char in normalized if not unicodedata.combining(char)
-            ).split()
-        ).casefold()
-    )
+    return " ".join(
+        "".join(char for char in normalized if not unicodedata.combining(char)).split()
+    ).casefold()
 
 
 def _calculate_age(birth_date, unit, as_of):
@@ -124,8 +120,10 @@ def _calculate_age(birth_date, unit, as_of):
         return None
     if birth_date > as_of:
         return None
-    years = as_of.year - birth_date.year - (
-        (as_of.month, as_of.day) < (birth_date.month, birth_date.day)
+    years = (
+        as_of.year
+        - birth_date.year
+        - ((as_of.month, as_of.day) < (birth_date.month, birth_date.day))
     )
     if unit == "anios":
         return years
@@ -160,9 +158,11 @@ def _build_adult_validation_map(documentos):
     ).values_list("documento", "estado_validacion_renaper"):
         matches[str(documento)].append(estado)
     return {
-        documento: "Sí"
-        if len(estados) == 1 and estados[0] == Ciudadano.RENAPER_VALIDADO
-        else "No"
+        documento: (
+            "Sí"
+            if len(estados) == 1 and estados[0] == Ciudadano.RENAPER_VALIDADO
+            else "No"
+        )
         for documento, estados in matches.items()
     }
 
@@ -353,12 +353,7 @@ def _register_fonts():
 
 
 def _escape_paragraph(value):
-    return (
-        str(value)
-        .replace("&", "&amp;")
-        .replace("<", "&lt;")
-        .replace(">", "&gt;")
-    )
+    return str(value).replace("&", "&amp;").replace("<", "&lt;").replace(">", "&gt;")
 
 
 def _paragraph(value, style):

--- a/centrodeinfancia/services_nomina_ninos_pdf.py
+++ b/centrodeinfancia/services_nomina_ninos_pdf.py
@@ -1,0 +1,623 @@
+from __future__ import annotations
+
+import logging
+import os
+import unicodedata
+from collections import defaultdict
+from dataclasses import dataclass
+from datetime import datetime
+from io import BytesIO
+from tempfile import TemporaryDirectory
+
+from django.core.exceptions import ObjectDoesNotExist
+from django.utils import timezone
+from pdf2image import convert_from_bytes
+from reportlab.lib import colors
+from reportlab.lib.enums import TA_CENTER, TA_LEFT
+from reportlab.lib.pagesizes import A4, landscape
+from reportlab.lib.styles import ParagraphStyle, getSampleStyleSheet
+from reportlab.lib.utils import ImageReader
+from reportlab.pdfbase import pdfmetrics
+from reportlab.pdfbase.ttfonts import TTFont
+from reportlab.pdfgen import canvas
+from reportlab.platypus import (
+    PageBreak,
+    Paragraph,
+    SimpleDocTemplate,
+    Spacer,
+    Table,
+    TableStyle,
+)
+
+from ciudadanos.models import Ciudadano
+from centrodeinfancia.models import AccesoCDI, NominaCentroInfancia
+
+
+logger = logging.getLogger(__name__)
+
+PAGE_SIZE = landscape(A4)
+PAGE_MARGIN = 18
+TABLE_FONT_SIZE = 9
+FONT_REGULAR = "Helvetica"
+FONT_BOLD = "Helvetica-Bold"
+AGE_MEASURE_LABELS = {"meses": "Meses", "anios": "Años"}
+
+
+class NominaNinosPDFError(Exception):
+    """Error controlado durante la construcción del descargable."""
+
+
+@dataclass(frozen=True)
+class NinoRow:
+    centro_id: int
+    apellido: str
+    nombre: str
+    dni: str
+    fecha_nacimiento: str
+    edad: str
+    medida: str
+    sexo: str
+    renaper_nino: str
+    adulto_apellido: str
+    adulto_nombre: str
+    adulto_cuit: str
+    adulto_fecha_nacimiento: str
+    adulto_renaper: str
+    sort_key: tuple
+
+
+@dataclass(frozen=True)
+class CDIGroup:
+    centro_id: int
+    codigo: str
+    nombre: str
+    referente: str
+    referente_cuil: str
+    rows: tuple[NinoRow, ...]
+
+
+@dataclass(frozen=True)
+class ExportData:
+    provincia: str
+    usuario: str
+    rol: str
+    usuario_cuil: str
+    generado_en: datetime
+    centros: tuple[CDIGroup, ...]
+
+    @property
+    def total_ninos(self):
+        return sum(len(centro.rows) for centro in self.centros)
+
+
+def _value(primary, fallback=None):
+    if primary not in (None, ""):
+        return primary
+    return fallback
+
+
+def _text(value):
+    if value in (None, ""):
+        return "-"
+    return str(value).strip() or "-"
+
+
+def _date_text(value):
+    if not value:
+        return "-"
+    return value.strftime("%d/%m/%Y")
+
+
+def _normalize(value):
+    normalized = unicodedata.normalize("NFKD", str(value or ""))
+    return (
+        " ".join(
+            "".join(
+                char for char in normalized if not unicodedata.combining(char)
+            ).split()
+        ).casefold()
+    )
+
+
+def _calculate_age(birth_date, unit, as_of):
+    if not birth_date or unit not in {"meses", "anios"}:
+        return None
+    if birth_date > as_of:
+        return None
+    years = as_of.year - birth_date.year - (
+        (as_of.month, as_of.day) < (birth_date.month, birth_date.day)
+    )
+    if unit == "anios":
+        return years
+    return (
+        (as_of.year - birth_date.year) * 12
+        + as_of.month
+        - birth_date.month
+        - (as_of.day < birth_date.day)
+    )
+
+
+def _document_sort_key(value):
+    digits = str(value or "").strip()
+    if digits.isdigit():
+        return 0, int(digits)
+    return 1, digits
+
+
+def _get_profile_cuil(user):
+    try:
+        return _text(user.profile.cuil)
+    except (AttributeError, ObjectDoesNotExist):
+        return "-"
+
+
+def _build_adult_validation_map(documentos):
+    matches = defaultdict(list)
+    if not documentos:
+        return {}
+    for documento, estado in Ciudadano.objects.filter(
+        documento__in=documentos
+    ).values_list("documento", "estado_validacion_renaper"):
+        matches[str(documento)].append(estado)
+    return {
+        documento: "Sí"
+        if len(estados) == 1 and estados[0] == Ciudadano.RENAPER_VALIDADO
+        else "No"
+        for documento, estados in matches.items()
+    }
+
+
+def _build_referent_cuil_map(centros):
+    center_by_id = {centro.pk: centro for centro in centros}
+    matches = defaultdict(list)
+    accesos = AccesoCDI.objects.filter(
+        centro_id__in=center_by_id,
+        activo=True,
+    ).select_related("user", "user__profile")
+    for acceso in accesos:
+        centro = center_by_id[acceso.centro_id]
+        expected_email = _normalize(centro.email_referente)
+        if expected_email and _normalize(acceso.user.email) == expected_email:
+            matches[centro.pk].append(_get_profile_cuil(acceso.user))
+    return {
+        centro_id: values[0] if len(values) == 1 else "-"
+        for centro_id, values in matches.items()
+    }
+
+
+def _resolved_child_fields(registro):
+    ciudadano = registro.ciudadano
+    apellido = _value(registro.apellido, ciudadano.apellido)
+    nombre = _value(registro.nombre, ciudadano.nombre)
+    dni = _value(registro.dni, ciudadano.documento)
+    birth_date = _value(registro.fecha_nacimiento, ciudadano.fecha_nacimiento)
+    sexo = _value(registro.sexo, ciudadano.sexo if ciudadano.sexo_id else None)
+    return apellido, nombre, dni, birth_date, sexo
+
+
+def _deduplicate_registros(registros):
+    selected = []
+    seen = set()
+    duplicate_count = 0
+    for registro in registros:
+        apellido, nombre, dni, birth_date, sexo = _resolved_child_fields(registro)
+        key = (
+            _normalize(apellido),
+            _normalize(nombre),
+            str(dni or ""),
+            birth_date.isoformat() if birth_date else "",
+            _normalize(sexo),
+        )
+        if key in seen:
+            duplicate_count += 1
+            continue
+        seen.add(key)
+        selected.append(registro)
+    return selected, duplicate_count
+
+
+def build_export_data(  # pylint: disable=too-many-locals
+    *, user, provincia, generado_en=None
+):
+    generado_en = timezone.localtime(generado_en or timezone.now())
+    registros = list(
+        NominaCentroInfancia.objects.filter(
+            centro__provincia=provincia,
+            estado=NominaCentroInfancia.ESTADO_ACTIVO,
+        )
+        .select_related("centro", "ciudadano", "ciudadano__sexo")
+        .order_by("-fecha", "-id")
+    )
+    registros, duplicate_count = _deduplicate_registros(registros)
+    if duplicate_count:
+        logger.warning(
+            "Se omitieron filas duplicadas de la nómina provincial",
+            extra={
+                "data": {
+                    "provincia_id": provincia.pk,
+                    "duplicados": duplicate_count,
+                }
+            },
+        )
+
+    adult_documents = {
+        str(registro.responsable_legal_1_dni)
+        for registro in registros
+        if registro.responsable_legal_1_dni
+    }
+    adult_validation = _build_adult_validation_map(adult_documents)
+    centros = {registro.centro_id: registro.centro for registro in registros}
+    referent_cuils = _build_referent_cuil_map(centros.values())
+    rows_by_center = defaultdict(list)
+    as_of = generado_en.date()
+
+    for registro in registros:
+        apellido, nombre, dni, birth_date, sexo = _resolved_child_fields(registro)
+        age = _calculate_age(birth_date, registro.edad_unidad, as_of)
+        medida = AGE_MEASURE_LABELS.get(registro.edad_unidad, "-")
+        measure_rank = {"meses": 0, "anios": 1}.get(registro.edad_unidad, 2)
+        age_rank = age if age is not None else 10**9
+        dni_text = _text(dni)
+        row = NinoRow(
+            centro_id=registro.centro_id,
+            apellido=_text(apellido),
+            nombre=_text(nombre),
+            dni=dni_text,
+            fecha_nacimiento=_date_text(birth_date),
+            edad=_text(age),
+            medida=_text(medida),
+            sexo=_text(sexo),
+            renaper_nino=(
+                "Sí"
+                if registro.ciudadano.estado_validacion_renaper
+                == Ciudadano.RENAPER_VALIDADO
+                else "No"
+            ),
+            adulto_apellido=_text(registro.responsable_legal_1_apellido),
+            adulto_nombre=_text(registro.responsable_legal_1_nombre),
+            adulto_cuit=_text(registro.responsable_legal_1_cuit),
+            adulto_fecha_nacimiento=_date_text(
+                registro.responsable_legal_1_fecha_nacimiento
+            ),
+            adulto_renaper=adult_validation.get(
+                str(registro.responsable_legal_1_dni),
+                "No",
+            ),
+            sort_key=(
+                measure_rank,
+                age_rank,
+                _normalize(apellido),
+                _normalize(nombre),
+                _document_sort_key(dni),
+                registro.pk,
+            ),
+        )
+        rows_by_center[registro.centro_id].append(row)
+
+    cdi_groups = []
+    for centro_id, centro in sorted(
+        centros.items(),
+        key=lambda item: (_normalize(item[1].nombre), item[0]),
+    ):
+        rows = tuple(sorted(rows_by_center[centro_id], key=lambda row: row.sort_key))
+        referente = " ".join(
+            part
+            for part in (centro.apellido_referente, centro.nombre_referente)
+            if part
+        )
+        cdi_groups.append(
+            CDIGroup(
+                centro_id=centro_id,
+                codigo=_text(centro.codigo_cdi),
+                nombre=_text(centro.nombre),
+                referente=_text(referente),
+                referente_cuil=referent_cuils.get(centro_id, "-"),
+                rows=rows,
+            )
+        )
+
+    return ExportData(
+        provincia=_text(provincia.nombre),
+        usuario=_text(user.get_username()),
+        rol="SIMEPI - EGP",
+        usuario_cuil=_get_profile_cuil(user),
+        generado_en=generado_en,
+        centros=tuple(cdi_groups),
+    )
+
+
+def _register_fonts():
+    global FONT_REGULAR, FONT_BOLD
+    if "SISOCArial" in pdfmetrics.getRegisteredFontNames():
+        FONT_REGULAR = "SISOCArial"
+        FONT_BOLD = "SISOCArial-Bold"
+        return
+    candidates = (
+        (
+            "/usr/share/fonts/truetype/liberation2/LiberationSans-Regular.ttf",
+            "/usr/share/fonts/truetype/liberation2/LiberationSans-Bold.ttf",
+        ),
+        (
+            "/usr/share/fonts/truetype/liberation/LiberationSans-Regular.ttf",
+            "/usr/share/fonts/truetype/liberation/LiberationSans-Bold.ttf",
+        ),
+        ("C:/Windows/Fonts/arial.ttf", "C:/Windows/Fonts/arialbd.ttf"),
+    )
+    for regular_path, bold_path in candidates:
+        if os.path.exists(regular_path) and os.path.exists(bold_path):
+            pdfmetrics.registerFont(TTFont("SISOCArial", regular_path))
+            pdfmetrics.registerFont(TTFont("SISOCArial-Bold", bold_path))
+            FONT_REGULAR = "SISOCArial"
+            FONT_BOLD = "SISOCArial-Bold"
+            return
+
+
+def _escape_paragraph(value):
+    return (
+        str(value)
+        .replace("&", "&amp;")
+        .replace("<", "&lt;")
+        .replace(">", "&gt;")
+    )
+
+
+def _paragraph(value, style):
+    return Paragraph(_escape_paragraph(value), style)
+
+
+def _header_footer(canvas_obj, _doc, export_data):
+    canvas_obj.saveState()
+    width, height = PAGE_SIZE
+    canvas_obj.setFont(FONT_BOLD, 10)
+    canvas_obj.drawString(PAGE_MARGIN, height - 22, "Nómina provincial de niños")
+    canvas_obj.setFont(FONT_REGULAR, 10)
+    actor = (
+        f"Provincia: {export_data.provincia} | Rol: {export_data.rol} | "
+        f"Usuario: {export_data.usuario} | CUIL: {export_data.usuario_cuil}"
+    )
+    canvas_obj.drawString(PAGE_MARGIN, height - 36, actor)
+    canvas_obj.setStrokeColor(colors.HexColor("#808080"))
+    canvas_obj.line(PAGE_MARGIN, height - 42, width - PAGE_MARGIN, height - 42)
+    canvas_obj.restoreState()
+
+
+class _NumberedCanvas(canvas.Canvas):
+    def __init__(self, *args, export_data, **kwargs):
+        super().__init__(*args, **kwargs)
+        self._saved_page_states = []
+        self.export_data = export_data
+
+    def showPage(self):
+        self._saved_page_states.append(dict(self.__dict__))
+        self._startPage()
+
+    def save(self):
+        page_count = len(self._saved_page_states)
+        for page_state in self._saved_page_states:
+            self.__dict__.update(page_state)
+            self._draw_page_details(page_count)
+            super().showPage()
+        super().save()
+
+    def _draw_page_details(self, page_count):
+        width, height = PAGE_SIZE
+        generated = self.export_data.generado_en.strftime("%d/%m/%Y - %H:%M:%S")
+        page_number = self._pageNumber
+        self.saveState()
+        self.setFillColor(colors.HexColor("#C7C7C7"))
+        self.setFont(FONT_BOLD, 16)
+        self.translate(width / 2, height / 2)
+        self.rotate(28)
+        watermark = (
+            f"Provincia: {self.export_data.provincia} - "
+            f"Usuario: {self.export_data.usuario} - {generated} - "
+            f"Páginas: {page_number} de {page_count}."
+        )
+        self.drawCentredString(0, 0, watermark)
+        self.restoreState()
+
+        self.saveState()
+        self.setFont(FONT_REGULAR, 9)
+        self.setFillColor(colors.HexColor("#333333"))
+        self.drawString(PAGE_MARGIN, 12, generated)
+        self.drawRightString(
+            width - PAGE_MARGIN,
+            12,
+            f"Página {page_number} de {page_count}",
+        )
+        self.restoreState()
+
+
+def _table_styles():
+    body = ParagraphStyle(
+        "NominaBody",
+        fontName=FONT_REGULAR,
+        fontSize=TABLE_FONT_SIZE,
+        leading=10,
+        alignment=TA_LEFT,
+        wordWrap="CJK",
+    )
+    header = ParagraphStyle(
+        "NominaHeader",
+        parent=body,
+        fontName=FONT_BOLD,
+        alignment=TA_CENTER,
+    )
+    cdi = ParagraphStyle(
+        "NominaCDI",
+        parent=body,
+        fontName=FONT_BOLD,
+        leading=11,
+    )
+    return body, header, cdi
+
+
+def _build_cdi_table(group, available_width):
+    body_style, header_style, cdi_style = _table_styles()
+    headers = (
+        "Apellido niño/a",
+        "Nombre niño/a",
+        "DNI niño/a",
+        "Fecha nac. niño/a",
+        "Edad",
+        "Medida",
+        "Sexo",
+        "RENAPER niño/a",
+        "Apellido adulto 1",
+        "Nombre adulto 1",
+        "CUIT adulto 1",
+        "Fecha nac. adulto 1",
+        "RENAPER adulto 1",
+    )
+    cdi_header = (
+        f"CDI {group.codigo} - {group.nombre} | Referente: {group.referente} | "
+        f"CUIL: {group.referente_cuil} | Niños activos únicos: {len(group.rows)}"
+    )
+    data = [
+        [_paragraph(cdi_header, cdi_style)] + [""] * (len(headers) - 1),
+        [_paragraph(header, header_style) for header in headers],
+    ]
+    for row in group.rows:
+        data.append(
+            [
+                _paragraph(value, body_style)
+                for value in (
+                    row.apellido,
+                    row.nombre,
+                    row.dni,
+                    row.fecha_nacimiento,
+                    row.edad,
+                    row.medida,
+                    row.sexo,
+                    row.renaper_nino,
+                    row.adulto_apellido,
+                    row.adulto_nombre,
+                    row.adulto_cuit,
+                    row.adulto_fecha_nacimiento,
+                    row.adulto_renaper,
+                )
+            ]
+        )
+    base_widths = (66, 66, 47, 55, 31, 40, 45, 52, 62, 62, 60, 55, 52)
+    scale = available_width / sum(base_widths)
+    table = Table(
+        data,
+        colWidths=[width * scale for width in base_widths],
+        repeatRows=2,
+        hAlign="LEFT",
+    )
+    table.setStyle(
+        TableStyle(
+            [
+                ("SPAN", (0, 0), (-1, 0)),
+                ("BACKGROUND", (0, 0), (-1, 0), colors.HexColor("#D9D9D9")),
+                ("BACKGROUND", (0, 1), (-1, 1), colors.HexColor("#EFEFEF")),
+                ("GRID", (0, 0), (-1, -1), 0.35, colors.HexColor("#777777")),
+                ("VALIGN", (0, 0), (-1, -1), "MIDDLE"),
+                ("LEFTPADDING", (0, 0), (-1, -1), 2),
+                ("RIGHTPADDING", (0, 0), (-1, -1), 2),
+                ("TOPPADDING", (0, 0), (-1, -1), 3),
+                ("BOTTOMPADDING", (0, 0), (-1, -1), 3),
+            ]
+        )
+    )
+    return table
+
+
+def build_vector_pdf(export_data):
+    _register_fonts()
+    buffer = BytesIO()
+    document = SimpleDocTemplate(
+        buffer,
+        pagesize=PAGE_SIZE,
+        leftMargin=PAGE_MARGIN,
+        rightMargin=PAGE_MARGIN,
+        topMargin=50,
+        bottomMargin=26,
+        title="Nómina provincial de niños",
+        author="SISOC - SIMEPI",
+    )
+    styles = getSampleStyleSheet()
+    summary_style = ParagraphStyle(
+        "NominaSummary",
+        parent=styles["Heading2"],
+        fontName=FONT_BOLD,
+        fontSize=14,
+        leading=18,
+        alignment=TA_CENTER,
+    )
+    story = []
+    for group in export_data.centros:
+        story.append(_build_cdi_table(group, document.width))
+        story.append(Spacer(1, 10))
+    if story:
+        story.append(PageBreak())
+    story.extend(
+        [
+            Spacer(1, 150),
+            Paragraph(
+                "Total de niños activos únicos de la provincia: "
+                f"{export_data.total_ninos}",
+                summary_style,
+            ),
+        ]
+    )
+    document.build(
+        story,
+        onFirstPage=lambda canvas_obj, doc: _header_footer(
+            canvas_obj, doc, export_data
+        ),
+        onLaterPages=lambda canvas_obj, doc: _header_footer(
+            canvas_obj, doc, export_data
+        ),
+        canvasmaker=lambda *args, **kwargs: _NumberedCanvas(
+            *args,
+            export_data=export_data,
+            **kwargs,
+        ),
+    )
+    return buffer.getvalue()
+
+
+def rasterize_pdf(vector_pdf):
+    with TemporaryDirectory(prefix="sisoc-nomina-ninos-") as temp_dir:
+        image_paths = convert_from_bytes(
+            vector_pdf,
+            dpi=150,
+            fmt="jpeg",
+            jpegopt={"quality": 88, "optimize": True},
+            output_folder=temp_dir,
+            paths_only=True,
+            thread_count=1,
+            timeout=120,
+        )
+        if not image_paths:
+            raise NominaNinosPDFError("La rasterización no generó páginas.")
+        output = BytesIO()
+        pdf = canvas.Canvas(output, pagesize=PAGE_SIZE, pageCompression=1)
+        width, height = PAGE_SIZE
+        for image_path in image_paths:
+            pdf.drawImage(
+                ImageReader(image_path),
+                0,
+                0,
+                width=width,
+                height=height,
+            )
+            pdf.showPage()
+        pdf.save()
+        return output.getvalue()
+
+
+def generar_nomina_ninos_pdf(*, user, provincia, generado_en=None):
+    try:
+        export_data = build_export_data(
+            user=user,
+            provincia=provincia,
+            generado_en=generado_en,
+        )
+        return rasterize_pdf(build_vector_pdf(export_data))
+    except NominaNinosPDFError:
+        raise
+    except Exception as exc:  # pylint: disable=broad-exception-caught
+        raise NominaNinosPDFError("No se pudo generar la nómina.") from exc

--- a/centrodeinfancia/services_nomina_ninos_pdf.py
+++ b/centrodeinfancia/services_nomina_ninos_pdf.py
@@ -327,7 +327,7 @@ def build_export_data(  # pylint: disable=too-many-locals
 
 
 def _register_fonts():
-    global FONT_REGULAR, FONT_BOLD
+    global FONT_REGULAR, FONT_BOLD  # pylint: disable=global-statement
     if "SISOCArial" in pdfmetrics.getRegisteredFontNames():
         FONT_REGULAR = "SISOCArial"
         FONT_BOLD = "SISOCArial-Bold"
@@ -376,7 +376,7 @@ def _header_footer(canvas_obj, _doc, export_data):
     canvas_obj.restoreState()
 
 
-class _NumberedCanvas(canvas.Canvas):
+class _NumberedCanvas(canvas.Canvas):  # pylint: disable=abstract-method
     def __init__(self, *args, export_data, **kwargs):
         super().__init__(*args, **kwargs)
         self._saved_page_states = []

--- a/centrodeinfancia/templates/centrodeinfancia/centrodeinfancia_list.html
+++ b/centrodeinfancia/templates/centrodeinfancia/centrodeinfancia_list.html
@@ -11,7 +11,7 @@
 
     <div class="comedor-list-container">
         {% url 'centrodeinfancia_exportar' as export_url %}
-        {% include 'components/search_bar.html' with titulo="Buscar Centro de Desarrollo Infantil" placeholder="Buscar por nombre u organización" help_text="Ingresar nombre u organización." reset_url='centrodeinfancia' add_url='centrodeinfancia_crear' add_text='Nuevo Centro' export_url=export_url query=query %}
+        {% include 'components/search_bar.html' with titulo="Buscar Centro de Desarrollo Infantil" placeholder="Buscar por nombre u organización" help_text="Ingresar nombre u organización." reset_url='centrodeinfancia' add_url='centrodeinfancia_crear' add_text='Nuevo Centro' export_url=export_url query=query additional_buttons=additional_buttons %}
 
         <div class="row mt-5 max-width-100">
             <div class="col-12">

--- a/centrodeinfancia/tests/test_nomina_ninos_pdf.py
+++ b/centrodeinfancia/tests/test_nomina_ninos_pdf.py
@@ -1,0 +1,309 @@
+from datetime import date, datetime
+from io import BytesIO
+from unittest.mock import patch
+
+import pytest
+from django.contrib.auth.models import Group, Permission, User
+from django.urls import reverse
+from django.utils import timezone
+from pypdf import PdfReader
+
+from ciudadanos.models import Ciudadano
+from centrodeinfancia.models import AccesoCDI, CentroDeInfancia, NominaCentroInfancia
+from centrodeinfancia.services_nomina_ninos_pdf import (
+    CDIGroup,
+    ExportData,
+    NinoRow,
+    NominaNinosPDFError,
+    build_export_data,
+    build_vector_pdf,
+    rasterize_pdf,
+)
+from core.constants import UserGroups
+from core.models import Municipio, Provincia
+from users.models import Profile, ProfileTerritorialScope
+
+
+def _create_egp(username, provincia, *, full_scope=True):
+    user = User.objects.create_user(
+        username=username,
+        password="test1234",
+        email=f"{username}@example.test",
+    )
+    group, _ = Group.objects.get_or_create(name=UserGroups.SIMEPI_EGP)
+    user.groups.add(group)
+    profile, _ = Profile.objects.get_or_create(user=user)
+    profile.es_usuario_provincial = True
+    profile.provincia = provincia
+    profile.cuil = "20-00000000-0"
+    profile.save()
+    municipio = None
+    if not full_scope:
+        municipio = Municipio.objects.create(
+            nombre=f"Municipio {username}",
+            provincia=provincia,
+        )
+    ProfileTerritorialScope.objects.create(
+        profile=profile,
+        provincia=provincia,
+        municipio=municipio,
+    )
+    return user
+
+
+def _create_child(documento, *, validated=True, birth_date=date(2020, 1, 15)):
+    return Ciudadano.objects.create(
+        apellido="Pérez",
+        nombre=f"Niño {documento}",
+        fecha_nacimiento=birth_date,
+        documento=documento,
+        estado_validacion_renaper=(
+            Ciudadano.RENAPER_VALIDADO
+            if validated
+            else Ciudadano.RENAPER_NO_VALIDADO
+        ),
+    )
+
+
+@pytest.mark.django_db
+def test_descarga_exige_egp_con_unico_scope_provincial_completo(client):
+    provincia = Provincia.objects.create(nombre="Provincia Uno")
+    user = User.objects.create_user(username="sin-rol", password="test1234")
+    client.force_login(user)
+    url = reverse("centrodeinfancia_nomina_ninos_pdf")
+
+    assert client.get(url).status_code == 403
+
+    partial_user = _create_egp("egp-parcial", provincia, full_scope=False)
+    client.force_login(partial_user)
+
+    assert client.get(url).status_code == 403
+
+
+@pytest.mark.django_db
+def test_descarga_pdf_define_attachment_y_no_cache(client):
+    provincia = Provincia.objects.create(nombre="Tierra de Prueba")
+    user = _create_egp("egp-descarga", provincia)
+    client.force_login(user)
+
+    with patch(
+        "centrodeinfancia.views_export.generar_nomina_ninos_pdf",
+        return_value=b"%PDF-1.4\nprueba",
+    ):
+        response = client.get(reverse("centrodeinfancia_nomina_ninos_pdf"))
+
+    assert response.status_code == 200
+    assert response["Content-Type"] == "application/pdf"
+    assert (
+        response["Content-Disposition"]
+        == 'attachment; filename="nomina-ninos-tierra-de-prueba.pdf"'
+    )
+    assert response["Cache-Control"] == "private, no-store"
+    assert response["Pragma"] == "no-cache"
+
+
+@pytest.mark.django_db
+def test_descarga_devuelve_error_controlado_sin_detalles(client):
+    provincia = Provincia.objects.create(nombre="Provincia Error")
+    user = _create_egp("egp-error", provincia)
+    client.force_login(user)
+
+    with patch(
+        "centrodeinfancia.views_export.generar_nomina_ninos_pdf",
+        side_effect=NominaNinosPDFError("detalle interno"),
+    ):
+        response = client.get(reverse("centrodeinfancia_nomina_ninos_pdf"))
+
+    assert response.status_code == 503
+    assert "detalle interno" not in response.content.decode()
+    assert response["Content-Type"].startswith("text/plain")
+
+
+@pytest.mark.django_db
+def test_boton_descarga_solo_se_muestra_a_egp(client):
+    provincia = Provincia.objects.create(nombre="Provincia Botón")
+    egp = _create_egp("egp-boton", provincia)
+    permission = Permission.objects.get(codename="view_centrodeinfancia")
+    egp.user_permissions.add(permission)
+    client.force_login(egp)
+
+    response = client.get(reverse("centrodeinfancia"))
+
+    assert response.status_code == 200
+    assert "Descargar nómina de niños" in response.content.decode()
+
+    regular = User.objects.create_user(username="regular", password="test1234")
+    regular.user_permissions.add(permission)
+    client.force_login(regular)
+
+    response = client.get(reverse("centrodeinfancia"))
+
+    assert response.status_code == 200
+    assert "Descargar nómina de niños" not in response.content.decode()
+
+
+@pytest.mark.django_db
+def test_export_data_filtra_deduplica_ordena_y_resuelve_validaciones():
+    provincia = Provincia.objects.create(nombre="Provincia Datos")
+    otra_provincia = Provincia.objects.create(nombre="Otra Provincia")
+    user = _create_egp("egp-datos", provincia)
+    centro = CentroDeInfancia.objects.create(
+        nombre="CDI Central",
+        codigo_cdi="CDI-001",
+        provincia=provincia,
+        nombre_referente="Ana",
+        apellido_referente="Referente",
+        email_referente="referente@example.test",
+    )
+    centro_ajeno = CentroDeInfancia.objects.create(
+        nombre="CDI Ajeno",
+        codigo_cdi="CDI-002",
+        provincia=otra_provincia,
+    )
+    referente = User.objects.create_user(
+        username="referente-cdi",
+        email="referente@example.test",
+    )
+    referente_profile, _ = Profile.objects.get_or_create(user=referente)
+    referente_profile.cuil = "27-00000000-1"
+    referente_profile.save()
+    AccesoCDI.objects.create(user=referente, centro=centro, activo=True)
+
+    child_months = _create_child(40000001, validated=True, birth_date=date(2024, 1, 1))
+    child_years = _create_child(40000002, validated=False, birth_date=date(2020, 1, 1))
+    child_foreign = _create_child(40000003)
+    adult = Ciudadano.objects.create(
+        apellido="Adulto",
+        nombre="Validado",
+        fecha_nacimiento=date(1985, 1, 1),
+        documento=30000001,
+        estado_validacion_renaper=Ciudadano.RENAPER_VALIDADO,
+    )
+    assert adult.pk
+
+    duplicate_old = NominaCentroInfancia.objects.create(
+        centro=centro,
+        ciudadano=child_months,
+        estado=NominaCentroInfancia.ESTADO_ACTIVO,
+        apellido="Álvarez",
+        nombre="Luz",
+        dni=40000001,
+        fecha_nacimiento=date(2024, 1, 1),
+        sexo=NominaCentroInfancia.SexoChoices.FEMENINO,
+        edad_unidad="meses",
+    )
+    NominaCentroInfancia.objects.filter(pk=duplicate_old.pk).update(
+        fecha=timezone.make_aware(datetime(2025, 1, 1, 10, 0))
+    )
+    duplicate_new = NominaCentroInfancia.objects.create(
+        centro=centro,
+        ciudadano=child_months,
+        estado=NominaCentroInfancia.ESTADO_ACTIVO,
+        apellido="Álvarez",
+        nombre="Luz",
+        dni=40000001,
+        fecha_nacimiento=date(2024, 1, 1),
+        sexo=NominaCentroInfancia.SexoChoices.FEMENINO,
+        edad_unidad="meses",
+        responsable_legal_1_apellido="Responsable",
+        responsable_legal_1_nombre="Uno",
+        responsable_legal_1_dni=30000001,
+        responsable_legal_1_cuit="20-00000001-1",
+        responsable_legal_1_fecha_nacimiento=date(1985, 1, 1),
+    )
+    NominaCentroInfancia.objects.filter(pk=duplicate_new.pk).update(
+        fecha=timezone.make_aware(datetime(2026, 1, 1, 10, 0))
+    )
+    NominaCentroInfancia.objects.create(
+        centro=centro,
+        ciudadano=child_years,
+        estado=NominaCentroInfancia.ESTADO_ACTIVO,
+        apellido="Zuluaga",
+        nombre="Sol",
+        edad_unidad="anios",
+    )
+    NominaCentroInfancia.objects.create(
+        centro=centro,
+        ciudadano=_create_child(40000004),
+        estado=NominaCentroInfancia.ESTADO_BAJA,
+    )
+    NominaCentroInfancia.objects.create(
+        centro=centro_ajeno,
+        ciudadano=child_foreign,
+        estado=NominaCentroInfancia.ESTADO_ACTIVO,
+    )
+
+    data = build_export_data(
+        user=user,
+        provincia=provincia,
+        generado_en=timezone.make_aware(datetime(2026, 8, 18, 12, 30)),
+    )
+
+    assert data.total_ninos == 2
+    assert len(data.centros) == 1
+    assert data.centros[0].referente_cuil == "27-00000000-1"
+    assert [row.medida for row in data.centros[0].rows] == ["Meses", "Años"]
+    assert data.centros[0].rows[0].adulto_apellido == "Responsable"
+    assert data.centros[0].rows[0].adulto_renaper == "Sí"
+    assert data.centros[0].rows[0].renaper_nino == "Sí"
+    assert data.centros[0].rows[1].renaper_nino == "No"
+
+
+def _sample_export_data():
+    row = NinoRow(
+        centro_id=1,
+        apellido="Apellido",
+        nombre="Nombre",
+        dni="40000000",
+        fecha_nacimiento="01/01/2020",
+        edad="6",
+        medida="Años",
+        sexo="Femenino",
+        renaper_nino="Sí",
+        adulto_apellido="Responsable",
+        adulto_nombre="Adulto",
+        adulto_cuit="20-00000000-0",
+        adulto_fecha_nacimiento="01/01/1980",
+        adulto_renaper="Sí",
+        sort_key=(1, 6, "apellido", "nombre", "40000000", 1),
+    )
+    return ExportData(
+        provincia="Provincia Visual",
+        usuario="egp-visual",
+        rol="SIMEPI - EGP",
+        usuario_cuil="20-00000000-0",
+        generado_en=timezone.make_aware(datetime(2026, 8, 18, 12, 30)),
+        centros=(
+            CDIGroup(
+                centro_id=1,
+                codigo="CDI-001",
+                nombre="CDI Visual",
+                referente="Persona Referente",
+                referente_cuil="27-00000000-1",
+                rows=(row,),
+            ),
+        ),
+    )
+
+
+def test_pdf_final_es_a4_apaisado_y_contiene_un_jpeg_por_pagina():
+    final_pdf = rasterize_pdf(build_vector_pdf(_sample_export_data()))
+    reader = PdfReader(BytesIO(final_pdf))
+
+    assert len(reader.pages) == 2
+    for page in reader.pages:
+        assert float(page.mediabox.width) > float(page.mediabox.height)
+        assert float(page.mediabox.width) == pytest.approx(841.89, abs=0.2)
+        assert float(page.mediabox.height) == pytest.approx(595.28, abs=0.2)
+        xobjects = page["/Resources"]["/XObject"].get_object()
+        images = [
+            obj.get_object()
+            for obj in xobjects.values()
+            if obj.get_object().get("/Subtype") == "/Image"
+        ]
+        assert len(images) == 1
+        filters = images[0]["/Filter"]
+        if not isinstance(filters, list):
+            filters = [filters]
+        assert "/DCTDecode" in filters
+        assert not (page.extract_text() or "").strip()

--- a/centrodeinfancia/tests/test_nomina_ninos_pdf.py
+++ b/centrodeinfancia/tests/test_nomina_ninos_pdf.py
@@ -58,9 +58,7 @@ def _create_child(documento, *, validated=True, birth_date=date(2020, 1, 15)):
         fecha_nacimiento=birth_date,
         documento=documento,
         estado_validacion_renaper=(
-            Ciudadano.RENAPER_VALIDADO
-            if validated
-            else Ciudadano.RENAPER_NO_VALIDADO
+            Ciudadano.RENAPER_VALIDADO if validated else Ciudadano.RENAPER_NO_VALIDADO
         ),
     )
 

--- a/centrodeinfancia/urls.py
+++ b/centrodeinfancia/urls.py
@@ -41,7 +41,10 @@ from centrodeinfancia.views_formulario_cdi import (
     FormularioCDIListView,
     FormularioCDIUpdateView,
 )
-from centrodeinfancia.views_export import CentroDeInfanciaExportView
+from centrodeinfancia.views_export import (
+    CentroDeInfanciaExportView,
+    NominaNinosPDFView,
+)
 from centrodeinfancia.views_usuario_cdi import GenerarUsuarioCDIView
 from centrodeinfancia.views_usuario_egp import GenerarUsuarioEGPView
 
@@ -65,6 +68,11 @@ urlpatterns = [
             ["centrodeinfancia.view_centrodeinfancia", "auth.role_exportar_a_csv"]
         )(CentroDeInfanciaExportView.as_view()),
         name="centrodeinfancia_exportar",
+    ),
+    path(
+        "centrodeinfancia/nomina-ninos/descargar/",
+        NominaNinosPDFView.as_view(),
+        name="centrodeinfancia_nomina_ninos_pdf",
     ),
     path(
         "centrodeinfancia/crear",

--- a/centrodeinfancia/views.py
+++ b/centrodeinfancia/views.py
@@ -48,6 +48,7 @@ from iam.services import user_has_permission_code
 from centrodeinfancia.access import (
     aplicar_scope_centros_cdi as _aplicar_scope_centros_cdi,
     es_auditor_simepi,
+    es_egp_simepi,
     get_object_scoped_cdi_or_404,
     puede_generar_usuario_cdi,
     puede_ver_usuarios_cdi,
@@ -338,6 +339,14 @@ class CentroDeInfanciaListView(LoginRequiredMixin, ListView):
             {"text": "Listar", "active": True},
         ]
         context["query"] = self.request.GET.get("busqueda", "")
+        if es_egp_simepi(self.request.user):
+            context["additional_buttons"] = [
+                {
+                    "url": reverse("centrodeinfancia_nomina_ninos_pdf"),
+                    "label": "Descargar nómina de niños",
+                    "class": "btn btn-outline-primary",
+                }
+            ]
         context["active_columns"] = columns_context.get("column_active_keys") or [
             field["name"] for field in CDI_LIST_FIELDS
         ]

--- a/centrodeinfancia/views_export.py
+++ b/centrodeinfancia/views_export.py
@@ -1,11 +1,27 @@
+import logging
+
 from django.contrib.auth.mixins import LoginRequiredMixin
+from django.core.exceptions import PermissionDenied
 from django.db.models import Q
+from django.http import HttpResponse
+from django.utils.text import slugify
 from django.views.generic import View
 
-from centrodeinfancia.access import aplicar_scope_centros_cdi
+from centrodeinfancia.access import (
+    aplicar_scope_centros_cdi,
+    get_provincia_completa_unica_egp_id,
+)
 from centrodeinfancia.models import CentroDeInfancia
+from centrodeinfancia.services_nomina_ninos_pdf import (
+    NominaNinosPDFError,
+    generar_nomina_ninos_pdf,
+)
 from core.mixins import CSVExportMixin
+from core.models import Provincia
 from core.services.column_preferences import build_columns_context_from_fields
+
+
+logger = logging.getLogger(__name__)
 
 
 class CentroDeInfanciaExportView(LoginRequiredMixin, CSVExportMixin, View):
@@ -82,3 +98,46 @@ class CentroDeInfanciaExportView(LoginRequiredMixin, CSVExportMixin, View):
     def get(self, request, *args, **kwargs):
         queryset = self.get_queryset()
         return self.export_csv(queryset)
+
+
+class NominaNinosPDFView(LoginRequiredMixin, View):
+    """Descarga provincial habilitada exclusivamente para SIMEPI - EGP."""
+
+    def get(self, request, *args, **kwargs):
+        provincia_id = get_provincia_completa_unica_egp_id(request.user)
+        if not provincia_id:
+            raise PermissionDenied(
+                "La descarga requiere un único alcance provincial completo."
+            )
+
+        provincia = Provincia.objects.filter(pk=provincia_id).first()
+        if provincia is None:
+            raise PermissionDenied("El alcance provincial no es válido.")
+
+        try:
+            pdf_bytes = generar_nomina_ninos_pdf(
+                user=request.user,
+                provincia=provincia,
+            )
+        except NominaNinosPDFError:
+            logger.exception(
+                "No se pudo generar la nómina provincial de niños",
+                extra={
+                    "data": {
+                        "usuario_id": request.user.pk,
+                        "provincia_id": provincia_id,
+                    }
+                },
+            )
+            return HttpResponse(
+                "No se pudo generar el archivo. Intente nuevamente más tarde.",
+                status=503,
+                content_type="text/plain; charset=utf-8",
+            )
+
+        filename = f"nomina-ninos-{slugify(provincia.nombre) or provincia.pk}.pdf"
+        response = HttpResponse(pdf_bytes, content_type="application/pdf")
+        response["Content-Disposition"] = f'attachment; filename="{filename}"'
+        response["Cache-Control"] = "private, no-store"
+        response["Pragma"] = "no-cache"
+        return response

--- a/docs/contexto/features/pr-2307-feat-centrodeinfancia-descargar-nomina-provincial-de-ninos-hml.md
+++ b/docs/contexto/features/pr-2307-feat-centrodeinfancia-descargar-nomina-provincial-de-ninos-hml.md
@@ -1,0 +1,58 @@
+# Contexto de feature PR #2307 - feat(centrodeinfancia): descargar nómina provincial de niños [HML]
+
+## Resumen
+
+- PR: https://github.com/dsocial118/SISOC/pull/2307
+- Base: `homologacion`
+- Rama origen: `codex/simepi-descarga-nomina-ninos`
+- Autor: `juanikitro`
+
+## Contexto funcional
+
+- No informado explícitamente; inferir desde el título del PR y el diff.
+
+## Arquitectura tocada
+
+- Hay cambios en vistas web y puede existir impacto en permisos o renderizado.
+- Se modifican templates, con posible impacto visual o de composición UI.
+
+## Decisiones y supuestos detectados
+
+- Tipo de cambio declarado: No informado
+- Área principal declarada: No informada
+- Impacto usuario declarado: No informado
+- Riesgos / rollback: No informado
+
+## Design system y UI
+
+- El PR toca piezas de UI y conviene revisar consistencia visual con el patrón existente.
+- Archivos visuales relevantes: centrodeinfancia/templates/centrodeinfancia/centrodeinfancia_list.html
+
+## Memoria operativa para agentes
+
+- Empezar por `docs/registro/prs/PR-2307.md` para contexto resumido del PR.
+- Revisar primero estos archivos del diff:
+- `AGENT_REPO_MAP.md`
+- `centrodeinfancia/access.py`
+- `centrodeinfancia/services_nomina_ninos_pdf.py`
+- `centrodeinfancia/templates/centrodeinfancia/centrodeinfancia_list.html`
+- `centrodeinfancia/tests/test_nomina_ninos_pdf.py`
+- `centrodeinfancia/urls.py`
+- `centrodeinfancia/views.py`
+- `centrodeinfancia/views_export.py`
+- `docs/plans/2026-08-18-simepi-descarga-nomina-ninos-design.md`
+- `docs/plans/2026-08-18-simepi-descarga-nomina-ninos-plan.md`
+- `docs/registro/cambios/2026-08-18-simepi-descarga-nomina-ninos.md`
+- Documentación sugerida para ampliar contexto:
+- `docs/indice.md`
+- `docs/ia/CONTEXT_HYGIENE.md`
+- `docs/ia/ARCHITECTURE.md`
+- `docs/ia/TESTING.md`
+- `docs/plans/2026-08-18-simepi-descarga-nomina-ninos-design.md`
+- `docs/plans/2026-08-18-simepi-descarga-nomina-ninos-plan.md`
+- `docs/registro/cambios/2026-08-18-simepi-descarga-nomina-ninos.md`
+
+## Trazabilidad
+
+- Documento generado automáticamente desde el evento de `pull_request`.
+- Si este PR cambia de título, el archivo se renombrará para mantener el slug alineado.

--- a/docs/contexto/features/pr-2307-feat-centrodeinfancia-descargar-nomina-provincial-de-ninos-hml.md
+++ b/docs/contexto/features/pr-2307-feat-centrodeinfancia-descargar-nomina-provincial-de-ninos-hml.md
@@ -33,6 +33,7 @@
 - Empezar por `docs/registro/prs/PR-2307.md` para contexto resumido del PR.
 - Revisar primero estos archivos del diff:
 - `AGENT_REPO_MAP.md`
+- `CHANGELOG.md`
 - `centrodeinfancia/access.py`
 - `centrodeinfancia/services_nomina_ninos_pdf.py`
 - `centrodeinfancia/templates/centrodeinfancia/centrodeinfancia_list.html`
@@ -40,17 +41,27 @@
 - `centrodeinfancia/urls.py`
 - `centrodeinfancia/views.py`
 - `centrodeinfancia/views_export.py`
+- `docs/contexto/features/pr-2307-feat-centrodeinfancia-descargar-nomina-provincial-de-ninos-hml.md`
+- `docs/contexto/features/pr-2308-feat-centrodeinfancia-descargar-nomina-provincial-de-ninos.md`
 - `docs/plans/2026-08-18-simepi-descarga-nomina-ninos-design.md`
 - `docs/plans/2026-08-18-simepi-descarga-nomina-ninos-plan.md`
 - `docs/registro/cambios/2026-08-18-simepi-descarga-nomina-ninos.md`
+- `docs/registro/prs/PR-2307.md`
+- `docs/registro/prs/PR-2308.md`
+- `docs/registro/releases/pending/2026-08-19-pr-2308.md`
 - Documentación sugerida para ampliar contexto:
 - `docs/indice.md`
 - `docs/ia/CONTEXT_HYGIENE.md`
 - `docs/ia/ARCHITECTURE.md`
 - `docs/ia/TESTING.md`
+- `docs/contexto/features/pr-2307-feat-centrodeinfancia-descargar-nomina-provincial-de-ninos-hml.md`
+- `docs/contexto/features/pr-2308-feat-centrodeinfancia-descargar-nomina-provincial-de-ninos.md`
 - `docs/plans/2026-08-18-simepi-descarga-nomina-ninos-design.md`
 - `docs/plans/2026-08-18-simepi-descarga-nomina-ninos-plan.md`
 - `docs/registro/cambios/2026-08-18-simepi-descarga-nomina-ninos.md`
+- `docs/registro/prs/PR-2307.md`
+- `docs/registro/prs/PR-2308.md`
+- `docs/registro/releases/pending/2026-08-19-pr-2308.md`
 
 ## Trazabilidad
 

--- a/docs/contexto/features/pr-2308-feat-centrodeinfancia-descargar-nomina-provincial-de-ninos.md
+++ b/docs/contexto/features/pr-2308-feat-centrodeinfancia-descargar-nomina-provincial-de-ninos.md
@@ -1,0 +1,62 @@
+# Contexto de feature PR #2308 - feat(centrodeinfancia): descargar nómina provincial de niños
+
+## Resumen
+
+- PR: https://github.com/dsocial118/SISOC/pull/2308
+- Base: `main`
+- Rama origen: `codex/simepi-descarga-nomina-ninos`
+- Autor: `juanikitro`
+
+## Contexto funcional
+
+- No informado explícitamente; inferir desde el título del PR y el diff.
+
+## Arquitectura tocada
+
+- Hay cambios en vistas web y puede existir impacto en permisos o renderizado.
+- Se modifican templates, con posible impacto visual o de composición UI.
+
+## Decisiones y supuestos detectados
+
+- Tipo de cambio declarado: No informado
+- Área principal declarada: No informada
+- Impacto usuario declarado: No informado
+- Riesgos / rollback: No informado
+
+## Design system y UI
+
+- El PR toca piezas de UI y conviene revisar consistencia visual con el patrón existente.
+- Archivos visuales relevantes: centrodeinfancia/templates/centrodeinfancia/centrodeinfancia_list.html
+
+## Memoria operativa para agentes
+
+- Empezar por `docs/registro/prs/PR-2308.md` para contexto resumido del PR.
+- Revisar primero estos archivos del diff:
+- `AGENT_REPO_MAP.md`
+- `centrodeinfancia/access.py`
+- `centrodeinfancia/services_nomina_ninos_pdf.py`
+- `centrodeinfancia/templates/centrodeinfancia/centrodeinfancia_list.html`
+- `centrodeinfancia/tests/test_nomina_ninos_pdf.py`
+- `centrodeinfancia/urls.py`
+- `centrodeinfancia/views.py`
+- `centrodeinfancia/views_export.py`
+- `docs/contexto/features/pr-2307-feat-centrodeinfancia-descargar-nomina-provincial-de-ninos-hml.md`
+- `docs/plans/2026-08-18-simepi-descarga-nomina-ninos-design.md`
+- `docs/plans/2026-08-18-simepi-descarga-nomina-ninos-plan.md`
+- `docs/registro/cambios/2026-08-18-simepi-descarga-nomina-ninos.md`
+- `docs/registro/prs/PR-2307.md`
+- Documentación sugerida para ampliar contexto:
+- `docs/indice.md`
+- `docs/ia/CONTEXT_HYGIENE.md`
+- `docs/ia/ARCHITECTURE.md`
+- `docs/ia/TESTING.md`
+- `docs/contexto/features/pr-2307-feat-centrodeinfancia-descargar-nomina-provincial-de-ninos-hml.md`
+- `docs/plans/2026-08-18-simepi-descarga-nomina-ninos-design.md`
+- `docs/plans/2026-08-18-simepi-descarga-nomina-ninos-plan.md`
+- `docs/registro/cambios/2026-08-18-simepi-descarga-nomina-ninos.md`
+- `docs/registro/prs/PR-2307.md`
+
+## Trazabilidad
+
+- Documento generado automáticamente desde el evento de `pull_request`.
+- Si este PR cambia de título, el archivo se renombrará para mantener el slug alineado.

--- a/docs/contexto/features/pr-2308-feat-centrodeinfancia-descargar-nomina-provincial-de-ninos.md
+++ b/docs/contexto/features/pr-2308-feat-centrodeinfancia-descargar-nomina-provincial-de-ninos.md
@@ -33,6 +33,7 @@
 - Empezar por `docs/registro/prs/PR-2308.md` para contexto resumido del PR.
 - Revisar primero estos archivos del diff:
 - `AGENT_REPO_MAP.md`
+- `CHANGELOG.md`
 - `centrodeinfancia/access.py`
 - `centrodeinfancia/services_nomina_ninos_pdf.py`
 - `centrodeinfancia/templates/centrodeinfancia/centrodeinfancia_list.html`
@@ -41,20 +42,26 @@
 - `centrodeinfancia/views.py`
 - `centrodeinfancia/views_export.py`
 - `docs/contexto/features/pr-2307-feat-centrodeinfancia-descargar-nomina-provincial-de-ninos-hml.md`
+- `docs/contexto/features/pr-2308-feat-centrodeinfancia-descargar-nomina-provincial-de-ninos.md`
 - `docs/plans/2026-08-18-simepi-descarga-nomina-ninos-design.md`
 - `docs/plans/2026-08-18-simepi-descarga-nomina-ninos-plan.md`
 - `docs/registro/cambios/2026-08-18-simepi-descarga-nomina-ninos.md`
 - `docs/registro/prs/PR-2307.md`
+- `docs/registro/prs/PR-2308.md`
+- `docs/registro/releases/pending/2026-08-19-pr-2308.md`
 - Documentación sugerida para ampliar contexto:
 - `docs/indice.md`
 - `docs/ia/CONTEXT_HYGIENE.md`
 - `docs/ia/ARCHITECTURE.md`
 - `docs/ia/TESTING.md`
 - `docs/contexto/features/pr-2307-feat-centrodeinfancia-descargar-nomina-provincial-de-ninos-hml.md`
+- `docs/contexto/features/pr-2308-feat-centrodeinfancia-descargar-nomina-provincial-de-ninos.md`
 - `docs/plans/2026-08-18-simepi-descarga-nomina-ninos-design.md`
 - `docs/plans/2026-08-18-simepi-descarga-nomina-ninos-plan.md`
 - `docs/registro/cambios/2026-08-18-simepi-descarga-nomina-ninos.md`
 - `docs/registro/prs/PR-2307.md`
+- `docs/registro/prs/PR-2308.md`
+- `docs/registro/releases/pending/2026-08-19-pr-2308.md`
 
 ## Trazabilidad
 

--- a/docs/plans/2026-08-18-simepi-descarga-nomina-ninos-design.md
+++ b/docs/plans/2026-08-18-simepi-descarga-nomina-ninos-design.md
@@ -1,0 +1,203 @@
+# Descarga provincial de nomina de ninos SIMEPI
+
+Fecha: 2026-08-18
+
+Estado: diseno aprobado
+
+Rama base: `main`
+
+Rama de trabajo: `codex/simepi-descarga-nomina-ninos`
+
+## Objetivo
+
+Permitir que un usuario con el rol exacto `SIMEPI - EGP` descargue un PDF con
+la nomina activa y unica de ninos correspondiente exclusivamente a su
+provincia. El documento debe seguir la especificacion funcional entregada en
+`Descargable_Ninos.docx`, incluyendo datos del usuario, del CDI, del nino y de
+su primer adulto responsable.
+
+La funcionalidad se desarrolla desde `main`. La misma rama se presenta primero
+contra `homologacion` para validar HML y, despues de esa validacion, contra
+`main`. No interviene `development` y el segundo PR no debe incorporar commits
+exclusivos de `homologacion`.
+
+## Alcance funcional
+
+- Mostrar `Descargar nomina de ninos` solamente a usuarios del grupo
+  `SIMEPI - EGP`.
+- Repetir la autorizacion en el servidor; ocultar el boton no es un control
+  suficiente.
+- Resolver una unica provincia completa desde el alcance territorial explicito
+  del perfil EGP.
+- Rechazar la descarga si el usuario no tiene exactamente una provincia
+  completa.
+- Incluir solo fichas `NominaCentroInfancia` activas y no eliminadas cuyos CDI
+  pertenezcan a esa provincia.
+- Omitir CDI sin ninos activos.
+- Agrupar las filas por CDI y repetir el encabezado del CDI y de las columnas
+  en cada pagina correspondiente.
+- Agregar una ultima pagina con la cantidad total provincial.
+- Generar el archivo en memoria o en un directorio temporal y no persistirlo en
+  `MEDIA_ROOT`.
+
+## Autorizacion y privacidad
+
+El endpoint debe exigir autenticacion y pertenencia efectiva al grupo
+`UserGroups.SIMEPI_EGP`. Otros roles SIMEPI, referentes CDI, trabajadores,
+usuarios sin alcance y usuarios anonimos no pueden descargar el archivo.
+
+El queryset debe quedar acotado por el alcance territorial antes de leer la
+nomina. No se aceptan provincia, CDI ni identificadores de personas enviados
+por el cliente.
+
+La respuesta se entrega como attachment e incluye `Cache-Control: private,
+no-store` y `Pragma: no-cache`. Los errores y logs pueden registrar solamente
+identificadores internos, provincia, cantidad de filas y tipo de error; nunca
+DNI, CUIL, nombres, payloads RENAPER ni contenido del PDF.
+
+## Fuentes y reglas de datos
+
+### Usuario EGP
+
+- Provincia: unica provincia completa de `ProfileTerritorialScope`.
+- Rol mostrado: literal `SIMEPI - EGP`.
+- Usuario: `request.user.username`.
+- Nombre: `first_name` y `last_name`.
+- CUIT/CUIL: `request.user.profile.cuil`; si esta vacio, mostrar `-`.
+
+### CDI
+
+- Identificador: `CentroDeInfancia.codigo_cdi`.
+- Nombre: `CentroDeInfancia.nombre`.
+- Referente: `nombre_referente` y `apellido_referente`.
+- CUIT/CUIL del referente: buscar un unico `AccesoCDI` activo cuyo email de
+  usuario coincida con `CentroDeInfancia.email_referente` y usar
+  `user.profile.cuil`. Ante ausencia o ambiguedad, mostrar `-`; no elegir un
+  acceso arbitrariamente.
+- Cantidad: cantidad de filas activas y unicas del CDI despues de aplicar la
+  deduplicacion provincial.
+
+### Nino
+
+Los valores visibles siguen el contrato actual de la nomina CDI: valor de
+`NominaCentroInfancia` y, cuando falte, fallback al `Ciudadano` vinculado.
+
+- Apellido, nombre, DNI, fecha de nacimiento y sexo: valores resueltos con el
+  fallback anterior.
+- Edad: calculada a la fecha y hora de descarga.
+- Medida: `Meses` o `Anos` segun `edad_unidad`. Si falta la unidad o la fecha de
+  nacimiento, mostrar `-` sin inferir un dato nuevo.
+- RENAPER: `Si` solo cuando el ciudadano tiene
+  `estado_validacion_renaper == Ciudadano.RENAPER_VALIDADO`; en cualquier otro
+  estado, `No`.
+
+### Adulto responsable 1
+
+- Apellido, nombre, CUIT/CUIL y fecha de nacimiento: campos
+  `responsable_legal_1_*`.
+- RENAPER: localizar en una unica consulta masiva los ciudadanos cuyo DNI
+  coincida con `responsable_legal_1_dni`. Mostrar `Si` solo para una coincidencia
+  validada; mostrar `No` si no existe, es ambigua o no esta validada.
+
+## Unicidad y orden
+
+La clave de deduplicacion pedida por la especificacion es la tupla normalizada:
+
+1. apellido;
+2. nombre;
+3. DNI;
+4. fecha de nacimiento;
+5. sexo.
+
+La normalizacion es solo para comparar: trim, espacios repetidos y
+case-insensitive en texto. Los valores impresos conservan el dato resuelto.
+
+La regla de vigencia actual evita nuevas fichas activas simultaneas en distintos
+CDI. Para duplicados historicos, se conserva la ficha activa mas reciente por
+`fecha` e `id`. Se registra solamente la cantidad de duplicados omitidos.
+
+El orden es:
+
+1. medida (`Meses`, luego `Anos`, luego sin dato);
+2. edad numerica ascendente;
+3. apellido;
+4. nombre;
+5. DNI;
+6. `id` como desempate tecnico estable.
+
+## Generacion del documento
+
+Se recomienda un pipeline en dos etapas:
+
+1. Crear un PDF vectorial intermedio con ReportLab.
+2. Rasterizar cada pagina a JPEG mediante `pdf2image` y Poppler.
+3. Crear el PDF final A4 horizontal colocando un unico JPEG a pagina completa
+   en cada pagina.
+
+El contenedor ya incluye ReportLab, Pillow, pdf2image, Poppler y Liberation
+Sans. Liberation Sans se utiliza como alternativa metricamente compatible con
+Arial; incorporar Arial requeriria una fuente licenciada y una decision
+operativa adicional.
+
+La pagina usa A4 horizontal, margenes minimos, texto general de 10 puntos y
+tabla de 9 puntos. Un canvas numerado o una segunda pasada debe conocer el total
+para dibujar en cada pagina:
+
+- marca de agua diagonal gris clara;
+- provincia;
+- usuario;
+- fecha y hora local de la descarga;
+- `Pagina X de Y`;
+- pie de pagina equivalente.
+
+Las columnas y encabezados de CDI se repiten en cada pagina. Los textos extensos
+se envuelven dentro de un maximo de lineas definido; no se truncan valores de
+identidad sin una marca visual.
+
+## Manejo de errores
+
+- Alcance inexistente o invalido: `PermissionDenied` sin revelar provincias.
+- Sin filas activas: generar un documento valido con total provincial cero.
+- Error de render o rasterizacion: respuesta 503 con mensaje generico.
+- Archivos temporales: `TemporaryDirectory`, siempre eliminado al terminar.
+- Tiempo de rasterizacion: timeout explicito y un solo worker para acotar
+  memoria.
+
+## Integracion de interfaz
+
+El boton se incorpora en el listado de Centro de Infancia porque la descarga es
+provincial, no de un unico CDI. Se reutiliza el soporte de botones adicionales
+de `components/search_bar.html` y se agrega al contexto solamente para EGP.
+
+## Enfoques descartados
+
+### HTML y WeasyPrint
+
+Facilita CSS, pero ofrece menos control determinista sobre trece columnas,
+encabezados repetidos, marca de agua y numeracion total antes de rasterizar.
+
+### DOCX y LibreOffice
+
+Existe un patron similar en el repositorio, pero editar tablas variables y
+controlar los saltos de pagina es mas fragil y agrega un proceso externo que no
+aporta valor en este caso.
+
+### PDF vectorial como salida final
+
+Es la opcion mas simple, pero no cumple el requisito literal de que cada pagina
+del PDF sea una imagen JPEG.
+
+## Flujo de ramas y release
+
+1. La rama nace del `origin/main` vigente.
+2. Primer PR: `codex/simepi-descarga-nomina-ninos -> homologacion`.
+3. Merge y despliegue de HML solo despues de CI completa.
+4. Validacion funcional y visual en HML con datos sinteticos.
+5. Segundo PR, desde la misma rama: `codex/simepi-descarga-nomina-ninos -> main`.
+6. Comparar el diff contra `main` y confirmar que contiene solo la feature.
+
+Antes del segundo PR se debe verificar en vivo la ruleset de `main`. La
+automatizacion versionada actual documenta `release_baseline` para promociones
+`development -> main`; si continua siendo obligatorio y no soporta esta rama,
+el release queda bloqueado hasta disponer de un camino formal. No se quitan
+checks, no se hace bypass y no se simula un baseline.

--- a/docs/plans/2026-08-18-simepi-descarga-nomina-ninos-plan.md
+++ b/docs/plans/2026-08-18-simepi-descarga-nomina-ninos-plan.md
@@ -1,0 +1,237 @@
+# Plan de implementacion: descarga provincial de nomina SIMEPI
+
+Fecha: 2026-08-18
+
+Diseno: `docs/plans/2026-08-18-simepi-descarga-nomina-ninos-design.md`
+
+Rama: `codex/simepi-descarga-nomina-ninos`
+
+Base: `main`
+
+## Criterio de finalizacion
+
+La tarea esta implementada cuando un usuario EGP puede descargar desde el
+listado de CDI un PDF rasterizado con solo la nomina activa y unica de su
+provincia, mientras todos los demas roles y alcances quedan bloqueados en el
+servidor. La suite focalizada, los checks de formato y una inspeccion visual del
+PDF deben pasar antes de abrir el PR a `homologacion`.
+
+La integracion a HML no equivale a publicacion en produccion. El segundo PR a
+`main`, su gate de release y el deploy productivo son estados separados.
+
+## Fase 1: contrato y autorizacion
+
+### Archivos
+
+- `centrodeinfancia/access.py`
+- `centrodeinfancia/views_export.py`
+- `centrodeinfancia/urls.py`
+- `centrodeinfancia/tests/test_nomina_ninos_pdf.py`
+
+### Trabajo
+
+1. Agregar un helper pequeno y reutilizable para detectar el rol exacto
+   `SIMEPI - EGP`.
+2. Implementar una view autenticada de descarga que haga el control del grupo
+   antes de construir cualquier queryset.
+3. Resolver la unica provincia completa mediante el alcance territorial
+   explicito; rechazar cero, multiples o alcances parciales.
+4. Agregar una ruta con nombre estable, sin aceptar provincia o CDI desde el
+   cliente.
+5. Configurar attachment, nombre de archivo seguro y headers anti-cache.
+
+### Pruebas
+
+- anonimo redirigido al login;
+- EGP con una provincia obtiene 200;
+- EGP sin alcance, con multiples provincias o alcance parcial obtiene 403;
+- Administrador, Analista, Equipo Nacional, Auditoria, Referente y Trabajador
+  no pueden acceder;
+- no se consulta el servicio de render si falla la autorizacion.
+
+## Fase 2: consulta y normalizacion de datos
+
+### Archivos
+
+- nuevo `centrodeinfancia/services_nomina_ninos_pdf.py`
+- `centrodeinfancia/tests/test_nomina_ninos_pdf.py`
+
+### Trabajo
+
+1. Definir dataclasses inmutables para usuario, CDI, nino, adulto y pagina.
+2. Construir un queryset de fichas activas y no eliminadas, acotado por la
+   provincia antes de evaluar resultados.
+3. Usar `select_related` para CDI, provincia, ciudadano, sexo y perfil del
+   actor.
+4. Resolver accesos de referentes y validaciones RENAPER de adultos con
+   consultas masivas, sin N+1.
+5. Aplicar fallbacks de campos de nomina a ciudadano.
+6. Calcular edad usando una unica fecha/hora de descarga compartida por todo el
+   documento.
+7. Normalizar la clave de identidad, deduplicar y conservar la ficha activa mas
+   reciente.
+8. Ordenar y agrupar por CDI; omitir CDI vacios.
+9. No loggear valores de identidad.
+
+### Pruebas
+
+- otra provincia nunca llega al DTO;
+- baja y soft-delete quedan fuera;
+- duplicado historico produce una sola fila;
+- desempate estable por fecha e id;
+- orden completo por medida, edad, apellido, nombre y DNI;
+- datos faltantes producen `-`;
+- validacion RENAPER del nino y adulto respeta el contrato `Si`/`No`;
+- referente ambiguo no expone un CUIL arbitrario;
+- cantidad de queries acotada al aumentar el numero de filas.
+
+## Fase 3: render vectorial
+
+### Archivos
+
+- `centrodeinfancia/services_nomina_ninos_pdf.py`
+- `centrodeinfancia/tests/test_nomina_ninos_pdf.py`
+
+### Trabajo
+
+1. Definir pagina A4 horizontal y margenes.
+2. Registrar Liberation Sans o mapearla de manera explicita como fuente
+   compatible; no depender de una Arial presente por casualidad.
+3. Crear encabezado provincial, encabezado CDI, tabla de trece columnas y pie.
+4. Repetir encabezados mediante `PageTemplate`/callbacks de ReportLab.
+5. Implementar marca de agua y numeracion `X de Y` con una pasada que conozca
+   el total.
+6. Agregar una pagina final de resumen provincial.
+7. Mantener anchos de columna y wrapping en constantes testeables.
+
+### Pruebas
+
+- el PDF intermedio abre con `pypdf`;
+- pagina A4 horizontal;
+- encabezados repetidos al forzar mas de una pagina;
+- total provincial y metadatos de pagina reciben el numero correcto;
+- documento de cero filas sigue siendo valido.
+
+## Fase 4: rasterizacion y PDF final
+
+### Archivos
+
+- `centrodeinfancia/services_nomina_ninos_pdf.py`
+- `centrodeinfancia/tests/test_nomina_ninos_pdf.py`
+
+### Trabajo
+
+1. Rasterizar el PDF intermedio con `pdf2image` a JPEG dentro de un
+   `TemporaryDirectory`.
+2. Usar timeout, un worker y resolucion fija suficiente para texto de 9 puntos.
+3. Crear un PDF final A4 horizontal que coloque una unica imagen por pagina.
+4. Eliminar temporales incluso ante excepciones.
+5. Traducir fallos de Poppler/render a una excepcion de servicio sin PII.
+
+### Pruebas
+
+- cada pagina final contiene un unico XObject de imagen;
+- el filtro del objeto es JPEG (`DCTDecode`);
+- el PDF final no contiene una capa de texto con DNI o nombres;
+- cantidad de paginas igual al intermedio;
+- falla de rasterizacion produce respuesta 503 y limpia temporales.
+
+## Fase 5: interfaz
+
+### Archivos
+
+- `centrodeinfancia/views.py`
+- `centrodeinfancia/templates/centrodeinfancia/centrodeinfancia_list.html`
+- `centrodeinfancia/tests/test_nomina_ninos_pdf.py`
+
+### Trabajo
+
+1. Exponer en el contexto un boton adicional solo para EGP.
+2. Reutilizar `components/search_bar.html`.
+3. Usar el texto literal `Descargar nomina de ninos` y un titulo accesible.
+4. No reutilizar el helper JavaScript de CSV si una descarga normal por enlace
+   es suficiente.
+
+### Pruebas
+
+- boton visible para EGP;
+- boton ausente para todos los demas roles;
+- el enlace apunta al endpoint nuevo;
+- la ausencia visual no reemplaza las pruebas de acceso directo.
+
+## Fase 6: documentacion y mapa
+
+### Archivos
+
+- `docs/registro/cambios/2026-08-18-simepi-descarga-nomina-ninos.md`
+- `AGENT_REPO_MAP.md`
+- este diseno y plan
+
+### Trabajo
+
+1. Documentar contrato funcional, alcance, privacidad y rollback.
+2. Agregar el nuevo servicio y endpoint al mapa del repositorio.
+3. Registrar que no se crean archivos persistentes ni migraciones.
+4. Documentar la dependencia operativa de Poppler ya presente en la imagen.
+
+## Validacion focalizada
+
+Ejecutar primero:
+
+```powershell
+docker compose run --build --rm --no-deps -T django pytest -q centrodeinfancia/tests/test_nomina_ninos_pdf.py
+```
+
+Luego, sobre los archivos tocados:
+
+```powershell
+docker compose run --build --rm --no-deps -T django black --check centrodeinfancia
+docker compose run --build --rm --no-deps -T django pylint centrodeinfancia
+docker compose run --build --rm --no-deps -T django djlint --check centrodeinfancia/templates/centrodeinfancia/centrodeinfancia_list.html
+git diff --check
+```
+
+La suite completa y el build quedan a cargo de CI salvo que un fallo focalizado
+indique acoplamiento adicional.
+
+## Verificacion visual y HML
+
+1. Generar un PDF local con datos sinteticos que cubran textos largos, valores
+   faltantes y mas de una pagina.
+2. Inspeccionar todas las paginas renderizadas: legibilidad, columnas, marca de
+   agua, encabezados, pie y resumen final.
+3. Comparar el diff de la rama contra `origin/main`.
+4. Verificar integrabilidad sin conflictos contra `origin/homologacion`.
+5. Abrir PR hacia `homologacion` y esperar CI completa.
+6. Despues del merge, verificar SHA desplegado y repetir la descarga con un EGP
+   de prueba en HML sin usar PII real.
+
+## Promocion selectiva a main
+
+1. Conservar la rama despues del primer merge.
+2. Confirmar que `git diff origin/main...codex/simepi-descarga-nomina-ninos`
+   contiene solamente esta funcionalidad.
+3. Revalidar que la rama sigue actualizada con `main`; incorporar `main` por un
+   merge normal si avanzo, sin rebase ni force-push.
+4. Abrir el segundo PR desde la misma rama hacia `main`.
+5. Revalidar rulesets y `release_baseline` en vivo.
+6. Si el baseline no admite este origen, detener el release y pedir un camino
+   formal; no quitar checks ni usar bypass.
+7. Tras merge autorizado, esperar aprobacion del Environment `production`,
+   verificar el SHA desplegado y ejecutar smoke de descarga.
+
+## Riesgos y mitigaciones
+
+- **PII fuera de provincia:** alcance aplicado antes de evaluar el queryset y
+  pruebas negativas con dos provincias.
+- **Permiso solo visual:** control de grupo duplicado en servidor.
+- **N+1 y descarga lenta:** precarga y consultas masivas, prueba de query count.
+- **Consumo de memoria:** temporales en disco, un worker y no conservar todas
+  las imagenes decodificadas simultaneamente.
+- **Datos faltantes:** `-` explicito; no inferir CUIL ni unidad de edad.
+- **Duplicados legacy:** desempate determinista y log agregado sin PII.
+- **Salida vectorial accidental:** inspeccionar objetos PDF y exigir JPEG por
+  pagina.
+- **Arrastre de HML a produccion:** rama nacida de `main` y diff del segundo PR
+  calculado contra `main`.
+- **Gate de release incompatible:** detenerse; no degradar la proteccion.

--- a/docs/registro/cambios/2026-08-18-simepi-descarga-nomina-ninos.md
+++ b/docs/registro/cambios/2026-08-18-simepi-descarga-nomina-ninos.md
@@ -49,8 +49,10 @@ runtime.
 
 La regresión focalizada cubre autorización, visibilidad del botón, filtros por
 provincia y estado, deduplicación, orden, datos RENAPER, headers HTTP y
-estructura del PDF final. Además se debe inspeccionar visualmente un documento
-sintético de varias páginas antes de publicar.
+estructura del PDF final. La inspección local de un documento sintético de tres
+páginas confirmó A4 apaisado, encabezados repetidos, legibilidad, marca de agua,
+pie numerado, resumen provincial y una imagen JPEG por página sin capa de
+texto.
 
 El rollback consiste en revertir la ruta, la acción de interfaz y el servicio;
 no requiere reversión de esquema ni limpieza de datos.

--- a/docs/registro/cambios/2026-08-18-simepi-descarga-nomina-ninos.md
+++ b/docs/registro/cambios/2026-08-18-simepi-descarga-nomina-ninos.md
@@ -1,0 +1,56 @@
+# Descarga provincial de nómina de niños SIMEPI
+
+Fecha: 2026-08-18
+
+## Cambio
+
+El listado de Centros de Desarrollo Infantil incorpora la acción `Descargar
+nómina de niños` para usuarios del grupo `SIMEPI - EGP`. La acción genera un
+PDF con las fichas activas y únicas de la única provincia completa asignada al
+perfil.
+
+El documento:
+
+- agrupa las filas por CDI;
+- ordena por medida, edad, apellido, nombre y DNI;
+- incluye los datos de identidad y la validación RENAPER solicitados;
+- repite encabezados en cada página;
+- agrega marca de agua, fecha, usuario y numeración total;
+- termina con el total provincial;
+- usa A4 apaisado y una imagen JPEG por página.
+
+## Autorización y privacidad
+
+El endpoint no recibe una provincia desde el cliente. Exige autenticación,
+pertenencia al grupo `SIMEPI - EGP` y exactamente un alcance territorial de
+provincia completa. Los demás roles, los alcances parciales y los perfiles
+ambiguos reciben una denegación antes de consultar la nómina.
+
+La respuesta usa `private, no-store`, se entrega como attachment y no persiste
+el archivo en `MEDIA_ROOT`. Los errores devuelven un mensaje genérico y los
+logs contienen únicamente identificadores internos y cantidades, sin DNI,
+CUIL, nombres ni datos RENAPER.
+
+## Implementación
+
+- `centrodeinfancia/services_nomina_ninos_pdf.py` concentra consulta,
+  normalización, deduplicación, render vectorial y rasterización.
+- ReportLab genera el documento intermedio con Liberation Sans como alternativa
+  compatible con Arial.
+- `pdf2image` y Poppler convierten cada página en JPEG dentro de un directorio
+  temporal.
+- ReportLab crea el PDF final con una única imagen por página.
+
+No se agregan dependencias, migraciones ni archivos persistentes. ReportLab,
+Pillow, pypdf, pdf2image, Poppler y las fuentes Liberation ya forman parte del
+runtime.
+
+## Validación y rollback
+
+La regresión focalizada cubre autorización, visibilidad del botón, filtros por
+provincia y estado, deduplicación, orden, datos RENAPER, headers HTTP y
+estructura del PDF final. Además se debe inspeccionar visualmente un documento
+sintético de varias páginas antes de publicar.
+
+El rollback consiste en revertir la ruta, la acción de interfaz y el servicio;
+no requiere reversión de esquema ni limpieza de datos.

--- a/docs/registro/prs/PR-2307.md
+++ b/docs/registro/prs/PR-2307.md
@@ -18,13 +18,16 @@
 ## Áreas afectadas
 
 - `AGENT_REPO_MAP.md`
+- `CHANGELOG.md`
 - `centrodeinfancia`
+- `docs/contexto`
 - `docs/plans`
 - `docs/registro`
 
 ## Archivos relevantes del diff
 
 - `AGENT_REPO_MAP.md`
+- `CHANGELOG.md`
 - `centrodeinfancia/access.py`
 - `centrodeinfancia/services_nomina_ninos_pdf.py`
 - `centrodeinfancia/templates/centrodeinfancia/centrodeinfancia_list.html`
@@ -32,9 +35,14 @@
 - `centrodeinfancia/urls.py`
 - `centrodeinfancia/views.py`
 - `centrodeinfancia/views_export.py`
+- `docs/contexto/features/pr-2307-feat-centrodeinfancia-descargar-nomina-provincial-de-ninos-hml.md`
+- `docs/contexto/features/pr-2308-feat-centrodeinfancia-descargar-nomina-provincial-de-ninos.md`
 - `docs/plans/2026-08-18-simepi-descarga-nomina-ninos-design.md`
 - `docs/plans/2026-08-18-simepi-descarga-nomina-ninos-plan.md`
 - `docs/registro/cambios/2026-08-18-simepi-descarga-nomina-ninos.md`
+- `docs/registro/prs/PR-2307.md`
+- `docs/registro/prs/PR-2308.md`
+- `docs/registro/releases/pending/2026-08-19-pr-2308.md`
 
 ## Validación declarada
 
@@ -51,9 +59,14 @@
 - `docs/ia/CONTEXT_HYGIENE.md`
 - `docs/ia/ARCHITECTURE.md`
 - `docs/ia/TESTING.md`
+- `docs/contexto/features/pr-2307-feat-centrodeinfancia-descargar-nomina-provincial-de-ninos-hml.md`
+- `docs/contexto/features/pr-2308-feat-centrodeinfancia-descargar-nomina-provincial-de-ninos.md`
 - `docs/plans/2026-08-18-simepi-descarga-nomina-ninos-design.md`
 - `docs/plans/2026-08-18-simepi-descarga-nomina-ninos-plan.md`
 - `docs/registro/cambios/2026-08-18-simepi-descarga-nomina-ninos.md`
+- `docs/registro/prs/PR-2307.md`
+- `docs/registro/prs/PR-2308.md`
+- `docs/registro/releases/pending/2026-08-19-pr-2308.md`
 
 ## Notas para continuidad
 

--- a/docs/registro/prs/PR-2307.md
+++ b/docs/registro/prs/PR-2307.md
@@ -1,0 +1,61 @@
+# PR #2307 - feat(centrodeinfancia): descargar nómina provincial de niños [HML]
+
+## Metadata
+
+- PR: https://github.com/dsocial118/SISOC/pull/2307
+- Base: `homologacion`
+- Rama origen: `codex/simepi-descarga-nomina-ninos`
+- Autor: `juanikitro`
+
+## Resumen operativo
+
+- Tipo de cambio: No informado
+- Área principal: No informada
+- Contexto funcional: No informado explícitamente; revisar título, diff y documentación relacionada.
+- Resumen para changelog: No informado
+- Impacto usuario: No informado
+
+## Áreas afectadas
+
+- `AGENT_REPO_MAP.md`
+- `centrodeinfancia`
+- `docs/plans`
+- `docs/registro`
+
+## Archivos relevantes del diff
+
+- `AGENT_REPO_MAP.md`
+- `centrodeinfancia/access.py`
+- `centrodeinfancia/services_nomina_ninos_pdf.py`
+- `centrodeinfancia/templates/centrodeinfancia/centrodeinfancia_list.html`
+- `centrodeinfancia/tests/test_nomina_ninos_pdf.py`
+- `centrodeinfancia/urls.py`
+- `centrodeinfancia/views.py`
+- `centrodeinfancia/views_export.py`
+- `docs/plans/2026-08-18-simepi-descarga-nomina-ninos-design.md`
+- `docs/plans/2026-08-18-simepi-descarga-nomina-ninos-plan.md`
+- `docs/registro/cambios/2026-08-18-simepi-descarga-nomina-ninos.md`
+
+## Validación declarada
+
+- Pruebas automáticas: No informado en el PR.
+- Pruebas manuales: No informado en el PR.
+
+## Riesgos y rollback
+
+- No informado explícitamente en el PR.
+
+## Documentación sugerida para lectura
+
+- `docs/indice.md`
+- `docs/ia/CONTEXT_HYGIENE.md`
+- `docs/ia/ARCHITECTURE.md`
+- `docs/ia/TESTING.md`
+- `docs/plans/2026-08-18-simepi-descarga-nomina-ninos-design.md`
+- `docs/plans/2026-08-18-simepi-descarga-nomina-ninos-plan.md`
+- `docs/registro/cambios/2026-08-18-simepi-descarga-nomina-ninos.md`
+
+## Notas para continuidad
+
+- Este documento es generado automáticamente desde el contexto del PR y sirve como índice rápido para revisión y futuras sesiones de agentes.
+- Si la metadata del body del PR está incompleta, varias secciones usarán fallbacks derivados del título o del diff.

--- a/docs/registro/prs/PR-2308.md
+++ b/docs/registro/prs/PR-2308.md
@@ -18,6 +18,7 @@
 ## Áreas afectadas
 
 - `AGENT_REPO_MAP.md`
+- `CHANGELOG.md`
 - `centrodeinfancia`
 - `docs/contexto`
 - `docs/plans`
@@ -26,6 +27,7 @@
 ## Archivos relevantes del diff
 
 - `AGENT_REPO_MAP.md`
+- `CHANGELOG.md`
 - `centrodeinfancia/access.py`
 - `centrodeinfancia/services_nomina_ninos_pdf.py`
 - `centrodeinfancia/templates/centrodeinfancia/centrodeinfancia_list.html`
@@ -34,10 +36,13 @@
 - `centrodeinfancia/views.py`
 - `centrodeinfancia/views_export.py`
 - `docs/contexto/features/pr-2307-feat-centrodeinfancia-descargar-nomina-provincial-de-ninos-hml.md`
+- `docs/contexto/features/pr-2308-feat-centrodeinfancia-descargar-nomina-provincial-de-ninos.md`
 - `docs/plans/2026-08-18-simepi-descarga-nomina-ninos-design.md`
 - `docs/plans/2026-08-18-simepi-descarga-nomina-ninos-plan.md`
 - `docs/registro/cambios/2026-08-18-simepi-descarga-nomina-ninos.md`
 - `docs/registro/prs/PR-2307.md`
+- `docs/registro/prs/PR-2308.md`
+- `docs/registro/releases/pending/2026-08-19-pr-2308.md`
 
 ## Validación declarada
 
@@ -55,10 +60,13 @@
 - `docs/ia/ARCHITECTURE.md`
 - `docs/ia/TESTING.md`
 - `docs/contexto/features/pr-2307-feat-centrodeinfancia-descargar-nomina-provincial-de-ninos-hml.md`
+- `docs/contexto/features/pr-2308-feat-centrodeinfancia-descargar-nomina-provincial-de-ninos.md`
 - `docs/plans/2026-08-18-simepi-descarga-nomina-ninos-design.md`
 - `docs/plans/2026-08-18-simepi-descarga-nomina-ninos-plan.md`
 - `docs/registro/cambios/2026-08-18-simepi-descarga-nomina-ninos.md`
 - `docs/registro/prs/PR-2307.md`
+- `docs/registro/prs/PR-2308.md`
+- `docs/registro/releases/pending/2026-08-19-pr-2308.md`
 
 ## Notas para continuidad
 

--- a/docs/registro/prs/PR-2308.md
+++ b/docs/registro/prs/PR-2308.md
@@ -1,0 +1,66 @@
+# PR #2308 - feat(centrodeinfancia): descargar nómina provincial de niños
+
+## Metadata
+
+- PR: https://github.com/dsocial118/SISOC/pull/2308
+- Base: `main`
+- Rama origen: `codex/simepi-descarga-nomina-ninos`
+- Autor: `juanikitro`
+
+## Resumen operativo
+
+- Tipo de cambio: No informado
+- Área principal: No informada
+- Contexto funcional: No informado explícitamente; revisar título, diff y documentación relacionada.
+- Resumen para changelog: No informado
+- Impacto usuario: No informado
+
+## Áreas afectadas
+
+- `AGENT_REPO_MAP.md`
+- `centrodeinfancia`
+- `docs/contexto`
+- `docs/plans`
+- `docs/registro`
+
+## Archivos relevantes del diff
+
+- `AGENT_REPO_MAP.md`
+- `centrodeinfancia/access.py`
+- `centrodeinfancia/services_nomina_ninos_pdf.py`
+- `centrodeinfancia/templates/centrodeinfancia/centrodeinfancia_list.html`
+- `centrodeinfancia/tests/test_nomina_ninos_pdf.py`
+- `centrodeinfancia/urls.py`
+- `centrodeinfancia/views.py`
+- `centrodeinfancia/views_export.py`
+- `docs/contexto/features/pr-2307-feat-centrodeinfancia-descargar-nomina-provincial-de-ninos-hml.md`
+- `docs/plans/2026-08-18-simepi-descarga-nomina-ninos-design.md`
+- `docs/plans/2026-08-18-simepi-descarga-nomina-ninos-plan.md`
+- `docs/registro/cambios/2026-08-18-simepi-descarga-nomina-ninos.md`
+- `docs/registro/prs/PR-2307.md`
+
+## Validación declarada
+
+- Pruebas automáticas: No informado en el PR.
+- Pruebas manuales: No informado en el PR.
+
+## Riesgos y rollback
+
+- No informado explícitamente en el PR.
+
+## Documentación sugerida para lectura
+
+- `docs/indice.md`
+- `docs/ia/CONTEXT_HYGIENE.md`
+- `docs/ia/ARCHITECTURE.md`
+- `docs/ia/TESTING.md`
+- `docs/contexto/features/pr-2307-feat-centrodeinfancia-descargar-nomina-provincial-de-ninos-hml.md`
+- `docs/plans/2026-08-18-simepi-descarga-nomina-ninos-design.md`
+- `docs/plans/2026-08-18-simepi-descarga-nomina-ninos-plan.md`
+- `docs/registro/cambios/2026-08-18-simepi-descarga-nomina-ninos.md`
+- `docs/registro/prs/PR-2307.md`
+
+## Notas para continuidad
+
+- Este documento es generado automáticamente desde el contexto del PR y sirve como índice rápido para revisión y futuras sesiones de agentes.
+- Si la metadata del body del PR está incompleta, varias secciones usarán fallbacks derivados del título o del diff.

--- a/docs/registro/releases/pending/2026-08-19-pr-2308.md
+++ b/docs/registro/releases/pending/2026-08-19-pr-2308.md
@@ -1,0 +1,19 @@
+---
+pr: 2308
+release_date: 2026-08-19
+category: Actualizaciones
+area: sin-area
+title: feat(centrodeinfancia): descargar nómina provincial de niños
+summary: feat(centrodeinfancia): descargar nómina provincial de niños
+impact: No informado
+source_url: https://github.com/dsocial118/SISOC/pull/2308
+---
+# Release note preliminar PR #2308
+
+- Fecha objetivo de release: 2026-08-19
+- Categoría: Actualizaciones
+- Área: sin-area
+- Título del PR: feat(centrodeinfancia): descargar nómina provincial de niños
+- Resumen: feat(centrodeinfancia): descargar nómina provincial de niños
+- Impacto usuario: No informado
+- Fuente: https://github.com/dsocial118/SISOC/pull/2308


### PR DESCRIPTION
## Qué cambia
- agrega la descarga provincial de nómina de niños para `SIMEPI - EGP`
- exige un único alcance provincial completo y bloquea otros roles/alcances
- filtra fichas activas, deduplica, ordena y agrupa por CDI
- genera A4 apaisado con encabezados repetidos, marca de agua y resumen provincial
- rasteriza cada página a JPEG y entrega el PDF sin caché ni persistencia

## Por qué
Implementa el descargable solicitado para que el Equipo de Gestión Provincial pueda probarlo en HML sin pasar por `development`.

## Impacto y seguridad
- contiene PII únicamente dentro del archivo solicitado por el usuario autorizado
- no acepta provincia ni CDI desde el cliente
- logs y errores no incluyen datos personales
- no agrega migraciones ni dependencias

## Validación
- `py_compile` sobre los Python modificados
- `git diff --check`
- inspección estructural: A4 horizontal, un JPEG por página, sin capa de texto
- inspección visual de tres páginas sintéticas, incluidos salto, encabezados y resumen
- CI del PR pendiente

## Rama
La rama nació de `origin/main` (`2feaec9246a5a43df41c8de9f393895939f1da8b`). Este PR apunta directo a `homologacion` y no pasa por `development`.