### PR TITLE
Fix: resolver observaciones de reapertura del issue 2305

### DIFF
--- a/dashboard/signals.py
+++ b/dashboard/signals.py
@@ -1,5 +1,7 @@
 """Actualización de métricas del dashboard mediante contratos de dominio."""
 
+from django.core.cache import cache
+
 from comedores.api import registrar_observador_dashboard as observar_comedores
 from dashboard.models import Dashboard
 from dashboard.utils import (
@@ -18,6 +20,14 @@ TABLES_REQUERIDAS = (
     "relevamientos_relevamiento",
     "relevamientos_prestacion",
     "comedores_valorcomida",
+)
+
+DASHBOARD_CACHE_KEYS = (
+    "contar_comedores_activos",
+    "contar_relevamientos_activos",
+    "calcular_presupuesto_desayuno",
+    "calcular_presupuesto_merienda",
+    "calcular_presupuesto_comida",
 )
 
 
@@ -42,6 +52,7 @@ def update_dashboard_comedores():
     if not _tablas_requeridas_existen():
         return
 
+    cache.delete_many(DASHBOARD_CACHE_KEYS)
     update_dashboard_key("cantidad_comedores_activos", contar_comedores_activos())
     update_dashboard_key(
         "cantidad_relevamientos_activos", contar_relevamientos_activos()

--- a/docs/contexto/features/pr-2321-fix-resolver-observaciones-de-reapertura-del-issue-2305.md
+++ b/docs/contexto/features/pr-2321-fix-resolver-observaciones-de-reapertura-del-issue-2305.md
@@ -1,0 +1,58 @@
+# Contexto de feature PR #2321 - Fix: resolver observaciones de reapertura del issue 2305
+
+## Resumen
+
+- PR: https://github.com/dsocial118/SISOC/pull/2321
+- Base: `development`
+- Rama origen: `codex/issue-2305`
+- Autor: `PabloCao1`
+
+## Contexto funcional
+
+- No informado explícitamente; inferir desde el título del PR y el diff.
+
+## Arquitectura tocada
+
+- Hay cambios en vistas web y puede existir impacto en permisos o renderizado.
+- Se modifican templates, con posible impacto visual o de composición UI.
+- Existen cambios de persistencia o migraciones que requieren revisión de datos.
+
+## Decisiones y supuestos detectados
+
+- Tipo de cambio declarado: No informado
+- Área principal declarada: No informada
+- Impacto usuario declarado: No informado
+- Riesgos / rollback: No informado
+
+## Design system y UI
+
+- El PR toca piezas de UI y conviene revisar consistencia visual con el patrón existente.
+- Archivos visuales relevantes: rendicioncuentasmensual/templates/rendicioncuentasmensual_datos_form.html, rendicioncuentasmensual/templates/rendicioncuentasmensual_global_list.html, static/custom/css/listModerno.css
+
+## Memoria operativa para agentes
+
+- Empezar por `docs/registro/prs/PR-2321.md` para contexto resumido del PR.
+- Revisar primero estos archivos del diff:
+- `dashboard/signals.py`
+- `docs/registro/cambios/2026-08-19-issue-2305-rendiciones.md`
+- `docs/registro/cambios/2026-08-20-fix-cache-metricas-dashboard.md`
+- `rendicioncuentasmensual/models.py`
+- `rendicioncuentasmensual/services.py`
+- `rendicioncuentasmensual/templates/rendicioncuentasmensual_datos_form.html`
+- `rendicioncuentasmensual/templates/rendicioncuentasmensual_global_list.html`
+- `rendicioncuentasmensual/views.py`
+- `static/custom/css/listModerno.css`
+- `tests/test_pwa_comedores_api.py`
+- `tests/test_rendicioncuentasmensual_views_unit.py`
+- Documentación sugerida para ampliar contexto:
+- `docs/indice.md`
+- `docs/ia/CONTEXT_HYGIENE.md`
+- `docs/ia/ARCHITECTURE.md`
+- `docs/ia/TESTING.md`
+- `docs/registro/cambios/2026-08-19-issue-2305-rendiciones.md`
+- `docs/registro/cambios/2026-08-20-fix-cache-metricas-dashboard.md`
+
+## Trazabilidad
+
+- Documento generado automáticamente desde el evento de `pull_request`.
+- Si este PR cambia de título, el archivo se renombrará para mantener el slug alineado.

--- a/docs/contexto/features/pr-2321-fix-resolver-observaciones-de-reapertura-del-issue-2305.md
+++ b/docs/contexto/features/pr-2321-fix-resolver-observaciones-de-reapertura-del-issue-2305.md
@@ -34,8 +34,10 @@
 - Empezar por `docs/registro/prs/PR-2321.md` para contexto resumido del PR.
 - Revisar primero estos archivos del diff:
 - `dashboard/signals.py`
+- `docs/contexto/features/pr-2321-fix-resolver-observaciones-de-reapertura-del-issue-2305.md`
 - `docs/registro/cambios/2026-08-19-issue-2305-rendiciones.md`
 - `docs/registro/cambios/2026-08-20-fix-cache-metricas-dashboard.md`
+- `docs/registro/prs/PR-2321.md`
 - `rendicioncuentasmensual/models.py`
 - `rendicioncuentasmensual/services.py`
 - `rendicioncuentasmensual/templates/rendicioncuentasmensual_datos_form.html`
@@ -49,8 +51,10 @@
 - `docs/ia/CONTEXT_HYGIENE.md`
 - `docs/ia/ARCHITECTURE.md`
 - `docs/ia/TESTING.md`
+- `docs/contexto/features/pr-2321-fix-resolver-observaciones-de-reapertura-del-issue-2305.md`
 - `docs/registro/cambios/2026-08-19-issue-2305-rendiciones.md`
 - `docs/registro/cambios/2026-08-20-fix-cache-metricas-dashboard.md`
+- `docs/registro/prs/PR-2321.md`
 
 ## Trazabilidad
 

--- a/docs/contexto/features/pr-2321-fix-resolver-observaciones-de-reapertura-del-issue-2305.md
+++ b/docs/contexto/features/pr-2321-fix-resolver-observaciones-de-reapertura-del-issue-2305.md
@@ -27,7 +27,7 @@
 ## Design system y UI
 
 - El PR toca piezas de UI y conviene revisar consistencia visual con el patrón existente.
-- Archivos visuales relevantes: rendicioncuentasmensual/templates/rendicioncuentasmensual_datos_form.html, rendicioncuentasmensual/templates/rendicioncuentasmensual_global_list.html, static/custom/css/listModerno.css
+- Archivos visuales relevantes: rendicioncuentasmensual/templates/components/rendicion_global_list_cell.html, rendicioncuentasmensual/templates/rendicioncuentasmensual_datos_form.html, rendicioncuentasmensual/templates/rendicioncuentasmensual_global_list.html, static/custom/css/listModerno.css, templates/components/column_config_modal.html, templates/components/data_table.html
 
 ## Memoria operativa para agentes
 
@@ -35,15 +35,20 @@
 - Revisar primero estos archivos del diff:
 - `dashboard/signals.py`
 - `docs/contexto/features/pr-2321-fix-resolver-observaciones-de-reapertura-del-issue-2305.md`
+- `docs/plans/2026-08-20-pr-2321-review-findings-design.md`
 - `docs/registro/cambios/2026-08-19-issue-2305-rendiciones.md`
 - `docs/registro/cambios/2026-08-20-fix-cache-metricas-dashboard.md`
 - `docs/registro/prs/PR-2321.md`
 - `rendicioncuentasmensual/models.py`
 - `rendicioncuentasmensual/services.py`
+- `rendicioncuentasmensual/templates/components/rendicion_global_list_cell.html`
 - `rendicioncuentasmensual/templates/rendicioncuentasmensual_datos_form.html`
 - `rendicioncuentasmensual/templates/rendicioncuentasmensual_global_list.html`
 - `rendicioncuentasmensual/views.py`
 - `static/custom/css/listModerno.css`
+- `templates/components/column_config_modal.html`
+- `templates/components/data_table.html`
+- `tests/test_dashboard_comedores_core_boundary.py`
 - `tests/test_pwa_comedores_api.py`
 - `tests/test_rendicioncuentasmensual_views_unit.py`
 - Documentación sugerida para ampliar contexto:
@@ -52,6 +57,7 @@
 - `docs/ia/ARCHITECTURE.md`
 - `docs/ia/TESTING.md`
 - `docs/contexto/features/pr-2321-fix-resolver-observaciones-de-reapertura-del-issue-2305.md`
+- `docs/plans/2026-08-20-pr-2321-review-findings-design.md`
 - `docs/registro/cambios/2026-08-19-issue-2305-rendiciones.md`
 - `docs/registro/cambios/2026-08-20-fix-cache-metricas-dashboard.md`
 - `docs/registro/prs/PR-2321.md`

--- a/docs/plans/2026-08-20-pr-2321-review-findings-design.md
+++ b/docs/plans/2026-08-20-pr-2321-review-findings-design.md
@@ -1,0 +1,22 @@
+# PR #2321: corrección de hallazgos de revisión
+
+## Objetivo
+
+Resolver los tres hallazgos P2 de la revisión sin cambiar el contrato funcional
+de rendiciones ni el alcance del PR #2321.
+
+## Diseño aprobado
+
+1. Cubrir la invalidación de caché del dashboard con una regresión que precargue
+   valores obsoletos, ejecute la actualización y compruebe las métricas
+   persistidas.
+2. Cubrir el formulario de edición de rendición mediante un GET autenticado y
+   autorizado que renderice el template específico y sus campos de datos.
+3. Sustituir el modal de preferencias duplicado del listado por el componente
+   estándar existente. Mantener la tabla actual y sus columnas configurables;
+   no crear una abstracción nueva para las celdas personalizadas.
+
+## Validación
+
+Ejecutar los tests focalizados de dashboard y rendiciones, más `black`,
+`djlint` y `git diff --check` sobre los archivos modificados.

--- a/docs/registro/cambios/2026-08-19-issue-2305-rendiciones.md
+++ b/docs/registro/cambios/2026-08-19-issue-2305-rendiciones.md
@@ -30,3 +30,37 @@ subsanación, exportación y edición con/sin permiso.
 - `black`, `djlint`, chequeo Django y control de migraciones: exitosos.
 - La navegación visual integrada quedó pendiente porque el entorno Docker local
   no pudo resolver el host `mysql`; no afecta los checks automatizados.
+
+## Correcciones posteriores a la reapertura
+
+- Durante una subsanación, las categorías que admiten múltiples archivos
+  permiten adjuntar documentación nueva sin exigir que reemplace un documento
+  observado. Si la carga indica un documento a subsanar, se conservan las
+  validaciones y la trazabilidad del reemplazo.
+- La edición web de datos generales usa un formulario específico para convenio,
+  número, período y nombre. Esto evita que el template general intente renderizar
+  campos de documentación que no existen y provoque un `CrispyError`.
+- El listado global carga el helper compartido que ejecuta la exportación CSV;
+  el botón conserva los filtros activos y deja de quedar sin respuesta al click.
+- La configuración de columnas deja el selector local artesanal y adopta el modal
+  estándar de SISOC, con preferencias persistidas por usuario, ordenamiento,
+  guardado y restablecimiento. La exportación respeta las columnas visibles y su
+  orden.
+- El PDF compilado adopta el nombre solicitado en el issue: código de proyecto,
+  convenio, número de rendición y mes/año abreviado en español; por ejemplo,
+  `APAR043-P01-RENDICION_1-JUL2026.pdf`. Los componentes variables se normalizan
+  para evitar separadores de ruta u otros caracteres inseguros; los guiones
+  medios separan los bloques y los separadores internos se convierten en guiones
+  bajos. El nombre final no contiene espacios.
+- Las pills de etapa se diferencian con una paleta pastel: Revisión Territorial
+  en azul claro, Revisión de Auditoría en lavanda y Auditoría en durazno. Carga
+  de documentación usa gris claro y Regularización amarillo crema. Los tonos
+  tienen saturación media para destacarse sin perder el carácter pastel. Se
+  conserva sin cambios el código semántico de estado: amarillo para en curso,
+  verde para finalizado y rojo para correcciones.
+
+## Validación de la reapertura
+
+- Suite focalizada de Rendiciones y API PWA: `88 passed`.
+- Suite completa del repositorio: `4068 passed`, `11 skipped`.
+- `black`, `djlint`, `pylint`, chequeo Django y control de migraciones: exitosos.

--- a/docs/registro/cambios/2026-08-20-fix-cache-metricas-dashboard.md
+++ b/docs/registro/cambios/2026-08-20-fix-cache-metricas-dashboard.md
@@ -1,0 +1,22 @@
+# Dashboard: invalidación de caché al actualizar métricas
+
+## Contexto
+
+La suite completa detectó que las señales de Comedores recalculaban el Dashboard
+usando valores de presupuesto previamente cacheados. Si primero se creaba un
+comedor, los presupuestos quedaban cacheados en cero y la creación posterior de
+`ValorComida` no actualizaba esos importes.
+
+## Cambio
+
+Antes de regenerar las métricas persistidas se invalidan exclusivamente las cinco
+claves de caché del Dashboard. La siguiente lectura reconstruye cantidad de
+comedores, relevamientos y presupuestos desde las proyecciones públicas de dominio.
+
+No se limpia la caché global ni se modifican contratos de Comedores o
+Relevamientos.
+
+## Validación
+
+- `tests/test_dashboard_comedores_core_boundary.py`
+- Suite completa de `pytest`.

--- a/docs/registro/prs/PR-2321.md
+++ b/docs/registro/prs/PR-2321.md
@@ -1,0 +1,61 @@
+# PR #2321 - Fix: resolver observaciones de reapertura del issue 2305
+
+## Metadata
+
+- PR: https://github.com/dsocial118/SISOC/pull/2321
+- Base: `development`
+- Rama origen: `codex/issue-2305`
+- Autor: `PabloCao1`
+
+## Resumen operativo
+
+- Tipo de cambio: No informado
+- Área principal: No informada
+- Contexto funcional: No informado explícitamente; revisar título, diff y documentación relacionada.
+- Resumen para changelog: No informado
+- Impacto usuario: No informado
+
+## Áreas afectadas
+
+- `dashboard`
+- `docs/registro`
+- `rendicioncuentasmensual`
+- `static`
+- `tests`
+
+## Archivos relevantes del diff
+
+- `dashboard/signals.py`
+- `docs/registro/cambios/2026-08-19-issue-2305-rendiciones.md`
+- `docs/registro/cambios/2026-08-20-fix-cache-metricas-dashboard.md`
+- `rendicioncuentasmensual/models.py`
+- `rendicioncuentasmensual/services.py`
+- `rendicioncuentasmensual/templates/rendicioncuentasmensual_datos_form.html`
+- `rendicioncuentasmensual/templates/rendicioncuentasmensual_global_list.html`
+- `rendicioncuentasmensual/views.py`
+- `static/custom/css/listModerno.css`
+- `tests/test_pwa_comedores_api.py`
+- `tests/test_rendicioncuentasmensual_views_unit.py`
+
+## Validación declarada
+
+- Pruebas automáticas: No informado en el PR.
+- Pruebas manuales: No informado en el PR.
+
+## Riesgos y rollback
+
+- No informado explícitamente en el PR.
+
+## Documentación sugerida para lectura
+
+- `docs/indice.md`
+- `docs/ia/CONTEXT_HYGIENE.md`
+- `docs/ia/ARCHITECTURE.md`
+- `docs/ia/TESTING.md`
+- `docs/registro/cambios/2026-08-19-issue-2305-rendiciones.md`
+- `docs/registro/cambios/2026-08-20-fix-cache-metricas-dashboard.md`
+
+## Notas para continuidad
+
+- Este documento es generado automáticamente desde el contexto del PR y sirve como índice rápido para revisión y futuras sesiones de agentes.
+- Si la metadata del body del PR está incompleta, varias secciones usarán fallbacks derivados del título o del diff.

--- a/docs/registro/prs/PR-2321.md
+++ b/docs/registro/prs/PR-2321.md
@@ -19,24 +19,31 @@
 
 - `dashboard`
 - `docs/contexto`
+- `docs/plans`
 - `docs/registro`
 - `rendicioncuentasmensual`
 - `static`
+- `templates`
 - `tests`
 
 ## Archivos relevantes del diff
 
 - `dashboard/signals.py`
 - `docs/contexto/features/pr-2321-fix-resolver-observaciones-de-reapertura-del-issue-2305.md`
+- `docs/plans/2026-08-20-pr-2321-review-findings-design.md`
 - `docs/registro/cambios/2026-08-19-issue-2305-rendiciones.md`
 - `docs/registro/cambios/2026-08-20-fix-cache-metricas-dashboard.md`
 - `docs/registro/prs/PR-2321.md`
 - `rendicioncuentasmensual/models.py`
 - `rendicioncuentasmensual/services.py`
+- `rendicioncuentasmensual/templates/components/rendicion_global_list_cell.html`
 - `rendicioncuentasmensual/templates/rendicioncuentasmensual_datos_form.html`
 - `rendicioncuentasmensual/templates/rendicioncuentasmensual_global_list.html`
 - `rendicioncuentasmensual/views.py`
 - `static/custom/css/listModerno.css`
+- `templates/components/column_config_modal.html`
+- `templates/components/data_table.html`
+- `tests/test_dashboard_comedores_core_boundary.py`
 - `tests/test_pwa_comedores_api.py`
 - `tests/test_rendicioncuentasmensual_views_unit.py`
 
@@ -56,6 +63,7 @@
 - `docs/ia/ARCHITECTURE.md`
 - `docs/ia/TESTING.md`
 - `docs/contexto/features/pr-2321-fix-resolver-observaciones-de-reapertura-del-issue-2305.md`
+- `docs/plans/2026-08-20-pr-2321-review-findings-design.md`
 - `docs/registro/cambios/2026-08-19-issue-2305-rendiciones.md`
 - `docs/registro/cambios/2026-08-20-fix-cache-metricas-dashboard.md`
 - `docs/registro/prs/PR-2321.md`

--- a/docs/registro/prs/PR-2321.md
+++ b/docs/registro/prs/PR-2321.md
@@ -18,6 +18,7 @@
 ## Áreas afectadas
 
 - `dashboard`
+- `docs/contexto`
 - `docs/registro`
 - `rendicioncuentasmensual`
 - `static`
@@ -26,8 +27,10 @@
 ## Archivos relevantes del diff
 
 - `dashboard/signals.py`
+- `docs/contexto/features/pr-2321-fix-resolver-observaciones-de-reapertura-del-issue-2305.md`
 - `docs/registro/cambios/2026-08-19-issue-2305-rendiciones.md`
 - `docs/registro/cambios/2026-08-20-fix-cache-metricas-dashboard.md`
+- `docs/registro/prs/PR-2321.md`
 - `rendicioncuentasmensual/models.py`
 - `rendicioncuentasmensual/services.py`
 - `rendicioncuentasmensual/templates/rendicioncuentasmensual_datos_form.html`
@@ -52,8 +55,10 @@
 - `docs/ia/CONTEXT_HYGIENE.md`
 - `docs/ia/ARCHITECTURE.md`
 - `docs/ia/TESTING.md`
+- `docs/contexto/features/pr-2321-fix-resolver-observaciones-de-reapertura-del-issue-2305.md`
 - `docs/registro/cambios/2026-08-19-issue-2305-rendiciones.md`
 - `docs/registro/cambios/2026-08-20-fix-cache-metricas-dashboard.md`
+- `docs/registro/prs/PR-2321.md`
 
 ## Notas para continuidad
 

--- a/rendicioncuentasmensual/models.py
+++ b/rendicioncuentasmensual/models.py
@@ -611,6 +611,16 @@ class RendicionCuentaMensual(SoftDeleteModelMixin, models.Model):
         }
 
     @property
+    def etapa_badge_class(self):
+        return {
+            self.ETAPA_CARGA_DOCUMENTACION: "etapa-carga",
+            self.ETAPA_REVISION_DOCUMENTACION: "etapa-territorial",
+            self.ETAPA_REVISION_AUDITORIA: "etapa-revision-auditoria",
+            self.ETAPA_AUDITORIA: "etapa-auditoria",
+            self.ETAPA_REGULARIZACION: "etapa-regularizacion",
+        }.get(self.etapa_proceso, "etapa-carga")
+
+    @property
     def validacion_auditoria_finalizada(self):
         return self.fecha_validacion_auditoria is not None or self.etapa_proceso in {
             self.ETAPA_AUDITORIA,

--- a/rendicioncuentasmensual/services.py
+++ b/rendicioncuentasmensual/services.py
@@ -520,6 +520,9 @@ class RendicionCuentaMensualService:  # pylint: disable=too-many-public-methods
                 rendicion
             ).filter(categoria=categoria)
         )
