### PR TITLE
fix(relevamientos): restringir PATCH PWA por provincia

### DIFF
--- a/docs/contexto/features/pr-2347-fix-relevamientos-restringir-patch-pwa-por-provincia.md
+++ b/docs/contexto/features/pr-2347-fix-relevamientos-restringir-patch-pwa-por-provincia.md
@@ -1,0 +1,47 @@
+# Contexto de feature PR #2347 - fix(relevamientos): restringir PATCH PWA por provincia
+
+## Resumen
+
+- PR: https://github.com/dsocial118/SISOC/pull/2347
+- Base: `development`
+- Rama origen: `codex/fix-pwa-territorial-idor`
+- Autor: `juanikitro`
+
+## Contexto funcional
+
+- No informado explícitamente; inferir desde el título del PR y el diff.
+
+## Arquitectura tocada
+
+- Hay cambios en capa API/DRF y conviene revisar contratos de request/response.
+- Hay cambios en vistas web y puede existir impacto en permisos o renderizado.
+
+## Decisiones y supuestos detectados
+
+- Tipo de cambio declarado: No informado
+- Área principal declarada: No informada
+- Impacto usuario declarado: No informado
+- Riesgos / rollback: No informado
+
+## Design system y UI
+
+- Sin cambios visibles de UI o design system detectados en el diff.
+
+## Memoria operativa para agentes
+
+- Empezar por `docs/registro/prs/PR-2347.md` para contexto resumido del PR.
+- Revisar primero estos archivos del diff:
+- `docs/registro/cambios/2026-08-26-pwa-territorial-idor.md`
+- `relevamientos/views/api_views.py`
+- `tests/test_relevamiento_api_patch.py`
+- Documentación sugerida para ampliar contexto:
+- `docs/indice.md`
+- `docs/ia/CONTEXT_HYGIENE.md`
+- `docs/ia/ARCHITECTURE.md`
+- `docs/ia/TESTING.md`
+- `docs/registro/cambios/2026-08-26-pwa-territorial-idor.md`
+
+## Trazabilidad
+
+- Documento generado automáticamente desde el evento de `pull_request`.
+- Si este PR cambia de título, el archivo se renombrará para mantener el slug alineado.

--- a/docs/registro/cambios/2026-08-26-pwa-territorial-idor.md
+++ b/docs/registro/cambios/2026-08-26-pwa-territorial-idor.md
@@ -1,0 +1,21 @@
+# 2026-08-26 - Autorizacion por objeto en PATCH territorial PWA
+
+## Cambio
+
+Los PATCH de relevamiento y primer seguimiento ahora distinguen el origen de la
+autorizacion:
+
+- solicitudes autenticadas por usuario (token DRF o sesion) solo resuelven
+  objetos cuyos comedores pertenecen a las provincias de
+  `TerritorialComedorProvincia`;
+- solicitudes por API key conservan el acceso global requerido por GESTIONAR.
+
+Un objeto fuera de alcance se responde como `404`, igual que uno inexistente,
+para no revelar su existencia. El control se hace antes de procesar serializers
+o bloques relacionados.
+
+## Cobertura
+
+Las pruebas cubren territorial dentro y fuera de alcance, los tres
+identificadores del primer seguimiento, usuarios autenticados no territoriales,
+representante PWA, sesion web, y API keys moderna y legacy.

