### PR TITLE
fix(rendiciones): resolver observaciones de subsanación

### DIFF
--- a/docs/contexto/features/pr-2331-fix-rendiciones-resolver-observaciones-de-subsanacion.md
+++ b/docs/contexto/features/pr-2331-fix-rendiciones-resolver-observaciones-de-subsanacion.md
@@ -30,7 +30,9 @@
 
 - Empezar por `docs/registro/prs/PR-2331.md` para contexto resumido del PR.
 - Revisar primero estos archivos del diff:
+- `docs/contexto/features/pr-2331-fix-rendiciones-resolver-observaciones-de-subsanacion.md`
 - `docs/registro/cambios/2026-08-19-issue-2305-rendiciones.md`
+- `docs/registro/prs/PR-2331.md`
 - `rendicioncuentasmensual/services.py`
 - `tests/test_pwa_comedores_api.py`
 - `tests/test_rendicioncuentasmensual_services_unit.py`
@@ -39,7 +41,9 @@
 - `docs/ia/CONTEXT_HYGIENE.md`
 - `docs/ia/ARCHITECTURE.md`
 - `docs/ia/TESTING.md`
+- `docs/contexto/features/pr-2331-fix-rendiciones-resolver-observaciones-de-subsanacion.md`
 - `docs/registro/cambios/2026-08-19-issue-2305-rendiciones.md`
+- `docs/registro/prs/PR-2331.md`
 
 ## Trazabilidad
 

--- a/docs/contexto/features/pr-2331-fix-rendiciones-resolver-observaciones-de-subsanacion.md
+++ b/docs/contexto/features/pr-2331-fix-rendiciones-resolver-observaciones-de-subsanacion.md
@@ -1,0 +1,47 @@
+# Contexto de feature PR #2331 - fix(rendiciones): resolver observaciones de subsanación
+
+## Resumen
+
+- PR: https://github.com/dsocial118/SISOC/pull/2331
+- Base: `development`
+- Rama origen: `Fixes-24-08`
+- Autor: `PabloCao1`
+
+## Contexto funcional
+
+- No informado explícitamente; inferir desde el título del PR y el diff.
+
+## Arquitectura tocada
+
+- No se detectó un patrón arquitectónico dominante más allá del diff observado.
+
+## Decisiones y supuestos detectados
+
+- Tipo de cambio declarado: No informado
+- Área principal declarada: No informada
+- Impacto usuario declarado: No informado
+- Riesgos / rollback: No informado
+
+## Design system y UI
+
+- Sin cambios visibles de UI o design system detectados en el diff.
+
+## Memoria operativa para agentes
+
+- Empezar por `docs/registro/prs/PR-2331.md` para contexto resumido del PR.
+- Revisar primero estos archivos del diff:
+- `docs/registro/cambios/2026-08-19-issue-2305-rendiciones.md`
+- `rendicioncuentasmensual/services.py`
+- `tests/test_pwa_comedores_api.py`
+- `tests/test_rendicioncuentasmensual_services_unit.py`
+- Documentación sugerida para ampliar contexto:
+- `docs/indice.md`
+- `docs/ia/CONTEXT_HYGIENE.md`
+- `docs/ia/ARCHITECTURE.md`
+- `docs/ia/TESTING.md`
+- `docs/registro/cambios/2026-08-19-issue-2305-rendiciones.md`
+
+## Trazabilidad
+
+- Documento generado automáticamente desde el evento de `pull_request`.
+- Si este PR cambia de título, el archivo se renombrará para mantener el slug alineado.

--- a/docs/contexto/features/pr-2331-fix-rendiciones-resolver-observaciones-de-subsanacion.md
+++ b/docs/contexto/features/pr-2331-fix-rendiciones-resolver-observaciones-de-subsanacion.md
@@ -3,7 +3,7 @@
 ## Resumen
 
 - PR: https://github.com/dsocial118/SISOC/pull/2331
-- Base: `development`
+- Base: `homologacion`
 - Rama origen: `Fixes-24-08`
 - Autor: `PabloCao1`
 

--- a/docs/registro/cambios/2026-08-19-issue-2305-rendiciones.md
+++ b/docs/registro/cambios/2026-08-19-issue-2305-rendiciones.md
@@ -64,3 +64,26 @@ subsanación, exportación y edición con/sin permiso.
 - Suite focalizada de Rendiciones y API PWA: `88 passed`.
 - Suite completa del repositorio: `4068 passed`, `11 skipped`.
 - `black`, `djlint`, `pylint`, chequeo Django y control de migraciones: exitosos.
