### PR TITLE
feat(admisiones): variables documentales para renovaciones

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 <!-- AUTO-GENERATED RELEASE START: 2026-08-26 -->
 # Versión SISOC 26.08.2026
 
+## Actualizaciones
+
+- [sin-area] feat(admisiones): variables documentales para renovaciones. (PR #2330)
+
 ## Corrección de Errores
 
 - [Centro de Infancia] Corrige permisos y validaciones urgentes del módulo CDI. (PR #2310)

--- a/admisiones/forms/admisiones_forms.py
+++ b/admisiones/forms/admisiones_forms.py
@@ -81,6 +81,11 @@ def _configurar_campos_informe_2233(form, admision, tipo_informe):
             and getattr(admision, "informe_complementario_modifica_prestaciones", None)
             == "si"
         ),
+        "if_it_complementario": (
+            es_renovacion
+            and getattr(admision, "informe_complementario_modifica_prestaciones", None)
+            == "si"
+        ),
     }
     for nombre, aplica in condiciones.items():
         if not aplica:

--- a/admisiones/migrations/0079_issue_1213_variables_documentales_renovacion.py
+++ b/admisiones/migrations/0079_issue_1213_variables_documentales_renovacion.py
@@ -48,7 +48,9 @@ VARIABLES_DOCUMENTALES = (
 
 def registrar_variables(apps, schema_editor):
     Variable = apps.get_model("admisiones", "VariableTemplateInformeTecnico")
-    for orden, (codigo, nombre, categoria) in enumerate(VARIABLES_DOCUMENTALES, start=1):
+    for orden, (codigo, nombre, categoria) in enumerate(
+        VARIABLES_DOCUMENTALES, start=1
+    ):
         Variable.objects.update_or_create(
             codigo=codigo,
             defaults={

--- a/admisiones/migrations/0079_issue_1213_variables_documentales_renovacion.py
+++ b/admisiones/migrations/0079_issue_1213_variables_documentales_renovacion.py
@@ -1,0 +1,85 @@
+from django.db import migrations, models
+
+
+VARIABLES_DOCUMENTALES = (
+    (
+        "informe.resolucion_o_disposicion_incorporacion",
+        "Resolución o disposición de incorporación",
+        "Renovaciones - antecedentes",
+    ),
+    (
+        "informe.renovaciones_anteriores_detalladas",
+        "Renovaciones anteriores detalladas",
+        "Renovaciones - antecedentes",
+    ),
+    (
+        "informe.referencia_itcomp_modificacion_prestaciones",
+        "Referencia IF IT Complementario",
+        "Renovaciones - Informe Complementario",
+    ),
+    (
+        "informe.expediente_pago_en_curso",
+        "Expediente de pago en curso",
+        "Renovaciones - antecedentes",
+    ),
+    (
+        "informe.expediente_ultimo_convenio",
+        "Expediente del último convenio",
+        "Renovaciones - antecedentes",
+    ),
+    *(
+        (
+            f"informe.total_semanal_ultimo_convenio_{comida}s",
+            f"Total semanal último convenio - {comida.capitalize()}",
+            "Renovaciones - prestaciones",
+        )
+        for comida in ("desayuno", "almuerzo", "merienda", "cena")
+    ),
+    *(
+        (
+            f"informe.total_semanal_actual_{comida}s",
+            f"Total semanal actual - {comida.capitalize()}",
+            "Renovaciones - prestaciones",
+        )
+        for comida in ("desayuno", "almuerzo", "merienda", "cena")
+    ),
+)
+
+
+def registrar_variables(apps, schema_editor):
+    Variable = apps.get_model("admisiones", "VariableTemplateInformeTecnico")
+    for orden, (codigo, nombre, categoria) in enumerate(VARIABLES_DOCUMENTALES, start=1):
+        Variable.objects.update_or_create(
+            codigo=codigo,
+            defaults={
+                "nombre": nombre,
+                "categoria": categoria,
+                "orden": orden,
+                "activo": True,
+            },
+        )
+
+
+def eliminar_variables(apps, schema_editor):
+    Variable = apps.get_model("admisiones", "VariableTemplateInformeTecnico")
+    Variable.objects.filter(
+        codigo__in=[codigo for codigo, _, _ in VARIABLES_DOCUMENTALES]
+    ).delete()
+
+
+class Migration(migrations.Migration):
+    dependencies = [("admisiones", "0078_issue_2234_campo_informe_complementario")]
+
+    operations = [
+        migrations.AddField(
+            model_name="informetecnico",
+            name="if_it_complementario",
+            field=models.CharField(
+                blank=True,
+                max_length=255,
+                null=True,
+                verbose_name="IF IT Complementario",
+            ),
+        ),
+        migrations.RunPython(registrar_variables, eliminar_variables),
+    ]

--- a/admisiones/models/admisiones.py
+++ b/admisiones/models/admisiones.py
@@ -653,6 +653,12 @@ class InformeTecnico(models.Model):
         null=True,
         blank=True,
     )
+    if_it_complementario = models.CharField(
+        "IF IT Complementario",
+        max_length=255,
+        null=True,
+        blank=True,
+    )
     observaciones_subsanacion = models.TextField(
         "Observaciones de Subsanación",
         null=True,

--- a/admisiones/services/docx_service/impl.py
+++ b/admisiones/services/docx_service/impl.py
@@ -184,7 +184,11 @@ class AdmisionesContextService:
     @staticmethod
     def preparar_contexto_informe_tecnico(informe):
         from ...utils import generar_texto_comidas
+        from ...services.informe_tecnico_variables_service import (
+            InformeTecnicoVariablesDocumentalesService,
+        )
 
+        InformeTecnicoVariablesDocumentalesService.enriquecer_informe(informe)
         prestaciones = AdmisionesContextService._generar_prestaciones_semanales(informe)
         texto_comidas_raw = generar_texto_comidas(informe)
         texto_comidas_clean = {}

--- a/admisiones/services/informe_tecnico_variables_service.py
+++ b/admisiones/services/informe_tecnico_variables_service.py
@@ -1,0 +1,157 @@
+"""Variables documentales derivadas para templates de Informes Técnicos."""
+
+from django.db.models import Q
+from django.utils.html import format_html_join
+
+from admisiones.models.admisiones import Admision
+from comedores.services.comedor_service import ComedorService
+
+
+class InformeTecnicoVariablesDocumentalesService:
+    """Resuelve valores históricos sin persistir copias en el informe actual."""
+
+    DIAS = (
+        "lunes",
+        "martes",
+        "miercoles",
+        "jueves",
+        "viernes",
+        "sabado",
+        "domingo",
+    )
+    COMIDAS = ("desayuno", "almuerzo", "merienda", "cena")
+    ESTADOS_DESCARTADOS = ("descartado", "inactivada")
+    ESTADOS_LEGALES_DESCARTADOS = ("Descartado", "Inactivada")
+
+    @classmethod
+    def enriquecer_informe(cls, informe):
+        """Agrega atributos de sólo lectura para ``{{ informe.<variable> }}``."""
+
+        valores = cls.obtener_valores(informe)
+        for nombre, valor in valores.items():
+            setattr(informe, nombre, valor)
+        return informe
+
+    @classmethod
+    def obtener_valores(cls, informe):
+        """Construye el catálogo documental; los datos ausentes quedan vacíos."""
+
+        valores = cls._valores_vacios()
+        if not informe or not getattr(informe, "admision_id", None):
+            return valores
+
+        admision_actual = informe.admision
+        admisiones_anteriores = cls._admisiones_anteriores(admision_actual)
+        ultima_admision = admisiones_anteriores.order_by("-creado", "-pk").first()
+        ultima_incorporacion = (
+            admisiones_anteriores.filter(tipo="incorporacion")
+            .order_by("-creado", "-pk")
+            .first()
+        )
+        renovaciones_anteriores = admisiones_anteriores.filter(
+            tipo="renovacion"
+        ).order_by("creado", "pk")
+
+        valores.update(
+            {
+                "resolucion_o_disposicion_incorporacion": cls._texto(
+                    getattr(ultima_incorporacion, "numero_disposicion", "")
+                ),
+                "renovaciones_anteriores_detalladas": cls._formatear_renovaciones(
+                    renovaciones_anteriores
+                ),
+                "referencia_itcomp_modificacion_prestaciones": cls._texto(
+                    getattr(informe, "if_it_complementario", "")
+                ),
+                "expediente_pago_en_curso": cls._texto(
+                    getattr(ultima_admision, "num_expediente", "")
+                ),
+                "expediente_ultimo_convenio": cls._texto(
+                    getattr(ultima_admision, "num_expediente", "")
+                ),
+            }
+        )
+        valores.update(cls._totales_semanales(informe, "total_semanal_actual"))
+
+        informe_ultimo_convenio = (
+            ComedorService.get_informe_tecnico_finalizado_efectivo(ultima_admision)
+            if ultima_admision
+            else None
+        )
+        if informe_ultimo_convenio:
+            valores.update(
+                cls._totales_semanales(
+                    informe_ultimo_convenio,
+                    "total_semanal_ultimo_convenio",
+                )
+            )
+        return valores
+
+    @classmethod
+    def _admisiones_anteriores(cls, admision_actual):
+        """Antecedentes válidos del mismo comedor, anteriores al trámite actual."""
+
+        if not getattr(admision_actual, "comedor_id", None):
+            return Admision.objects.none()
+
+        criterio_anterior = Q(creado__lt=admision_actual.creado) | Q(
+            creado=admision_actual.creado,
+            pk__lt=admision_actual.pk,
+        )
+        return (
+            Admision.objects.filter(
+                comedor_id=admision_actual.comedor_id,
+                activa=True,
+            )
+            .filter(criterio_anterior)
+            .exclude(estado_admision__in=cls.ESTADOS_DESCARTADOS)
+            .exclude(estado_legales__in=cls.ESTADOS_LEGALES_DESCARTADOS)
+        )
+
+    @classmethod
+    def _totales_semanales(cls, informe, prefijo):
+        return {
+            f"{prefijo}_{comida}s": str(
+                sum(
+                    getattr(informe, f"aprobadas_{comida}_{dia}", 0) or 0
+                    for dia in cls.DIAS
+                )
+            )
+            for comida in cls.COMIDAS
+        }
+
+    @classmethod
+    def _valores_vacios(cls):
+        valores = {
+            "resolucion_o_disposicion_incorporacion": "",
+            "renovaciones_anteriores_detalladas": "",
+            "referencia_itcomp_modificacion_prestaciones": "",
+            "expediente_pago_en_curso": "",
+            "expediente_ultimo_convenio": "",
+        }
+        for prefijo in (
+            "total_semanal_ultimo_convenio",
+            "total_semanal_actual",
+        ):
+            for comida in cls.COMIDAS:
+                valores[f"{prefijo}_{comida}s"] = ""
+        return valores
+
+    @staticmethod
+    def _texto(valor):
+        return str(valor or "")
+
+    @classmethod
+    def _formatear_renovaciones(cls, renovaciones):
+        return format_html_join(
+            "<br>",
+            "Resolución / Disposición: {}; Convenio: {}; Expediente: {}",
+            (
+                (
+                    cls._texto(renovacion.numero_disposicion),
+                    cls._texto(renovacion.numero_convenio),
+                    cls._texto(renovacion.num_expediente),
+                )
+                for renovacion in renovaciones
+            ),
+        )

--- a/admisiones/tests/test_variables_documentales_renovacion.py
+++ b/admisiones/tests/test_variables_documentales_renovacion.py
@@ -1,0 +1,218 @@
+from decimal import Decimal
+from importlib import import_module
+
+import pytest
+from django.apps import apps
+from django.db import models
+from django.template import Context, Engine
+from django.utils import timezone
+
+from admisiones.forms.admisiones_forms import InformeTecnicoBaseForm
+from admisiones.models.admisiones import (
+    Admision,
+    InformeTecnico,
+    TipoConvenio,
+    VariableTemplateInformeTecnico,
+)
+from admisiones.services.docx_service import AdmisionesContextService
+from admisiones.services.informe_tecnico_variables_service import (
+    InformeTecnicoVariablesDocumentalesService,
+)
+from comedores.models import Comedor
+
+
+def _valor_para_campo(field):
+    if field.choices:
+        return field.choices[0][0]
+    if isinstance(field, models.EmailField):
+        return "test@example.com"
+    if isinstance(field, (models.CharField, models.TextField)):
+        return "test"
+    if isinstance(field, models.BooleanField):
+        return False
+    if isinstance(field, models.DecimalField):
+        return Decimal("1.0")
+    if isinstance(field, models.DateField):
+        return timezone.now().date()
+    if isinstance(field, models.IntegerField):
+        return 1
+    return "test"
+
+
+def crear_informe(admision, **overrides):
+    datos = {}
+    for field in InformeTecnico._meta.fields:
+        if field.primary_key or field.auto_created or field.has_default():
+            continue
+        if getattr(field, "auto_now", False) or getattr(field, "auto_now_add", False):
+            continue
+        if isinstance(field, models.ForeignKey) or field.null:
+            continue
+        datos[field.name] = _valor_para_campo(field)
+
+    datos.update(
+        {
+            "admision": admision,
+            "tipo": "base",
+            "estado": "Validado",
+            "estado_formulario": "finalizado",
+        }
+    )
+    datos.update(overrides)
+    return InformeTecnico.objects.create(**datos)
+
+
+@pytest.fixture
+def comedor():
+    return Comedor.objects.create(nombre="Comedor de prueba")
+
+
+@pytest.mark.django_db
+def test_resuelve_antecedentes_y_totales_desde_admisiones_validas(comedor):
+    Admision.objects.create(
+        comedor=comedor,
+        tipo="incorporacion",
+        numero_disposicion="DI-INC-1",
+        num_expediente="EXP-INC-1",
+    )
+    renovacion_anterior = Admision.objects.create(
+        comedor=comedor,
+        tipo="renovacion",
+        numero_disposicion="DI-REN-1",
+        numero_convenio="CONV-1",
+        num_expediente="EXP-REN-1",
+    )
+    crear_informe(
+        renovacion_anterior,
+        aprobadas_desayuno_lunes=10,
+        aprobadas_desayuno_martes=2,
+        aprobadas_almuerzo_lunes=3,
+        aprobadas_merienda_lunes=4,
+        aprobadas_cena_lunes=5,
+    )
+    Admision.objects.create(
+        comedor=comedor,
+        tipo="renovacion",
+        activa=False,
+        numero_disposicion="NO-DEBE-USARSE",
+        numero_convenio="NO-DEBE-USARSE",
+        num_expediente="NO-DEBE-USARSE",
+    )
+    actual = Admision.objects.create(comedor=comedor, tipo="renovacion")
+    informe_actual = crear_informe(
+        actual,
+        if_it_complementario="IF-2026-123",
+        aprobadas_desayuno_lunes=7,
+        aprobadas_almuerzo_lunes=8,
+        aprobadas_merienda_lunes=9,
+        aprobadas_cena_lunes=10,
+    )
+
+    valores = InformeTecnicoVariablesDocumentalesService.obtener_valores(informe_actual)
+
+    assert valores["resolucion_o_disposicion_incorporacion"] == "DI-INC-1"
+    assert valores["expediente_pago_en_curso"] == "EXP-REN-1"
+    assert valores["expediente_ultimo_convenio"] == "EXP-REN-1"
+    assert valores["referencia_itcomp_modificacion_prestaciones"] == "IF-2026-123"
+    assert valores["total_semanal_ultimo_convenio_desayunos"] == "12"
+    assert valores["total_semanal_ultimo_convenio_almuerzos"] == "3"
+    assert valores["total_semanal_ultimo_convenio_meriendas"] == "4"
+    assert valores["total_semanal_ultimo_convenio_cenas"] == "5"
+    assert valores["total_semanal_actual_desayunos"] == "7"
+    assert valores["total_semanal_actual_almuerzos"] == "8"
+    assert valores["total_semanal_actual_meriendas"] == "9"
+    assert valores["total_semanal_actual_cenas"] == "10"
+    assert "DI-REN-1" in valores["renovaciones_anteriores_detalladas"]
+    assert "CONV-1" in valores["renovaciones_anteriores_detalladas"]
+    assert "EXP-REN-1" in valores["renovaciones_anteriores_detalladas"]
+    assert "NO-DEBE-USARSE" not in valores["renovaciones_anteriores_detalladas"]
+
+
+@pytest.mark.django_db
+def test_deja_vacias_las_variables_historicas_sin_antecedentes(comedor):
+    actual = Admision.objects.create(comedor=comedor, tipo="renovacion")
+    informe = crear_informe(actual)
+
+    valores = InformeTecnicoVariablesDocumentalesService.obtener_valores(informe)
+
+    assert valores["resolucion_o_disposicion_incorporacion"] == ""
+    assert valores["renovaciones_anteriores_detalladas"] == ""
+    assert valores["expediente_pago_en_curso"] == ""
+    assert valores["expediente_ultimo_convenio"] == ""
+    assert valores["total_semanal_ultimo_convenio_desayunos"] == ""
+    assert valores["referencia_itcomp_modificacion_prestaciones"] == ""
+
+
+@pytest.mark.django_db
+def test_renderiza_las_variables_documentales_desde_el_contexto(comedor):
+    Admision.objects.create(
+        comedor=comedor,
+        tipo="incorporacion",
+        numero_disposicion="DI-INC-1",
+    )
+    actual = Admision.objects.create(comedor=comedor, tipo="renovacion")
+    informe = crear_informe(actual, if_it_complementario="IF-2026-123")
+
+    contexto = AdmisionesContextService.preparar_contexto_informe_tecnico(informe)
+    contenido = (
+        Engine(debug=False)
+        .from_string(
+            "{{ informe.resolucion_o_disposicion_incorporacion }}|"
+            "{{ informe.referencia_itcomp_modificacion_prestaciones }}"
+        )
+        .render(Context(contexto, autoescape=True))
+    )
+
+    assert contenido == "DI-INC-1|IF-2026-123"
+
+
+@pytest.mark.django_db
+def test_muestra_if_it_complementario_solo_para_renovacion_con_modificacion(comedor):
+    convenio = TipoConvenio.objects.create(nombre="Organización Base")
+    admision_con_modificacion = Admision.objects.create(
+        comedor=comedor,
+        tipo="renovacion",
+        tipo_convenio=convenio,
+        informe_complementario_modifica_prestaciones="si",
+    )
+    admision_sin_modificacion = Admision.objects.create(
+        comedor=comedor,
+        tipo="renovacion",
+        tipo_convenio=convenio,
+        informe_complementario_modifica_prestaciones="no",
+    )
+
+    form_con_modificacion = InformeTecnicoBaseForm(admision=admision_con_modificacion)
+    form_sin_modificacion = InformeTecnicoBaseForm(admision=admision_sin_modificacion)
+
+    assert "if_it_complementario" in form_con_modificacion.fields
+    assert not form_con_modificacion.fields["if_it_complementario"].required
+    assert "if_it_complementario" not in form_sin_modificacion.fields
+
+
+@pytest.mark.django_db
+def test_catalogo_registra_todas_las_variables_documentales():
+    migracion = import_module(
+        "admisiones.migrations.0079_issue_1213_variables_documentales_renovacion"
+    )
+    migracion.registrar_variables(apps, None)
+    codigos = {
+        "informe.resolucion_o_disposicion_incorporacion",
+        "informe.renovaciones_anteriores_detalladas",
+        "informe.referencia_itcomp_modificacion_prestaciones",
+        "informe.expediente_pago_en_curso",
+        "informe.expediente_ultimo_convenio",
+        *(
+            f"informe.total_semanal_ultimo_convenio_{comida}s"
+            for comida in ("desayuno", "almuerzo", "merienda", "cena")
+        ),
+        *(
+            f"informe.total_semanal_actual_{comida}s"
+            for comida in ("desayuno", "almuerzo", "merienda", "cena")
+        ),
+    }
+
+    variables = VariableTemplateInformeTecnico.objects.filter(codigo__in=codigos)
+
+    assert set(variables.values_list("codigo", flat=True)) == codigos
+    assert not variables.filter(activo=False).exists()

--- a/docs/contexto/features/pr-2330-feat-admisiones-variables-documentales-para-renovaciones.md
+++ b/docs/contexto/features/pr-2330-feat-admisiones-variables-documentales-para-renovaciones.md
@@ -1,0 +1,53 @@
+# Contexto de feature PR #2330 - feat(admisiones): variables documentales para renovaciones
+
+## Resumen
+
+- PR: https://github.com/dsocial118/SISOC/pull/2330
+- Base: `main`
+- Rama origen: `codex/issue-1213-variables-documentales`
+- Autor: `juanikitro`
+
+## Contexto funcional
+
+- No informado explícitamente; inferir desde el título del PR y el diff.
+
+## Arquitectura tocada
+
+- El PR toca lógica en `services/`, por lo que impacta reglas de negocio u orquestación.
+- Existen cambios de persistencia o migraciones que requieren revisión de datos.
+
+## Decisiones y supuestos detectados
+
+- Tipo de cambio declarado: No informado
+- Área principal declarada: No informada
+- Impacto usuario declarado: No informado
+- Riesgos / rollback: No informado
+
+## Design system y UI
+
+- Sin cambios visibles de UI o design system detectados en el diff.
+
+## Memoria operativa para agentes
+
+- Empezar por `docs/registro/prs/PR-2330.md` para contexto resumido del PR.
+- Revisar primero estos archivos del diff:
+- `admisiones/forms/admisiones_forms.py`
+- `admisiones/migrations/0079_issue_1213_variables_documentales_renovacion.py`
+- `admisiones/models/admisiones.py`
+- `admisiones/services/docx_service/impl.py`
+- `admisiones/services/informe_tecnico_variables_service.py`
+- `admisiones/tests/test_variables_documentales_renovacion.py`
+- `docs/plans/2026-08-24-variables-documentales-renovacion-design.md`
+- `docs/registro/cambios/2026-08-24-issue-1213-variables-documentales-renovacion.md`
+- Documentación sugerida para ampliar contexto:
+- `docs/indice.md`
+- `docs/ia/CONTEXT_HYGIENE.md`
+- `docs/ia/ARCHITECTURE.md`
+- `docs/ia/TESTING.md`
+- `docs/plans/2026-08-24-variables-documentales-renovacion-design.md`
+- `docs/registro/cambios/2026-08-24-issue-1213-variables-documentales-renovacion.md`
+
+## Trazabilidad
+
+- Documento generado automáticamente desde el evento de `pull_request`.
+- Si este PR cambia de título, el archivo se renombrará para mantener el slug alineado.

--- a/docs/plans/2026-08-24-variables-documentales-renovacion-design.md
+++ b/docs/plans/2026-08-24-variables-documentales-renovacion-design.md
@@ -1,0 +1,23 @@
+# Variables documentales para renovaciones
+
+## Decisiones aprobadas
+
+- Las referencias se resuelven al generar el documento, sin copiar datos en el informe.
+- La admisión anterior es la más reciente del mismo comedor, previa a la actual, excluyendo las descartadas e inactivadas.
+- Los totales se calculan desde cantidades aprobadas por día del Informe Técnico.
+- El detalle de renovaciones anteriores incluye disposición, convenio y expediente, de la más antigua a la más reciente.
+- Los datos faltantes se resuelven como texto vacío para completar manualmente.
+- Los expedientes se exponen solo para los templates de financiamiento vigente; Personería/PJE y Base usan variables distintas.
+
+## Alcance técnico
+
+- Campo opcional de referencia IF IT Complementario en `InformeTecnico`.
+- Servicio central de contexto para las variables documentales.
+- Migración de esquema y migración de datos para registrar las variables activas del catálogo.
+- Pruebas de selección de antecedentes, cálculo de totales, formato y faltantes.
+
+## Fuera de alcance
+
+- Publicar versiones de templates.
+- Reemplazar marcadores de los borradores ya cargados en SISOC.
+- Backfill de datos históricos.

--- a/docs/registro/cambios/2026-08-24-issue-1213-variables-documentales-renovacion.md
+++ b/docs/registro/cambios/2026-08-24-issue-1213-variables-documentales-renovacion.md
@@ -1,0 +1,21 @@
+# 2026-08-24 - Variables documentales para renovaciones del issue 1213
+
+## Contexto
+
+- Los templates de renovación requieren referencias históricas y totales de prestaciones que no estaban disponibles en el catálogo.
+
+## Cambios aplicados
+
+- Se incorporó el campo opcional `IF IT Complementario` al formulario del Informe Técnico cuando la admisión tiene modificación de prestaciones.
+- Se agregaron variables de catálogo para antecedentes de incorporación y renovaciones, expedientes y totales semanales de prestaciones.
+- Los antecedentes se resuelven desde admisiones previas activas del mismo comedor; las descartadas o inactivadas no participan.
+- Los datos ausentes se entregan vacíos para permitir su completado manual en el documento.
+
+## Impacto esperado
+
+- Las nuevas versiones de templates podrán usar las variables documentales sin copiar información histórica en el Informe Técnico actual.
+- Este cambio no publica ni modifica versiones de templates existentes.
+
+## Riesgos y rollback
+
+- La migración agrega un campo nullable y registros de catálogo. Revertir la migración elimina ambos registros de catálogo y el campo.

--- a/docs/registro/prs/PR-2330.md
+++ b/docs/registro/prs/PR-2330.md
@@ -1,0 +1,56 @@
+# PR #2330 - feat(admisiones): variables documentales para renovaciones
+
+## Metadata
+
+- PR: https://github.com/dsocial118/SISOC/pull/2330
+- Base: `main`
+- Rama origen: `codex/issue-1213-variables-documentales`
+- Autor: `juanikitro`
+
+## Resumen operativo
+
+- Tipo de cambio: No informado
+- Área principal: No informada
+- Contexto funcional: No informado explícitamente; revisar título, diff y documentación relacionada.
+- Resumen para changelog: No informado
+- Impacto usuario: No informado
+
+## Áreas afectadas
+
+- `admisiones`
+- `docs/plans`
+- `docs/registro`
+
+## Archivos relevantes del diff
+
+- `admisiones/forms/admisiones_forms.py`
+- `admisiones/migrations/0079_issue_1213_variables_documentales_renovacion.py`
+- `admisiones/models/admisiones.py`
+- `admisiones/services/docx_service/impl.py`
+- `admisiones/services/informe_tecnico_variables_service.py`
+- `admisiones/tests/test_variables_documentales_renovacion.py`
+- `docs/plans/2026-08-24-variables-documentales-renovacion-design.md`
+- `docs/registro/cambios/2026-08-24-issue-1213-variables-documentales-renovacion.md`
+
+## Validación declarada
+
+- Pruebas automáticas: No informado en el PR.
+- Pruebas manuales: No informado en el PR.
+
+## Riesgos y rollback
+
+- No informado explícitamente en el PR.
+
+## Documentación sugerida para lectura
+
+- `docs/indice.md`
+- `docs/ia/CONTEXT_HYGIENE.md`
+- `docs/ia/ARCHITECTURE.md`
+- `docs/ia/TESTING.md`
+- `docs/plans/2026-08-24-variables-documentales-renovacion-design.md`
+- `docs/registro/cambios/2026-08-24-issue-1213-variables-documentales-renovacion.md`
+
+## Notas para continuidad
+
+- Este documento es generado automáticamente desde el contexto del PR y sirve como índice rápido para revisión y futuras sesiones de agentes.
+- Si la metadata del body del PR está incompleta, varias secciones usarán fallbacks derivados del título o del diff.

--- a/docs/registro/releases/pending/2026-08-26-pr-2330.md
+++ b/docs/registro/releases/pending/2026-08-26-pr-2330.md
@@ -1,0 +1,19 @@
+---
+pr: 2330
+release_date: 2026-08-26
+category: Actualizaciones
+area: sin-area
+title: feat(admisiones): variables documentales para renovaciones
+summary: feat(admisiones): variables documentales para renovaciones
+impact: No informado
+source_url: https://github.com/dsocial118/SISOC/pull/2330
+---
+# Release note preliminar PR #2330
+
+- Fecha objetivo de release: 2026-08-26
+- Categoría: Actualizaciones
+- Área: sin-area
+- Título del PR: feat(admisiones): variables documentales para renovaciones
+- Resumen: feat(admisiones): variables documentales para renovaciones
+- Impacto usuario: No informado
+- Fuente: https://github.com/dsocial118/SISOC/pull/2330


### PR DESCRIPTION
## Alcance\n\nImplementa las variables requeridas para los templates del punto 2.2 del issue #1213.\n\n- Agrega el campo opcional IF IT Complementario para renovaciones con modificación de prestaciones.\n- Registra 13 variables de template para antecedentes, expedientes y totales actuales e históricos.\n- Resuelve antecedentes usando admisiones vigentes/finalizadas, excluyendo descartadas e inactivadas.\n- Mantiene en blanco los valores sin fuente disponible para completar manualmente.\n\n## Validación\n\n- docker compose run --rm --no-deps django pytest admisiones/tests/test_variables_documentales_renovacion.py → 5 passed\n- lack --check sobre archivos modificados\n- python manage.py makemigrations admisiones --check --dry-run\n\nNo incluye el entorno SQLite local de demostración ni modifica los templates ya cargados en producción.