### PR TITLE
feat(centrodeinfancia): habilitar descarga superadmin [HML]

### DIFF
--- a/centrodeinfancia/templates/centrodeinfancia/centrodeinfancia_list.html
+++ b/centrodeinfancia/templates/centrodeinfancia/centrodeinfancia_list.html
@@ -13,6 +13,46 @@
         {% url 'centrodeinfancia_exportar' as export_url %}
         {% include 'components/search_bar.html' with titulo="Buscar Centro de Desarrollo Infantil" placeholder="Buscar por nombre u organización" help_text="Ingresar nombre u organización." reset_url='centrodeinfancia' add_url='centrodeinfancia_crear' add_text='Nuevo Centro' export_url=export_url query=query additional_buttons=additional_buttons %}
 
+        {% if mostrar_modal_nomina_ninos %}
+            <div class="modal fade"
+                 id="nomina-ninos-provincia-modal"
+                 tabindex="-1"
+                 aria-labelledby="nomina-ninos-provincia-modal-label"
+                 aria-hidden="true">
+                <div class="modal-dialog modal-dialog-centered">
+                    <div class="modal-content">
+                        <form method="get" action="{% url 'centrodeinfancia_nomina_ninos_pdf' %}">
+                            <div class="modal-header">
+                                <h5 class="modal-title" id="nomina-ninos-provincia-modal-label">Descargar nómina de niños</h5>
+                                <button type="button"
+                                        class="btn-close"
+                                        data-bs-dismiss="modal"
+                                        aria-label="Cerrar"></button>
+                            </div>
+                            <div class="modal-body">
+                                <label class="form-label" for="nomina-ninos-provincia">Provincia</label>
+                                <select class="form-select"
+                                        id="nomina-ninos-provincia"
+                                        name="provincia"
+                                        required>
+                                    <option value="" selected>Seleccionar provincia</option>
+                                    {% for provincia in nomina_ninos_provincias %}
+                                        <option value="{{ provincia.pk }}">{{ provincia.nombre }}</option>
+                                    {% endfor %}
+                                </select>
+                            </div>
+                            <div class="modal-footer">
+                                <button type="button"
+                                        class="btn btn-outline-secondary"
+                                        data-bs-dismiss="modal">Cancelar</button>
+                                <button type="submit" class="btn btn-primary">Descargar</button>
+                            </div>
+                        </form>
+                    </div>
+                </div>
+            </div>
+        {% endif %}
+
         <div class="row mt-5 max-width-100">
             <div class="col-12">
                 <div class="card comedor-table-card">

--- a/centrodeinfancia/tests/test_nomina_ninos_pdf.py
+++ b/centrodeinfancia/tests/test_nomina_ninos_pdf.py
@@ -203,7 +203,9 @@ def test_boton_descarga_solo_se_muestra_a_egp(client):
     response = client.get(reverse("centrodeinfancia"))
 
     assert response.status_code == 200
-    assert "Descargar nómina de niños" in response.content.decode()
+    content = response.content.decode()
+    assert "Descargar nómina de niños" in content
+    assert "poncho-btn poncho-btn--descarga" in content
 
     regular = User.objects.create_user(username="regular", password="test1234")
     regular.user_permissions.add(permission)
@@ -231,6 +233,7 @@ def test_superadmin_ve_modal_con_selector_provincial_obligatorio(client):
 
     assert response.status_code == 200
     assert "Descargar nómina de niños" in content
+    assert "poncho-btn poncho-btn--descarga" in content
     assert 'data-bs-target="#nomina-ninos-provincia-modal"' in content
     assert 'id="nomina-ninos-provincia-modal"' in content
     assert 'name="provincia"' in content

--- a/centrodeinfancia/tests/test_nomina_ninos_pdf.py
+++ b/centrodeinfancia/tests/test_nomina_ninos_pdf.py
@@ -79,6 +79,81 @@ def test_descarga_exige_egp_con_unico_scope_provincial_completo(client):
 
 
 @pytest.mark.django_db
+def test_superadmin_descarga_la_provincia_seleccionada(client):
+    provincia = Provincia.objects.create(nombre="Provincia Seleccionada")
+    superadmin = User.objects.create_superuser(
+        username="superadmin-descarga",
+        password="test1234",
+        email="superadmin@example.test",
+    )
+    client.force_login(superadmin)
+
+    with patch(
+        "centrodeinfancia.views_export.generar_nomina_ninos_pdf",
+        return_value=b"%PDF-1.4\nprueba",
+    ) as generar_pdf:
+        response = client.get(
+            reverse("centrodeinfancia_nomina_ninos_pdf"),
+            {"provincia": provincia.pk},
+        )
+
+    assert response.status_code == 200
+    generar_pdf.assert_called_once_with(user=superadmin, provincia=provincia)
+    assert (
+        response["Content-Disposition"]
+        == 'attachment; filename="nomina-ninos-provincia-seleccionada.pdf"'
+    )
+
+
+@pytest.mark.django_db
+@pytest.mark.parametrize(
+    "query",
+    [
+        {},
+        {"provincia": "no-es-un-id"},
+        {"provincia": "999999"},
+    ],
+)
+def test_superadmin_debe_elegir_una_provincia_valida(client, query):
+    superadmin = User.objects.create_superuser(
+        username=f"superadmin-invalido-{query.get('provincia', 'vacio')}",
+        password="test1234",
+        email="superadmin@example.test",
+    )
+    client.force_login(superadmin)
+
+    with patch("centrodeinfancia.views_export.generar_nomina_ninos_pdf") as generar_pdf:
+        response = client.get(
+            reverse("centrodeinfancia_nomina_ninos_pdf"),
+            query,
+        )
+
+    assert response.status_code == 400
+    assert "Seleccione una provincia válida." in response.content.decode()
+    generar_pdf.assert_not_called()
+
+
+@pytest.mark.django_db
+def test_egp_ignora_una_provincia_inyectada_en_la_descarga(client):
+    provincia_egp = Provincia.objects.create(nombre="Provincia EGP")
+    provincia_inyectada = Provincia.objects.create(nombre="Provincia Inyectada")
+    egp = _create_egp("egp-parametro-inyectado", provincia_egp)
+    client.force_login(egp)
+
+    with patch(
+        "centrodeinfancia.views_export.generar_nomina_ninos_pdf",
+        return_value=b"%PDF-1.4\nprueba",
+    ) as generar_pdf:
+        response = client.get(
+            reverse("centrodeinfancia_nomina_ninos_pdf"),
+            {"provincia": provincia_inyectada.pk},
+        )
+
+    assert response.status_code == 200
+    generar_pdf.assert_called_once_with(user=egp, provincia=provincia_egp)
+
+
+@pytest.mark.django_db
 def test_descarga_pdf_define_attachment_y_no_cache(client):
     provincia = Provincia.objects.create(nombre="Tierra de Prueba")
     user = _create_egp("egp-descarga", provincia)