+
+## Correcciones del comentario del 24 de agosto
+
+- La confirmación de reenvío lista solo solicitudes de documentos faltantes y
+  versiones que continúan efectivamente a subsanar; una versión ya reemplazada
+  no vuelve a aparecer por conservar su estado histórico.
+- La progresividad y la prohibición de períodos repetidos se aplican a todo el
+  proyecto, incluso cuando las rendiciones usan convenios diferentes. La PWA
+  replica la validación antes de crear el registro offline.
+- El PDF consolidado incluye exclusivamente las versiones vigentes con estado
+  validado y excluye del exportable los documentos históricos subsanados.
+- Se conserva la carga de documentos nuevos en categorías múltiples durante una
+  subsanación sin exigir un documento observado para reemplazar.
+- Las consultas PWA reconocen las rendiciones creadas desde un espacio para
+  otro proyecto de la misma organización. Esto evita que el alta termine bien
+  pero las cargas posteriores reciban `Rendición no encontrada`.
+
+La PWA compiló correctamente con TypeScript y Vite. La suite focalizada de
+servicios de rendiciones y API PWA finalizó con `71 passed`.
+La regresión adicional de creación y carga multiproyecto finalizó correctamente
+junto con los casos de scope y períodos (`3 passed`).
+La suite completa posterior a las correcciones finalizó con `4096 passed` y
+`11 skipped`.

--- a/docs/registro/prs/PR-2331.md
+++ b/docs/registro/prs/PR-2331.md
@@ -17,13 +17,16 @@
 
 ## Áreas afectadas
 
+- `docs/contexto`
 - `docs/registro`
 - `rendicioncuentasmensual`
 - `tests`
 
 ## Archivos relevantes del diff
 
+- `docs/contexto/features/pr-2331-fix-rendiciones-resolver-observaciones-de-subsanacion.md`
 - `docs/registro/cambios/2026-08-19-issue-2305-rendiciones.md`
+- `docs/registro/prs/PR-2331.md`
 - `rendicioncuentasmensual/services.py`
 - `tests/test_pwa_comedores_api.py`
 - `tests/test_rendicioncuentasmensual_services_unit.py`
@@ -43,7 +46,9 @@
 - `docs/ia/CONTEXT_HYGIENE.md`
 - `docs/ia/ARCHITECTURE.md`
 - `docs/ia/TESTING.md`
+- `docs/contexto/features/pr-2331-fix-rendiciones-resolver-observaciones-de-subsanacion.md`
 - `docs/registro/cambios/2026-08-19-issue-2305-rendiciones.md`
+- `docs/registro/prs/PR-2331.md`
 
 ## Notas para continuidad
 

--- a/docs/registro/prs/PR-2331.md
+++ b/docs/registro/prs/PR-2331.md
@@ -1,0 +1,51 @@
+# PR #2331 - fix(rendiciones): resolver observaciones de subsanación
+
+## Metadata
+
+- PR: https://github.com/dsocial118/SISOC/pull/2331
+- Base: `development`
+- Rama origen: `Fixes-24-08`
+- Autor: `PabloCao1`
+
+## Resumen operativo
+
+- Tipo de cambio: No informado
+- Área principal: No informada
+- Contexto funcional: No informado explícitamente; revisar título, diff y documentación relacionada.
+- Resumen para changelog: No informado
+- Impacto usuario: No informado
+
+## Áreas afectadas
+
+- `docs/registro`
+- `rendicioncuentasmensual`
+- `tests`
+
+## Archivos relevantes del diff
+
+- `docs/registro/cambios/2026-08-19-issue-2305-rendiciones.md`
+- `rendicioncuentasmensual/services.py`
+- `tests/test_pwa_comedores_api.py`
+- `tests/test_rendicioncuentasmensual_services_unit.py`
+
+## Validación declarada
+
+- Pruebas automáticas: No informado en el PR.
+- Pruebas manuales: No informado en el PR.
+
+## Riesgos y rollback
+
+- No informado explícitamente en el PR.
+
+## Documentación sugerida para lectura
+
+- `docs/indice.md`
+- `docs/ia/CONTEXT_HYGIENE.md`
+- `docs/ia/ARCHITECTURE.md`
+- `docs/ia/TESTING.md`
+- `docs/registro/cambios/2026-08-19-issue-2305-rendiciones.md`
+
+## Notas para continuidad
+
+- Este documento es generado automáticamente desde el contexto del PR y sirve como índice rápido para revisión y futuras sesiones de agentes.
+- Si la metadata del body del PR está incompleta, varias secciones usarán fallbacks derivados del título o del diff.