+        if config["multiple"] and not documento_subsanado_id:
+            return {"config": config, "documento_subsanado": None}
+
         if (
             not documentos_categoria.exists()
             or rendicion.solicitudes_documentos_faltantes.filter(

--- a/rendicioncuentasmensual/templates/components/rendicion_global_list_cell.html
+++ b/rendicioncuentasmensual/templates/components/rendicion_global_list_cell.html
@@ -1,0 +1,33 @@
+{% if column_key == "proyecto" %}
+    <td>{{ rendicion.comedor.codigo_de_proyecto|default:"Sin proyecto" }}</td>
+{% elif column_key == "organizacion" %}
+    <td>{{ rendicion.comedor.organizacion.nombre|default:"Sin organización" }}</td>
+{% elif column_key == "convenio" %}
+    <td>{{ rendicion.convenio|default:"-" }}</td>
+{% elif column_key == "numero_rendicion" %}
+    <td>{{ rendicion.numero_rendicion|default:rendicion.id }}</td>
+{% elif column_key == "periodo" %}
+    <td>
+        {% if rendicion.periodo_inicio and rendicion.periodo_fin %}
+            {{ rendicion.periodo_inicio|date:"d/m/Y" }} - {{ rendicion.periodo_fin|date:"d/m/Y" }}
+        {% else %}
+            {{ rendicion.mes }}/{{ rendicion.anio }}
+        {% endif %}
+    </td>
+{% elif column_key == "etapa" %}
+    <td>
+        <span class="badge etapa-badge {{ rendicion.etapa_badge_class }}">{{ rendicion.get_etapa_proceso_display }}</span>
+    </td>
+{% elif column_key == "estado" %}
+    <td>
+        {% if rendicion.subestado_proceso == "finalizada" %}
+            <span class="badge-validacion validado">{{ rendicion.estado_proceso_display }}</span>
+        {% elif rendicion.subestado_proceso == "pendiente_correcciones" %}
+            <span class="badge-validacion no-validado">{{ rendicion.estado_proceso_display }}</span>
+        {% else %}
+            <span class="badge-validacion pendiente">{{ rendicion.estado_proceso_display }}</span>
+        {% endif %}
+    </td>
+{% elif column_key == "ultima_modificacion" %}
+    <td>{{ rendicion.ultima_modificacion|date:"d/m/Y H:i" }}</td>
+{% endif %}

--- a/rendicioncuentasmensual/templates/rendicioncuentasmensual_datos_form.html
+++ b/rendicioncuentasmensual/templates/rendicioncuentasmensual_datos_form.html
@@ -1,0 +1,37 @@
+{% extends "includes/main.html" %}
+{% load crispy_forms_tags %}
+{% block title %}Editar datos de rendición{% endblock %}
+{% block breadcrumb %}
+    <ol class="breadcrumb float-sm-right">
+        <li class="breadcrumb-item">
+            <a href="{% url 'rendicioncuentasmensual_detail' form.instance.pk %}"
+               title="Volver al detalle de la rendición">Rendición {{ form.instance.numero_rendicion|default:form.instance.pk }}</a>
+        </li>
+        <li class="breadcrumb-item active">Editar datos</li>
+    </ol>
+{% endblock %}
+{% block content %}
+    <div class="container mt-4">
+        <div class="card">
+            <div class="card-header bg-primary text-white">
+                <h5 class="mb-0">Editar datos de rendición</h5>
+            </div>
+            <div class="card-body">
+                <form method="post">
+                    {% csrf_token %}
+                    {{ form.non_field_errors }}
+                    {{ form.convenio|as_crispy_field }}
+                    {{ form.numero_rendicion|as_crispy_field }}
+                    {{ form.periodo_inicio|as_crispy_field }}
+                    {{ form.periodo_fin|as_crispy_field }}
+                    {{ form.nombre|as_crispy_field }}
+                    <div class="mt-4 text-center">
+                        <button type="submit" class="btn btn-success">Guardar</button>
+                        <a href="{% url 'rendicioncuentasmensual_detail' form.instance.pk %}"
+                           class="btn btn-secondary">Cancelar</a>
+                    </div>
+                </form>
+            </div>
+        </div>
+    </div>
+{% endblock %}

--- a/rendicioncuentasmensual/templates/rendicioncuentasmensual_global_list.html
+++ b/rendicioncuentasmensual/templates/rendicioncuentasmensual_global_list.html
@@ -12,62 +12,124 @@
             <div class="col-12">
                 <div class="card comedor-table-card">
                     <div class="card-body">
-                        <details class="mb-3">
-                            <summary class="btn btn-outline-warning btn-sm">Configurar columnas</summary>
-                            <div class="d-flex flex-wrap gap-3 mt-3">
-                                {% for key, label in columnas_configurables %}
-                                    <label>
-                                        <input class="form-check-input js-rendicion-column"
-                                               type="checkbox"
-                                               value="{{ key }}"
-                                               checked />
-                                        {{ label }}
-                                    </label>
-                                {% endfor %}
+                        {{ column_config|json_script:column_config.script_id }}
+                        <div class="d-flex justify-content-start mb-2">
+                            <button type="button"
+                                    class="btn btn-outline-warning btn-sm"
+                                    data-bs-toggle="modal"
+                                    data-bs-target="#{{ column_config.modal_id }}">Configurar columnas</button>
+                        </div>
+                        <div class="modal fade"
+                             id="{{ column_config.modal_id }}"
+                             tabindex="-1"
+                             aria-hidden="true"
+                             data-column-config="true"
+                             data-config-id="{{ column_config.script_id }}">
+                            <div class="modal-dialog modal-dialog-centered modal-lg">
+                                <div class="modal-content">
+                                    <div class="modal-header">
+                                        <h5 class="modal-title">Columnas visibles</h5>
+                                        <button type="button"
+                                                class="btn-close"
+                                                data-bs-dismiss="modal"
+                                                aria-label="Cerrar"></button>
+                                    </div>
+                                    <div class="modal-body">
+                                        <p class="text-muted mb-3">Seleccioná qué columnas mostrar y ordenalas con las flechas.</p>
+                                        <div class="list-group column-config-list">
+                                            {% for col in column_config.available %}
+                                                <div class="list-group-item d-flex flex-wrap align-items-center justify-content-between gap-2"
+                                                     data-column-key="{{ col.key }}">
+                                                    <div class="form-check">
+                                                        <input class="form-check-input column-config-checkbox"
+                                                               type="checkbox"
+                                                               id="{{ column_config.modal_id }}-{{ col.key }}"
+                                                               {% if col.active %}checked{% endif %}
+                                                               {% if col.required %}disabled{% endif %} />
+                                                        <label class="form-check-label"
+                                                               for="{{ column_config.modal_id }}-{{ col.key }}">
+                                                            {{ col.title }}
+                                                        </label>
+                                                        {% if col.required %}<span class="badge bg-secondary ms-2">Obligatoria</span>{% endif %}
+                                                    </div>
+                                                    <div class="btn-group btn-group-sm" role="group">
+                                                        <button type="button"
+                                                                class="btn btn-light column-move-up"
+                                                                title="Mover arriba">
+                                                            <i class="fas fa-arrow-up"></i>
+                                                        </button>
+                                                        <button type="button"
+                                                                class="btn btn-light column-move-down"
+                                                                title="Mover abajo">
+                                                            <i class="fas fa-arrow-down"></i>
+                                                        </button>
+                                                    </div>
+                                                </div>
+                                            {% endfor %}
+                                        </div>
+                                        <div class="alert alert-danger d-none mt-3 column-config-error"></div>
+                                    </div>
+                                    <div class="modal-footer">
+                                        <button type="button" class="btn btn-outline-secondary column-config-reset">Restablecer</button>
+                                        <button type="button" class="btn btn-primary column-config-save">Guardar</button>
+                                    </div>
+                                </div>
                             </div>
-                        </details>
+                        </div>
                         <div class="table-responsive-lg">
                             <table class="table table-comedor-moderno">
                                 <thead>
                                     <tr>
-                                        <th data-column="proyecto">Proyecto</th>
-                                        <th>Organización</th>
-                                        <th data-column="convenio">Convenio</th>
-                                        <th>Rendición</th>
-                                        <th>Período</th>
-                                        <th data-column="etapa">Etapa</th>
-                                        <th data-column="estado">Estado</th>
-                                        <th>Última modificación</th>
+                                        {% for column_key in active_columns %}
+                                            {% if column_key == "proyecto" %}<th>Proyecto</th>{% endif %}
+                                            {% if column_key == "organizacion" %}<th>Organización</th>{% endif %}
+                                            {% if column_key == "convenio" %}<th>Convenio</th>{% endif %}
+                                            {% if column_key == "numero_rendicion" %}<th>Rendición</th>{% endif %}
+                                            {% if column_key == "periodo" %}<th>Período</th>{% endif %}
+                                            {% if column_key == "etapa" %}<th>Etapa</th>{% endif %}
+                                            {% if column_key == "estado" %}<th>Estado</th>{% endif %}
+                                            {% if column_key == "ultima_modificacion" %}<th>Última modificación</th>{% endif %}
+                                        {% endfor %}
                                         <th>Acciones</th>
                                     </tr>
                                 </thead>
                                 <tbody>
                                     {% for rendicion in rendiciones_cuentas_mensuales %}
                                         <tr>
-                                            <td data-column="proyecto">{{ rendicion.comedor.codigo_de_proyecto|default:"Sin proyecto" }}</td>
-                                            <td>{{ rendicion.comedor.organizacion.nombre|default:"Sin organización" }}</td>
-                                            <td data-column="convenio">{{ rendicion.convenio|default:"-" }}</td>
-                                            <td>{{ rendicion.numero_rendicion|default:rendicion.id }}</td>
-                                            <td>
-                                                {% if rendicion.periodo_inicio and rendicion.periodo_fin %}
-                                                    {{ rendicion.periodo_inicio|date:"d/m/Y" }} - {{ rendicion.periodo_fin|date:"d/m/Y" }}
-                                                {% else %}
-                                                    {{ rendicion.mes }}/{{ rendicion.anio }}
+                                            {% for column_key in active_columns %}
+                                                {% if column_key == "proyecto" %}<td>{{ rendicion.comedor.codigo_de_proyecto|default:"Sin proyecto" }}</td>{% endif %}
+                                                {% if column_key == "organizacion" %}
+                                                    <td>{{ rendicion.comedor.organizacion.nombre|default:"Sin organización" }}</td>
                                                 {% endif %}
-                                            </td>
-                                            <td data-column="etapa">
-                                                <span class="badge bg-info text-dark">{{ rendicion.get_etapa_proceso_display }}</span>
-                                            </td>
-                                            <td data-column="estado">
-                                                {% if rendicion.subestado_proceso == 'finalizada' %}
-                                                    <span class="badge-validacion validado">{{ rendicion.estado_proceso_display }}</span>
-                                                {% elif rendicion.subestado_proceso == 'pendiente_correcciones' %}
-                                                    <span class="badge-validacion no-validado">{{ rendicion.estado_proceso_display }}</span>
-                                                {% else %}
-                                                    <span class="badge-validacion pendiente">{{ rendicion.estado_proceso_display }}</span>
+                                                {% if column_key == "convenio" %}<td>{{ rendicion.convenio|default:"-" }}</td>{% endif %}
+                                                {% if column_key == "numero_rendicion" %}<td>{{ rendicion.numero_rendicion|default:rendicion.id }}</td>{% endif %}
+                                                {% if column_key == "periodo" %}
+                                                    <td>
+                                                        {% if rendicion.periodo_inicio and rendicion.periodo_fin %}
+                                                            {{ rendicion.periodo_inicio|date:"d/m/Y" }} - {{ rendicion.periodo_fin|date:"d/m/Y" }}
+                                                        {% else %}
+                                                            {{ rendicion.mes }}/{{ rendicion.anio }}
+                                                        {% endif %}
+                                                    </td>
                                                 {% endif %}
-                                            </td>
-                                            <td>{{ rendicion.ultima_modificacion|date:"d/m/Y H:i" }}</td>
+                                                {% if column_key == "etapa" %}
+                                                    <td>
+                                                        <span class="badge etapa-badge {{ rendicion.etapa_badge_class }}">{{ rendicion.get_etapa_proceso_display }}</span>
+                                                    </td>
+                                                {% endif %}
+                                                {% if column_key == "estado" %}
+                                                    <td>
+                                                        {% if rendicion.subestado_proceso == 'finalizada' %}
+                                                            <span class="badge-validacion validado">{{ rendicion.estado_proceso_display }}</span>
+                                                        {% elif rendicion.subestado_proceso == 'pendiente_correcciones' %}
+                                                            <span class="badge-validacion no-validado">{{ rendicion.estado_proceso_display }}</span>
+                                                        {% else %}
+                                                            <span class="badge-validacion pendiente">{{ rendicion.estado_proceso_display }}</span>
+                                                        {% endif %}
+                                                    </td>
+                                                {% endif %}
+                                                {% if column_key == "ultima_modificacion" %}<td>{{ rendicion.ultima_modificacion|date:"d/m/Y H:i" }}</td>{% endif %}
+                                            {% endfor %}
                                             <td>
                                                 <div class="comedor-actions">
                                                     <a href="{% url 'rendicioncuentasmensual_detail' rendicion.id %}"
@@ -93,19 +155,8 @@
         </div>
         {% include 'components/pagination.html' with is_paginated=is_paginated page_obj=page_obj prev_text='Volver' next_text='Continuar' %}
     </div>
-    <script nonce="{{ request.csp_nonce }}">
-        (function () {
-            var key = "rendiciones-columnas-visibles";
-            var checks = Array.from(document.querySelectorAll(".js-rendicion-column"));
-            var saved = JSON.parse(localStorage.getItem(key) || "null");
-            function apply() {
-                var visible = checks.filter(function (item) { return item.checked; }).map(function (item) { return item.value; });
-                document.querySelectorAll("[data-column]").forEach(function (cell) { cell.classList.toggle("d-none", !visible.includes(cell.dataset.column)); });
-                localStorage.setItem(key, JSON.stringify(visible));
-            }
-            if (Array.isArray(saved)) checks.forEach(function (item) { item.checked = saved.includes(item.value); });
-            checks.forEach(function (item) { item.addEventListener("change", apply); });
-            apply();
-        })();
-    </script>
+{% endblock %}
+{% block customJS %}
+    <script src="{% static 'custom/js/column_config.js' %}"></script>
+    <script src="{% static 'custom/js/export_helper.js' %}"></script>
 {% endblock %}

--- a/rendicioncuentasmensual/templates/rendicioncuentasmensual_global_list.html
+++ b/rendicioncuentasmensual/templates/rendicioncuentasmensual_global_list.html
@@ -12,84 +12,12 @@
             <div class="col-12">
                 <div class="card comedor-table-card">
                     <div class="card-body">
-                        {{ column_config|json_script:column_config.script_id }}
-                        <div class="d-flex justify-content-start mb-2">
-                            <button type="button"
-                                    class="btn btn-outline-warning btn-sm"
-                                    data-bs-toggle="modal"
-                                    data-bs-target="#{{ column_config.modal_id }}">Configurar columnas</button>
-                        </div>
-                        <div class="modal fade"
-                             id="{{ column_config.modal_id }}"
-                             tabindex="-1"
-                             aria-hidden="true"
-                             data-column-config="true"
-                             data-config-id="{{ column_config.script_id }}">
-                            <div class="modal-dialog modal-dialog-centered modal-lg">
-                                <div class="modal-content">
-                                    <div class="modal-header">
-                                        <h5 class="modal-title">Columnas visibles</h5>
-                                        <button type="button"
-                                                class="btn-close"
-                                                data-bs-dismiss="modal"
-                                                aria-label="Cerrar"></button>
-                                    </div>
-                                    <div class="modal-body">
-                                        <p class="text-muted mb-3">Seleccioná qué columnas mostrar y ordenalas con las flechas.</p>
-                                        <div class="list-group column-config-list">
-                                            {% for col in column_config.available %}
-                                                <div class="list-group-item d-flex flex-wrap align-items-center justify-content-between gap-2"
-                                                     data-column-key="{{ col.key }}">
-                                                    <div class="form-check">
-                                                        <input class="form-check-input column-config-checkbox"
-                                                               type="checkbox"
-                                                               id="{{ column_config.modal_id }}-{{ col.key }}"
-                                                               {% if col.active %}checked{% endif %}
-                                                               {% if col.required %}disabled{% endif %} />
-                                                        <label class="form-check-label"
-                                                               for="{{ column_config.modal_id }}-{{ col.key }}">
-                                                            {{ col.title }}
-                                                        </label>
-                                                        {% if col.required %}<span class="badge bg-secondary ms-2">Obligatoria</span>{% endif %}
-                                                    </div>
-                                                    <div class="btn-group btn-group-sm" role="group">
-                                                        <button type="button"
-                                                                class="btn btn-light column-move-up"
-                                                                title="Mover arriba">
-                                                            <i class="fas fa-arrow-up"></i>
-                                                        </button>
-                                                        <button type="button"
-                                                                class="btn btn-light column-move-down"
-                                                                title="Mover abajo">
-                                                            <i class="fas fa-arrow-down"></i>
-                                                        </button>
-                                                    </div>
-                                                </div>
-                                            {% endfor %}
-                                        </div>
-                                        <div class="alert alert-danger d-none mt-3 column-config-error"></div>
-                                    </div>
-                                    <div class="modal-footer">
-                                        <button type="button" class="btn btn-outline-secondary column-config-reset">Restablecer</button>
-                                        <button type="button" class="btn btn-primary column-config-save">Guardar</button>
-                                    </div>
-                                </div>
-                            </div>
-                        </div>
+                        {% include "components/column_config_modal.html" %}
                         <div class="table-responsive-lg">
                             <table class="table table-comedor-moderno">
                                 <thead>
                                     <tr>
-                                        {% for column_key in active_columns %}
-                                            {% if column_key == "proyecto" %}<th>Proyecto</th>{% endif %}
-                                            {% if column_key == "organizacion" %}<th>Organización</th>{% endif %}
-                                            {% if column_key == "convenio" %}<th>Convenio</th>{% endif %}
-                                            {% if column_key == "numero_rendicion" %}<th>Rendición</th>{% endif %}
-                                            {% if column_key == "periodo" %}<th>Período</th>{% endif %}
-                                            {% if column_key == "etapa" %}<th>Etapa</th>{% endif %}
-                                            {% if column_key == "estado" %}<th>Estado</th>{% endif %}
-                                            {% if column_key == "ultima_modificacion" %}<th>Última modificación</th>{% endif %}
-                                        {% endfor %}
+                                        {% for header in table_headers %}<th>{{ header.title }}</th>{% endfor %}
                                         <th>Acciones</th>
                                     </tr>
                                 </thead>
@@ -97,38 +25,7 @@
                                     {% for rendicion in rendiciones_cuentas_mensuales %}
                                         <tr>
                                             {% for column_key in active_columns %}
-                                                {% if column_key == "proyecto" %}<td>{{ rendicion.comedor.codigo_de_proyecto|default:"Sin proyecto" }}</td>{% endif %}
-                                                {% if column_key == "organizacion" %}
-                                                    <td>{{ rendicion.comedor.organizacion.nombre|default:"Sin organización" }}</td>
-                                                {% endif %}
-                                                {% if column_key == "convenio" %}<td>{{ rendicion.convenio|default:"-" }}</td>{% endif %}
-                                                {% if column_key == "numero_rendicion" %}<td>{{ rendicion.numero_rendicion|default:rendicion.id }}</td>{% endif %}
-                                                {% if column_key == "periodo" %}
-                                                    <td>
-                                                        {% if rendicion.periodo_inicio and rendicion.periodo_fin %}
-                                                            {{ rendicion.periodo_inicio|date:"d/m/Y" }} - {{ rendicion.periodo_fin|date:"d/m/Y" }}
-                                                        {% else %}
-                                                            {{ rendicion.mes }}/{{ rendicion.anio }}
-                                                        {% endif %}
-                                                    </td>
-                                                {% endif %}
-                                                {% if column_key == "etapa" %}
-                                                    <td>
-                                                        <span class="badge etapa-badge {{ rendicion.etapa_badge_class }}">{{ rendicion.get_etapa_proceso_display }}</span>
-                                                    </td>
-                                                {% endif %}
-                                                {% if column_key == "estado" %}
-                                                    <td>
-                                                        {% if rendicion.subestado_proceso == 'finalizada' %}
-                                                            <span class="badge-validacion validado">{{ rendicion.estado_proceso_display }}</span>
-                                                        {% elif rendicion.subestado_proceso == 'pendiente_correcciones' %}
-                                                            <span class="badge-validacion no-validado">{{ rendicion.estado_proceso_display }}</span>
-                                                        {% else %}
-                                                            <span class="badge-validacion pendiente">{{ rendicion.estado_proceso_display }}</span>
-                                                        {% endif %}
-                                                    </td>
-                                                {% endif %}
-                                                {% if column_key == "ultima_modificacion" %}<td>{{ rendicion.ultima_modificacion|date:"d/m/Y H:i" }}</td>{% endif %}
+                                                {% include "components/rendicion_global_list_cell.html" %}
                                             {% endfor %}
                                             <td>
                                                 <div class="comedor-actions">
@@ -143,7 +40,7 @@
                                         </tr>
                                     {% empty %}
                                         <tr>
-                                            <td colspan="9">No hay rendiciones registradas.</td>
+                                            <td colspan="{{ active_columns|length|add:1 }}">No hay rendiciones registradas.</td>
                                         </tr>
                                     {% endfor %}
                                 </tbody>

--- a/rendicioncuentasmensual/views.py
+++ b/rendicioncuentasmensual/views.py
@@ -1,3 +1,5 @@
+import re
+
 from django.contrib import messages
 from django.contrib.auth.decorators import login_required
 from django.contrib.auth.mixins import LoginRequiredMixin
@@ -18,6 +20,7 @@ from comedores.models import Comedor
 from core.services.advanced_filters import AdvancedFilterEngine
 from core.services.favorite_filters import SeccionesFiltrosFavoritos
 from core.mixins import CSVExportMixin
+from core.services.column_preferences import build_columns_context_from_fields
 from core.soft_delete.preview import build_delete_preview
 from core.soft_delete.view_helpers import (
     SoftDeleteDeleteViewMixin,
@@ -99,18 +102,40 @@ class RendicionCuentaMensualGlobalListView(
     context_object_name = "rendiciones_cuentas_mensuales"
     paginate_by = 25
     export_filename = "listado_rendiciones.csv"
+    COLUMN_LIST_KEY = "rendiciones_global_list"
+    COLUMN_DEFINITIONS = (
+        ("proyecto", "Proyecto", "comedor.codigo_de_proyecto"),
+        ("organizacion", "Organización", "comedor.organizacion.nombre"),
+        ("convenio", "Convenio", "convenio"),
+        ("numero_rendicion", "Rendición", "numero_rendicion"),
+        ("periodo", "Período", "periodo_exportacion"),
+        ("etapa", "Etapa", "get_etapa_proceso_display"),
+        ("estado", "Estado", "estado_proceso_display"),
+        ("ultima_modificacion", "Última modificación", "ultima_modificacion"),
+    )
+
+    def _get_columns_context(self):
+        return build_columns_context_from_fields(
+            self.request,
+            self.COLUMN_LIST_KEY,
+            [{"title": title} for _key, title, _field in self.COLUMN_DEFINITIONS],
+            [{"name": key} for key, _title, _field in self.COLUMN_DEFINITIONS],
+            required_keys=["proyecto"],
+        )
 
     def get_export_columns(self):
-        return [
-            ("Proyecto", "comedor.codigo_de_proyecto"),
-            ("Organización", "comedor.organizacion.nombre"),
-            ("Convenio", "convenio"),
-            ("Rendición", "numero_rendicion"),
-            ("Período inicio", "periodo_inicio"),
-            ("Período fin", "periodo_fin"),
-            ("Estado", "get_estado_display"),
-            ("Etapa", "get_etapa_proceso_display"),
-        ]
+        active_keys = self._get_columns_context()["column_active_keys"]
+        definitions = {
+            key: (title, field) for key, title, field in self.COLUMN_DEFINITIONS
+        }
+        return [definitions[key] for key in active_keys]
+
+    def resolve_field(self, obj, field_path):
+        if field_path == "periodo_exportacion":
+            if obj.periodo_inicio and obj.periodo_fin:
+                return f"{obj.periodo_inicio:%d/%m/%Y} - {obj.periodo_fin:%d/%m/%Y}"
+            return f"{obj.mes}/{obj.anio}"
+        return super().resolve_field(obj, field_path)
 
     def get(self, request, *args, **kwargs):
         if request.GET.get("export") == "csv":
@@ -151,12 +176,8 @@ class RendicionCuentaMensualGlobalListView(
         context["filters_config"] = get_filters_ui_config()
         context["filters_js"] = "custom/js/advanced_filters.js"
         context["seccion_filtros_favoritos"] = SeccionesFiltrosFavoritos.RENDICIONES
-        context["columnas_configurables"] = [
-            ("proyecto", "Proyecto"),
-            ("convenio", "Convenio"),
-            ("etapa", "Etapa"),
-            ("estado", "Estado"),
-        ]
+        context.update(self._get_columns_context())
+        context["active_columns"] = context["column_active_keys"]
         context["breadcrumb_items"] = [
             {"text": "Organizaciones", "url": reverse_lazy("organizaciones")},
             {"text": "Rendiciones", "active": True},
@@ -436,6 +457,50 @@ class RendicionCuentaMensualDetailView(LoginRequiredMixin, DetailView):
 
 class RendicionCuentaMensualDownloadPdfView(LoginRequiredMixin, DetailView):
     model = RendicionCuentaMensual
+    MESES_ARCHIVO = (
+        "",
+        "ENE",
+        "FEB",
+        "MAR",
+        "ABR",
+        "MAY",
+        "JUN",
+        "JUL",
+        "AGO",
+        "SEP",
+        "OCT",
+        "NOV",
+        "DIC",
+    )
+
+    @staticmethod
+    def _normalizar_parte_nombre(value, fallback):
+        value = str(value or "").strip()
+        normalizado = re.sub(r"[^A-Za-z0-9.]+", "_", value).strip("_.")
+        return normalizado or fallback
+
+    @classmethod
+    def construir_nombre_archivo(cls, rendicion):
+        if not hasattr(rendicion, "periodo_inicio") and not hasattr(rendicion, "anio"):
+            return f"rendicion-{rendicion.numero_rendicion or rendicion.id}.pdf"
+
+        proyecto = getattr(
+            getattr(rendicion, "proyecto", None), "codigo", ""
+        ) or getattr(getattr(rendicion, "comedor", None), "codigo_de_proyecto", "")
+        proyecto = cls._normalizar_parte_nombre(proyecto, "SIN_PROYECTO")
+        convenio = cls._normalizar_parte_nombre(
+            getattr(rendicion, "convenio", None), "SIN_CONVENIO"
+        )
+        numero = rendicion.numero_rendicion or rendicion.id
+        periodo_inicio = getattr(rendicion, "periodo_inicio", None)
+        mes = periodo_inicio.month if periodo_inicio else getattr(rendicion, "mes", 0)
+        anio = (
+            periodo_inicio.year
+            if periodo_inicio
+            else getattr(rendicion, "anio", "SIN-ANIO")
+        )
+        mes_archivo = cls.MESES_ARCHIVO[mes] if mes in range(1, 13) else "MES"
+        return f"{proyecto}-{convenio}-RENDICION_{numero}-{mes_archivo}{anio}.pdf"
 
     def get(self, request, *args, **kwargs):
         rendicion = RendicionCuentaMensualService.obtener_rendicion_cuenta_mensual(
@@ -454,27 +519,10 @@ class RendicionCuentaMensualDownloadPdfView(LoginRequiredMixin, DetailView):
                 reverse("rendicioncuentasmensual_detail", kwargs={"pk": rendicion.pk})
             )
 
-        proyecto = (
-            getattr(getattr(rendicion, "proyecto", None), "codigo", "")
-            or getattr(getattr(rendicion, "comedor", None), "codigo_de_proyecto", "")
-            or "sin-proyecto"
-        )
-        periodo_inicio = getattr(rendicion, "periodo_inicio", None)
-        anio = getattr(rendicion, "anio", "sin-anio")
-        mes = getattr(rendicion, "mes", 0)
-        periodo = (
-            periodo_inicio.strftime("%Y-%m") if periodo_inicio else f"{anio}-{mes:02d}"
-        )
-        if not hasattr(rendicion, "periodo_inicio") and not hasattr(rendicion, "anio"):
-            filename = f"rendicion-{rendicion.numero_rendicion or rendicion.id}.pdf"
-        else:
-            convenio = getattr(rendicion, "convenio", None) or "sin-convenio"
-            numero = rendicion.numero_rendicion or rendicion.id
-            filename = f"{proyecto}_{convenio}_rendicion-{numero}_{periodo}.pdf"
         return FileResponse(
             pdf_buffer,
             as_attachment=True,
-            filename=filename,
+            filename=self.construir_nombre_archivo(rendicion),
             content_type="application/pdf",
         )
 
@@ -522,7 +570,7 @@ class RendicionCuentaMensualCreateView(LoginRequiredMixin, CreateView):
 
 class RendicionCuentaMensualUpdateView(LoginRequiredMixin, UpdateView):
     model = RendicionCuentaMensual
-    template_name = "rendicioncuentasmensual_form.html"
+    template_name = "rendicioncuentasmensual_datos_form.html"
     form_class = RendicionDatosForm
 
     def dispatch(self, request, *args, **kwargs):
@@ -553,9 +601,9 @@ class RendicionCuentaMensualUpdateView(LoginRequiredMixin, UpdateView):
 
     def get_context_data(self, **kwargs):
         context = super().get_context_data(**kwargs)
-        comedor_id = self.object.comedor.id
-        context["comedorid"] = comedor_id
-        context["form"] = RendicionDatosForm(instance=self.object)
+        context["form"] = context.get("form") or RendicionDatosForm(
+            instance=self.object
+        )
         return context
 
 

--- a/static/custom/css/listModerno.css
+++ b/static/custom/css/listModerno.css
@@ -344,6 +344,42 @@
   font-size: 10px;
 }
 
+/* Etapas de rendición: paleta pastel independiente del estado semántico. */
+.etapa-badge {
+    border: 1px solid transparent;
+    font-weight: 600;
+}
+
+.etapa-badge.etapa-carga {
+    color: #2f3439;
+    background-color: #dee2e6;
+    border-color: #adb5bd;
+}
+
+.etapa-badge.etapa-territorial {
+    color: #073b82;
+    background-color: #b6d4fe;
+    border-color: #86b7fe;
+}
+
+.etapa-badge.etapa-revision-auditoria {
+    color: #3d2368;
+    background-color: #d2c1ed;
+    border-color: #b197db;
+}
+
+.etapa-badge.etapa-auditoria {
+    color: #743800;
+    background-color: #ffd7b5;
+    border-color: #ffb97a;
+}
+
+.etapa-badge.etapa-regularizacion {
+    color: #5f4700;
+    background-color: #ffe69c;
+    border-color: #ffd75e;
+}
+
 .fecha-validacion {
   display: block;
   margin-top: 4px;

--- a/templates/components/column_config_modal.html
+++ b/templates/components/column_config_modal.html
@@ -1,0 +1,62 @@
+{{ column_config|json_script:column_config.script_id }}
+<div class="d-flex justify-content-start mb-2">
+    <button type="button"
+            class="btn btn-outline-warning btn-sm"
+            data-bs-toggle="modal"
+            data-bs-target="#{{ column_config.modal_id }}">Configurar columnas</button>
+</div>
+<div class="modal fade"
+     id="{{ column_config.modal_id }}"
+     tabindex="-1"
+     aria-hidden="true"
+     data-column-config="true"
+     data-config-id="{{ column_config.script_id }}">
+    <div class="modal-dialog modal-dialog-centered modal-lg">
+        <div class="modal-content">
+            <div class="modal-header">
+                <h5 class="modal-title">Columnas visibles</h5>
+                <button type="button"
+                        class="btn-close"
+                        data-bs-dismiss="modal"
+                        aria-label="Cerrar"></button>
+            </div>
+            <div class="modal-body">
+                <p class="text-muted mb-3">Seleccioná qué columnas mostrar y ordenalas con las flechas.</p>
+                <div class="list-group column-config-list">
+                    {% for col in column_config.available %}
+                        <div class="list-group-item d-flex flex-wrap align-items-center justify-content-between gap-2"
+                             data-column-key="{{ col.key }}">
+                            <div class="form-check">
+                                <input class="form-check-input column-config-checkbox"
+                                       type="checkbox"
+                                       id="{{ column_config.modal_id }}-{{ col.key }}"
+                                       {% if col.active %}checked{% endif %}
+                                       {% if col.required %}disabled{% endif %} />
+                                <label class="form-check-label"
+                                       for="{{ column_config.modal_id }}-{{ col.key }}">{{ col.title }}</label>
+                                {% if col.required %}<span class="badge bg-secondary ms-2">Obligatoria</span>{% endif %}
+                            </div>
+                            <div class="btn-group btn-group-sm" role="group">
+                                <button type="button"
+                                        class="btn btn-light column-move-up"
+                                        title="Mover arriba">
+                                    <i class="fas fa-arrow-up"></i>
+                                </button>
+                                <button type="button"
+                                        class="btn btn-light column-move-down"
+                                        title="Mover abajo">
+                                    <i class="fas fa-arrow-down"></i>
+                                </button>
+                            </div>
+                        </div>
+                    {% endfor %}
+                </div>
+                <div class="alert alert-danger d-none mt-3 column-config-error"></div>
+            </div>
+            <div class="modal-footer">
+                <button type="button" class="btn btn-outline-secondary column-config-reset">Restablecer</button>
+                <button type="button" class="btn btn-primary column-config-save">Guardar</button>
+            </div>
+        </div>
+    </div>
+</div>

--- a/templates/components/data_table.html
+++ b/templates/components/data_table.html
@@ -46,7 +46,8 @@
                                         {% if custom_cells %}
                                             <!-- Modo personalizado - permite definir las celdas manualmente -->
                                             {% for cell in item.cells %}
-                                                <td {% if cell.class %}class="{{ cell.class }}"{% endif %} {% if cell.data_attr %}data-{{ cell.data_attr }}="{{ cell.data_value|default:cell.content }}"{% endif %}>
+                                                <td {% if cell.class %}class="{{ cell.class }}"{% endif %}
+                                                    {% if cell.data_attr %}data-{{ cell.data_attr }}="{{ cell.data_value|default:cell.content }}"{% endif %}>
                                                     {% if cell.link_url and not disable_links %}
                                                         <a href="{{ cell.link_url }}"
                                                            {% if cell.link_class %}class="{{ cell.link_class }}"{% endif %}

--- a/templates/components/data_table.html
+++ b/templates/components/data_table.html
@@ -6,70 +6,7 @@
             <div class="card">
                 <div class="card-body">
                     {% if column_config %}
-                        {{ column_config|json_script:column_config.script_id }}
-                        <div class="d-flex justify-content-start mb-2">
-                            <button type="button"
-                                    class="btn btn-outline-warning btn-sm"
-                                    data-bs-toggle="modal"
-                                    data-bs-target="#{{ column_config.modal_id }}">Configurar columnas</button>
-                        </div>
-                        <div class="modal fade"
-                             id="{{ column_config.modal_id }}"
-                             tabindex="-1"
-                             aria-hidden="true"
-                             data-column-config="true"
-                             data-config-id="{{ column_config.script_id }}">
-                            <div class="modal-dialog modal-dialog-centered modal-lg">
-                                <div class="modal-content">
-                                    <div class="modal-header">
-                                        <h5 class="modal-title">Columnas visibles</h5>
-                                        <button type="button"
-                                                class="btn-close"
-                                                data-bs-dismiss="modal"
-                                                aria-label="Cerrar"></button>
-                                    </div>
-                                    <div class="modal-body">
-                                        <p class="text-muted mb-3">Seleccioná qué columnas mostrar y ordenalas con las flechas.</p>
-                                        <div class="list-group column-config-list">
-                                            {% for col in column_config.available %}
-                                                <div class="list-group-item d-flex flex-wrap align-items-center justify-content-between gap-2"
-                                                     data-column-key="{{ col.key }}">
-                                                    <div class="form-check">
-                                                        <input class="form-check-input column-config-checkbox"
-                                                               type="checkbox"
-                                                               id="{{ column_config.modal_id }}-{{ col.key }}"
-                                                               {% if col.active %}checked{% endif %}
-                                                               {% if col.required %}disabled{% endif %} />
-                                                        <label class="form-check-label"
-                                                               for="{{ column_config.modal_id }}-{{ col.key }}">
-                                                            {{ col.title }}
-                                                        </label>
-                                                        {% if col.required %}<span class="badge bg-secondary ms-2">Obligatoria</span>{% endif %}
-                                                    </div>
-                                                    <div class="btn-group btn-group-sm" role="group">
-                                                        <button type="button"
-                                                                class="btn btn-light column-move-up"
-                                                                title="Mover arriba">
-                                                            <i class="fas fa-arrow-up"></i>
-                                                        </button>
-                                                        <button type="button"
-                                                                class="btn btn-light column-move-down"
-                                                                title="Mover abajo">
-                                                            <i class="fas fa-arrow-down"></i>
-                                                        </button>
-                                                    </div>
-                                                </div>
-                                            {% endfor %}
-                                        </div>
-                                        <div class="alert alert-danger d-none mt-3 column-config-error"></div>
-                                    </div>
-                                    <div class="modal-footer">
-                                        <button type="button" class="btn btn-outline-secondary column-config-reset">Restablecer</button>
-                                        <button type="button" class="btn btn-primary column-config-save">Guardar</button>
-                                    </div>
-                                </div>
-                            </div>
-                        </div>
+                        {% include "components/column_config_modal.html" %}
                     {% endif %}
                     <div class="table-responsive-lg">
                         <table class="table table-bordered table-striped projects {{ table_class|default:'' }}">
@@ -109,8 +46,7 @@
                                         {% if custom_cells %}
                                             <!-- Modo personalizado - permite definir las celdas manualmente -->
                                             {% for cell in item.cells %}
-                                                <td {% if cell.class %}class="{{ cell.class }}"{% endif %}
-                                                    {% if cell.data_attr %} data-{{ cell.data_attr }}="{{ cell.data_value|default:cell.content }}"{% endif %}>
+                                                <td {% if cell.class %}class="{{ cell.class }}"{% endif %} {% if cell.data_attr %}data-{{ cell.data_attr }}="{{ cell.data_value|default:cell.content }}"{% endif %}>
                                                     {% if cell.link_url and not disable_links %}
                                                         <a href="{{ cell.link_url }}"
                                                            {% if cell.link_class %}class="{{ cell.link_class }}"{% endif %}

--- a/tests/test_dashboard_comedores_core_boundary.py
+++ b/tests/test_dashboard_comedores_core_boundary.py
@@ -4,6 +4,8 @@ from decimal import Decimal
 from django.core.cache import cache
 
 from comedores.models import Comedor, ValorComida
+from dashboard import signals
+from dashboard.models import Dashboard
 from dashboard.utils import (
     calcular_presupuesto_comida,
     calcular_presupuesto_desayuno,
@@ -34,3 +36,32 @@ def test_dashboard_uses_public_comedores_projection(db):
 
 def test_relevamientos_public_count_starts_empty(db):
     assert contar_relevamientos() == 0
+
+
+def test_dashboard_refresh_invalidates_cached_metrics_before_persisting(db, mocker):
+    cache.clear()
+    metrics = (
+        ("contar_comedores_activos", "cantidad_comedores_activos", 3),
+        ("contar_relevamientos_activos", "cantidad_relevamientos_activos", 4),
+        ("calcular_presupuesto_desayuno", "presupuesto_desayuno", 5),
+        ("calcular_presupuesto_merienda", "presupuesto_merienda", 6),
+        ("calcular_presupuesto_comida", "presupuesto_comida", 7),
+    )
+    for cache_key, _dashboard_key, _value in metrics:
+        cache.set(cache_key, 0)
+
+    mocker.patch.object(signals, "_tablas_requeridas_existen", return_value=True)
+
+    for function_name, cache_key, value in metrics:
+
+        def calculate(key=cache_key, result=value):
+            assert cache.get(key) is None
+            return result
+
+        mocker.patch.object(signals, function_name, side_effect=calculate)
+
+    signals.update_dashboard_comedores()
+
+    assert dict(Dashboard.objects.values_list("llave", "cantidad")) == {
+        dashboard_key: value for _cache_key, dashboard_key, value in metrics
+    }

--- a/tests/test_pwa_comedores_api.py
+++ b/tests/test_pwa_comedores_api.py
@@ -1417,6 +1417,64 @@ def test_rendicion_en_subsanar_permite_agregar_historial_para_comprobantes(
     assert observado_payload["observaciones"] == "Subir una versión legible"
 
 
+@pytest.mark.django_db
+@override_settings(ROOT_URLCONF="tests.test_urls_pwa_comedores_api")
+def test_rendicion_en_subsanar_permite_agregar_documento_nuevo_en_categoria_multiple(
+    comedores, settings, tmp_path
+):
+    settings.MEDIA_ROOT = str(tmp_path)
+    comedor_1, _ = comedores
+    representante = _create_pwa_user(
+        comedor=comedor_1,
+        role=AccesoComedorPWA.ROL_REPRESENTANTE,
+        username="rep_subsanar_documento_nuevo",
+    )
+    _grant_mobile_rendicion_permission(representante)
+    client = _token_client(representante)
+
+    rendicion = RendicionCuentaMensual.objects.create(
+        comedor=comedor_1,
+        mes=6,
+        anio=2026,
+        estado=RendicionCuentaMensual.ESTADO_SUBSANAR,
+    )
+    existente = DocumentacionAdjunta.objects.create(
+        nombre="formulario-i-original.pdf",
+        categoria=DocumentacionAdjunta.CATEGORIA_FORMULARIO_I,
+        estado=DocumentacionAdjunta.ESTADO_VALIDADO,
+        rendicion_cuenta_mensual=rendicion,
+        archivo=SimpleUploadedFile(
+            "formulario-i-original.pdf",
+            b"%PDF-1.4 original",
+            content_type="application/pdf",
+        ),
+    )
+
+    response = client.post(
+        f"/api/comedores/{comedor_1.id}/rendiciones/{rendicion.id}/documentacion/",
+        {
+            "archivo": SimpleUploadedFile(
+                "formulario-i-nuevo.pdf",
+                b"%PDF-1.4 nuevo",
+                content_type="application/pdf",
+            ),
+            "categoria": DocumentacionAdjunta.CATEGORIA_FORMULARIO_I,
+        },
+        format="multipart",
+    )
+
+    assert response.status_code == 201
+    documentos = DocumentacionAdjunta.objects.filter(
+        rendicion_cuenta_mensual=rendicion,
+        categoria=DocumentacionAdjunta.CATEGORIA_FORMULARIO_I,
+    ).order_by("id")
+    assert documentos.count() == 2
+    nuevo = documentos.last()
+    assert nuevo.id != existente.id
+    assert nuevo.estado == DocumentacionAdjunta.ESTADO_PRESENTADO
+    assert nuevo.documento_subsanado_id is None
+
+
 def _comedor_alimentar_comunidad(*, username):
     provincia = Provincia.objects.create(nombre="Cordoba")
     programa = Programas.objects.create(nombre="Alimentar Comunidad")

--- a/tests/test_rendicioncuentasmensual_views_unit.py
+++ b/tests/test_rendicioncuentasmensual_views_unit.py
@@ -1,6 +1,7 @@
 """Tests unitarios para vistas web de rendiciones mensuales."""
 
 import json
+from datetime import date
 from io import BytesIO
 from types import SimpleNamespace
 
@@ -41,12 +42,72 @@ def test_global_list_view_contexto_expone_titulo(mocker):
         "django.views.generic.list.MultipleObjectMixin.get_context_data",
         return_value={"rendiciones_cuentas_mensuales": []},
     )
+    mocker.patch.object(
+        view,
+        "_get_columns_context",
+        return_value={
+            "column_active_keys": ["proyecto", "estado"],
+            "column_config": {"available": []},
+        },
+    )
 
     contexto = view.get_context_data()
 
     assert contexto["titulo_listado"] == "Rendiciones"
     assert contexto["rendiciones_cuentas_mensuales"] == []
+    assert contexto["active_columns"] == ["proyecto", "estado"]
     assert contexto["breadcrumb_items"][0]["text"] == "Organizaciones"
+
+
+def test_global_list_exporta_solo_columnas_activas_y_en_su_orden(mocker):
+    view = module.RendicionCuentaMensualGlobalListView()
+    view.request = _Req(user=_user(), GET={})
+    mocker.patch.object(
+        view,
+        "_get_columns_context",
+        return_value={"column_active_keys": ["estado", "proyecto"]},
+    )
+
+    assert view.get_export_columns() == [
+        ("Estado", "estado_proceso_display"),
+        ("Proyecto", "comedor.codigo_de_proyecto"),
+    ]
+
+
+def test_global_list_exporta_periodo_como_se_muestra_en_la_grilla():
+    view = module.RendicionCuentaMensualGlobalListView()
+    rendicion = SimpleNamespace(
+        periodo_inicio=date(2026, 8, 3),
+        periodo_fin=date(2026, 8, 31),
+        mes=8,
+        anio=2026,
+    )
+
+    assert view.resolve_field(rendicion, "periodo_exportacion") == (
+        "03/08/2026 - 31/08/2026"
+    )
+
+
+@pytest.mark.parametrize(
+    ("etapa", "badge_class"),
+    [
+        ("revision_documentacion", "etapa-territorial"),
+        ("revision_auditoria", "etapa-revision-auditoria"),
+        ("auditoria", "etapa-auditoria"),
+        ("carga_documentacion", "etapa-carga"),
+        ("regularizacion", "etapa-regularizacion"),
+    ],
+)
+def test_global_list_diferencia_colores_por_etapa(etapa, badge_class):
+    rendicion = module.RendicionCuentaMensual(etapa_proceso=etapa)
+
+    assert rendicion.etapa_badge_class == badge_class
+
+
+def test_update_view_usa_template_especifico_para_datos():
+    assert module.RendicionCuentaMensualUpdateView.template_name == (
+        "rendicioncuentasmensual_datos_form.html"
+    )
 
 
 def test_detail_view_contexto_expone_documentacion_agrupada(mocker):
@@ -271,6 +332,42 @@ def test_download_pdf_view_devuelve_archivo(mocker):
     assert isinstance(response, FileResponse)
     assert 'filename="rendicion-12.pdf"' in response.headers["Content-Disposition"]
     pdf_mock.assert_called_once_with(rendicion)
+
+
+def test_download_pdf_view_usa_nombre_solicitado_por_issue_2305():
+    rendicion = SimpleNamespace(
+        id=88,
+        numero_rendicion=1,
+        proyecto=SimpleNamespace(codigo="APAR043"),
+        comedor=SimpleNamespace(codigo_de_proyecto="CODIGO-LEGACY"),
+        convenio="P01",
+        periodo_inicio=date(2026, 7, 6),
+        mes=7,
+        anio=2026,
+    )
+
+    assert (
+        module.RendicionCuentaMensualDownloadPdfView.construir_nombre_archivo(rendicion)
+        == "APAR043-P01-RENDICION_1-JUL2026.pdf"
+    )
+
+
+def test_download_pdf_view_normaliza_partes_inseguras_del_nombre():
+    rendicion = SimpleNamespace(
+        id=88,
+        numero_rendicion=2,
+        proyecto=None,
+        comedor=SimpleNamespace(codigo_de_proyecto="PROY/ 02"),
+        convenio="P/02",
+        periodo_inicio=None,
+        mes=8,
+        anio=2026,
+    )
+
+    assert (
+        module.RendicionCuentaMensualDownloadPdfView.construir_nombre_archivo(rendicion)
+        == "PROY_02-P_02-RENDICION_2-AGO2026.pdf"
+    )
 
 
 def test_detail_view_post_muestra_error_si_documento_no_existe(mocker):

--- a/tests/test_rendicioncuentasmensual_views_unit.py
+++ b/tests/test_rendicioncuentasmensual_views_unit.py
@@ -8,6 +8,7 @@ from types import SimpleNamespace
 import pytest
 from django.test import RequestFactory
 from django.http import FileResponse
+from django.urls import reverse
 
 from rendicioncuentasmensual import views as module
 
@@ -108,6 +109,23 @@ def test_update_view_usa_template_especifico_para_datos():
     assert module.RendicionCuentaMensualUpdateView.template_name == (
         "rendicioncuentasmensual_datos_form.html"
     )
+
+
+@pytest.mark.django_db
+def test_update_view_renderiza_datos_de_rendicion_para_usuario_autorizado(
+    client, superuser
+):
+    rendicion = module.RendicionCuentaMensual.objects.create(mes=4, anio=2026)
+    client.force_login(superuser)
+
+    response = client.get(
+        reverse("rendicioncuentasmensual_update", kwargs={"pk": rendicion.pk})
+    )
+
+    assert response.status_code == 200
+    assert 'name="convenio"' in response.content.decode()
+    assert 'name="numero_rendicion"' in response.content.decode()
+    assert 'name="periodo_inicio"' in response.content.decode()
 
 
 def test_detail_view_contexto_expone_documentacion_agrupada(mocker):


### PR DESCRIPTION
## Resumen

Resuelve las observaciones informadas luego de reabrir el issue #2305:

- permite adjuntar documentos nuevos durante una subsanacion en categorias multiples;
- corrige el error al abrir la edicion de datos de rendicion;
- reactiva la descarga CSV y adopta la configuracion estandar de columnas;
- ajusta el nombre del PDF al formato solicitado, sin espacios;
- diferencia las etapas con una paleta pastel de mayor contraste;
- conserva los colores semanticos de estado;
- invalida de forma selectiva la cache de metricas de Dashboard para corregir el unico fallo reproducible de la suite completa.

## Validacion

- Suite focalizada de Rendiciones y API PWA: 88 passed.
- Suite completa: 4068 passed, 11 skipped.
- Regresiones finales: 22 passed.
- pylint: 10.00/10.
- black, djlint, manage.py check, control de migraciones y git diff --check: correctos.

Closes #2305