### PR TITLE
feat(cdi): prevenir duplicados por referente

### DIFF
--- a/centrodeinfancia/forms.py
+++ b/centrodeinfancia/forms.py
@@ -203,6 +203,12 @@ class CentroDeInfanciaForm(forms.ModelForm):
                 "required"
             ] = "Este campo es obligatorio."
 
+        if not self.instance.pk:
+            self.fields["cuil_referente"].required = True
+            self.fields["cuil_referente"].error_messages[
+                "required"
+            ] = "Este campo es obligatorio para dar de alta un CDI."
+
     def _configurar_campos_dinamicos_horarios(self):
         horarios_instancia = {}
         if getattr(self.instance, "pk", None):
@@ -498,6 +504,33 @@ class CentroDeInfanciaForm(forms.ModelForm):
         except ValidationError as exc:
             raise forms.ValidationError(exc.messages) from exc
 
+    def _validar_cdi_unico(self, cleaned_data):
+        provincia = cleaned_data.get("provincia")
+        cuit = cleaned_data.get("cuit_organizacion_gestiona")
+        cuil = cleaned_data.get("cuil_referente")
+        if not provincia or not cuit or not cuil:
+            return
+
+        existentes = CentroDeInfancia.objects.filter(
+            provincia=provincia,
+            cuit_organizacion_gestiona=cuit,
+            cuil_referente=cuil,
+        )
+        if self.instance.pk:
+            existentes = existentes.exclude(pk=self.instance.pk)
+
+        existente = existentes.order_by("pk").first()
+        if existente:
+            mensaje = (
+                f"Ya existe el CDI “{existente.nombre}” en la provincia seleccionada "
+                "con el mismo CUIT del organismo y CUIL del referente."
+            )
+            self.add_error(
+                "cuil_referente",
+                mensaje,
+            )
+            self.add_error(None, mensaje)
+
     def _clean_coordenada(self, field_name, minimo, maximo, etiqueta):
         value = self.cleaned_data.get(field_name)
         if value in (None, ""):
@@ -553,6 +586,7 @@ class CentroDeInfanciaForm(forms.ModelForm):
                     "hora_cierre": cierre,
                 }
         cleaned_data["horarios_funcionamiento_data"] = horarios
+        self._validar_cdi_unico(cleaned_data)
         return cleaned_data
 
     def save(self, commit=True):

--- a/centrodeinfancia/management/__init__.py
+++ b/centrodeinfancia/management/__init__.py
@@ -1,0 +1,1 @@
+"""Management commands del módulo Centro de Desarrollo Infantil."""

--- a/centrodeinfancia/management/commands/__init__.py
+++ b/centrodeinfancia/management/commands/__init__.py
@@ -1,0 +1,1 @@
+"""Comandos de gestión para Centro de Desarrollo Infantil."""

--- a/centrodeinfancia/management/commands/relevar_cdi_duplicados.py
+++ b/centrodeinfancia/management/commands/relevar_cdi_duplicados.py
@@ -1,0 +1,56 @@
+from collections import defaultdict
+
+from django.core.management.base import BaseCommand
+
+from centrodeinfancia.models import CentroDeInfancia, normalizar_cuit
+
+
+def _enmascarar_identificador(value):
+    if len(value) <= 4:
+        return value
+    return f"{'*' * (len(value) - 4)}{value[-4:]}"
+
+
+class Command(BaseCommand):
+    help = (
+        "Lista CDI activos duplicados por provincia, CUIT del organismo y CUIL "
+        "del referente. No modifica registros."
+    )
+
+    def handle(self, *args, **options):
+        grupos = defaultdict(list)
+        centros = CentroDeInfancia.objects.select_related("provincia").iterator()
+
+        for centro in centros:
+            cuit = normalizar_cuit(centro.cuit_organizacion_gestiona)
+            cuil = normalizar_cuit(centro.cuil_referente)
+            if not centro.provincia_id or not cuit or not cuil:
+                continue
+            grupos[(centro.provincia_id, cuit, cuil)].append(centro)
+
+        duplicados = [
+            (clave, centros_grupo)
+            for clave, centros_grupo in grupos.items()
+            if len(centros_grupo) > 1
+        ]
+        duplicados.sort(key=lambda item: item[0])
+
+        if not duplicados:
+            self.stdout.write("No se encontraron CDI duplicados.")
+            return
+
+        for (_provincia_id, cuit, cuil), centros_grupo in duplicados:
+            provincia = centros_grupo[0].provincia.nombre
+            detalle_centros = ", ".join(
+                f"{centro.pk} | {centro.nombre}"
+                for centro in sorted(centros_grupo, key=lambda centro: centro.pk)
+            )
+            self.stdout.write(
+                f"Provincia: {provincia} | CUIT: {_enmascarar_identificador(cuit)} "
+                f"| CUIL referente: {_enmascarar_identificador(cuil)} "
+                f"| {len(centros_grupo)} CDI(s): {detalle_centros}"
+            )
+
+        self.stdout.write(
+            self.style.WARNING(f"Grupos duplicados detectados: {len(duplicados)}.")
+        )

