### PR TITLE
fix(ci): advertir artefactos en promociones protegidas

### DIFF
--- a/.github/workflows/pr-docs.yml
+++ b/.github/workflows/pr-docs.yml
@@ -105,8 +105,20 @@ jobs:
                     exit 0
                   fi
 
+                  protected_source=false
+                  if [ "${{ github.event.pull_request.head.repo.full_name }}" = "${{ github.repository }}" ] && \
+                    { [ "${{ github.event.pull_request.head.ref }}" = "development" ] || \
+                      [ "${{ github.event.pull_request.head.ref }}" = "homologacion" ] || \
+                      [ "${{ github.event.pull_request.head.ref }}" = "main" ]; }; then
+                    protected_source=true
+                  fi
+
                   {
-                    echo "### Artefactos spec-as-source pendientes"
+                    if [ "$protected_source" = true ]; then
+                      echo "### Advertencia: artefactos spec-as-source pendientes"
+                    else
+                      echo "### Artefactos spec-as-source pendientes"
+                    fi
                     echo ""
                     echo "Faltan los siguientes paths en la rama origen:"
                     echo '```text'
@@ -114,6 +126,11 @@ jobs:
                     echo '```'
                     echo "Regenerá y commiteá los artefactos con \`python scripts/ci/pr_doc_automation.py --repository ${{ github.repository }} --pr ${{ github.event.pull_request.number }}\`."
                   } >> "$GITHUB_STEP_SUMMARY"
+
+                  if [ "$protected_source" = true ]; then
+                    echo "La rama origen está protegida; los artefactos faltantes no bloquean esta promoción."
+                    exit 0
+                  fi
 
                   echo "Faltan artefactos spec-as-source requeridos para mergear."
                   exit 1

--- a/docs/contexto/features/pr-2348-fix-ci-advertir-artefactos-en-promociones-protegidas.md
+++ b/docs/contexto/features/pr-2348-fix-ci-advertir-artefactos-en-promociones-protegidas.md
@@ -1,0 +1,50 @@
+# Contexto de feature PR #2348 - fix(ci): advertir artefactos en promociones protegidas
+
+## Resumen
+
+- PR: https://github.com/dsocial118/SISOC/pull/2348
+- Base: `development`
+- Rama origen: `codex/soft-gate-pr-artifacts-current`
+- Autor: `juanikitro`
+
+## Contexto funcional
+
+- No informado explícitamente; inferir desde el título del PR y el diff.
+
+## Arquitectura tocada
+
+- El alcance incluye automatización o tooling de CI/CD.
+
+## Decisiones y supuestos detectados
+
+- Tipo de cambio declarado: No informado
+- Área principal declarada: No informada
+- Impacto usuario declarado: No informado
+- Riesgos / rollback: No informado
+
+## Design system y UI
+
+- Sin cambios visibles de UI o design system detectados en el diff.
+
+## Memoria operativa para agentes
+
+- Empezar por `docs/registro/prs/PR-2348.md` para contexto resumido del PR.
+- Revisar primero estos archivos del diff:
+- `.github/workflows/pr-docs.yml`
+- `docs/plans/2026-08-26-pr-artifacts-protected-source-warning-design.md`
+- `docs/registro/README.md`
+- `docs/registro/cambios/2026-08-26-artefactos-pr-ramas-protegidas.md`
+- `tests/test_pr_doc_automation_unit.py`
+- Documentación sugerida para ampliar contexto:
+- `docs/indice.md`
+- `docs/ia/CONTEXT_HYGIENE.md`
+- `docs/ia/ARCHITECTURE.md`
+- `docs/ia/TESTING.md`
+- `docs/plans/2026-08-26-pr-artifacts-protected-source-warning-design.md`
+- `docs/registro/README.md`
+- `docs/registro/cambios/2026-08-26-artefactos-pr-ramas-protegidas.md`
+
+## Trazabilidad
+
+- Documento generado automáticamente desde el evento de `pull_request`.
+- Si este PR cambia de título, el archivo se renombrará para mantener el slug alineado.

--- a/docs/plans/2026-08-26-pr-artifacts-protected-source-warning-design.md
+++ b/docs/plans/2026-08-26-pr-artifacts-protected-source-warning-design.md
@@ -1,0 +1,29 @@
+# Artefactos de PR desde ramas protegidas
+
+## Contexto
+
+El workflow `pr-docs.yml` no puede commitear artefactos en una rama protegida
+origen (`development`, `homologacion` o `main`). Sin embargo, el job
+`sync_pr_artifacts` exigía esos archivos y bloqueaba las promociones aunque la
+ausencia no afectara al código ni a la calidad de la entrega.
+
+## Decisión
+
+Para un PR interno cuya rama origen sea protegida, `sync_pr_artifacts` seguirá
+identificando y mostrando los artefactos faltantes en el resumen de GitHub
+Actions, pero finalizará exitosamente. Para ramas de trabajo o forks, conserva
+el fallo estricto: allí la automatización debe poder generar y commitear los
+artefactos o el PR debe traerlos.
+
+## Alternativas descartadas
+
+- Omitir el job para promociones: elimina la trazabilidad de artefactos
+  faltantes.
+- Volver advertencia todos los PR: ocultaría fallas reales en ramas de trabajo.
+
+## Validación
+
+- Validar la sintaxis y el diff del workflow.
+- Comprobar estáticamente que el caso protegido devuelve éxito y que los demás
+  casos mantienen `exit 1`.
+- La ejecución remota de un PR de prueba es la prueba final del comportamiento.