@@ -138,6 +213,32 @@ def test_boton_descarga_solo_se_muestra_a_egp(client):
 
     assert response.status_code == 200
     assert "Descargar nómina de niños" not in response.content.decode()
+
+
+@pytest.mark.django_db
+def test_superadmin_ve_modal_con_selector_provincial_obligatorio(client):
+    provincia_b = Provincia.objects.create(nombre="Zeta")
+    provincia_a = Provincia.objects.create(nombre="Alfa")
+    superadmin = User.objects.create_superuser(
+        username="superadmin-modal",
+        password="test1234",
+        email="superadmin@example.test",
+    )
+    client.force_login(superadmin)
+
+    response = client.get(reverse("centrodeinfancia"))
+    content = response.content.decode()
+
+    assert response.status_code == 200
+    assert "Descargar nómina de niños" in content
+    assert 'data-bs-target="#nomina-ninos-provincia-modal"' in content
+    assert 'id="nomina-ninos-provincia-modal"' in content
+    assert 'name="provincia"' in content
+    assert "required" in content
+    assert list(response.context["nomina_ninos_provincias"]) == [
+        provincia_a,
+        provincia_b,
+    ]
 
 
 @pytest.mark.django_db

--- a/centrodeinfancia/views.py
+++ b/centrodeinfancia/views.py
@@ -39,7 +39,7 @@ from ciudadanos.api import (
 )
 from ciudadanos.models import Ciudadano
 from core.decorators import permissions_any_required
-from core.models import Nacionalidad, Sexo
+from core.models import Nacionalidad, Provincia, Sexo
 from core.security import safe_redirect
 from core.services.column_preferences import build_columns_context_from_fields
 from core.soft_delete.view_helpers import SoftDeleteDeleteViewMixin
@@ -339,7 +339,17 @@ class CentroDeInfanciaListView(LoginRequiredMixin, ListView):
             {"text": "Listar", "active": True},
         ]
         context["query"] = self.request.GET.get("busqueda", "")