--- a/centrodeinfancia/templates/centrodeinfancia/centrodeinfancia_form.html
+++ b/centrodeinfancia/templates/centrodeinfancia/centrodeinfancia_form.html
@@ -29,7 +29,10 @@
             {% csrf_token %}
 
             {% if form.errors %}
-                <div class="alert alert-danger" role="alert">No se pudo guardar el legajo. Revisá los campos marcados.</div>
+                <div class="alert alert-danger" role="alert">
+                    No se pudo guardar el legajo. Revisá los campos marcados.
+                    {% if form.non_field_errors %}<div class="mt-2">{{ form.non_field_errors }}</div>{% endif %}
+                </div>
             {% endif %}
 
             <div class="section-card mb-3">

--- a/centrodeinfancia/tests/test_centrodeinfancia_form.py
+++ b/centrodeinfancia/tests/test_centrodeinfancia_form.py
@@ -72,6 +72,7 @@ def datos_validos(ubicacion, servicio, **overrides):
         "apellido_referente": "Pérez",
         "email_referente": "ana.perez@cdi.com",
         "telefono_referente": "4774-2015",
+        "cuil_referente": CUIT_VALIDO,
     }
     datos.update(overrides)
     return datos
@@ -109,9 +110,7 @@ def test_alta_con_todos_los_campos_validos_guarda(user, ubicacion, servicio):
 
 
 @pytest.mark.django_db
