### PR TITLE
fix(centrodeinfancia): asegurar nómina provincial única [HML]

### DIFF
--- a/centrodeinfancia/services_nomina_ninos_pdf.py
+++ b/centrodeinfancia/services_nomina_ninos_pdf.py
@@ -197,21 +197,31 @@ def _resolved_child_fields(registro):
 
 def _deduplicate_registros(registros):
     selected = []
-    seen = set()
+    seen_citizen_ids = set()
+    seen_documents = set()
+    seen_identity_keys = set()
     duplicate_count = 0
     for registro in registros:
         apellido, nombre, dni, birth_date, sexo = _resolved_child_fields(registro)
-        key = (
+        document_key = str(dni).strip() if dni not in (None, "") else None
+        identity_key = (
             _normalize(apellido),
             _normalize(nombre),
-            str(dni or ""),
+            document_key or "",
             birth_date.isoformat() if birth_date else "",
             _normalize(sexo),
         )
-        if key in seen:
+        if (
+            registro.ciudadano_id in seen_citizen_ids
+            or (document_key is not None and document_key in seen_documents)
+            or identity_key in seen_identity_keys
+        ):
             duplicate_count += 1
             continue
-        seen.add(key)
+        seen_citizen_ids.add(registro.ciudadano_id)
+        if document_key is not None:
+            seen_documents.add(document_key)
+        seen_identity_keys.add(identity_key)
         selected.append(registro)
     return selected, duplicate_count
 

--- a/centrodeinfancia/tests/test_nomina_ninos_pdf.py
+++ b/centrodeinfancia/tests/test_nomina_ninos_pdf.py
@@ -247,6 +247,131 @@ def test_export_data_filtra_deduplica_ordena_y_resuelve_validaciones():
     assert data.centros[0].rows[1].renaper_nino == "No"
 
 
+@pytest.mark.django_db
+def test_export_data_usa_provincia_del_centro_aunque_falte_domicilio_del_nino():
+    provincia = Provincia.objects.create(nombre="Buenos Aires")
+    user = _create_egp("egp-buenos-aires", provincia)
+    centro = CentroDeInfancia.objects.create(
+        nombre="CDI Buenos Aires",
+        provincia=provincia,
+    )
+    con_provincia = _create_child(41000001)
+    sin_provincia = _create_child(41000002)
+
+    NominaCentroInfancia.objects.create(
+        centro=centro,
+        ciudadano=con_provincia,
+        estado=NominaCentroInfancia.ESTADO_ACTIVO,
+        provincia_domicilio=provincia,
+    )
+    NominaCentroInfancia.objects.create(
+        centro=centro,
+        ciudadano=sin_provincia,
+        estado=NominaCentroInfancia.ESTADO_ACTIVO,
+        provincia_domicilio=None,
+    )
+
+    data = build_export_data(user=user, provincia=provincia)
+
+    assert data.total_ninos == 2
+    assert {row.dni for row in data.centros[0].rows} == {"41000001", "41000002"}
+
+
+@pytest.mark.django_db
+def test_export_data_no_duplica_mismo_ciudadano_si_sus_fichas_difieren():
+    provincia = Provincia.objects.create(nombre="Provincia Sin Duplicados")
+    user = _create_egp("egp-sin-duplicados", provincia)
+    centro = CentroDeInfancia.objects.create(
+        nombre="CDI Sin Duplicados",
+        provincia=provincia,
+    )
+    child = _create_child(42000001)
+
+    ficha_anterior = NominaCentroInfancia.objects.create(
+        centro=centro,
+        ciudadano=child,
+        estado=NominaCentroInfancia.ESTADO_ACTIVO,
+        apellido="Apellido anterior",
+        nombre="Nombre anterior",
+        dni=42000001,
+        fecha_nacimiento=date(2020, 1, 15),
+        sexo=NominaCentroInfancia.SexoChoices.MASCULINO,
+    )
+    NominaCentroInfancia.objects.filter(pk=ficha_anterior.pk).update(
+        fecha=timezone.make_aware(datetime(2025, 1, 1, 10, 0))
+    )
+    ficha_reciente = NominaCentroInfancia.objects.create(
+        centro=centro,
+        ciudadano=child,
+        estado=NominaCentroInfancia.ESTADO_ACTIVO,
+        apellido="Apellido corregido",
+        nombre="Nombre corregido",
+        dni=42000001,
+        fecha_nacimiento=date(2020, 1, 16),
+        sexo=NominaCentroInfancia.SexoChoices.FEMENINO,
+    )
+    NominaCentroInfancia.objects.filter(pk=ficha_reciente.pk).update(
+        fecha=timezone.make_aware(datetime(2026, 1, 1, 10, 0))
+    )
+
+    data = build_export_data(user=user, provincia=provincia)
+
+    assert data.total_ninos == 1
+    assert data.centros[0].rows[0].apellido == "Apellido corregido"
+
+
+@pytest.mark.django_db
+def test_export_data_no_duplica_mismo_dni_en_ciudadanos_distintos():
+    provincia = Provincia.objects.create(nombre="Provincia DNI Único")
+    user = _create_egp("egp-dni-unico", provincia)
+    centro = CentroDeInfancia.objects.create(
+        nombre="CDI DNI Único",
+        provincia=provincia,
+    )
+    child_anterior = Ciudadano.objects.create(
+        apellido="Apellido ciudadano anterior",
+        nombre="Nombre ciudadano anterior",
+        fecha_nacimiento=date(2020, 1, 15),
+        documento=43000001,
+        tipo_registro_identidad=Ciudadano.TIPO_REGISTRO_DNI_NO_VALIDADO,
+    )
+    child_reciente = Ciudadano.objects.create(
+        apellido="Apellido ciudadano reciente",
+        nombre="Nombre ciudadano reciente",
+        fecha_nacimiento=date(2020, 1, 16),
+        documento=43000001,
+        tipo_registro_identidad=Ciudadano.TIPO_REGISTRO_DNI_NO_VALIDADO,
+    )
+
+    ficha_anterior = NominaCentroInfancia.objects.create(
+        centro=centro,
+        ciudadano=child_anterior,
+        estado=NominaCentroInfancia.ESTADO_ACTIVO,
+        apellido="Apellido anterior",
+        nombre="Nombre anterior",
+        dni=43000001,
+    )
+    NominaCentroInfancia.objects.filter(pk=ficha_anterior.pk).update(
+        fecha=timezone.make_aware(datetime(2025, 1, 1, 10, 0))
+    )
+    ficha_reciente = NominaCentroInfancia.objects.create(
+        centro=centro,
+        ciudadano=child_reciente,
+        estado=NominaCentroInfancia.ESTADO_ACTIVO,
+        apellido="Apellido corregido",
+        nombre="Nombre corregido",
+        dni=43000001,
+    )
+    NominaCentroInfancia.objects.filter(pk=ficha_reciente.pk).update(
+        fecha=timezone.make_aware(datetime(2026, 1, 1, 10, 0))
+    )
+
+    data = build_export_data(user=user, provincia=provincia)
+
+    assert data.total_ninos == 1
+    assert data.centros[0].rows[0].apellido == "Apellido corregido"
+
+
 def _sample_export_data():
     row = NinoRow(
         centro_id=1,

--- a/docs/contexto/features/pr-2308-feat-centrodeinfancia-descargar-nomina-provincial-de-ninos.md
+++ b/docs/contexto/features/pr-2308-feat-centrodeinfancia-descargar-nomina-provincial-de-ninos.md
@@ -43,11 +43,13 @@
 - `centrodeinfancia/views_export.py`
 - `docs/contexto/features/pr-2307-feat-centrodeinfancia-descargar-nomina-provincial-de-ninos-hml.md`
 - `docs/contexto/features/pr-2308-feat-centrodeinfancia-descargar-nomina-provincial-de-ninos.md`
+- `docs/contexto/features/pr-2311-fix-centrodeinfancia-asegurar-nomina-provincial-unica-hml.md`
 - `docs/plans/2026-08-18-simepi-descarga-nomina-ninos-design.md`
 - `docs/plans/2026-08-18-simepi-descarga-nomina-ninos-plan.md`
 - `docs/registro/cambios/2026-08-18-simepi-descarga-nomina-ninos.md`
 - `docs/registro/prs/PR-2307.md`
 - `docs/registro/prs/PR-2308.md`
+- `docs/registro/prs/PR-2311.md`
 - `docs/registro/releases/pending/2026-08-19-pr-2308.md`
 - Documentación sugerida para ampliar contexto:
 - `docs/indice.md`
@@ -56,11 +58,13 @@
 - `docs/ia/TESTING.md`
 - `docs/contexto/features/pr-2307-feat-centrodeinfancia-descargar-nomina-provincial-de-ninos-hml.md`
 - `docs/contexto/features/pr-2308-feat-centrodeinfancia-descargar-nomina-provincial-de-ninos.md`
+- `docs/contexto/features/pr-2311-fix-centrodeinfancia-asegurar-nomina-provincial-unica-hml.md`
 - `docs/plans/2026-08-18-simepi-descarga-nomina-ninos-design.md`
 - `docs/plans/2026-08-18-simepi-descarga-nomina-ninos-plan.md`
 - `docs/registro/cambios/2026-08-18-simepi-descarga-nomina-ninos.md`
 - `docs/registro/prs/PR-2307.md`
 - `docs/registro/prs/PR-2308.md`
+- `docs/registro/prs/PR-2311.md`
 - `docs/registro/releases/pending/2026-08-19-pr-2308.md`
 
 ## Trazabilidad

--- a/docs/contexto/features/pr-2311-fix-centrodeinfancia-asegurar-nomina-provincial-unica-hml.md
+++ b/docs/contexto/features/pr-2311-fix-centrodeinfancia-asegurar-nomina-provincial-unica-hml.md
@@ -1,0 +1,48 @@
+# Contexto de feature PR #2311 - fix(centrodeinfancia): asegurar nómina provincial única [HML]
+
+## Resumen
+
+- PR: https://github.com/dsocial118/SISOC/pull/2311
+- Base: `homologacion`
+- Rama origen: `codex/simepi-descarga-nomina-ninos`
+- Autor: `juanikitro`
+
+## Contexto funcional
+
+- No informado explícitamente; inferir desde el título del PR y el diff.
+
+## Arquitectura tocada
+
+- No se detectó un patrón arquitectónico dominante más allá del diff observado.
+
+## Decisiones y supuestos detectados
+
+- Tipo de cambio declarado: No informado
+- Área principal declarada: No informada
+- Impacto usuario declarado: No informado
+- Riesgos / rollback: No informado
+
+## Design system y UI
+
+- Sin cambios visibles de UI o design system detectados en el diff.
+
+## Memoria operativa para agentes
+
+- Empezar por `docs/registro/prs/PR-2311.md` para contexto resumido del PR.
+- Revisar primero estos archivos del diff:
+- `centrodeinfancia/services_nomina_ninos_pdf.py`
+- `centrodeinfancia/tests/test_nomina_ninos_pdf.py`
+- `docs/plans/2026-08-18-simepi-descarga-nomina-ninos-design.md`
+- `docs/registro/cambios/2026-08-18-simepi-descarga-nomina-ninos.md`
+- Documentación sugerida para ampliar contexto:
+- `docs/indice.md`
+- `docs/ia/CONTEXT_HYGIENE.md`
+- `docs/ia/ARCHITECTURE.md`
+- `docs/ia/TESTING.md`
+- `docs/plans/2026-08-18-simepi-descarga-nomina-ninos-design.md`
+- `docs/registro/cambios/2026-08-18-simepi-descarga-nomina-ninos.md`
+
+## Trazabilidad
+
+- Documento generado automáticamente desde el evento de `pull_request`.
+- Si este PR cambia de título, el archivo se renombrará para mantener el slug alineado.

--- a/docs/plans/2026-08-18-simepi-descarga-nomina-ninos-design.md
+++ b/docs/plans/2026-08-18-simepi-descarga-nomina-ninos-design.md
@@ -33,6 +33,8 @@ exclusivos de `homologacion`.
   completa.
 - Incluir solo fichas `NominaCentroInfancia` activas y no eliminadas cuyos CDI
   pertenezcan a esa provincia.
+- La provincia domiciliaria del nino no interviene en el alcance: una ficha sin
+  `provincia_domicilio` se incluye si el CDI pertenece a la provincia del EGP.
 - Omitir CDI sin ninos activos.
 - Agrupar las filas por CDI y repetir el encabezado del CDI y de las columnas
   en cada pagina correspondiente.
@@ -101,20 +103,27 @@ Los valores visibles siguen el contrato actual de la nomina CDI: valor de
 
 ## Unicidad y orden
 
-La clave de deduplicacion pedida por la especificacion es la tupla normalizada:
+La salida aplica defensas de unicidad en orden, considerando duplicada una
+ficha si coincide cualquiera de estas identidades con una fila ya seleccionada:
 
-1. apellido;
-2. nombre;
-3. DNI;
-4. fecha de nacimiento;
-5. sexo.
+1. el `ciudadano_id` interno;
+2. el DNI resuelto, cuando existe;
+3. la tupla normalizada pedida por la especificacion:
+
+   - apellido;
+   - nombre;
+   - DNI;
+   - fecha de nacimiento;
+   - sexo.
 
 La normalizacion es solo para comparar: trim, espacios repetidos y
 case-insensitive en texto. Los valores impresos conservan el dato resuelto.
 
 La regla de vigencia actual evita nuevas fichas activas simultaneas en distintos
-CDI. Para duplicados historicos, se conserva la ficha activa mas reciente por
-`fecha` e `id`. Se registra solamente la cantidad de duplicados omitidos.
+CDI. Las defensas adicionales cubren fichas historicas inconsistentes del mismo
+ciudadano y ciudadanos legacy distintos con el mismo DNI. Siempre se conserva
+la ficha activa mas reciente por `fecha` e `id`. Se registra solamente la
+cantidad de duplicados omitidos.
 
 El orden es:
 

--- a/docs/registro/cambios/2026-08-18-simepi-descarga-nomina-ninos.md
+++ b/docs/registro/cambios/2026-08-18-simepi-descarga-nomina-ninos.md
@@ -35,6 +35,11 @@ CUIL, nombres ni datos RENAPER.
 
 - `centrodeinfancia/services_nomina_ninos_pdf.py` concentra consulta,
   normalización, deduplicación, render vectorial y rasterización.
+- El alcance territorial se toma exclusivamente de la provincia del CDI. La
+  provincia domiciliaria del niño puede estar vacía sin excluirlo.
+- La deduplicación conserva la ficha activa más reciente y evita repetir tanto
+  un mismo ciudadano como un mismo DNI, incluso en identidades legacy, además
+  de mantener la comparación compuesta original.
 - ReportLab genera el documento intermedio con Liberation Sans como alternativa
   compatible con Arial.
 - `pdf2image` y Poppler convierten cada página en JPEG dentro de un directorio
@@ -48,11 +53,12 @@ runtime.
 ## Validación y rollback
 
 La regresión focalizada cubre autorización, visibilidad del botón, filtros por
-provincia y estado, deduplicación, orden, datos RENAPER, headers HTTP y
-estructura del PDF final. La inspección local de un documento sintético de tres
-páginas confirmó A4 apaisado, encabezados repetidos, legibilidad, marca de agua,
-pie numerado, resumen provincial y una imagen JPEG por página sin capa de
-texto.
+provincia del CDI y estado, inclusión con provincia domiciliaria vacía,
+deduplicación por ciudadano, DNI e identidad compuesta, orden, datos RENAPER,
+headers HTTP y estructura del PDF final. La inspección local de un documento
+sintético de tres páginas confirmó A4 apaisado, encabezados repetidos,
+legibilidad, marca de agua, pie numerado, resumen provincial y una imagen JPEG
+por página sin capa de texto.
 
 El rollback consiste en revertir la ruta, la acción de interfaz y el servicio;
 no requiere reversión de esquema ni limpieza de datos.

--- a/docs/registro/prs/PR-2308.md
+++ b/docs/registro/prs/PR-2308.md
@@ -37,11 +37,13 @@
 - `centrodeinfancia/views_export.py`
 - `docs/contexto/features/pr-2307-feat-centrodeinfancia-descargar-nomina-provincial-de-ninos-hml.md`
 - `docs/contexto/features/pr-2308-feat-centrodeinfancia-descargar-nomina-provincial-de-ninos.md`
+- `docs/contexto/features/pr-2311-fix-centrodeinfancia-asegurar-nomina-provincial-unica-hml.md`
 - `docs/plans/2026-08-18-simepi-descarga-nomina-ninos-design.md`
 - `docs/plans/2026-08-18-simepi-descarga-nomina-ninos-plan.md`
 - `docs/registro/cambios/2026-08-18-simepi-descarga-nomina-ninos.md`
 - `docs/registro/prs/PR-2307.md`
 - `docs/registro/prs/PR-2308.md`
+- `docs/registro/prs/PR-2311.md`
 - `docs/registro/releases/pending/2026-08-19-pr-2308.md`
 
 ## Validación declarada
@@ -61,11 +63,13 @@
 - `docs/ia/TESTING.md`
 - `docs/contexto/features/pr-2307-feat-centrodeinfancia-descargar-nomina-provincial-de-ninos-hml.md`
 - `docs/contexto/features/pr-2308-feat-centrodeinfancia-descargar-nomina-provincial-de-ninos.md`
+- `docs/contexto/features/pr-2311-fix-centrodeinfancia-asegurar-nomina-provincial-unica-hml.md`
 - `docs/plans/2026-08-18-simepi-descarga-nomina-ninos-design.md`
 - `docs/plans/2026-08-18-simepi-descarga-nomina-ninos-plan.md`
 - `docs/registro/cambios/2026-08-18-simepi-descarga-nomina-ninos.md`
 - `docs/registro/prs/PR-2307.md`
 - `docs/registro/prs/PR-2308.md`
+- `docs/registro/prs/PR-2311.md`
 - `docs/registro/releases/pending/2026-08-19-pr-2308.md`
 
 ## Notas para continuidad

--- a/docs/registro/prs/PR-2311.md
+++ b/docs/registro/prs/PR-2311.md
@@ -1,0 +1,52 @@
+# PR #2311 - fix(centrodeinfancia): asegurar nómina provincial única [HML]
+
+## Metadata
+
+- PR: https://github.com/dsocial118/SISOC/pull/2311
+- Base: `homologacion`
+- Rama origen: `codex/simepi-descarga-nomina-ninos`
+- Autor: `juanikitro`
+
+## Resumen operativo
+
+- Tipo de cambio: No informado
+- Área principal: No informada
+- Contexto funcional: No informado explícitamente; revisar título, diff y documentación relacionada.
+- Resumen para changelog: No informado
+- Impacto usuario: No informado
+
+## Áreas afectadas
+
+- `centrodeinfancia`
+- `docs/plans`
+- `docs/registro`
+
+## Archivos relevantes del diff
+
+- `centrodeinfancia/services_nomina_ninos_pdf.py`
+- `centrodeinfancia/tests/test_nomina_ninos_pdf.py`
+- `docs/plans/2026-08-18-simepi-descarga-nomina-ninos-design.md`
+- `docs/registro/cambios/2026-08-18-simepi-descarga-nomina-ninos.md`
+
+## Validación declarada
+
+- Pruebas automáticas: No informado en el PR.
+- Pruebas manuales: No informado en el PR.
+
+## Riesgos y rollback
+
+- No informado explícitamente en el PR.
+
+## Documentación sugerida para lectura
+
+- `docs/indice.md`
+- `docs/ia/CONTEXT_HYGIENE.md`
+- `docs/ia/ARCHITECTURE.md`
+- `docs/ia/TESTING.md`
+- `docs/plans/2026-08-18-simepi-descarga-nomina-ninos-design.md`
+- `docs/registro/cambios/2026-08-18-simepi-descarga-nomina-ninos.md`
+
+## Notas para continuidad
+
+- Este documento es generado automáticamente desde el contexto del PR y sirve como índice rápido para revisión y futuras sesiones de agentes.
+- Si la metadata del body del PR está incompleta, varias secciones usarán fallbacks derivados del título o del diff.


### PR DESCRIPTION
## Qué cambia
- mantiene el alcance por la provincia del CDI aunque el niño no tenga provincia domiciliaria
- deduplica por `ciudadano_id`, por DNI resuelto y por la identidad compuesta original
- conserva siempre la ficha activa más reciente por fecha e ID

## Causa raíz
La deduplicación anterior exigía que coincidieran simultáneamente apellido, nombre, DNI, fecha de nacimiento y sexo. Una misma persona podía aparecer dos veces si sus fichas históricas diferían en alguno de esos datos.

## Riesgo mitigado
La nómina se usa para desembolsos; la salida no debe repetir beneficiarios, incluso ante fichas activas legacy inconsistentes o ciudadanos legacy distintos con el mismo DNI.

## Validación local
- 9 pruebas focalizadas aprobadas
- caso de niño sin provincia domiciliaria incluido por provincia del CDI
- casos de mismo ciudadano y mismo DNI legacy reducidos a una sola fila
- Black aprobado
- Pylint 10/10
- `git diff --check` aprobado