-        if es_egp_simepi(self.request.user):
+        if self.request.user.is_superuser:
+            context["additional_buttons"] = [
+                {
+                    "label": "Descargar nómina de niños",
+                    "class": "btn btn-outline-primary",
+                    "modal_target": "#nomina-ninos-provincia-modal",
+                }
+            ]
+            context["nomina_ninos_provincias"] = Provincia.objects.order_by("nombre")
+            context["mostrar_modal_nomina_ninos"] = True
+        elif es_egp_simepi(self.request.user):
             context["additional_buttons"] = [
                 {
                     "url": reverse("centrodeinfancia_nomina_ninos_pdf"),

--- a/centrodeinfancia/views.py
+++ b/centrodeinfancia/views.py
@@ -343,7 +343,7 @@ class CentroDeInfanciaListView(LoginRequiredMixin, ListView):
             context["additional_buttons"] = [
                 {
                     "label": "Descargar nómina de niños",
-                    "class": "btn btn-outline-primary",
+                    "class": "poncho-btn poncho-btn--descarga",
                     "modal_target": "#nomina-ninos-provincia-modal",
                 }
             ]
@@ -354,7 +354,7 @@ class CentroDeInfanciaListView(LoginRequiredMixin, ListView):
                 {
                     "url": reverse("centrodeinfancia_nomina_ninos_pdf"),
                     "label": "Descargar nómina de niños",
-                    "class": "btn btn-outline-primary",
+                    "class": "poncho-btn poncho-btn--descarga",
                 }
             ]
         context["active_columns"] = columns_context.get("column_active_keys") or [

--- a/centrodeinfancia/views_export.py
+++ b/centrodeinfancia/views_export.py
@@ -101,16 +101,33 @@ class CentroDeInfanciaExportView(LoginRequiredMixin, CSVExportMixin, View):
 
 
 class NominaNinosPDFView(LoginRequiredMixin, View):
-    """Descarga provincial habilitada exclusivamente para SIMEPI - EGP."""
+    """Descarga provincial para SIMEPI - EGP y superadministradores."""
 
     def get(self, request, *args, **kwargs):
-        provincia_id = get_provincia_completa_unica_egp_id(request.user)
+        if request.user.is_superuser:
+            provincia_id = request.GET.get("provincia", "")
+            if not provincia_id.isdecimal():
+                return HttpResponse(
+                    "Seleccione una provincia válida.",
+                    status=400,
+                    content_type="text/plain; charset=utf-8",
+                )
+            provincia = Provincia.objects.filter(pk=provincia_id).first()
+            if provincia is None:
+                return HttpResponse(
+                    "Seleccione una provincia válida.",
+                    status=400,
+                    content_type="text/plain; charset=utf-8",
+                )
+        else:
+            provincia_id = get_provincia_completa_unica_egp_id(request.user)
+            provincia = Provincia.objects.filter(pk=provincia_id).first()
+
         if not provincia_id:
             raise PermissionDenied(
                 "La descarga requiere un único alcance provincial completo."
             )
 
-        provincia = Provincia.objects.filter(pk=provincia_id).first()
         if provincia is None:
             raise PermissionDenied("El alcance provincial no es válido.")
 

--- a/docs/contexto/features/pr-2308-feat-centrodeinfancia-descargar-nomina-provincial-de-ninos.md
+++ b/docs/contexto/features/pr-2308-feat-centrodeinfancia-descargar-nomina-provincial-de-ninos.md
@@ -26,7 +26,7 @@
 ## Design system y UI
 
 - El PR toca piezas de UI y conviene revisar consistencia visual con el patrón existente.
-- Archivos visuales relevantes: centrodeinfancia/templates/centrodeinfancia/centrodeinfancia_list.html, templates/components/search_bar.html
+- Archivos visuales relevantes: centrodeinfancia/templates/centrodeinfancia/centrodeinfancia_list.html, static/custom/css/comedoresSearchBar.css, templates/components/search_bar.html
 
 ## Memoria operativa para agentes
 
@@ -44,6 +44,7 @@
 - `docs/contexto/features/pr-2307-feat-centrodeinfancia-descargar-nomina-provincial-de-ninos-hml.md`
 - `docs/contexto/features/pr-2308-feat-centrodeinfancia-descargar-nomina-provincial-de-ninos.md`
 - `docs/contexto/features/pr-2311-fix-centrodeinfancia-asegurar-nomina-provincial-unica-hml.md`
+- `docs/contexto/features/pr-2312-feat-centrodeinfancia-habilitar-descarga-superadmin-hml.md`
 - `docs/plans/2026-08-18-simepi-descarga-nomina-ninos-design.md`
 - `docs/plans/2026-08-18-simepi-descarga-nomina-ninos-plan.md`
 - `docs/plans/2026-08-18-simepi-superadmin-nomina-provincial-design.md`
@@ -51,8 +52,7 @@
 - `docs/registro/cambios/2026-08-18-simepi-descarga-nomina-ninos.md`
 - `docs/registro/prs/PR-2307.md`
 - `docs/registro/prs/PR-2308.md`
-- `docs/registro/prs/PR-2311.md`
-- ... y 2 archivo(s) adicional(es) relacionados.
+- ... y 5 archivo(s) adicional(es) relacionados.
 - Documentación sugerida para ampliar contexto:
 - `docs/indice.md`
 - `docs/ia/CONTEXT_HYGIENE.md`
@@ -61,6 +61,7 @@
 - `docs/contexto/features/pr-2307-feat-centrodeinfancia-descargar-nomina-provincial-de-ninos-hml.md`
 - `docs/contexto/features/pr-2308-feat-centrodeinfancia-descargar-nomina-provincial-de-ninos.md`
 - `docs/contexto/features/pr-2311-fix-centrodeinfancia-asegurar-nomina-provincial-unica-hml.md`
+- `docs/contexto/features/pr-2312-feat-centrodeinfancia-habilitar-descarga-superadmin-hml.md`
 - `docs/plans/2026-08-18-simepi-descarga-nomina-ninos-design.md`
 - `docs/plans/2026-08-18-simepi-descarga-nomina-ninos-plan.md`
 - `docs/plans/2026-08-18-simepi-superadmin-nomina-provincial-design.md`
@@ -69,6 +70,7 @@
 - `docs/registro/prs/PR-2307.md`
 - `docs/registro/prs/PR-2308.md`
 - `docs/registro/prs/PR-2311.md`
+- `docs/registro/prs/PR-2312.md`
 - `docs/registro/releases/pending/2026-08-19-pr-2308.md`
 
 ## Trazabilidad

--- a/docs/contexto/features/pr-2308-feat-centrodeinfancia-descargar-nomina-provincial-de-ninos.md
+++ b/docs/contexto/features/pr-2308-feat-centrodeinfancia-descargar-nomina-provincial-de-ninos.md
@@ -26,7 +26,7 @@
 ## Design system y UI
 
 - El PR toca piezas de UI y conviene revisar consistencia visual con el patrón existente.
-- Archivos visuales relevantes: centrodeinfancia/templates/centrodeinfancia/centrodeinfancia_list.html
+- Archivos visuales relevantes: centrodeinfancia/templates/centrodeinfancia/centrodeinfancia_list.html, templates/components/search_bar.html
 
 ## Memoria operativa para agentes
 
@@ -46,11 +46,13 @@
 - `docs/contexto/features/pr-2311-fix-centrodeinfancia-asegurar-nomina-provincial-unica-hml.md`
 - `docs/plans/2026-08-18-simepi-descarga-nomina-ninos-design.md`
 - `docs/plans/2026-08-18-simepi-descarga-nomina-ninos-plan.md`
+- `docs/plans/2026-08-18-simepi-superadmin-nomina-provincial-design.md`
+- `docs/plans/2026-08-18-simepi-superadmin-nomina-provincial-plan.md`
 - `docs/registro/cambios/2026-08-18-simepi-descarga-nomina-ninos.md`
 - `docs/registro/prs/PR-2307.md`
 - `docs/registro/prs/PR-2308.md`
 - `docs/registro/prs/PR-2311.md`
-- `docs/registro/releases/pending/2026-08-19-pr-2308.md`
+- ... y 2 archivo(s) adicional(es) relacionados.
 - Documentación sugerida para ampliar contexto:
 - `docs/indice.md`
 - `docs/ia/CONTEXT_HYGIENE.md`
@@ -61,6 +63,8 @@
 - `docs/contexto/features/pr-2311-fix-centrodeinfancia-asegurar-nomina-provincial-unica-hml.md`
 - `docs/plans/2026-08-18-simepi-descarga-nomina-ninos-design.md`
 - `docs/plans/2026-08-18-simepi-descarga-nomina-ninos-plan.md`
+- `docs/plans/2026-08-18-simepi-superadmin-nomina-provincial-design.md`
+- `docs/plans/2026-08-18-simepi-superadmin-nomina-provincial-plan.md`
 - `docs/registro/cambios/2026-08-18-simepi-descarga-nomina-ninos.md`
 - `docs/registro/prs/PR-2307.md`
 - `docs/registro/prs/PR-2308.md`

--- a/docs/contexto/features/pr-2312-feat-centrodeinfancia-habilitar-descarga-superadmin-hml.md
+++ b/docs/contexto/features/pr-2312-feat-centrodeinfancia-habilitar-descarga-superadmin-hml.md
@@ -1,0 +1,59 @@
+# Contexto de feature PR #2312 - feat(centrodeinfancia): habilitar descarga superadmin [HML]
+
+## Resumen
+
+- PR: https://github.com/dsocial118/SISOC/pull/2312
+- Base: `homologacion`
+- Rama origen: `codex/simepi-descarga-nomina-ninos`
+- Autor: `juanikitro`
+
+## Contexto funcional
+
+- No informado explícitamente; inferir desde el título del PR y el diff.
+
+## Arquitectura tocada
+
+- Hay cambios en vistas web y puede existir impacto en permisos o renderizado.
+- Se modifican templates, con posible impacto visual o de composición UI.
+
+## Decisiones y supuestos detectados
+
+- Tipo de cambio declarado: No informado
+- Área principal declarada: No informada
+- Impacto usuario declarado: No informado
+- Riesgos / rollback: No informado
+
+## Design system y UI
+
+- El PR toca piezas de UI y conviene revisar consistencia visual con el patrón existente.
+- Archivos visuales relevantes: centrodeinfancia/templates/centrodeinfancia/centrodeinfancia_list.html, templates/components/search_bar.html
+
+## Memoria operativa para agentes
+
+- Empezar por `docs/registro/prs/PR-2312.md` para contexto resumido del PR.
+- Revisar primero estos archivos del diff:
+- `centrodeinfancia/templates/centrodeinfancia/centrodeinfancia_list.html`
+- `centrodeinfancia/tests/test_nomina_ninos_pdf.py`
+- `centrodeinfancia/views.py`
+- `centrodeinfancia/views_export.py`
+- `docs/contexto/features/pr-2308-feat-centrodeinfancia-descargar-nomina-provincial-de-ninos.md`
+- `docs/plans/2026-08-18-simepi-superadmin-nomina-provincial-design.md`
+- `docs/plans/2026-08-18-simepi-superadmin-nomina-provincial-plan.md`
+- `docs/registro/cambios/2026-08-18-simepi-descarga-nomina-ninos.md`
+- `docs/registro/prs/PR-2308.md`
+- `templates/components/search_bar.html`
+- Documentación sugerida para ampliar contexto:
+- `docs/indice.md`
+- `docs/ia/CONTEXT_HYGIENE.md`
+- `docs/ia/ARCHITECTURE.md`
+- `docs/ia/TESTING.md`
+- `docs/contexto/features/pr-2308-feat-centrodeinfancia-descargar-nomina-provincial-de-ninos.md`
+- `docs/plans/2026-08-18-simepi-superadmin-nomina-provincial-design.md`
+- `docs/plans/2026-08-18-simepi-superadmin-nomina-provincial-plan.md`
+- `docs/registro/cambios/2026-08-18-simepi-descarga-nomina-ninos.md`
+- `docs/registro/prs/PR-2308.md`
+
+## Trazabilidad
+
+- Documento generado automáticamente desde el evento de `pull_request`.
+- Si este PR cambia de título, el archivo se renombrará para mantener el slug alineado.

--- a/docs/contexto/features/pr-2312-feat-centrodeinfancia-habilitar-descarga-superadmin-hml.md
+++ b/docs/contexto/features/pr-2312-feat-centrodeinfancia-habilitar-descarga-superadmin-hml.md
@@ -26,7 +26,7 @@
 ## Design system y UI
 
 - El PR toca piezas de UI y conviene revisar consistencia visual con el patrón existente.
-- Archivos visuales relevantes: centrodeinfancia/templates/centrodeinfancia/centrodeinfancia_list.html, templates/components/search_bar.html
+- Archivos visuales relevantes: centrodeinfancia/templates/centrodeinfancia/centrodeinfancia_list.html, static/custom/css/comedoresSearchBar.css, templates/components/search_bar.html
 
 ## Memoria operativa para agentes
 
@@ -37,10 +37,13 @@
 - `centrodeinfancia/views.py`
 - `centrodeinfancia/views_export.py`
 - `docs/contexto/features/pr-2308-feat-centrodeinfancia-descargar-nomina-provincial-de-ninos.md`
+- `docs/contexto/features/pr-2312-feat-centrodeinfancia-habilitar-descarga-superadmin-hml.md`
 - `docs/plans/2026-08-18-simepi-superadmin-nomina-provincial-design.md`
 - `docs/plans/2026-08-18-simepi-superadmin-nomina-provincial-plan.md`
 - `docs/registro/cambios/2026-08-18-simepi-descarga-nomina-ninos.md`
 - `docs/registro/prs/PR-2308.md`
+- `docs/registro/prs/PR-2312.md`
+- `static/custom/css/comedoresSearchBar.css`
 - `templates/components/search_bar.html`
 - Documentación sugerida para ampliar contexto:
 - `docs/indice.md`
@@ -48,10 +51,12 @@
 - `docs/ia/ARCHITECTURE.md`
 - `docs/ia/TESTING.md`
 - `docs/contexto/features/pr-2308-feat-centrodeinfancia-descargar-nomina-provincial-de-ninos.md`
+- `docs/contexto/features/pr-2312-feat-centrodeinfancia-habilitar-descarga-superadmin-hml.md`
 - `docs/plans/2026-08-18-simepi-superadmin-nomina-provincial-design.md`
 - `docs/plans/2026-08-18-simepi-superadmin-nomina-provincial-plan.md`
 - `docs/registro/cambios/2026-08-18-simepi-descarga-nomina-ninos.md`
 - `docs/registro/prs/PR-2308.md`
+- `docs/registro/prs/PR-2312.md`
 
 ## Trazabilidad
 

--- a/docs/plans/2026-08-18-simepi-superadmin-nomina-provincial-design.md
+++ b/docs/plans/2026-08-18-simepi-superadmin-nomina-provincial-design.md
@@ -1,0 +1,76 @@
+# 2026-08-18 - Descarga provincial de nomina SIMEPI para superadmin
+
+## Objetivo
+
+Permitir que un superadministrador descargue la nomina de ninos desde el
+listado de Centros de Desarrollo Infantil, eligiendo obligatoriamente una
+provincia antes de generar el PDF.
+
+Este alcance surge de la instruccion posterior del usuario y amplía la regla
+original del documento funcional, que habilitaba la descarga solamente al rol
+SIMEPI - EGP.
+
+## Decision
+
+- El EGP mantiene la descarga directa para su unico alcance provincial
+  completo.
+- El superadministrador ve el mismo llamado a la accion en el listado, pero el
+  boton abre un modal sin abandonar la pagina.
+- El modal contiene un selector obligatorio con las provincias disponibles y
+  envia la seleccion por `GET` al endpoint de descarga existente.
+- Los demas usuarios no ven el boton y continúan recibiendo `403` si intentan
+  acceder directamente al endpoint.
+
+## Interfaz
+
+El listado reutiliza el modal Bootstrap ya usado por el modulo. El boton
+adicional del buscador admitira opcionalmente un destino modal, sin cambiar el
+comportamiento de los botones que siguen siendo enlaces.
+
+El modal muestra:
+
+- titulo `Descargar nomina de ninos`;
+- selector `Provincia` con opcion inicial vacia;
+- boton para cancelar;
+- boton `Descargar` que envia el formulario.
+
+No se agregara JavaScript propio: la validacion HTML `required` evita el envio
+normal sin seleccion y la validacion del servidor protege el acceso directo o
+manipulado.
+
+## Autorizacion y seleccion territorial
+
+El endpoint resuelve la provincia en este orden:
+
+1. Si el usuario es superadministrador, exige el parametro `provincia`, valida
+   que identifique una provincia existente y usa exclusivamente esa seleccion.
+2. Si es EGP, ignora cualquier parametro territorial recibido y usa su unico
+   alcance provincial completo.
+3. En cualquier otro caso, rechaza la descarga con `403`.
+
+Una seleccion ausente o invalida del superadministrador devuelve `400` y no
+invoca el generador del PDF. Esto mantiene separados un error de entrada y una
+falta de permisos.
+
+## Datos e integridad
+
+La generacion sigue usando el servicio provincial existente. Por lo tanto:
+
+- el filtro se aplica por la provincia del centro, no por el domicilio del
+  nino;
+- se conserva la deduplicacion reforzada por ciudadano, DNI e identidad
+  historica;
+- el nombre y el encabezado del PDF corresponden a la provincia elegida;
+- no hay cambios de esquema, migraciones ni dependencias.
+
+## Validacion prevista
+
+- Superadmin ve boton y modal con selector obligatorio.
+- Superadmin descarga solamente la provincia seleccionada.
+- Superadmin sin provincia o con provincia invalida recibe `400` y no genera
+  archivo.
+- EGP conserva su descarga directa e ignora una provincia inyectada por URL.
+- Usuario comun no ve el boton y recibe `403` en acceso directo.
+- La suite focal de nomina conserva los casos de filtro provincial y no
+  duplicacion.
+

--- a/docs/plans/2026-08-18-simepi-superadmin-nomina-provincial-plan.md
+++ b/docs/plans/2026-08-18-simepi-superadmin-nomina-provincial-plan.md
@@ -1,0 +1,64 @@
+# 2026-08-18 - Plan de implementacion de descarga provincial superadmin
+
+## Alcance
+
+Implementar el diseño aprobado en
+`docs/plans/2026-08-18-simepi-superadmin-nomina-provincial-design.md` con un
+cambio pequeno, compatible con la descarga EGP existente y sin tocar el
+servicio que arma o deduplica la nomina.
+
+## Paso 1 - Contrato backend y autorizacion
+
+Archivos:
+
+- `centrodeinfancia/tests/test_nomina_ninos_pdf.py`
+- `centrodeinfancia/views_export.py`
+
+Secuencia:
+
+1. Agregar tests que fallen para descarga superadmin con provincia valida,
+   seleccion ausente/invalida y parametro inyectado en una descarga EGP.
+2. Resolver la provincia seleccionada solamente para superadmin.
+3. Responder `400` antes de generar el PDF si la seleccion superadmin no es
+   valida.
+4. Mantener `403` para usuarios sin rol y el alcance unico para EGP.
+
+## Paso 2 - Modal en el listado
+
+Archivos:
+
+- `centrodeinfancia/tests/test_nomina_ninos_pdf.py`
+- `centrodeinfancia/views.py`
+- `templates/components/search_bar.html`
+- `centrodeinfancia/templates/centrodeinfancia/centrodeinfancia_list.html`
+
+Secuencia:
+
+1. Agregar tests que fallen para la visibilidad del boton, modal, selector
+   requerido y opciones provinciales del superadmin.
+2. Extender de manera optativa los botones adicionales para abrir un modal.
+3. Cargar provincias ordenadas solamente en el contexto superadmin.
+4. Renderizar en el listado el formulario `GET` con selector obligatorio.
+5. Conservar el enlace directo para EGP y ocultar ambos flujos a usuarios
+   comunes.
+
+## Paso 3 - Validacion focal
+
+Ejecutar:
+
+1. Tests de `centrodeinfancia/tests/test_nomina_ninos_pdf.py`.
+2. `black --check` sobre Python modificado.
+3. `djlint --check` sobre templates modificados, si la version instalada
+   admite el template actual sin reformatos amplios.
+4. `pylint` focal sobre Python modificado.
+5. `git diff --check` y revision manual del diff.
+
+## Paso 4 - Publicacion y homologacion
+
+1. Commit convencional y push de la rama existente.
+2. Actualizar el PR abierto hacia `main` con el nuevo alcance.
+3. Crear un PR incremental hacia `homologacion` desde la misma rama.
+4. Esperar todos los checks requeridos, mergear solamente ese PR y verificar
+   el despliegue de homologacion contra el SHA mergeado.
+5. Mantener abierto el PR hacia `main` para su promocion posterior.
+

--- a/docs/registro/cambios/2026-08-18-simepi-descarga-nomina-ninos.md
+++ b/docs/registro/cambios/2026-08-18-simepi-descarga-nomina-ninos.md
@@ -40,6 +40,8 @@ CUIL, nombres ni datos RENAPER.
   normalización, deduplicación, render vectorial y rasterización.
 - El listado reutiliza un modal Bootstrap con un selector provincial obligatorio
   para superadministradores, sin JavaScript ni dependencias adicionales.
+- La acción de descarga reutiliza la forma y el radio de los botones Poncho del
+  buscador, con fondo verde azulado para distinguirla de las demás acciones.
 - El alcance territorial se toma exclusivamente de la provincia del CDI. La
   provincia domiciliaria del niño puede estar vacía sin excluirlo.
 - La deduplicación conserva la ficha activa más reciente y evita repetir tanto

--- a/docs/registro/cambios/2026-08-18-simepi-descarga-nomina-ninos.md
+++ b/docs/registro/cambios/2026-08-18-simepi-descarga-nomina-ninos.md
@@ -5,9 +5,10 @@ Fecha: 2026-08-18
 ## Cambio
 
 El listado de Centros de Desarrollo Infantil incorpora la acción `Descargar
-nómina de niños` para usuarios del grupo `SIMEPI - EGP`. La acción genera un
-PDF con las fichas activas y únicas de la única provincia completa asignada al
-perfil.
+nómina de niños` para usuarios del grupo `SIMEPI - EGP` y
+superadministradores. El EGP descarga directamente su única provincia completa;
+el superadministrador debe elegir una provincia en un modal antes de generar el
+PDF.
 
 El documento:
 
@@ -21,10 +22,12 @@ El documento:
 
 ## Autorización y privacidad
 
-El endpoint no recibe una provincia desde el cliente. Exige autenticación,
-pertenencia al grupo `SIMEPI - EGP` y exactamente un alcance territorial de
-provincia completa. Los demás roles, los alcances parciales y los perfiles
-ambiguos reciben una denegación antes de consultar la nómina.
+El endpoint exige autenticación. Para un EGP, toma exclusivamente su único
+alcance territorial de provincia completa e ignora cualquier provincia enviada
+por el cliente. Para un superadministrador, exige y valida la provincia elegida
+en el modal; una selección ausente o inválida recibe `400` antes de generar el
+archivo. Los demás roles, los alcances parciales y los perfiles ambiguos reciben
+una denegación antes de consultar la nómina.
 
 La respuesta usa `private, no-store`, se entrega como attachment y no persiste
 el archivo en `MEDIA_ROOT`. Los errores devuelven un mensaje genérico y los
@@ -35,6 +38,8 @@ CUIL, nombres ni datos RENAPER.
 
 - `centrodeinfancia/services_nomina_ninos_pdf.py` concentra consulta,
   normalización, deduplicación, render vectorial y rasterización.
+- El listado reutiliza un modal Bootstrap con un selector provincial obligatorio
+  para superadministradores, sin JavaScript ni dependencias adicionales.
 - El alcance territorial se toma exclusivamente de la provincia del CDI. La
   provincia domiciliaria del niño puede estar vacía sin excluirlo.
 - La deduplicación conserva la ficha activa más reciente y evita repetir tanto
@@ -52,11 +57,12 @@ runtime.
 
 ## Validación y rollback
 
-La regresión focalizada cubre autorización, visibilidad del botón, filtros por
-provincia del CDI y estado, inclusión con provincia domiciliaria vacía,
-deduplicación por ciudadano, DNI e identidad compuesta, orden, datos RENAPER,
-headers HTTP y estructura del PDF final. La inspección local de un documento
-sintético de tres páginas confirmó A4 apaisado, encabezados repetidos,
+La regresión focalizada cubre autorización, visibilidad del botón, modal y
+selección obligatoria del superadministrador, aislamiento del alcance EGP,
+filtros por provincia del CDI y estado, inclusión con provincia domiciliaria
+vacía, deduplicación por ciudadano, DNI e identidad compuesta, orden, datos
+RENAPER, headers HTTP y estructura del PDF final. La inspección local de un
+documento sintético de tres páginas confirmó A4 apaisado, encabezados repetidos,
 legibilidad, marca de agua, pie numerado, resumen provincial y una imagen JPEG
 por página sin capa de texto.
 

--- a/docs/registro/prs/PR-2308.md
+++ b/docs/registro/prs/PR-2308.md
@@ -23,6 +23,7 @@
 - `docs/contexto`
 - `docs/plans`
 - `docs/registro`
+- `templates`
 
 ## Archivos relevantes del diff
 
@@ -40,11 +41,14 @@
 - `docs/contexto/features/pr-2311-fix-centrodeinfancia-asegurar-nomina-provincial-unica-hml.md`
 - `docs/plans/2026-08-18-simepi-descarga-nomina-ninos-design.md`
 - `docs/plans/2026-08-18-simepi-descarga-nomina-ninos-plan.md`
+- `docs/plans/2026-08-18-simepi-superadmin-nomina-provincial-design.md`
+- `docs/plans/2026-08-18-simepi-superadmin-nomina-provincial-plan.md`
 - `docs/registro/cambios/2026-08-18-simepi-descarga-nomina-ninos.md`
 - `docs/registro/prs/PR-2307.md`
 - `docs/registro/prs/PR-2308.md`
 - `docs/registro/prs/PR-2311.md`
 - `docs/registro/releases/pending/2026-08-19-pr-2308.md`
+- `templates/components/search_bar.html`
 
 ## Validación declarada
 
@@ -66,6 +70,8 @@
 - `docs/contexto/features/pr-2311-fix-centrodeinfancia-asegurar-nomina-provincial-unica-hml.md`
 - `docs/plans/2026-08-18-simepi-descarga-nomina-ninos-design.md`
 - `docs/plans/2026-08-18-simepi-descarga-nomina-ninos-plan.md`
+- `docs/plans/2026-08-18-simepi-superadmin-nomina-provincial-design.md`
+- `docs/plans/2026-08-18-simepi-superadmin-nomina-provincial-plan.md`
 - `docs/registro/cambios/2026-08-18-simepi-descarga-nomina-ninos.md`
 - `docs/registro/prs/PR-2307.md`
 - `docs/registro/prs/PR-2308.md`

--- a/docs/registro/prs/PR-2308.md
+++ b/docs/registro/prs/PR-2308.md
@@ -23,6 +23,7 @@
 - `docs/contexto`
 - `docs/plans`
 - `docs/registro`
+- `static`
 - `templates`
 
 ## Archivos relevantes del diff
@@ -39,6 +40,7 @@
 - `docs/contexto/features/pr-2307-feat-centrodeinfancia-descargar-nomina-provincial-de-ninos-hml.md`
 - `docs/contexto/features/pr-2308-feat-centrodeinfancia-descargar-nomina-provincial-de-ninos.md`
 - `docs/contexto/features/pr-2311-fix-centrodeinfancia-asegurar-nomina-provincial-unica-hml.md`
+- `docs/contexto/features/pr-2312-feat-centrodeinfancia-habilitar-descarga-superadmin-hml.md`
 - `docs/plans/2026-08-18-simepi-descarga-nomina-ninos-design.md`
 - `docs/plans/2026-08-18-simepi-descarga-nomina-ninos-plan.md`
 - `docs/plans/2026-08-18-simepi-superadmin-nomina-provincial-design.md`
@@ -47,7 +49,9 @@
 - `docs/registro/prs/PR-2307.md`
 - `docs/registro/prs/PR-2308.md`
 - `docs/registro/prs/PR-2311.md`
+- `docs/registro/prs/PR-2312.md`
 - `docs/registro/releases/pending/2026-08-19-pr-2308.md`
+- `static/custom/css/comedoresSearchBar.css`
 - `templates/components/search_bar.html`
 
 ## Validación declarada
@@ -68,6 +72,7 @@
 - `docs/contexto/features/pr-2307-feat-centrodeinfancia-descargar-nomina-provincial-de-ninos-hml.md`
 - `docs/contexto/features/pr-2308-feat-centrodeinfancia-descargar-nomina-provincial-de-ninos.md`
 - `docs/contexto/features/pr-2311-fix-centrodeinfancia-asegurar-nomina-provincial-unica-hml.md`
+- `docs/contexto/features/pr-2312-feat-centrodeinfancia-habilitar-descarga-superadmin-hml.md`
 - `docs/plans/2026-08-18-simepi-descarga-nomina-ninos-design.md`
 - `docs/plans/2026-08-18-simepi-descarga-nomina-ninos-plan.md`
 - `docs/plans/2026-08-18-simepi-superadmin-nomina-provincial-design.md`
@@ -76,6 +81,7 @@
 - `docs/registro/prs/PR-2307.md`
 - `docs/registro/prs/PR-2308.md`
 - `docs/registro/prs/PR-2311.md`
+- `docs/registro/prs/PR-2312.md`
 - `docs/registro/releases/pending/2026-08-19-pr-2308.md`
 
 ## Notas para continuidad

--- a/docs/registro/prs/PR-2312.md
+++ b/docs/registro/prs/PR-2312.md
@@ -21,6 +21,7 @@
 - `docs/contexto`
 - `docs/plans`
 - `docs/registro`
+- `static`
 - `templates`
 
 ## Archivos relevantes del diff
@@ -30,10 +31,13 @@
 - `centrodeinfancia/views.py`
 - `centrodeinfancia/views_export.py`
 - `docs/contexto/features/pr-2308-feat-centrodeinfancia-descargar-nomina-provincial-de-ninos.md`
+- `docs/contexto/features/pr-2312-feat-centrodeinfancia-habilitar-descarga-superadmin-hml.md`
 - `docs/plans/2026-08-18-simepi-superadmin-nomina-provincial-design.md`
 - `docs/plans/2026-08-18-simepi-superadmin-nomina-provincial-plan.md`
 - `docs/registro/cambios/2026-08-18-simepi-descarga-nomina-ninos.md`
 - `docs/registro/prs/PR-2308.md`
+- `docs/registro/prs/PR-2312.md`
+- `static/custom/css/comedoresSearchBar.css`
 - `templates/components/search_bar.html`
 
 ## Validación declarada
@@ -52,10 +56,12 @@
 - `docs/ia/ARCHITECTURE.md`
 - `docs/ia/TESTING.md`
 - `docs/contexto/features/pr-2308-feat-centrodeinfancia-descargar-nomina-provincial-de-ninos.md`
+- `docs/contexto/features/pr-2312-feat-centrodeinfancia-habilitar-descarga-superadmin-hml.md`
 - `docs/plans/2026-08-18-simepi-superadmin-nomina-provincial-design.md`
 - `docs/plans/2026-08-18-simepi-superadmin-nomina-provincial-plan.md`
 - `docs/registro/cambios/2026-08-18-simepi-descarga-nomina-ninos.md`
 - `docs/registro/prs/PR-2308.md`
+- `docs/registro/prs/PR-2312.md`
 
 ## Notas para continuidad
 

--- a/docs/registro/prs/PR-2312.md
+++ b/docs/registro/prs/PR-2312.md
@@ -1,0 +1,63 @@
+# PR #2312 - feat(centrodeinfancia): habilitar descarga superadmin [HML]
+
+## Metadata
+
+- PR: https://github.com/dsocial118/SISOC/pull/2312
+- Base: `homologacion`
+- Rama origen: `codex/simepi-descarga-nomina-ninos`
+- Autor: `juanikitro`
+
+## Resumen operativo
+
+- Tipo de cambio: No informado
+- Área principal: No informada
+- Contexto funcional: No informado explícitamente; revisar título, diff y documentación relacionada.
+- Resumen para changelog: No informado
+- Impacto usuario: No informado
+
+## Áreas afectadas
+
+- `centrodeinfancia`
+- `docs/contexto`
+- `docs/plans`
+- `docs/registro`
+- `templates`
+
+## Archivos relevantes del diff
+
+- `centrodeinfancia/templates/centrodeinfancia/centrodeinfancia_list.html`
+- `centrodeinfancia/tests/test_nomina_ninos_pdf.py`
+- `centrodeinfancia/views.py`
+- `centrodeinfancia/views_export.py`
+- `docs/contexto/features/pr-2308-feat-centrodeinfancia-descargar-nomina-provincial-de-ninos.md`
+- `docs/plans/2026-08-18-simepi-superadmin-nomina-provincial-design.md`
+- `docs/plans/2026-08-18-simepi-superadmin-nomina-provincial-plan.md`
+- `docs/registro/cambios/2026-08-18-simepi-descarga-nomina-ninos.md`
+- `docs/registro/prs/PR-2308.md`
+- `templates/components/search_bar.html`
+
+## Validación declarada
+
+- Pruebas automáticas: No informado en el PR.
+- Pruebas manuales: No informado en el PR.
+
+## Riesgos y rollback
+
+- No informado explícitamente en el PR.
+
+## Documentación sugerida para lectura
+
+- `docs/indice.md`
+- `docs/ia/CONTEXT_HYGIENE.md`
+- `docs/ia/ARCHITECTURE.md`
+- `docs/ia/TESTING.md`
+- `docs/contexto/features/pr-2308-feat-centrodeinfancia-descargar-nomina-provincial-de-ninos.md`
+- `docs/plans/2026-08-18-simepi-superadmin-nomina-provincial-design.md`
+- `docs/plans/2026-08-18-simepi-superadmin-nomina-provincial-plan.md`
+- `docs/registro/cambios/2026-08-18-simepi-descarga-nomina-ninos.md`
+- `docs/registro/prs/PR-2308.md`
+
+## Notas para continuidad
+
+- Este documento es generado automáticamente desde el contexto del PR y sirve como índice rápido para revisión y futuras sesiones de agentes.
+- Si la metadata del body del PR está incompleta, varias secciones usarán fallbacks derivados del título o del diff.

--- a/static/custom/css/comedoresSearchBar.css
+++ b/static/custom/css/comedoresSearchBar.css
@@ -420,6 +420,18 @@
   color: var(--poncho-blanco);
 }
 
+.poncho-btn--descarga {
+  background: var(--poncho-verde-azulado);
+  border-color: var(--poncho-verde-azulado);
+  color: var(--poncho-blanco);
+}
+
+.poncho-btn--descarga:hover,
+.poncho-btn--descarga:focus {
+  filter: brightness(.88);
+  color: var(--poncho-blanco);
+}
+
 .poncho-btn--neutro {
   background: transparent;
   border-color: var(--poncho-blanco);

--- a/templates/components/search_bar.html
+++ b/templates/components/search_bar.html
@@ -238,10 +238,19 @@ Layout (prototipo Figma "SISOC_ Versión UX", nodo 13501:32237):
 
             {% if additional_buttons %}
                 {% for button in additional_buttons %}
-                    <a href="{{ button.url }}"
-                       class="{{ button.class|default:'btn btn-primary btn-lg' }}"
-                       {% if button.id %}id="{{ button.id }}"{% endif %}
-                       {% if button.title %}title="{{ button.title }}"{% endif %}>{{ button.label }}</a>
+                    {% if button.modal_target %}
+                        <button type="button"
+                                class="{{ button.class|default:'btn btn-primary btn-lg' }}"
+                                data-bs-toggle="modal"
+                                data-bs-target="{{ button.modal_target }}"
+                                {% if button.id %}id="{{ button.id }}"{% endif %}
+                                {% if button.title %}title="{{ button.title }}"{% endif %}>{{ button.label }}</button>
+                    {% else %}
+                        <a href="{{ button.url }}"
+                           class="{{ button.class|default:'btn btn-primary btn-lg' }}"
+                           {% if button.id %}id="{{ button.id }}"{% endif %}
+                           {% if button.title %}title="{{ button.title }}"{% endif %}>{{ button.label }}</a>
+                    {% endif %}
                 {% endfor %}
             {% endif %}
         </div>


### PR DESCRIPTION
## Qué cambia
- habilita al superadmin a descargar la nómina desde el listado de CDI
- abre un modal con selección provincial obligatoria
- valida la provincia nuevamente en servidor y responde `400` si falta o es inválida
- conserva la descarga directa y el alcance fijo del rol `SIMEPI - EGP`
- no modifica el filtro provincial por CDI ni la deduplicación ya homologada

## Seguridad e integridad
- un EGP no puede cambiar su provincia manipulando el query string
- usuarios comunes siguen recibiendo `403`
- el generador no se invoca ante una selección superadmin inválida
- sin migraciones ni dependencias nuevas

## Validación local
- 15 tests focales aprobados
- Black aprobado
- Pylint focal 10/10
- djLint aprobado para el template del listado
- `git diff --check` aprobado

## Relación
Incremental sobre los cambios ya mergeados a homologación en #2307 y #2311. El PR completo hacia `main` es #2308.

## Ajuste visual
- el botón usa la forma y el radio Poncho del resto de las acciones
- incorpora fondo verde azulado sólido y estado hover para distinguir la descarga

