### PR TITLE
feat(admisiones): agregar descarga DOCX para GDE

### DIFF
--- a/AGENT_REPO_MAP.md
+++ b/AGENT_REPO_MAP.md
@@ -487,6 +487,10 @@ La siguiente tabla mezcla hechos observados con inferencias explicitas cuando no
   marca de agua y nunca se adjuntan a la admisión. Al crear un template, el
   tipo de convenio se limita al catálogo de Personerías o Organización Base,
   presentada funcionalmente como Asociación de hecho.
+- La descarga del Informe Técnico ofrece una copia transitoria "Descargar para
+  GDE": prioriza el DOCX editado y, si no existe, el borrador. Se normaliza la
+  geometría OOXML de sus tablas antes de responder, sin reemplazar archivos ni
+  modificar estados.
 - El Informe Tecnico Complementario se abre tanto desde Admision como desde el
   convenio seleccionado en `acompanamientos/views.py` y
   `acompanamientos/templates/acompañamiento_detail.html`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 <!-- AUTO-GENERATED RELEASE START: 2026-08-26 -->
 # Versión SISOC 26.08.2026
 
+## Actualizaciones
+
+- [sin-area] feat(admisiones): agregar descarga DOCX para GDE. (PR #2332)
+
 ## Corrección de Errores
 
 - [Centro de Infancia] Corrige permisos y validaciones urgentes del módulo CDI. (PR #2310)

--- a/admisiones/services/informes_service/impl.py
+++ b/admisiones/services/informes_service/impl.py
@@ -61,6 +61,146 @@ DIAS_SEMANA = (
 )
 
 
+class GdeDocxService:
+    """Prepara copias transitorias de DOCX para su importación en GDE."""
+
+    @staticmethod
+    def seleccionar_ultimo_archivo(documento_informe):
+        """Devuelve el DOCX editado o, en su defecto, el borrador disponible."""
+
+        if documento_informe is None:
+            return None
+        archivo_editado = getattr(documento_informe, "archivo_docx_editado", None)
+        if getattr(archivo_editado, "name", ""):
+            return archivo_editado
+        archivo_borrador = getattr(documento_informe, "archivo_docx", None)
+        if getattr(archivo_borrador, "name", ""):
+            return archivo_borrador
+        return None
+
+    @classmethod
+    def generar(cls, archivo_docx, informe_pk=None):
+        """Genera una copia con tablas de ancho explícito para importar en GDE."""
+
+        if not archivo_docx:
+            return None
+
+        try:
+            if hasattr(archivo_docx, "open"):
+                archivo_docx.open("rb")
+            contenido = archivo_docx.read()
+            documento = Document(BytesIO(contenido))
+            ancho_disponible = cls._ancho_disponible_documento_dxa(documento)
+            for tabla in documento.tables:
+                cls._normalizar_tabla(tabla, ancho_disponible)
+
+            buffer = BytesIO()
+            documento.save(buffer)
+            return ContentFile(buffer.getvalue(), name="informe-para-gde.docx")
+        except Exception:
+            logger.exception(
+                "No se pudo preparar el DOCX para GDE",
+                extra={"informe_pk": informe_pk},
+            )
+            return None
+        finally:
+            if hasattr(archivo_docx, "close"):
+                archivo_docx.close()
+
+    @staticmethod
+    def _ancho_disponible_documento_dxa(documento):
+        seccion = documento.sections[0]
+        return (
+            seccion.page_width.twips
+            - seccion.left_margin.twips
+            - seccion.right_margin.twips
+        )
+
+    @classmethod
+    def _normalizar_tabla(cls, tabla, ancho_disponible):
+        """Fija grilla, celdas y ancho de una tabla sin cambiar su contenido."""
+
+        tabla_ooxml = tabla._tbl  # pylint: disable=protected-access
+        columnas = list(tabla_ooxml.tblGrid.gridCol_lst)
+        if not columnas:
+            return
+
+        anchos = cls._calcular_anchos_columnas(columnas, ancho_disponible)
+        propiedades_tabla = tabla_ooxml.tblPr
+        cls._asignar_ancho_dxa(propiedades_tabla, "w:tblW", ancho_disponible)
+        cls._fijar_layout_tabla(propiedades_tabla)
+        tabla.alignment = WD_TABLE_ALIGNMENT.CENTER  # pylint: disable=no-member
+        tabla.autofit = False
+        for columna, ancho in zip(columnas, anchos):
+            columna.set(qn("w:w"), str(ancho))
+        for fila in tabla_ooxml.tr_lst:
+            cls._normalizar_fila(fila, anchos)
+
+    @staticmethod
+    def _fijar_layout_tabla(propiedades_tabla):
+        layout = propiedades_tabla.first_child_found_in("w:tblLayout")
+        if layout is None:
+            layout = OxmlElement("w:tblLayout")
+            propiedades_tabla.append(layout)
+        layout.set(qn("w:type"), "fixed")
+
+        indentacion = propiedades_tabla.first_child_found_in("w:tblInd")
+        if indentacion is not None:
+            propiedades_tabla.remove(indentacion)
+
+    @classmethod
+    def _normalizar_fila(cls, fila, anchos):
+        columna_actual = cls._obtener_grid_before(fila)
+        for celda in fila.tc_lst:
+            propiedades_celda = celda.get_or_add_tcPr()
+            span = cls._obtener_grid_span(propiedades_celda)
+            ancho_celda = sum(anchos[columna_actual : columna_actual + span])
+            cls._asignar_ancho_dxa(propiedades_celda, "w:tcW", ancho_celda)
+            columna_actual += span
+
+    @staticmethod
+    def _calcular_anchos_columnas(columnas, ancho_disponible):
+        pesos = []
+        for columna in columnas:
+            try:
+                pesos.append(max(0, int(columna.get(qn("w:w")) or 0)))
+            except ValueError:
+                pesos.append(0)
+        if not any(pesos):
+            pesos = [1] * len(columnas)
+
+        total_pesos = sum(pesos)
+        anchos = [max(1, ancho_disponible * peso // total_pesos) for peso in pesos]
+        anchos[-1] += ancho_disponible - sum(anchos)
+        return anchos
+
+    @staticmethod
+    def _obtener_grid_before(fila):
+        propiedades_fila = fila.trPr
+        if propiedades_fila is None:
+            return 0
+        grid_before = propiedades_fila.first_child_found_in("w:gridBefore")
+        if grid_before is None:
+            return 0
+        return int(grid_before.get(qn("w:val")) or 0)
+
+    @staticmethod
+    def _obtener_grid_span(propiedades_celda):
+        grid_span = propiedades_celda.first_child_found_in("w:gridSpan")
+        if grid_span is None:
+            return 1
+        return int(grid_span.get(qn("w:val")) or 1)
+
+    @staticmethod
+    def _asignar_ancho_dxa(propiedades, etiqueta, ancho):
+        elemento = propiedades.first_child_found_in(etiqueta)
+        if elemento is None:
+            elemento = OxmlElement(etiqueta)
+            propiedades.append(elemento)
+        elemento.set(qn("w:w"), str(ancho))
+        elemento.set(qn("w:type"), "dxa")
+
+
 class InformeService:
     COLOR_BORDE_TABLA_TEMPLATE = "7A8EA1"
     COLOR_ENCABEZADO_TABLA_TEMPLATE = "EAF3F2"
@@ -971,6 +1111,7 @@ class InformeService:
                 and informe.estado != "Validado"
                 else None
             )
+            documento_docx = pdf_final or pdf_borrador
 
             return {
                 "tipo": tipo,
@@ -978,6 +1119,9 @@ class InformeService:
                 "campos": InformeService.get_campos_visibles_informe(informe),
                 "pdf": pdf_final,
                 "pdf_borrador": pdf_borrador,
+                "docx_para_gde_disponible": bool(
+                    GdeDocxService.seleccionar_ultimo_archivo(documento_docx)
+                ),
             }
         except Exception:
             logger.exception(

--- a/admisiones/templates/admisiones/informe_tecnico_detalle.html
+++ b/admisiones/templates/admisiones/informe_tecnico_detalle.html
@@ -29,6 +29,10 @@
                                 data-bs-toggle="modal"
                                 data-bs-target="#subirDocxModal">📤 Subir DOCX Editado</button>
                     {% endif %}
+                    {% if docx_para_gde_disponible %}
+                        <a href="{% url 'informe_tecnico_descargar_para_gde' tipo object.pk %}"
+                           class="btn btn-outline-success mr-1">📄 Descargar para GDE</a>
+                    {% endif %}
                 {% endif %}
                 {% if request.user|has_any_perm:"comedores.view_comedor,admisiones.view_admision,acompanamientos.view_informacionrelevante" or request.user.is_superuser %}
                     {% if object.estado == "Docx editado" and pdf_borrador and pdf_borrador.archivo_docx_editado %}

--- a/admisiones/urls/web_urls.py
+++ b/admisiones/urls/web_urls.py
@@ -12,6 +12,7 @@ from admisiones.views.web_views import (
     actualizar_num_expediente,
     crear_documento_personalizado,
     previsualizar_informe_tecnico_template,
+    descargar_informe_tecnico_para_gde,
     reportar_configuracion_faltante_template,
     resync_convenio_admision,
     AdmisionesTecnicosListView,
@@ -208,6 +209,17 @@ urlpatterns = [
         "comedores/admision/informe_tecnico/<str:tipo>/<int:pk>/previsualizar/",
         previsualizar_informe_tecnico_template,
         name="informe_tecnico_previsualizar_template",
+    ),
+    path(
+        "comedores/admision/informe_tecnico/<str:tipo>/<int:pk>/descargar-para-gde/",
+        permissions_any_required(
+            [
+                "comedores.view_comedor",
+                "admisiones.view_admision",
+                "acompanamientos.view_informacionrelevante",
+            ]
+        )(descargar_informe_tecnico_para_gde),
+        name="informe_tecnico_descargar_para_gde",
     ),
     path(
         "comedores/admisiones/<int:pk>/templates/reportar-faltante/",

--- a/admisiones/views/web_views.py
+++ b/admisiones/views/web_views.py
@@ -34,6 +34,7 @@ from admisiones.models.admisiones import (
     ArchivoAdmision,
     InformeComplementario,
     InformeTecnico,
+    InformeTecnicoPDF,
 )
 from admisiones.services.admisiones_service import AdmisionService
 from admisiones.services.admisiones_filter_config import (
@@ -42,7 +43,7 @@ from admisiones.services.admisiones_filter_config import (
 from admisiones.services.legales_filter_config import (
     get_filters_ui_config as get_legales_filters_ui_config,
 )
-from admisiones.services.informes_service import InformeService
+from admisiones.services.informes_service import GdeDocxService, InformeService
 from admisiones.services.legales_service import LegalesService
 from core.services.column_preferences import build_columns_context_for_custom_cells
 from core.services.favorite_filters import SeccionesFiltrosFavoritos
@@ -308,6 +309,54 @@ def previsualizar_informe_tecnico_template(request, tipo, pk):
         docx_content,
         as_attachment=True,
         filename=f"vista-previa-informe-{informe.pk}.docx",
+        content_type=(
+            "application/vnd.openxmlformats-officedocument.wordprocessingml.document"
+        ),
+    )
+
+
+@login_required
+def descargar_informe_tecnico_para_gde(request, tipo, pk):
+    """Descarga el último DOCX del informe con tablas aptas para GDE."""
+
+    informe = get_object_or_404(
+        InformeTecnico.objects.select_related("admision", "admision__comedor"),
+        pk=pk,
+        tipo=tipo,
+    )
+    permisos = [
+        "comedores.view_comedor",
+        "admisiones.view_admision",
+        "acompanamientos.view_informacionrelevante",
+    ]
+    if not (
+        request.user.is_superuser
+        or user_has_any_permission_codes(request.user, permisos)
+    ):
+        return HttpResponse(status=403)
+
+    documento_informe = InformeTecnicoPDF.objects.filter(
+        admision=informe.admision,
+        tipo=tipo,
+        informe_id=informe.id,
+    ).first()
+    archivo_docx = GdeDocxService.seleccionar_ultimo_archivo(documento_informe)
+    if archivo_docx is None:
+        messages.error(request, "No hay un DOCX disponible para preparar para GDE.")
+        return redirect("informe_tecnico_ver", tipo=tipo, pk=informe.pk)
+
+    docx_content = GdeDocxService.generar(
+        archivo_docx,
+        informe_pk=informe.pk,
+    )
+    if docx_content is None:
+        messages.error(request, "No se pudo preparar el DOCX para GDE.")
+        return redirect("informe_tecnico_ver", tipo=tipo, pk=informe.pk)
+
+    return FileResponse(
+        docx_content,
+        as_attachment=True,
+        filename=f"informe-{informe.pk}-para-gde.docx",
         content_type=(
             "application/vnd.openxmlformats-officedocument.wordprocessingml.document"
         ),

--- a/docs/contexto/features/pr-2332-feat-admisiones-agregar-descarga-docx-para-gde.md
+++ b/docs/contexto/features/pr-2332-feat-admisiones-agregar-descarga-docx-para-gde.md
@@ -1,0 +1,54 @@
+# Contexto de feature PR #2332 - feat(admisiones): agregar descarga DOCX para GDE
+
+## Resumen
+
+- PR: https://github.com/dsocial118/SISOC/pull/2332
+- Base: `main`
+- Rama origen: `codex/gde-docx-download`
+- Autor: `juanikitro`
+
+## Contexto funcional
+
+- No informado explícitamente; inferir desde el título del PR y el diff.
+
+## Arquitectura tocada
+
+- El PR toca lógica en `services/`, por lo que impacta reglas de negocio u orquestación.
+- Hay cambios en vistas web y puede existir impacto en permisos o renderizado.
+- Se modifican templates, con posible impacto visual o de composición UI.
+
+## Decisiones y supuestos detectados
+
+- Tipo de cambio declarado: No informado
+- Área principal declarada: No informada
+- Impacto usuario declarado: No informado
+- Riesgos / rollback: No informado
+
+## Design system y UI
+
+- El PR toca piezas de UI y conviene revisar consistencia visual con el patrón existente.
+- Archivos visuales relevantes: admisiones/templates/admisiones/informe_tecnico_detalle.html
+
+## Memoria operativa para agentes
+
+- Empezar por `docs/registro/prs/PR-2332.md` para contexto resumido del PR.
+- Revisar primero estos archivos del diff:
+- `AGENT_REPO_MAP.md`
+- `admisiones/services/informes_service/impl.py`
+- `admisiones/templates/admisiones/informe_tecnico_detalle.html`
+- `admisiones/urls/web_urls.py`
+- `admisiones/views/web_views.py`
+- `docs/registro/cambios/2026-08-24-descarga-docx-para-gde.md`
+- `tests/test_admisiones_web_views_unit.py`
+- `tests/test_informes_service_unit.py`
+- Documentación sugerida para ampliar contexto:
+- `docs/indice.md`
+- `docs/ia/CONTEXT_HYGIENE.md`
+- `docs/ia/ARCHITECTURE.md`
+- `docs/ia/TESTING.md`
+- `docs/registro/cambios/2026-08-24-descarga-docx-para-gde.md`
+
+## Trazabilidad
+
+- Documento generado automáticamente desde el evento de `pull_request`.
+- Si este PR cambia de título, el archivo se renombrará para mantener el slug alineado.

--- a/docs/registro/cambios/2026-08-24-descarga-docx-para-gde.md
+++ b/docs/registro/cambios/2026-08-24-descarga-docx-para-gde.md
@@ -1,0 +1,17 @@
+# Descarga de Informe Técnico para GDE
+
+## Cambio
+
+Se incorpora la descarga transitoria "Descargar para GDE" en el detalle de un
+Informe Técnico. Toma el último archivo disponible: el DOCX editado si existe o,
+en caso contrario, el borrador generado por SISOC.
+
+Antes de responder, SISOC normaliza la geometría OOXML de cada tabla con ancho,
+grilla y celdas expresados en DXA y layout fijo. No altera el contenido, los
+archivos almacenados, las plantillas publicadas ni el estado del informe.
+
+## Motivo y validación pendiente
+
+La descarga busca evitar que las tablas se desarmen al importar el documento
+como IFTEC en GDE. La compatibilidad final requiere importar casos reales de
+prueba en GDE, ya que SISOC no integra ni controla ese sistema.

--- a/docs/registro/prs/PR-2332.md
+++ b/docs/registro/prs/PR-2332.md
@@ -1,0 +1,56 @@
+# PR #2332 - feat(admisiones): agregar descarga DOCX para GDE
+
+## Metadata
+
+- PR: https://github.com/dsocial118/SISOC/pull/2332
+- Base: `main`
+- Rama origen: `codex/gde-docx-download`
+- Autor: `juanikitro`
+
+## Resumen operativo
+
+- Tipo de cambio: No informado
+- Área principal: No informada
+- Contexto funcional: No informado explícitamente; revisar título, diff y documentación relacionada.
+- Resumen para changelog: No informado
+- Impacto usuario: No informado
+
+## Áreas afectadas
+
+- `AGENT_REPO_MAP.md`
+- `admisiones`
+- `docs/registro`
+- `tests`
+
+## Archivos relevantes del diff
+
+- `AGENT_REPO_MAP.md`
+- `admisiones/services/informes_service/impl.py`
+- `admisiones/templates/admisiones/informe_tecnico_detalle.html`
+- `admisiones/urls/web_urls.py`
+- `admisiones/views/web_views.py`
+- `docs/registro/cambios/2026-08-24-descarga-docx-para-gde.md`
+- `tests/test_admisiones_web_views_unit.py`
+- `tests/test_informes_service_unit.py`
+
+## Validación declarada
+
+- Pruebas automáticas: No informado en el PR.
+- Pruebas manuales: No informado en el PR.
+
+## Riesgos y rollback
+
+- No informado explícitamente en el PR.
+
+## Documentación sugerida para lectura
+
+- `docs/indice.md`
+- `docs/ia/CONTEXT_HYGIENE.md`
+- `docs/ia/ARCHITECTURE.md`
+- `docs/ia/TESTING.md`
+- `docs/registro/cambios/2026-08-24-descarga-docx-para-gde.md`
+
+## Notas para continuidad
+
+- Este documento es generado automáticamente desde el contexto del PR y sirve como índice rápido para revisión y futuras sesiones de agentes.
+- Si la metadata del body del PR está incompleta, varias secciones usarán fallbacks derivados del título o del diff.

--- a/docs/registro/releases/pending/2026-08-26-pr-2332.md
+++ b/docs/registro/releases/pending/2026-08-26-pr-2332.md
@@ -1,0 +1,19 @@
+---
+pr: 2332
+release_date: 2026-08-26
+category: Actualizaciones
+area: sin-area
+title: feat(admisiones): agregar descarga DOCX para GDE
+summary: feat(admisiones): agregar descarga DOCX para GDE
+impact: No informado
+source_url: https://github.com/dsocial118/SISOC/pull/2332
+---
+# Release note preliminar PR #2332
+
+- Fecha objetivo de release: 2026-08-26
+- Categoría: Actualizaciones
+- Área: sin-area
+- Título del PR: feat(admisiones): agregar descarga DOCX para GDE
+- Resumen: feat(admisiones): agregar descarga DOCX para GDE
+- Impacto usuario: No informado
+- Fuente: https://github.com/dsocial118/SISOC/pull/2332

--- a/tests/test_admisiones_web_views_unit.py
+++ b/tests/test_admisiones_web_views_unit.py
@@ -1,5 +1,6 @@
 """Tests for test admisiones web views unit."""
 
+from io import BytesIO
 from types import SimpleNamespace
 
 import pytest
@@ -975,6 +976,40 @@ def test_informe_tecnico_detail_context_muestra_revision_tecnico(mocker):
 
     assert context["k"] == "v"
     assert context["mostrar_revision_tecnico"] is True
+
+
+def test_descargar_informe_tecnico_para_gde_usa_el_docx_editado(mocker):
+    request = _Req(user=_user(superuser=True), method="GET")
+    informe = SimpleNamespace(
+        pk=44,
+        id=44,
+        admision=SimpleNamespace(pk=12),
+    )
+    archivo_borrador = SimpleNamespace(name="borrador.docx")
+    archivo_editado = SimpleNamespace(name="editado.docx")
+    documento_informe = SimpleNamespace(
+        archivo_docx=archivo_borrador,
+        archivo_docx_editado=archivo_editado,
+    )
+    mocker.patch("admisiones.views.web_views.get_object_or_404", return_value=informe)
+    mocker.patch(
+        "admisiones.views.web_views.InformeTecnicoPDF.objects.filter",
+        return_value=SimpleNamespace(first=lambda: documento_informe),
+    )
+    generar = mocker.patch(
+        "admisiones.views.web_views.GdeDocxService.generar",
+        return_value=BytesIO(b"contenido"),
+    )
+
+    response = module.descargar_informe_tecnico_para_gde(
+        request,
+        tipo="base",
+        pk=44,
+    )
+
+    assert response.status_code == 200
+    assert "informe-44-para-gde.docx" in response["Content-Disposition"]
+    generar.assert_called_once_with(archivo_editado, informe_pk=44)
 
 
 def test_informe_tecnico_detail_post_subir_docx_branches(mocker):

--- a/tests/test_informes_service_unit.py
+++ b/tests/test_informes_service_unit.py
@@ -8,6 +8,7 @@ from zipfile import ZipFile
 import pytest
 from django.utils import timezone
 from docx import Document
+from docx.oxml.ns import qn
 from docx.shared import Mm, Pt
 
 from admisiones.services import informes_service as module
@@ -371,6 +372,64 @@ def test_generate_docx_content_estiliza_tablas_de_templates_dinamicos():
     assert abs(seccion.left_margin - Mm(20)) <= 635
     assert estilo_normal.font.name == "Times New Roman"
     assert estilo_normal.font.size == Pt(12)
+
+
+def test_generar_docx_para_gde_normaliza_tablas_y_prioriza_docx_editado():
+    documento = Document()
+    tabla = documento.add_table(rows=2, cols=3)
+    tabla.cell(0, 0).text = "Encabezado"
+    tabla.cell(0, 1).merge(tabla.cell(0, 2))
+    tabla.cell(1, 0).text = "A"
+    tabla.cell(1, 1).text = "B"
+    tabla.cell(1, 2).text = "C"
+    buffer = BytesIO()
+    documento.save(buffer)
+
+    original = BytesIO(buffer.getvalue())
+    original.name = "borrador.docx"
+    editado = BytesIO(buffer.getvalue())
+    editado.name = "editado.docx"
+    informe_pdf = SimpleNamespace(
+        archivo_docx=original,
+        archivo_docx_editado=editado,
+    )
+
+    archivo = module.GdeDocxService.seleccionar_ultimo_archivo(informe_pdf)
+    resultado = module.GdeDocxService.generar(archivo)
+
+    assert archivo is editado
+    assert resultado is not None
+    normalizado = Document(BytesIO(resultado.read()))
+    tabla_normalizada = normalizado.tables[0]
+    ancho_disponible = (
+        normalizado.sections[0].page_width.twips
+        - normalizado.sections[0].left_margin.twips
+        - normalizado.sections[0].right_margin.twips
+    )
+    columnas = list(tabla_normalizada._tbl.tblGrid.gridCol_lst)
+    anchos = [int(columna.get(qn("w:w"))) for columna in columnas]
+    propiedades = tabla_normalizada._tbl.tblPr.xml
+    ancho_tabla = tabla_normalizada._tbl.tblPr.first_child_found_in("w:tblW")
+
+    assert sum(anchos) == ancho_disponible
+    assert int(ancho_tabla.get(qn("w:w"))) == ancho_disponible
+    assert ancho_tabla.get(qn("w:type")) == "dxa"
+    assert 'w:tblLayout w:type="fixed"' in propiedades
+    assert "w:tblInd" not in propiedades
+
+    for fila in tabla_normalizada._tbl.tr_lst:
+        columna_actual = 0
+        for celda in fila.tc_lst:
+            propiedades_celda = celda.tcPr
+            span_elemento = propiedades_celda.first_child_found_in("w:gridSpan")
+            span = (
+                int(span_elemento.get(qn("w:val"))) if span_elemento is not None else 1
+            )
+            ancho_celda = propiedades_celda.first_child_found_in("w:tcW")
+            assert int(ancho_celda.get(qn("w:w"))) == sum(
+                anchos[columna_actual : columna_actual + span]
+            )
+            columna_actual += span
 
 
 def test_generar_y_guardar_pdf_and_context_helpers(mocker):


### PR DESCRIPTION
## Resumen
- agrega el botón **Descargar para GDE** en el detalle de informes técnicos.
- genera una copia transitoria del último DOCX disponible, priorizando el editado, con geometría de tablas normalizada para importar en IFTEC.
- no modifica documentos almacenados, estado del informe ni esquema de base de datos.

## Validación
- pytest focalizado: 2 pruebas aprobadas.
- black y djlint focalizados aprobados.
- git diff --check aprobado.

## Pendiente manual
- importar un informe representativo en GDE/IFTEC, ya que no hay acceso ni contrato público verificable del importador.