--- a/docs/registro/prs/PR-2331.md
+++ b/docs/registro/prs/PR-2331.md
@@ -3,7 +3,7 @@
 ## Metadata
 
 - PR: https://github.com/dsocial118/SISOC/pull/2331
-- Base: `development`
+- Base: `homologacion`
 - Rama origen: `Fixes-24-08`
 - Autor: `PabloCao1`
 

--- a/rendicioncuentasmensual/services.py
+++ b/rendicioncuentasmensual/services.py
@@ -244,10 +244,13 @@ class RendicionCuentaMensualService:  # pylint: disable=too-many-public-methods
     @staticmethod
     def _get_project_queryset(comedor, proyecto=None):
         queryset = RendicionCuentaMensual.objects.filter(deleted_at__isnull=True)
+        proyecto_explicito = proyecto is not None
         if proyecto is None:
             proyecto = getattr(comedor, "proyecto", None)
         if proyecto is not None:
-            return queryset.filter(proyecto=proyecto)
+            if proyecto_explicito:
+                return queryset.filter(proyecto=proyecto)
+            return queryset.filter(Q(proyecto=proyecto) | Q(comedor=comedor)).distinct()
         proyecto_codigo = (getattr(comedor, "codigo_de_proyecto", "") or "").strip()
         if proyecto_codigo:
             filters = {"comedor__codigo_de_proyecto": proyecto_codigo}
@@ -354,7 +357,6 @@ class RendicionCuentaMensualService:  # pylint: disable=too-many-public-methods
         )
         ultimo_periodo = (
             queryset.filter(
-                convenio=convenio,
                 periodo_inicio__isnull=False,
             )
             .order_by("-periodo_inicio")
@@ -380,7 +382,6 @@ class RendicionCuentaMensualService:  # pylint: disable=too-many-public-methods
             )
 
         if queryset.filter(
-            convenio=convenio,
             periodo_inicio__lte=periodo_fin,
             periodo_fin__gte=periodo_inicio,
         ).exists():
@@ -625,8 +626,8 @@ class RendicionCuentaMensualService:  # pylint: disable=too-many-public-methods
             rendicion
         ):
             for archivo in categoria["archivos"]:
-                documentos.append(archivo)
-                documentos.extend(getattr(archivo, "subsanaciones_historial", []))
+                if archivo.estado == DocumentacionAdjunta.ESTADO_VALIDADO:
+                    documentos.append(archivo)
         return documentos
 
     @staticmethod

--- a/tests/test_pwa_comedores_api.py
+++ b/tests/test_pwa_comedores_api.py
@@ -32,7 +32,7 @@ from comedores.models import (
     Programas,
 )
 from core.models import Localidad, Municipio, Provincia