--- a/docs/registro/prs/PR-2347.md
+++ b/docs/registro/prs/PR-2347.md
@@ -1,0 +1,50 @@
+# PR #2347 - fix(relevamientos): restringir PATCH PWA por provincia
+
+## Metadata
+
+- PR: https://github.com/dsocial118/SISOC/pull/2347
+- Base: `development`
+- Rama origen: `codex/fix-pwa-territorial-idor`
+- Autor: `juanikitro`
+
+## Resumen operativo
+
+- Tipo de cambio: No informado
+- Área principal: No informada
+- Contexto funcional: No informado explícitamente; revisar título, diff y documentación relacionada.
+- Resumen para changelog: No informado
+- Impacto usuario: No informado
+
+## Áreas afectadas
+
+- `docs/registro`
+- `relevamientos`
+- `tests`
+
+## Archivos relevantes del diff
+
+- `docs/registro/cambios/2026-08-26-pwa-territorial-idor.md`
+- `relevamientos/views/api_views.py`
+- `tests/test_relevamiento_api_patch.py`
+
+## Validación declarada
+
+- Pruebas automáticas: No informado en el PR.
+- Pruebas manuales: No informado en el PR.
+
+## Riesgos y rollback
+
+- No informado explícitamente en el PR.
+
+## Documentación sugerida para lectura
+
+- `docs/indice.md`
+- `docs/ia/CONTEXT_HYGIENE.md`
+- `docs/ia/ARCHITECTURE.md`
+- `docs/ia/TESTING.md`
+- `docs/registro/cambios/2026-08-26-pwa-territorial-idor.md`
+
+## Notas para continuidad
+
+- Este documento es generado automáticamente desde el contexto del PR y sirve como índice rápido para revisión y futuras sesiones de agentes.
+- Si la metadata del body del PR está incompleta, varias secciones usarán fallbacks derivados del título o del diff.

--- a/relevamientos/views/api_views.py
+++ b/relevamientos/views/api_views.py
@@ -11,8 +11,30 @@ from core.api_auth import HasAPIKeyOrToken
 from core.utils import format_error_detail
 from relevamientos.models import PrimerSeguimiento, Relevamiento
 from relevamientos.serializer import PrimerSeguimientoSerializer, RelevamientoSerializer
+from users.services_pwa import get_territorial_comedor_provincia_ids
 
 logger = logging.getLogger("django")
+
+
+def _scope_relevamientos_for_authenticated_user(
+    request,
+    queryset,
+    *,
+    comedor_lookup="comedor",
+):
+    """Restringe solicitudes de usuario al alcance provincial territorial.
+
+    Las API keys de integraci\u00f3n no autentican ``request.user`` y conservan el
+    acceso global necesario para GESTIONAR. Un token DRF o una sesi\u00f3n web, en
+    cambio, solo puede resolver relevamientos de las provincias asignadas al
+    territorial; una lista vac\u00eda falla cerrada.
+    """
+    user = request.user
+    if not user or not user.is_authenticated:
+        return queryset
+
+    provincia_ids = get_territorial_comedor_provincia_ids(user)
+    return queryset.filter(**{f"{comedor_lookup}__provincia_id__in": provincia_ids})
 
 
 class RelevamientoApiView(APIView):
@@ -28,7 +50,10 @@ class RelevamientoApiView(APIView):
             )
         relevamiento_serializer = None
         try:
-            relevamiento = Relevamiento.objects.get(
+            relevamiento = _scope_relevamientos_for_authenticated_user(
+                request,
+                Relevamiento.objects.all(),
+            ).get(
                 id=sisoc_id,
             )
             try:
@@ -89,7 +114,7 @@ class PrimerSeguimientoApiView(APIView):
     permission_classes = [HasAPIKeyOrToken]
 
     @staticmethod
-    def _resolve_seguimiento(data):
+    def _resolve_seguimiento(data, queryset):
         """Resuelve el PrimerSeguimiento por cualquiera de los identificadores
         que GESTIONAR puede enviar: sisoc_id (PK SISOC), gestionar_id /
         ID_Seguimiento1 / id_seguimiento1 (PK GESTIONAR) o id_relevamiento
@@ -119,7 +144,6 @@ class PrimerSeguimientoApiView(APIView):
                 status=status.HTTP_400_BAD_REQUEST,
             )
 
-        queryset = PrimerSeguimiento.objects.select_related("id_relevamiento__comedor")
         try:
             if sisoc_id:
                 seguimiento = queryset.get(id=int(sisoc_id))
@@ -158,7 +182,15 @@ class PrimerSeguimientoApiView(APIView):
         return seguimiento, None
 
     def patch(self, request):
-        seguimiento, error_response = self._resolve_seguimiento(request.data)
+        seguimiento_queryset = _scope_relevamientos_for_authenticated_user(
+            request,
+            PrimerSeguimiento.objects.select_related("id_relevamiento__comedor"),
+            comedor_lookup="id_relevamiento__comedor",
+        )
+        seguimiento, error_response = self._resolve_seguimiento(
+            request.data,
+            seguimiento_queryset,
+        )
         if error_response is not None:
             return error_response
 

--- a/tests/test_relevamiento_api_patch.py
+++ b/tests/test_relevamiento_api_patch.py
@@ -4,6 +4,36 @@ import pytest
 from django.contrib.auth import get_user_model
 from rest_framework.authtoken.models import Token
 from rest_framework.test import APIClient
+from rest_framework_api_key.models import APIKey
+
+from comedores.models import Comedor
+from core.models import Provincia
+from relevamientos.models import PrimerSeguimiento, Relevamiento
+from users.models import AccesoComedorPWA, TerritorialComedorProvincia
+
+
+def _token_client(user):
+    token, _ = Token.objects.get_or_create(user=user)
+    client = APIClient()
+    client.credentials(HTTP_AUTHORIZATION=f"Token {token.key}")
+    return client
+
+
+def _make_territorial(username, provincias):
+    user_model = get_user_model()
+    user = user_model.objects.create_user(
+        username=username,
+        email=f"{username}@example.com",
+        password="testpass123",
+    )
+    user.profile.es_territorial_comedor = True
+    user.profile.save(update_fields=["es_territorial_comedor"])
+    for provincia in provincias:
+        TerritorialComedorProvincia.objects.create(
+            profile=user.profile,
+            provincia=provincia,
+        )
+    return user
 
 
 @pytest.mark.django_db
@@ -38,3 +68,229 @@ def test_patch_relevamiento_unknown_sisoc_id_returns_404():
     response = client.patch("/api/relevamiento", {"sisoc_id": 999999}, format="json")
 
     assert response.status_code == 404
+
+
+@pytest.mark.django_db
+def test_territorial_patch_relevamiento_inside_scope_is_allowed():
+    provincia = Provincia.objects.create(nombre="Provincia permitida")
+    comedor = Comedor.objects.create(nombre="Comedor permitido", provincia=provincia)
+    relevamiento = Relevamiento.objects.create(comedor=comedor, estado="Pendiente")
+    client = _token_client(_make_territorial("territorial_permitido", [provincia]))
+
+    response = client.patch(
+        "/api/relevamiento",
+        {"sisoc_id": relevamiento.id, "estado": "Finalizado"},
+        format="json",
+    )
+
+    assert response.status_code == 200
+    relevamiento.refresh_from_db()
+    assert relevamiento.estado == "Finalizado"
+    assert relevamiento.sincronizado_gestionar is True
+
+
+@pytest.mark.django_db
+def test_territorial_patch_relevamiento_outside_scope_returns_404_without_mutation():
+    provincia_permitida = Provincia.objects.create(nombre="Provincia permitida")
+    provincia_ajena = Provincia.objects.create(nombre="Provincia ajena")
+    comedor_ajeno = Comedor.objects.create(
+        nombre="Comedor ajeno",
+        provincia=provincia_ajena,
+    )
+    relevamiento = Relevamiento.objects.create(
+        comedor=comedor_ajeno, estado="Pendiente"
+    )
+    client = _token_client(
+        _make_territorial("territorial_sin_acceso", [provincia_permitida])
+    )
+
+    response = client.patch(
+        "/api/relevamiento",
+        {"sisoc_id": relevamiento.id, "estado": "Finalizado"},
+        format="json",
+    )
+
+    assert response.status_code == 404
+    relevamiento.refresh_from_db()
+    assert relevamiento.estado == "Pendiente"
+    assert relevamiento.sincronizado_gestionar is False
+
+
+@pytest.mark.django_db
+def test_territorial_patch_primer_seguimiento_inside_scope_is_allowed():
+    provincia = Provincia.objects.create(nombre="Provincia seguimiento permitida")
+    comedor = Comedor.objects.create(
+        nombre="Comedor seguimiento permitido",
+        provincia=provincia,
+    )
+    relevamiento = Relevamiento.objects.create(comedor=comedor, estado="Pendiente")
+    seguimiento = PrimerSeguimiento.objects.create(
+        id_relevamiento=relevamiento,
+        estado=PrimerSeguimiento.ESTADO_ASIGNADO,
+    )
+    client = _token_client(
+        _make_territorial("territorial_seguimiento_permitido", [provincia])
+    )
+
+    response = client.patch(
+        "/api/relevamiento/primer-seguimiento",
+        {"sisoc_id": seguimiento.id, "estado": PrimerSeguimiento.ESTADO_COMPLETO},
+        format="json",
+    )
+
+    assert response.status_code == 200
+    seguimiento.refresh_from_db()
+    assert seguimiento.estado == PrimerSeguimiento.ESTADO_COMPLETO
+    assert seguimiento.sincronizado_gestionar is True
+
+
+@pytest.mark.django_db
+@pytest.mark.parametrize("identifier", ["sisoc_id", "gestionar_id", "id_relevamiento"])
+def test_territorial_patch_primer_seguimiento_outside_scope_returns_404_without_mutation(
+    identifier,
+):
+    provincia_permitida = Provincia.objects.create(nombre="Provincia seguimiento")
+    provincia_ajena = Provincia.objects.create(nombre="Provincia seguimiento ajena")
+    comedor_ajeno = Comedor.objects.create(
+        nombre="Comedor seguimiento ajeno",
+        provincia=provincia_ajena,
+    )
+    relevamiento = Relevamiento.objects.create(
+        comedor=comedor_ajeno, estado="Pendiente"
+    )
+    seguimiento = PrimerSeguimiento.objects.create(
+        id_relevamiento=relevamiento,
+        estado=PrimerSeguimiento.ESTADO_ASIGNADO,
+        gestionar_id="seguimiento-externo",
+    )
+    client = _token_client(
+        _make_territorial("territorial_seguimiento", [provincia_permitida])
+    )
+    payload = {
+        "sisoc_id": seguimiento.id,
+        "gestionar_id": seguimiento.gestionar_id,
+        "id_relevamiento": relevamiento.id,
+    }
+
+    response = client.patch(
+        "/api/relevamiento/primer-seguimiento",
+        {identifier: payload[identifier], "estado": PrimerSeguimiento.ESTADO_COMPLETO},
+        format="json",
+    )
+
+    assert response.status_code == 404
+    seguimiento.refresh_from_db()
+    assert seguimiento.estado == PrimerSeguimiento.ESTADO_ASIGNADO
+    assert seguimiento.sincronizado_gestionar is False
+
+
+@pytest.mark.django_db
+def test_authenticated_non_territorial_token_cannot_patch_existing_relevamiento():
+    provincia = Provincia.objects.create(nombre="Provincia sin rol")
+    comedor = Comedor.objects.create(nombre="Comedor sin rol", provincia=provincia)
+    relevamiento = Relevamiento.objects.create(comedor=comedor, estado="Pendiente")
+    user = get_user_model().objects.create_user(
+        username="usuario_sin_rol",
+        email="usuario_sin_rol@example.com",
+        password="testpass123",
+    )
+
+    response = _token_client(user).patch(
+        "/api/relevamiento",
+        {"sisoc_id": relevamiento.id, "estado": "Finalizado"},
+        format="json",
+    )
+
+    assert response.status_code == 404
+    relevamiento.refresh_from_db()
+    assert relevamiento.estado == "Pendiente"
+
+
+@pytest.mark.django_db
+def test_pwa_representative_token_cannot_patch_existing_relevamiento():
+    provincia = Provincia.objects.create(nombre="Provincia representante")
+    comedor = Comedor.objects.create(
+        nombre="Comedor representante", provincia=provincia
+    )
+    relevamiento = Relevamiento.objects.create(comedor=comedor, estado="Pendiente")
+    representante = get_user_model().objects.create_user(
+        username="representante_pwa",
+        email="representante_pwa@example.com",
+        password="testpass123",
+    )
+    AccesoComedorPWA.objects.create(
+        user=representante,
+        comedor=comedor,
+        rol=AccesoComedorPWA.ROL_REPRESENTANTE,
+    )
+
+    response = _token_client(representante).patch(
+        "/api/relevamiento",
+        {"sisoc_id": relevamiento.id, "estado": "Finalizado"},
+        format="json",
+    )
+
+    assert response.status_code == 404
+    relevamiento.refresh_from_db()
+    assert relevamiento.estado == "Pendiente"
+
+
+@pytest.mark.django_db
+def test_web_session_cannot_patch_existing_relevamiento(client):
+    provincia = Provincia.objects.create(nombre="Provincia sesion")
+    comedor = Comedor.objects.create(nombre="Comedor sesion", provincia=provincia)
+    relevamiento = Relevamiento.objects.create(comedor=comedor, estado="Pendiente")
+    user = get_user_model().objects.create_user(
+        username="usuario_sesion",
+        email="usuario_sesion@example.com",
+        password="testpass123",
+    )
+    client.force_login(user)
+
+    response = client.patch(
+        "/api/relevamiento",
+        {"sisoc_id": relevamiento.id, "estado": "Finalizado"},
+        content_type="application/json",
+    )
+
+    assert response.status_code == 404
+    relevamiento.refresh_from_db()
+    assert relevamiento.estado == "Pendiente"
+
+
+@pytest.mark.django_db
+@pytest.mark.parametrize("header_name", ["HTTP_AUTHORIZATION", "HTTP_API_KEY"])
+def test_api_key_can_patch_relevamiento_and_primer_seguimiento(header_name):
+    provincia = Provincia.objects.create(nombre="Provincia integracion")
+    comedor = Comedor.objects.create(nombre="Comedor integracion", provincia=provincia)
+    relevamiento = Relevamiento.objects.create(comedor=comedor, estado="Pendiente")
+    seguimiento = PrimerSeguimiento.objects.create(
+        id_relevamiento=relevamiento,
+        estado=PrimerSeguimiento.ESTADO_ASIGNADO,
+    )
+    _, key = APIKey.objects.create_key(name="gestionar-tests")
+    client = APIClient()
+    credentials = (
+        {header_name: f"Api-Key {key}"}
+        if header_name == "HTTP_AUTHORIZATION"
+        else {header_name: key}
+    )
+    client.credentials(**credentials)
+
+    relevamiento_response = client.patch(
+        "/api/relevamiento",
+        {"sisoc_id": relevamiento.id, "estado": "Finalizado"},
+        format="json",
+    )
+    seguimiento_response = client.patch(
+        "/api/relevamiento/primer-seguimiento",
+        {"sisoc_id": seguimiento.id, "estado": PrimerSeguimiento.ESTADO_COMPLETO},
+        format="json",
+    )
+
+    assert relevamiento_response.status_code == 200
+    assert seguimiento_response.status_code == 200
+    relevamiento.refresh_from_db()
+    seguimiento.refresh_from_db()
+    assert relevamiento.estado == "Finalizado"
+    assert seguimiento.estado == PrimerSeguimiento.ESTADO_COMPLETO


### PR DESCRIPTION
## Resumen\n- Scopea los PATCH de relevamientos y primer seguimiento para tokens y sesiones de usuario.\n- Conserva el acceso global de GESTIONAR por API key moderna y legacy.\n- Devuelve 404 fuera de alcance antes de procesar serializers.\n\n## Validacion\n- docker compose run --rm --no-deps django pytest tests/test_relevamiento_api_patch.py tests/test_territorial_api.py tests/test_primer_seguimiento_relevamientos.py -q (61 passed)\n- Black --check sobre los archivos Python modificados.