-def test_alta_admite_identificadores_opcionales_del_referente(
-    user, ubicacion, servicio
-):
+def test_alta_normaliza_identificadores_del_referente(user, ubicacion, servicio):
     form = construir_form(
         datos_validos(
             ubicacion,
@@ -126,6 +125,80 @@ def test_alta_admite_identificadores_opcionales_del_referente(
     centro = form.save()
     assert centro.dni_referente == "30123456"
     assert centro.cuil_referente == "20445350304"
+
+
+@pytest.mark.django_db
+def test_alta_requiere_cuil_del_referente(user, ubicacion, servicio):
+    datos = datos_validos(ubicacion, servicio)
+    datos.pop("cuil_referente")
+    form = construir_form(datos, user=user)
+
+    assert not form.is_valid()
+    assert form.errors["cuil_referente"] == [
+        "Este campo es obligatorio para dar de alta un CDI."
+    ]
+
+
+@pytest.mark.django_db
+def test_alta_rechaza_cdi_duplicado_por_provincia_cuit_y_cuil(
+    user, ubicacion, servicio
+):
+    CentroDeInfancia.objects.create(
+        nombre="CDI Existente",
+        provincia=ubicacion["provincia"],
+        cuit_organizacion_gestiona="20445350304",
+        cuil_referente="20445350304",
+    )
+    form = construir_form(datos_validos(ubicacion, servicio), user=user)
+
+    assert not form.is_valid()
+    assert "CDI Existente" in form.errors["cuil_referente"][0]
+    assert "CDI Existente" in form.non_field_errors()[0]
+
+
+@pytest.mark.django_db
+def test_alta_permite_misma_identidad_en_otra_provincia(user, ubicacion, servicio):
+    otra_provincia = Provincia.objects.create(nombre="Catamarca")
+    CentroDeInfancia.objects.create(
+        nombre="CDI Catamarca",
+        provincia=otra_provincia,
+        cuit_organizacion_gestiona="20445350304",
+        cuil_referente="20445350304",
+    )
+    form = construir_form(datos_validos(ubicacion, servicio), user=user)
+
+    assert form.is_valid(), form.errors
+
+
+@pytest.mark.django_db
+def test_edicion_permite_conservar_la_identidad_del_propio_cdi(
+    user, ubicacion, servicio
+):
+    centro = CentroDeInfancia.objects.create(
+        nombre="CDI Existente",
+        provincia=ubicacion["provincia"],
+        cuit_organizacion_gestiona="20445350304",
+        cuil_referente="20445350304",
+    )
+    form = construir_form(
+        datos_validos(ubicacion, servicio), user=user, instance=centro
+    )
+
+    assert form.is_valid(), form.errors
+
+
+@pytest.mark.django_db
+def test_alta_ignora_cdi_dado_de_baja_al_validar_duplicados(user, ubicacion, servicio):
+    centro = CentroDeInfancia.objects.create(
+        nombre="CDI Dado de baja",
+        provincia=ubicacion["provincia"],
+        cuit_organizacion_gestiona="20445350304",
+        cuil_referente="20445350304",
+    )
+    centro.delete()
+    form = construir_form(datos_validos(ubicacion, servicio), user=user)
+
+    assert form.is_valid(), form.errors
 
 
 # --- BUG-01 / BUG-02: campos obligatorios en el alta -------------------------

--- a/centrodeinfancia/tests/test_relevar_cdi_duplicados_command.py
+++ b/centrodeinfancia/tests/test_relevar_cdi_duplicados_command.py
@@ -1,0 +1,47 @@
+from io import StringIO
+
+import pytest
+from django.core.management import call_command
+
+from centrodeinfancia.models import CentroDeInfancia
+from core.models import Provincia
+
+
+@pytest.mark.django_db
+def test_comando_lista_solo_grupos_activos_completos_y_duplicados():
+    provincia = Provincia.objects.create(nombre="Buenos Aires")
+    duplicado_1 = CentroDeInfancia.objects.create(
+        nombre="CDI Uno",
+        provincia=provincia,
+        cuit_organizacion_gestiona="20-44535030-4",
+        cuil_referente="20-44535030-4",
+    )
+    duplicado_2 = CentroDeInfancia.objects.create(
+        nombre="CDI Dos",
+        provincia=provincia,
+        cuit_organizacion_gestiona="20445350304",
+        cuil_referente="20445350304",
+    )
+    CentroDeInfancia.objects.create(
+        nombre="CDI Sin CUIL",
+        provincia=provincia,
+        cuit_organizacion_gestiona="20445350304",
+    )
+    dado_de_baja = CentroDeInfancia.objects.create(
+        nombre="CDI Dado de baja",
+        provincia=provincia,
+        cuit_organizacion_gestiona="20445350304",
+        cuil_referente="20445350304",
+    )
+    dado_de_baja.delete()
+
+    output = StringIO()
+    call_command("relevar_cdi_duplicados", stdout=output)
+
+    resultado = output.getvalue()
+    assert "Grupos duplicados detectados: 1." in resultado
+    assert f"{duplicado_1.pk} | CDI Uno" in resultado
+    assert f"{duplicado_2.pk} | CDI Dos" in resultado
+    assert "CDI Sin CUIL" not in resultado
+    assert "CDI Dado de baja" not in resultado
+    assert "*******0304" in resultado

--- a/docs/contexto/features/pr-2350-feat-cdi-prevenir-duplicados-por-referente.md
+++ b/docs/contexto/features/pr-2350-feat-cdi-prevenir-duplicados-por-referente.md
@@ -1,0 +1,52 @@
+# Contexto de feature PR #2350 - feat(cdi): prevenir duplicados por referente
+
+## Resumen
+
+- PR: https://github.com/dsocial118/SISOC/pull/2350
+- Base: `development`
+- Rama origen: `codex/issue-2349-cdi-duplicados`
+- Autor: `juanikitro`
+
+## Contexto funcional
+
+- No informado explícitamente; inferir desde el título del PR y el diff.
+
+## Arquitectura tocada
+
+- Se modifican templates, con posible impacto visual o de composición UI.
+
+## Decisiones y supuestos detectados
+
+- Tipo de cambio declarado: No informado
+- Área principal declarada: No informada
+- Impacto usuario declarado: No informado
+- Riesgos / rollback: No informado
+
+## Design system y UI
+
+- El PR toca piezas de UI y conviene revisar consistencia visual con el patrón existente.
+- Archivos visuales relevantes: centrodeinfancia/templates/centrodeinfancia/centrodeinfancia_form.html
+
+## Memoria operativa para agentes
+
+- Empezar por `docs/registro/prs/PR-2350.md` para contexto resumido del PR.
+- Revisar primero estos archivos del diff:
+- `centrodeinfancia/forms.py`
+- `centrodeinfancia/management/__init__.py`
+- `centrodeinfancia/management/commands/__init__.py`
+- `centrodeinfancia/management/commands/relevar_cdi_duplicados.py`
+- `centrodeinfancia/templates/centrodeinfancia/centrodeinfancia_form.html`
+- `centrodeinfancia/tests/test_centrodeinfancia_form.py`
+- `centrodeinfancia/tests/test_relevar_cdi_duplicados_command.py`
+- `docs/registro/cambios/2026-08-26-issue-2349-cdi-duplicados.md`
+- Documentación sugerida para ampliar contexto:
+- `docs/indice.md`
+- `docs/ia/CONTEXT_HYGIENE.md`
+- `docs/ia/ARCHITECTURE.md`
+- `docs/ia/TESTING.md`
+- `docs/registro/cambios/2026-08-26-issue-2349-cdi-duplicados.md`
+
+## Trazabilidad
+
+- Documento generado automáticamente desde el evento de `pull_request`.
+- Si este PR cambia de título, el archivo se renombrará para mantener el slug alineado.

--- a/docs/registro/cambios/2026-08-26-issue-2349-cdi-duplicados.md
+++ b/docs/registro/cambios/2026-08-26-issue-2349-cdi-duplicados.md
@@ -1,0 +1,30 @@
+# CDI: prevención y relevamiento de duplicados
+
+Fecha: 2026-08-26
+
+## Cambio funcional
+
+- El alta de CDI exige el CUIL del referente.
+- Antes de guardar un alta o edición, SISOC rechaza otro CDI activo de la misma
+  provincia con la misma combinación de CUIT del organismo y CUIL del referente.
+- El mensaje de validación identifica el CDI existente para que la persona
+  operadora pueda corregir la carga.
+
+## Relevamiento operativo
+
+Se incorpora el comando de solo lectura:
+
+```powershell
+.\scripts\ai\codex_run.ps1 manage relevar_cdi_duplicados
+```
+
+El comando agrupa CDI activos con CUIT y CUIL completos, normaliza ambos
+identificadores para la comparación y enmascara los valores en su salida. No
+actualiza ni elimina registros.
+
+## Límite conocido
+
+No se agrega una restricción única de base de datos en esta entrega. Los
+duplicados históricos se deben relevar y resolver primero, y la combinación
+con bajas lógicas requiere una estrategia específica para MySQL antes de
+imponer esa garantía a nivel de base.

--- a/docs/registro/prs/PR-2350.md
+++ b/docs/registro/prs/PR-2350.md
@@ -1,0 +1,54 @@
+# PR #2350 - feat(cdi): prevenir duplicados por referente
+
+## Metadata
+
+- PR: https://github.com/dsocial118/SISOC/pull/2350
+- Base: `development`
+- Rama origen: `codex/issue-2349-cdi-duplicados`
+- Autor: `juanikitro`
+
+## Resumen operativo
+
+- Tipo de cambio: No informado
+- Área principal: No informada
+- Contexto funcional: No informado explícitamente; revisar título, diff y documentación relacionada.
+- Resumen para changelog: No informado
+- Impacto usuario: No informado
+
+## Áreas afectadas
+
+- `centrodeinfancia`
+- `docs/registro`
+
+## Archivos relevantes del diff
+
+- `centrodeinfancia/forms.py`
+- `centrodeinfancia/management/__init__.py`
+- `centrodeinfancia/management/commands/__init__.py`
+- `centrodeinfancia/management/commands/relevar_cdi_duplicados.py`
+- `centrodeinfancia/templates/centrodeinfancia/centrodeinfancia_form.html`
+- `centrodeinfancia/tests/test_centrodeinfancia_form.py`
+- `centrodeinfancia/tests/test_relevar_cdi_duplicados_command.py`
+- `docs/registro/cambios/2026-08-26-issue-2349-cdi-duplicados.md`
+
+## Validación declarada
+
+- Pruebas automáticas: No informado en el PR.
+- Pruebas manuales: No informado en el PR.
+
+## Riesgos y rollback
+
+- No informado explícitamente en el PR.
+
+## Documentación sugerida para lectura
+
+- `docs/indice.md`
+- `docs/ia/CONTEXT_HYGIENE.md`
+- `docs/ia/ARCHITECTURE.md`
+- `docs/ia/TESTING.md`
+- `docs/registro/cambios/2026-08-26-issue-2349-cdi-duplicados.md`
+
+## Notas para continuidad
+
+- Este documento es generado automáticamente desde el contexto del PR y sirve como índice rápido para revisión y futuras sesiones de agentes.
+- Si la metadata del body del PR está incompleta, varias secciones usarán fallbacks derivados del título o del diff.


### PR DESCRIPTION
## Resumen
- exige CUIL del referente al crear un CDI;
- bloquea coincidencias activas por provincia, CUIT y CUIL, identificando el CDI existente;
- agrega un comando de solo lectura para relevar duplicados históricos.

## Validación
- `pytest centrodeinfancia/tests/test_centrodeinfancia_form.py centrodeinfancia/tests/test_relevar_cdi_duplicados_command.py` (94 aprobados)
- Black, djlint y pylint focalizados
- `makemigrations --check --dry-run` sin cambios de modelo

Closes #2349