--- a/docs/registro/README.md
+++ b/docs/registro/README.md
@@ -38,11 +38,12 @@ Cuando el destino es `main`, también debe incluir una nota en
 
 Para ramas internas no protegidas, `.github/workflows/pr-docs.yml` genera y
 pushea estos archivos. Las ramas protegidas (`development`, `homologacion` y
-`main`) no se autoescriben: el mismo workflow verifica los artefactos ya
-versionados y bloquea el merge si faltan.
+`main`) no se autoescriben: si faltan artefactos, el workflow los informa en
+su Summary sin bloquear la promoción.
 
-En una promoción o cuando el bot no puede escribir la rama, generar de forma
-explícita antes de abrir o actualizar el PR:
+Cuando se requiera conservar los artefactos de una promoción o el bot no pueda
+escribir la rama, generarlos de forma explícita antes de abrir o actualizar el
+PR:
 
 ```powershell
 $env:GITHUB_TOKEN = gh auth token

--- a/docs/registro/cambios/2026-08-26-artefactos-pr-ramas-protegidas.md
+++ b/docs/registro/cambios/2026-08-26-artefactos-pr-ramas-protegidas.md
@@ -1,0 +1,11 @@
+# Artefactos de PR en promociones desde ramas protegidas
+
+`pr-docs.yml` ahora informa, sin bloquear, los artefactos spec-as-source que
+falten en un PR interno cuyo origen sea `development`, `homologacion` o `main`.
+La advertencia queda en el Summary del workflow con los paths y el comando de
+generación correspondiente.
+
+Los PRs desde ramas de trabajo o forks mantienen el gate estricto. Así se evita
+que una promoción quede bloqueada porque GitHub Actions no puede escribir su
+rama protegida, sin ocultar la falta de artefactos cuando el workflow sí puede
+generarlos.

--- a/docs/registro/prs/PR-2348.md
+++ b/docs/registro/prs/PR-2348.md
@@ -1,0 +1,55 @@
+# PR #2348 - fix(ci): advertir artefactos en promociones protegidas
+
+## Metadata
+
+- PR: https://github.com/dsocial118/SISOC/pull/2348
+- Base: `development`
+- Rama origen: `codex/soft-gate-pr-artifacts-current`
+- Autor: `juanikitro`
+
+## Resumen operativo
+
+- Tipo de cambio: No informado
+- Área principal: No informada
+- Contexto funcional: No informado explícitamente; revisar título, diff y documentación relacionada.
+- Resumen para changelog: No informado
+- Impacto usuario: No informado
+
+## Áreas afectadas
+
+- `.github/workflows`
+- `docs/plans`
+- `docs/registro`
+- `tests`
+
+## Archivos relevantes del diff
+
+- `.github/workflows/pr-docs.yml`
+- `docs/plans/2026-08-26-pr-artifacts-protected-source-warning-design.md`
+- `docs/registro/README.md`
+- `docs/registro/cambios/2026-08-26-artefactos-pr-ramas-protegidas.md`
+- `tests/test_pr_doc_automation_unit.py`
+
+## Validación declarada
+
+- Pruebas automáticas: No informado en el PR.
+- Pruebas manuales: No informado en el PR.
+
+## Riesgos y rollback
+
+- No informado explícitamente en el PR.
+
+## Documentación sugerida para lectura
+
+- `docs/indice.md`
+- `docs/ia/CONTEXT_HYGIENE.md`
+- `docs/ia/ARCHITECTURE.md`
+- `docs/ia/TESTING.md`
+- `docs/plans/2026-08-26-pr-artifacts-protected-source-warning-design.md`
+- `docs/registro/README.md`
+- `docs/registro/cambios/2026-08-26-artefactos-pr-ramas-protegidas.md`
+
+## Notas para continuidad
+
+- Este documento es generado automáticamente desde el contexto del PR y sirve como índice rápido para revisión y futuras sesiones de agentes.
+- Si la metadata del body del PR está incompleta, varias secciones usarán fallbacks derivados del título o del diff.

--- a/tests/test_pr_doc_automation_unit.py
+++ b/tests/test_pr_doc_automation_unit.py
@@ -45,6 +45,13 @@ def test_pr_docs_workflow_detecta_artefactos_nuevos_no_trackeados():
     assert "git ls-tree -r --name-only refs/remotes/origin/pr-head" in workflow
     assert "docs/registro/releases/pending" in workflow
     assert "github.event.pull_request.base.ref" in workflow
+    assert "protected_source=false" in workflow
+    assert "### Advertencia: artefactos spec-as-source pendientes" in workflow
+    assert (
+        "La rama origen está protegida; los artefactos faltantes no bloquean "
+        "esta promoción."
+    ) in workflow
+    assert 'if [ "$protected_source" = true ]; then' in workflow
     assert "Faltan artefactos spec-as-source requeridos para mergear." in workflow
     assert "exit 1" in workflow
 


### PR DESCRIPTION
## Contexto
Las promociones desde ramas protegidas no pueden autogenerar los artefactos spec-as-source y quedaban bloqueadas por sync_pr_artifacts.

## Cambio
El workflow ahora deja una advertencia en el Summary y finaliza exitosamente solo para PRs internos desde development, homologacion o main. Las ramas de trabajo y forks mantienen el gate estricto.

## Validación
- Aserción de regresión del workflow ejecutada directamente.
- YAML parseable y py_compile correctos.
- pytest tests/test_pr_doc_automation_unit.py no inició localmente por falta de crispy_forms; lack tampoco está instalado.