-from organizaciones.models import Organizacion
+from organizaciones.models import Organizacion, ProyectoOrganizacion
 from relevamientos.models import (
     Anexo,
     CantidadColaboradores,
@@ -831,6 +831,19 @@ def test_crear_rendicion_mobile_rechaza_numero_repetido_y_periodo_solapado(comed
     assert overlap_response.status_code == 400
     assert "periodo" in str(overlap_response.data["detail"])
 
+    overlap_otro_convenio_response = client.post(
+        f"/api/comedores/{comedor_1.id}/rendiciones/",
+        {
+            "convenio": "P03",
+            "numero_rendicion": 3,
+            "periodo_inicio": "2026-01-01",
+            "periodo_fin": "2026-01-31",
+        },
+        format="json",
+    )
+    assert overlap_otro_convenio_response.status_code == 400
+    assert "periodo" in str(overlap_otro_convenio_response.data["detail"])
+
     otro_mes_response = client.post(
         f"/api/comedores/{comedor_1.id}/rendiciones/",
         {
@@ -1027,6 +1040,74 @@ def test_crear_rendicion_mobile_permite_mismo_proyecto_en_otra_organizacion():
     assert response.status_code == 201
     assert response.data["convenio"] == "P03"
     assert response.data["numero_rendicion"] == 1
+
+
+@pytest.mark.django_db
+def test_rendicion_mobile_creada_para_otro_proyecto_del_espacio_permite_adjuntar(
+    settings, tmp_path
+):
+    settings.MEDIA_ROOT = str(tmp_path)
+    provincia = Provincia.objects.create(nombre="Mendoza")
+    programa = Programas.objects.create(nombre="Abordaje Comunitario")
+    organizacion = Organizacion.objects.create(nombre="Organización multiproyecto")
+    comedor = Comedor.objects.create(
+        nombre="Espacio representante multiproyecto",
+        provincia=provincia,
+        organizacion=organizacion,
+        programa=programa,
+        codigo_de_proyecto="PROY-BASE",
+    )
+    proyecto_base = ProyectoOrganizacion.objects.create(
+        organizacion=organizacion,
+        codigo="PROY-BASE",
+        nombre="Proyecto base",
+    )
+    proyecto_seleccionado = ProyectoOrganizacion.objects.create(
+        organizacion=organizacion,
+        codigo="PROY-OTRO",
+        nombre="Proyecto seleccionado",
+    )
+    comedor.proyecto = proyecto_base
+    comedor.save(update_fields=["proyecto"])
+    representante = _create_pwa_user(
+        comedor=comedor,
+        role=AccesoComedorPWA.ROL_REPRESENTANTE,
+        username="rep_rendicion_multiproyecto",
+    )
+    _grant_mobile_rendicion_permission(representante)
+    client = _token_client(representante)
+
+    create_response = client.post(
+        f"/api/comedores/{comedor.id}/rendiciones/",
+        {
+            "proyecto_id": proyecto_seleccionado.id,
+            "convenio": "P01",
+            "numero_rendicion": 1,
+            "periodo_inicio": "2026-08-01",
+            "periodo_fin": "2026-08-31",
+        },
+        format="json",
+    )
+    assert create_response.status_code == 201
+
+    upload_response = client.post(
+        f"/api/comedores/{comedor.id}/rendiciones/{create_response.data['id']}/documentacion/",
+        {
+            "archivo": SimpleUploadedFile(
+                "formulario-ii.pdf",
+                b"%PDF-1.4 multiproyecto",
+                content_type="application/pdf",
+            ),
+            "categoria": DocumentacionAdjunta.CATEGORIA_FORMULARIO_II,
+        },
+        format="multipart",
+    )
+
+    assert upload_response.status_code == 201
+    assert DocumentacionAdjunta.objects.filter(
+        rendicion_cuenta_mensual_id=create_response.data["id"],
+        categoria=DocumentacionAdjunta.CATEGORIA_FORMULARIO_II,
+    ).exists()
 
 
 @pytest.mark.django_db

--- a/tests/test_rendicioncuentasmensual_services_unit.py
+++ b/tests/test_rendicioncuentasmensual_services_unit.py
@@ -362,7 +362,9 @@ def test_obtener_documentacion_para_detalle_mantiene_vigente_reemplazo_categoria
 
 
 @pytest.mark.django_db
-def test_obtener_documentos_para_descarga_pdf_respeta_orden_visible(settings, tmp_path):
+def test_obtener_documentos_para_descarga_pdf_solo_incluye_vigentes_validados(
+    settings, tmp_path
+):
     settings.MEDIA_ROOT = str(tmp_path)
     rendicion = RendicionCuentaMensual.objects.create(
         mes=4,
@@ -411,7 +413,6 @@ def test_obtener_documentos_para_descarga_pdf_respeta_orden_visible(settings, tm
     assert [item.id for item in documentos] == [
         formulario.id,
         subsanacion.id,
-        comprobante.id,
     ]
 
 


### PR DESCRIPTION
## Resumen
- valida períodos por proyecto y exporta solo documentos vigentes validados
- corrige el alcance multiproyecto para crear la rendición y adjuntar archivos desde PWA
- agrega regresiones para períodos, exportación y carga multiproyecto
- coordina la corrección con SISOC-Mobile main (commit 4e8f87f)

## Validación
- docker compose exec django pytest -n auto: 4096 passed, 11 skipped
- python manage.py check: sin errores
- makemigrations --check --dry-run: sin cambios
- SISOC-Mobile npm run build: correcto
- SISOC-Mobile lint focalizado: 0 errores, 1 warning preexistente