### PR TITLE
docs(postman): cubrir la API pública completa de VAT

### DIFF
--- a/docs/contexto/features/pr-2351-docs-postman-cubrir-la-api-publica-completa-de-vat.md
+++ b/docs/contexto/features/pr-2351-docs-postman-cubrir-la-api-publica-completa-de-vat.md
@@ -1,0 +1,49 @@
+# Contexto de feature PR #2351 - docs(postman): cubrir la API pública completa de VAT
+
+## Resumen
+
+- PR: https://github.com/dsocial118/SISOC/pull/2351
+- Base: `development`
+- Rama origen: `codex/vat-postman-api-completa`
+- Autor: `juanikitro`
+
+## Contexto funcional
+
+- No informado explícitamente; inferir desde el título del PR y el diff.
+
+## Arquitectura tocada
+
+- Hay cambios en capa API/DRF y conviene revisar contratos de request/response.
+
+## Decisiones y supuestos detectados
+
+- Tipo de cambio declarado: No informado
+- Área principal declarada: No informada
+- Impacto usuario declarado: No informado
+- Riesgos / rollback: No informado
+
+## Design system y UI
+
+- Sin cambios visibles de UI o design system detectados en el diff.
+
+## Memoria operativa para agentes
+
+- Empezar por `docs/registro/prs/PR-2351.md` para contexto resumido del PR.
+- Revisar primero estos archivos del diff:
+- `docs/plans/2026-08-26-vat-postman-api-completa-design.md`
+- `docs/registro/cambios/2026-08-26-vat-postman-api-completa.md`
+- `postman/Local.postman_environment.json`
+- `postman/SISOC APIs.postman_collection.json`
+- `postman/api_inventory.md`
+- Documentación sugerida para ampliar contexto:
+- `docs/indice.md`
+- `docs/ia/CONTEXT_HYGIENE.md`
+- `docs/ia/ARCHITECTURE.md`
+- `docs/ia/TESTING.md`
+- `docs/plans/2026-08-26-vat-postman-api-completa-design.md`
+- `docs/registro/cambios/2026-08-26-vat-postman-api-completa.md`
+
+## Trazabilidad
+
+- Documento generado automáticamente desde el evento de `pull_request`.
+- Si este PR cambia de título, el archivo se renombrará para mantener el slug alineado.

--- a/docs/plans/2026-08-26-vat-postman-api-completa-design.md
+++ b/docs/plans/2026-08-26-vat-postman-api-completa-design.md
@@ -1,0 +1,48 @@
+# Coleccion Postman completa de la API VAT
+
+Fecha: 2026-08-26
+
+## Objetivo
+
+Actualizar la coleccion general de SISOC para que la carpeta VAT represente toda
+la API publica registrada en `VAT/api_urls.py`, tanto la API operativa
+`/api/vat/` como la API web `/api/vat/web/`.
+
+## Alcance
+
+- Incluir los metodos estandar habilitados por cada ViewSet: list, retrieve,
+  create, update, partial update y destroy, segun corresponda.
+- Incluir las acciones personalizadas del router VAT.
+- Usar cuerpos de ejemplo alineados con los serializers y variables Postman para
+  todos los identificadores reutilizables.
+- Mantener descripciones de autenticacion, efectos y precondiciones, en especial
+  para requests que crean, modifican o eliminan datos.
+- Excluir las rutas de `VAT/urls.py`, incluidas vistas HTML y AJAX internas.
+
+## Estructura
+
+La carpeta VAT se organiza por superficie y recurso:
+
+1. Informacion y autenticacion.
+2. API operativa, agrupada por ubicacion, catalogos, estructura academica,
+   instituciones, oferta, inscripciones, vouchers y evaluaciones.
+3. API web, agrupada por centros, titulos, cursos, ciudadanos e inscripciones.
+
+Los requests de escritura permanecen disponibles, pero un pre-request guard los
+omite mientras `allowVatMutations` no se configure explícitamente en `true`.
+
+## Validacion
+
+- Parseo JSON de la coleccion y del ambiente.
+- Inventario de metodo y ruta de todos los requests VAT.
+- Cobertura de cada ruta y metodo generados por el router de DRF.
+- Cobertura explicita de acciones personalizadas.
+- Comprobacion de que no se incluyan rutas AJAX ni rutas HTML de `VAT/urls.py`.
+- Comprobacion de variables usadas y definidas.
+- Comprobacion de que todas las escrituras tengan el guard de seguridad.
+
+## Fuera de alcance
+
+- Cambios en endpoints, serializers, permisos o reglas de negocio.
+- Ejecucion contra QA, homologacion o produccion.
+- Rutas internas de la interfaz Django.

--- a/docs/registro/cambios/2026-08-26-vat-postman-api-completa.md
+++ b/docs/registro/cambios/2026-08-26-vat-postman-api-completa.md
@@ -1,0 +1,61 @@
+# Colección Postman completa de la API VAT
+
+Fecha: 2026-08-26
+
+## Objetivo
+
+Entregar una única carpeta VAT, dentro de la colección general de SISOC, que
+represente toda la superficie pública registrada por el router de VAT.
+
+## Cambios
+
+- Se reorganizó la carpeta VAT por dominio y superficie operativa/web.
+- Se incorporaron los métodos list, retrieve, create, update, partial update y
+  destroy que cada ViewSet expone.
+- Se documentaron las acciones `activos`, `disponible`, `por_ciudadano`,
+  `buscar`, `prioritarios`, `voucher-estado` y `prevalidar`.
+- Se agregaron cuerpos de ejemplo, filtros opcionales, descripciones de
+  autenticación y advertencias para operaciones de escritura.
+- Los 85 requests que pueden modificar estado quedan bloqueados por un
+  pre-request guard hasta
+  configurar explícitamente `allowVatMutations=true`.
+- `POST /api/vat/web/inscripciones/prevalidar/` queda exceptuado del guard porque
+  sólo consulta y calcula elegibilidad; no persiste cambios.
+- Los tests de respuesta guardan los IDs tanto en el ambiente activo como en la
+  colección, para que el encadenamiento funcione al usar el ambiente Local.
+- El alta web distingue entre una `Inscripcion` y una
+  `SolicitudInscripcionPublica` y guarda cada ID en su variable correspondiente.
+- Se completaron las variables de colección y del ambiente local para los IDs
+  usados por los requests VAT.
+- Se actualizó `postman/api_inventory.md` con la cobertura y los conteos reales.
+
+## Alcance
+
+La colección incluye `/api/vat/` y `/api/vat/web/`. No incluye vistas HTML ni
+rutas AJAX internas de `VAT/urls.py`. Tampoco duplica HEAD u OPTIONS, que DRF
+deriva automáticamente de las operaciones HTTP de negocio.
+
+## Validación
+
+- JSON válido para colección y ambiente.
+- 29 registros de router analizados.
+- 147 combinaciones método/ruta esperadas y 147 presentes.
+- Sin combinaciones faltantes, extra o duplicadas.
+- Siete acciones personalizadas representadas.
+- Variables utilizadas definidas en colección o ambiente.
+- Cuerpos JSON válidos luego de sustituir variables Postman.
+- 85 operaciones con efectos potenciales protegidas por el guard de seguridad.
+- 122 scripts de encadenamiento escribiendo en el ambiente activo y la
+  colección.
+- Sin rutas AJAX ni vistas HTML internas.
+
+## Limitación contractual detectada
+
+`POST /api/vat/vouchers/` está registrado por el `ModelViewSet`, pero no es
+ejecutable con el contrato actual: `cantidad_disponible` es obligatoria en el
+modelo, de solo lectura en el serializer y el ViewSet no la inicializa. La
+colección conserva el request para representar fielmente la ruta expuesta, lo
+marca como riesgo conocido y no afirma un resultado 201.
+
+No se ejecutaron requests de escritura ni se probaron datos reales contra un
+servidor VAT.

--- a/docs/registro/prs/PR-2351.md
+++ b/docs/registro/prs/PR-2351.md
@@ -1,0 +1,53 @@
+# PR #2351 - docs(postman): cubrir la API pública completa de VAT
+
+## Metadata
+
+- PR: https://github.com/dsocial118/SISOC/pull/2351
+- Base: `development`
+- Rama origen: `codex/vat-postman-api-completa`
+- Autor: `juanikitro`
+
+## Resumen operativo
+
+- Tipo de cambio: No informado
+- Área principal: No informada
+- Contexto funcional: No informado explícitamente; revisar título, diff y documentación relacionada.
+- Resumen para changelog: No informado
+- Impacto usuario: No informado
+
+## Áreas afectadas
+
+- `docs/plans`
+- `docs/registro`
+- `postman`
+
+## Archivos relevantes del diff
+
+- `docs/plans/2026-08-26-vat-postman-api-completa-design.md`
+- `docs/registro/cambios/2026-08-26-vat-postman-api-completa.md`
+- `postman/Local.postman_environment.json`
+- `postman/SISOC APIs.postman_collection.json`
+- `postman/api_inventory.md`
+
+## Validación declarada
+
+- Pruebas automáticas: No informado en el PR.
+- Pruebas manuales: No informado en el PR.
+
+## Riesgos y rollback
+
+- No informado explícitamente en el PR.
+
+## Documentación sugerida para lectura
+
+- `docs/indice.md`
+- `docs/ia/CONTEXT_HYGIENE.md`
+- `docs/ia/ARCHITECTURE.md`
+- `docs/ia/TESTING.md`
+- `docs/plans/2026-08-26-vat-postman-api-completa-design.md`
+- `docs/registro/cambios/2026-08-26-vat-postman-api-completa.md`
+
+## Notas para continuidad
+
+- Este documento es generado automáticamente desde el contexto del PR y sirve como índice rápido para revisión y futuras sesiones de agentes.
+- Si la metadata del body del PR está incompleta, varias secciones usarán fallbacks derivados del título o del diff.

--- a/postman/Local.postman_environment.json
+++ b/postman/Local.postman_environment.json
@@ -35,7 +35,7 @@
 		{
 			"key": "centro_id",
 			"value": "1",
-			"description": "ID de un CentroFamilia o Centro VAT",
+			"description": "ID de un Centro VAT/INET (también puede usarse en otras carpetas SISOC según el request).",
 			"enabled": true
 		},
 		{
@@ -87,6 +87,12 @@
 			"enabled": true
 		},
 		{
+			"key": "allowVatMutations",
+			"value": "false",
+			"description": "Guard de seguridad del ambiente activo. Debe ser true para enviar POST, PUT, PATCH o DELETE de VAT.",
+			"enabled": true
+		},
+		{
 			"key": "provincia_id",
 			"value": "",
 			"description": "ID de una Provincia (VAT - se autocompleta con test scripts)",
@@ -96,6 +102,12 @@
 			"key": "municipio_id",
 			"value": "",
 			"description": "ID de un Municipio (VAT - se autocompleta con test scripts)",
+			"enabled": true
+		},
+		{
+			"key": "localidad_id",
+			"value": "",
+			"description": "ID de una Localidad VAT.",
 			"enabled": true
 		},
 		{
@@ -137,7 +149,19 @@
 		{
 			"key": "modalidad_id",
 			"value": "",
-			"description": "ID de una Modalidad (VAT)",
+			"description": "Variable legacy para modalidad VAT; los requests nuevos usan modalidad_cursada_id.",
+			"enabled": true
+		},
+		{
+			"key": "modalidad_institucional_id",
+			"value": "",
+			"description": "ID de una ModalidadInstitucional VAT.",
+			"enabled": true
+		},
+		{
+			"key": "modalidad_cursada_id",
+			"value": "",
+			"description": "ID de una ModalidadCursada VAT.",
 			"enabled": true
 		},
 		{
@@ -159,6 +183,90 @@
 			"enabled": true
 		},
 		{
+			"key": "institucion_contacto_id",
+			"value": "",
+			"description": "ID de un InstitucionContacto VAT.",
+			"enabled": true
+		},
+		{
+			"key": "institucion_identificador_id",
+			"value": "",
+			"description": "ID de un InstitucionIdentificadorHist VAT.",
+			"enabled": true
+		},
+		{
+			"key": "institucion_ubicacion_id",
+			"value": "",
+			"description": "ID de una InstitucionUbicacion VAT.",
+			"enabled": true
+		},
+		{
+			"key": "oferta_institucional_id",
+			"value": "",
+			"description": "ID de una OfertaInstitucional VAT.",
+			"enabled": true
+		},
+		{
+			"key": "comision_id",
+			"value": "",
+			"description": "ID de una Comision de oferta institucional VAT.",
+			"enabled": true
+		},
+		{
+			"key": "comision_horario_id",
+			"value": "",
+			"description": "ID de un ComisionHorario VAT.",
+			"enabled": true
+		},
+		{
+			"key": "inscripcion_oferta_id",
+			"value": "",
+			"description": "ID de una InscripcionOferta VAT.",
+			"enabled": true
+		},
+		{
+			"key": "inscripcion_id",
+			"value": "",
+			"description": "ID de una Inscripcion VAT general.",
+			"enabled": true
+		},
+		{
+			"key": "inscripcion_curso_id",
+			"value": "",
+			"description": "ID de una Inscripcion expuesta por /inscripciones-curso/.",
+			"enabled": true
+		},
+		{
+			"key": "solicitud_inscripcion_id",
+			"value": "",
+			"description": "ID de una SolicitudInscripcionPublica devuelta por el alta web cuando no se crea una inscripción directa.",
+			"enabled": true
+		},
+		{
+			"key": "evaluacion_id",
+			"value": "",
+			"description": "ID de una Evaluacion VAT.",
+			"enabled": true
+		},
+		{
+			"key": "resultado_evaluacion_id",
+			"value": "",
+			"description": "ID de un ResultadoEvaluacion VAT.",
+			"enabled": true
+		},
+		{
+			"key": "usuario_id",
+			"value": "",
+			"description": "ID del usuario que registra un resultado de evaluación.",
+			"enabled": true
+		},
+		{
+			"key": "dia_semana_id",
+			"value": "",
+			"description": "ID de un Día usado en horarios de comisión.",
+			"enabled": true
+		},
+		{
 			"key": "documento",
 			"value": "",
 			"description": "Numero de DNI de un ciudadano (VAT Web)",
@@ -173,7 +281,7 @@
 		{
 			"key": "estado_curso",
 			"value": "activo",
-			"description": "Estado de curso para filtros VAT (activo / inactivo)",
+			"description": "Estado de curso VAT: planificado, activo, finalizado o cancelado.",
 			"enabled": true
 		},
 		{

--- a/postman/SISOC APIs.postman_collection.json
+++ b/postman/SISOC APIs.postman_collection.json
@@ -26,7 +26,7 @@
     {
       "key": "centro_id",
       "value": "1",
-      "description": "ID de un CentroFamilia"
+      "description": "ID de un Centro VAT/INET (también puede usarse en otras carpetas SISOC según el request)."
     },
     {
       "key": "actividad_id",
@@ -121,6 +121,11 @@
       "description": "URL base del servidor VAT operativo (puede ser distinto de SISOC)"
     },
     {
+      "key": "allowVatMutations",
+      "value": "false",
+      "description": "Guard de seguridad del ambiente activo. Debe ser true para enviar POST, PUT, PATCH o DELETE de VAT."
+    },
+    {
       "key": "provincia_id",
       "value": "",
       "description": "ID de una Provincia (VAT)"
@@ -129,6 +134,11 @@
       "key": "municipio_id",
       "value": "",
       "description": "ID de un Municipio (VAT)"
+    },
+    {
+      "key": "localidad_id",
+      "value": "",
+      "description": "ID de una Localidad VAT."
     },
     {
       "key": "plan_id",
@@ -163,7 +173,17 @@
     {
       "key": "modalidad_id",
       "value": "",
-      "description": "ID de una Modalidad (VAT)"
+      "description": "Variable legacy para modalidad VAT; los requests nuevos usan modalidad_cursada_id."
+    },
+    {
+      "key": "modalidad_institucional_id",
+      "value": "",
+      "description": "ID de una ModalidadInstitucional VAT."
+    },
+    {
+      "key": "modalidad_cursada_id",
+      "value": "",
+      "description": "ID de una ModalidadCursada VAT."
     },
     {
       "key": "programa_id",
@@ -181,6 +201,76 @@
       "description": "ID de un Voucher (VAT)"
     },
     {
+      "key": "institucion_contacto_id",
+      "value": "",
+      "description": "ID de un InstitucionContacto VAT."
+    },
+    {
+      "key": "institucion_identificador_id",
+      "value": "",
+      "description": "ID de un InstitucionIdentificadorHist VAT."
+    },
+    {
+      "key": "institucion_ubicacion_id",
+      "value": "",
+      "description": "ID de una InstitucionUbicacion VAT."
+    },
+    {
+      "key": "oferta_institucional_id",
+      "value": "",
+      "description": "ID de una OfertaInstitucional VAT."
+    },
+    {
+      "key": "comision_id",
+      "value": "",
+      "description": "ID de una Comision de oferta institucional VAT."
+    },
+    {
+      "key": "comision_horario_id",
+      "value": "",
+      "description": "ID de un ComisionHorario VAT."
+    },
+    {
+      "key": "inscripcion_oferta_id",
+      "value": "",
+      "description": "ID de una InscripcionOferta VAT."
+    },
+    {
+      "key": "inscripcion_id",
+      "value": "",
+      "description": "ID de una Inscripcion VAT general."
+    },
+    {
+      "key": "inscripcion_curso_id",
+      "value": "",
+      "description": "ID de una Inscripcion expuesta por /inscripciones-curso/."
+    },
+    {
+      "key": "solicitud_inscripcion_id",
+      "value": "",
+      "description": "ID de una SolicitudInscripcionPublica devuelta por el alta web cuando no se crea una inscripción directa."
+    },
+    {
+      "key": "evaluacion_id",
+      "value": "",
+      "description": "ID de una Evaluacion VAT."
+    },
+    {
+      "key": "resultado_evaluacion_id",
+      "value": "",
+      "description": "ID de un ResultadoEvaluacion VAT."
+    },
+    {
+      "key": "usuario_id",
+      "value": "",
+      "description": "ID del usuario que registra un resultado de evaluación."
+    },
+    {
+      "key": "dia_semana_id",
+      "value": "",
+      "description": "ID de un Día usado en horarios de comisión."
+    },
+    {
       "key": "documento",
       "value": "",
       "description": "Numero de DNI de un ciudadano (VAT Web)"
@@ -193,7 +283,7 @@
     {
       "key": "estado_curso",
       "value": "activo",
-      "description": "Estado de curso para filtros VAT"
+      "description": "Estado de curso VAT: planificado, activo, finalizado o cancelado."
     },
     {
       "key": "estado_inscripcion",
@@ -3451,15 +3541,20 @@
     },
     {
       "name": "VAT",
-      "description": "API del modulo VAT (Voucher de Apoyo a la Terminalidad).\n\n- **Operativo:** endpoints protegidos con Api-Key para integraciones server-to-server (usa ).\n- **Web:** endpoints para Mi Argentina y portales externos, sobre el servidor SISOC (usa ).\n\n**Auth:** header .",
+      "description": "Colección completa de la API pública VAT/INET registrada en `VAT/api_urls.py`.\n\n- API operativa: `{{vatBaseUrl}}{{apiPrefix}}/vat/`, autenticada con `Authorization: Api-Key {{apiKey}}`.\n- API web: `{{baseUrl}}{{apiPrefix}}/vat/web/`, acepta Api-Key o token; los ejemplos usan Api-Key.\n- Incluye todos los métodos de negocio registrados por los ViewSets: GET, POST, PUT, PATCH y DELETE según corresponda, más las acciones custom.\n- HEAD y OPTIONS, derivados automáticamente por HTTP/DRF, no se duplican como requests de negocio.\n- Las escrituras incluyen un pre-request guard y se omiten mientras `allowVatMutations` no sea `true` en el ambiente activo. Verifique ambiente, IDs, permisos y efectos antes de habilitarlas.\n- `programa_id`, `ciudadano_id`, `usuario_id` y `dia_semana_id` son precondiciones externas al router VAT y deben configurarse con IDs válidos del ambiente.\n- Se excluyen deliberadamente las vistas HTML y rutas AJAX internas de `VAT/urls.py`.",
       "item": [
         {
-          "name": "Operativo - Planes, Centros, Cursos, Comisiones",
-          "description": "Coleccion para consultar la API operativa de VAT con el flujo: planes curriculares, centros, cursos por centro y comisiones de curso por curso. Usa endpoints protegidos con API key.",
+          "name": "0 - Guía de uso y autenticación",
+          "description": "Configuración previa:\n\n1. Importe `Local.postman_environment.json` y seleccione el ambiente Local.\n2. Configure `apiKey` sin incluir el prefijo; los requests envían `Authorization: Api-Key {{apiKey}}`.\n3. Ajuste `vatBaseUrl` para la API operativa y `baseUrl` para la API web. Pueden apuntar al mismo servidor.\n4. Ejecute primero los listados para capturar IDs disponibles. Los tests guardan IDs tanto en el ambiente activo como en las variables de colección.\n5. Configure manualmente `programa_id`, `ciudadano_id`, `usuario_id` y `dia_semana_id`, porque el router VAT no ofrece catálogos para esas entidades.\n6. POST, PUT, PATCH y DELETE están bloqueados por defecto. Sólo para una ejecución controlada, cambie `allowVatMutations` a `true` en el ambiente Local activo y vuelva a dejarlo en `false` al terminar. No ejecute escrituras exploratorias en producción.\n\nLa API web también acepta token de usuario; para probarlo, reemplace el valor del header Authorization por `Token {{authToken}}` en el request correspondiente.",
+          "item": []
+        },
+        {
+          "name": "1 - API operativa - Geografía",
+          "description": "Catálogos geográficos de solo lectura.",
           "item": [
             {
-              "name": "0 - Ubicacion",
-              "description": "Requests auxiliares para obtener provincia y municipio antes de filtrar centros.",
+              "name": "Provincias",
+              "description": "Catálogo geográfico de provincias.\n\nEndpoint de solo lectura. Autenticación: Authorization: Api-Key <clave>.",
               "item": [
                 {
                   "name": "Listar provincias",
@@ -3469,7 +3564,8 @@
                       {
                         "key": "Authorization",
                         "value": "Api-Key {{apiKey}}",
-                        "type": "text"
+                        "type": "text",
+                        "description": "API key VAT. En los endpoints web también puede reemplazarse por Token <token>."
                       }
                     ],
                     "url": {
@@ -3481,8 +3577,23 @@
                         "vat",
                         "provincias",
                         ""
+                      ],
+                      "query": [
+                        {
+                          "key": "page",
+                          "value": "1",
+                          "description": "Número de página.",
+                          "disabled": true
+                        },
+                        {
+                          "key": "page_size",
+                          "value": "20",
+                          "description": "Cantidad de resultados por página (máximo 200).",
+                          "disabled": true
+                        }
                       ]
-                    }
+                    },
+                    "description": "Catálogo geográfico de provincias.\n\nEndpoint de solo lectura. Autenticación: Authorization: Api-Key <clave>.\n\nLos filtros opcionales están cargados y deshabilitados."
                   },
                   "event": [
                     {
@@ -3490,13 +3601,14 @@
                       "script": {
                         "type": "text/javascript",
                         "exec": [
-                          "pm.test('Status code is 200', function () {",
-                          "  pm.response.to.have.status(200);",
-                          "});",
+                          "pm.test('Status code 200', function () { pm.response.to.have.status(200); });",
                           "const body = pm.response.json();",
                           "const rows = Array.isArray(body) ? body : (body.results || []);",
-                          "if (rows.length && rows[0].id) {",
-                          "  pm.collectionVariables.set('provincia_id', String(rows[0].id));",
+                          "pm.test('La respuesta contiene una lista', function () { pm.expect(Array.isArray(rows)).to.eql(true); });",
+                          "if (rows.length && rows[0].id !== undefined) {",
+                          "  const value = String(rows[0].id);",
+                          "  pm.collectionVariables.set('provincia_id', value);",
+                          "  if (pm.environment && pm.environment.name) { pm.environment.set('provincia_id', value); }",
                           "}"
                         ]
                       }
@@ -3505,18 +3617,70 @@
                   "response": []
                 },
                 {
-                  "name": "Listar municipios por provincia_id",
+                  "name": "Obtener provincia por ID",
                   "request": {
                     "method": "GET",
                     "header": [
                       {
                         "key": "Authorization",
                         "value": "Api-Key {{apiKey}}",
-                        "type": "text"
+                        "type": "text",
+                        "description": "API key VAT. En los endpoints web también puede reemplazarse por Token <token>."
                       }
                     ],
                     "url": {
-                      "raw": "{{vatBaseUrl}}{{apiPrefix}}/vat/municipios/?provincia_id={{provincia_id}}",
+                      "raw": "{{vatBaseUrl}}{{apiPrefix}}/vat/provincias/{{provincia_id}}/",
+                      "host": [
+                        "{{vatBaseUrl}}{{apiPrefix}}"
+                      ],
+                      "path": [
+                        "vat",
+                        "provincias",
+                        "{{provincia_id}}",
+                        ""
+                      ]
+                    },
+                    "description": "Catálogo geográfico de provincias.\n\nEndpoint de solo lectura. Autenticación: Authorization: Api-Key <clave>."
+                  },
+                  "event": [
+                    {
+                      "listen": "test",
+                      "script": {
+                        "type": "text/javascript",
+                        "exec": [
+                          "pm.test('Status code 200', function () { pm.response.to.have.status(200); });",
+                          "const body = pm.response.json();",
+                          "if (body.id !== undefined) {",
+                          "  const value = String(body.id);",
+                          "  pm.collectionVariables.set('provincia_id', value);",
+                          "  if (pm.environment && pm.environment.name) { pm.environment.set('provincia_id', value); }",
+                          "}"
+                        ]
+                      }
+                    }
+                  ],
+                  "response": []
+                }
+              ]
+            },
+            {
+              "name": "Municipios",
+              "description": "Catálogo geográfico de municipios.\n\nEndpoint de solo lectura. Autenticación: Authorization: Api-Key <clave>.",
+              "item": [
+                {
+                  "name": "Listar municipios",
+                  "request": {
+                    "method": "GET",
+                    "header": [
+                      {
+                        "key": "Authorization",
+                        "value": "Api-Key {{apiKey}}",
+                        "type": "text",
+                        "description": "API key VAT. En los endpoints web también puede reemplazarse por Token <token>."
+                      }
+                    ],
+                    "url": {
+                      "raw": "{{vatBaseUrl}}{{apiPrefix}}/vat/municipios/",
                       "host": [
                         "{{vatBaseUrl}}{{apiPrefix}}"
                       ],
@@ -3528,323 +3692,25 @@
                       "query": [
                         {
                           "key": "provincia_id",
-                          "value": "{{provincia_id}}"
-                        }
-                      ]
-                    }
-                  },
-                  "event": [
-                    {
-                      "listen": "test",
-                      "script": {
-                        "type": "text/javascript",
-                        "exec": [
-                          "pm.test('Status code is 200', function () {",
-                          "  pm.response.to.have.status(200);",
-                          "});",
-                          "const body = pm.response.json();",
-                          "const rows = Array.isArray(body) ? body : (body.results || []);",
-                          "if (rows.length && rows[0].id) {",
-                          "  pm.collectionVariables.set('municipio_id', String(rows[0].id));",
-                          "}"
-                        ]
-                      }
-                    }
-                  ],
-                  "response": []
-                }
-              ]
-            },
-            {
-              "name": "1 - Inicio Operativo",
-              "description": "Request inicial para validar API key y disponibilidad de un endpoint operativo antes de encadenar el resto del flujo.",
-              "item": [
-                {
-                  "name": "Validar autenticacion con planes curriculares",
-                  "request": {
-                    "method": "GET",
-                    "header": [
-                      {
-                        "key": "Authorization",
-                        "value": "Api-Key {{apiKey}}",
-                        "type": "text"
-                      }
-                    ],
-                    "url": {
-                      "raw": "{{vatBaseUrl}}{{apiPrefix}}/vat/planes-curriculares/?activo=true",
-                      "host": [
-                        "{{vatBaseUrl}}{{apiPrefix}}"
-                      ],
-                      "path": [
-                        "vat",
-                        "planes-curriculares",
-                        ""
-                      ],
-                      "query": [
-                        {
-                          "key": "activo",
-                          "value": "true"
-                        }
-                      ]
-                    }
-                  },
-                  "event": [
-                    {
-                      "listen": "test",
-                      "script": {
-                        "type": "text/javascript",
-                        "exec": [
-                          "pm.test('Status code is 200', function () {",
-                          "  pm.response.to.have.status(200);",
-                          "});"
-                        ]
-                      }
-                    }
-                  ],
-                  "response": []
-                }
-              ]
-            },
-            {
-              "name": "2 - Planes Curriculares",
-              "description": "Obtiene planes curriculares operativos. Guarda plan_id y sector_id con el primer registro devuelto.",
-              "item": [
-                {
-                  "name": "Listar planes curriculares activos",
-                  "request": {
-                    "method": "GET",
-                    "header": [
-                      {
-                        "key": "Authorization",
-                        "value": "Api-Key {{apiKey}}",
-                        "type": "text"
-                      }
-                    ],
-                    "url": {
-                      "raw": "{{vatBaseUrl}}{{apiPrefix}}/vat/planes-curriculares/?activo=true",
-                      "host": [
-                        "{{vatBaseUrl}}{{apiPrefix}}"
-                      ],
-                      "path": [
-                        "vat",
-                        "planes-curriculares",
-                        ""
-                      ],
-                      "query": [
-                        {
-                          "key": "activo",
-                          "value": "true"
-                        }
-                      ]
-                    }
-                  },
-                  "event": [
-                    {
-                      "listen": "test",
-                      "script": {
-                        "type": "text/javascript",
-                        "exec": [
-                          "pm.test('Status code is 200', function () {",
-                          "  pm.response.to.have.status(200);",
-                          "});",
-                          "const body = pm.response.json();",
-                          "const rows = Array.isArray(body) ? body : (body.results || []);",
-                          "pm.test('La respuesta contiene una lista', function () {",
-                          "  pm.expect(Array.isArray(rows)).to.eql(true);",
-                          "});",
-                          "if (rows.length && rows[0].id) {",
-                          "  pm.collectionVariables.set('plan_id', String(rows[0].id));",
-                          "}",
-                          "if (rows.length && rows[0].sector) {",
-                          "  pm.collectionVariables.set('sector_id', String(rows[0].sector));",
-                          "}"
-                        ]
-                      }
-                    }
-                  ],
-                  "response": []
-                },
-                {
-                  "name": "Listar planes curriculares por sector_id",
-                  "request": {
-                    "method": "GET",
-                    "header": [
-                      {
-                        "key": "Authorization",
-                        "value": "Api-Key {{apiKey}}",
-                        "type": "text"
-                      }
-                    ],
-                    "url": {
-                      "raw": "{{vatBaseUrl}}{{apiPrefix}}/vat/planes-curriculares/?activo=true&sector_id={{sector_id}}",
-                      "host": [
-                        "{{vatBaseUrl}}{{apiPrefix}}"
-                      ],
-                      "path": [
-                        "vat",
-                        "planes-curriculares",
-                        ""
-                      ],
-                      "query": [
-                        {
-                          "key": "activo",
-                          "value": "true"
-                        },
-                        {
-                          "key": "sector_id",
-                          "value": "{{sector_id}}"
-                        }
-                      ]
-                    }
-                  },
-                  "response": []
-                }
-              ]
-            },
-            {
-              "name": "3 - Centros",
-              "description": "Obtiene centros operativos. Guarda centro_id con el primer registro devuelto. La respuesta es paginada: `count` informa el total, `results` contiene la pagina actual y `next`/`previous` permiten navegar.",
-              "item": [
-                {
-                  "name": "Listar centros activos",
-                  "request": {
-                    "method": "GET",
-                    "header": [
-                      {
-                        "key": "Authorization",
-                        "value": "Api-Key {{apiKey}}",
-                        "type": "text"
-                      }
-                    ],
-                    "url": {
-                      "raw": "{{vatBaseUrl}}{{apiPrefix}}/vat/centros/?activo=true",
-                      "host": [
-                        "{{vatBaseUrl}}{{apiPrefix}}"
-                      ],
-                      "path": [
-                        "vat",
-                        "centros",
-                        ""
-                      ],
-                      "query": [
-                        {
-                          "key": "activo",
-                          "value": "true"
-                        }
-                      ]
-                    }
-                  },
-                  "event": [
-                    {
-                      "listen": "test",
-                      "script": {
-                        "type": "text/javascript",
-                        "exec": [
-                          "pm.test('Status code is 200', function () {",
-                          "  pm.response.to.have.status(200);",
-                          "});",
-                          "const body = pm.response.json();",
-                          "const rows = Array.isArray(body) ? body : (body.results || []);",
-                          "pm.test('La respuesta contiene una lista', function () {",
-                          "  pm.expect(Array.isArray(rows)).to.eql(true);",
-                          "});",
-                          "if (rows.length && rows[0].id) {",
-                          "  pm.collectionVariables.set('centro_id', String(rows[0].id));",
-                          "}"
-                        ]
-                      }
-                    }
-                  ],
-                  "response": []
-                },
-                {
-                  "name": "Ejemplo paginacion centros activos - page=2",
-                  "request": {
-                    "method": "GET",
-                    "header": [
-                      {
-                        "key": "Authorization",
-                        "value": "Api-Key {{apiKey}}",
-                        "type": "text"
-                      }
-                    ],
-                    "url": {
-                      "raw": "{{vatBaseUrl}}{{apiPrefix}}/vat/centros/?activo=true&page=2",
-                      "host": [
-                        "{{vatBaseUrl}}{{apiPrefix}}"
-                      ],
-                      "path": [
-                        "vat",
-                        "centros",
-                        ""
-                      ],
-                      "query": [
-                        {
-                          "key": "activo",
-                          "value": "true"
+                          "value": "{{provincia_id}}",
+                          "description": "Filtra por provincia.",
+                          "disabled": true
                         },
                         {
                           "key": "page",
-                          "value": "2"
-                        }
-                      ]
-                    },
-                    "description": "Ejemplo para inspeccionar la segunda pagina del padron de centros. Sirve para verificar que `count` refleja el total y que `results` devuelve solo la pagina actual."
-                  },
-                  "event": [
-                    {
-                      "listen": "test",
-                      "script": {
-                        "type": "text/javascript",
-                        "exec": [
-                          "pm.test('Status code is 200', function () {",
-                          "  pm.response.to.have.status(200);",
-                          "});",
-                          "const body = pm.response.json();",
-                          "pm.test('La respuesta paginada contiene count y results', function () {",
-                          "  pm.expect(body).to.have.property('count');",
-                          "  pm.expect(body).to.have.property('results');",
-                          "  pm.expect(Array.isArray(body.results)).to.eql(true);",
-                          "});"
-                        ]
-                      }
-                    }
-                  ],
-                  "response": []
-                },
-                {
-                  "name": "Ejemplo paginacion centros activos - page=3",
-                  "request": {
-                    "method": "GET",
-                    "header": [
-                      {
-                        "key": "Authorization",
-                        "value": "Api-Key {{apiKey}}",
-                        "type": "text"
-                      }
-                    ],
-                    "url": {
-                      "raw": "{{vatBaseUrl}}{{apiPrefix}}/vat/centros/?activo=true&page=3",
-                      "host": [
-                        "{{vatBaseUrl}}{{apiPrefix}}"
-                      ],
-                      "path": [
-                        "vat",
-                        "centros",
-                        ""
-                      ],
-                      "query": [
-                        {
-                          "key": "activo",
-                          "value": "true"
+                          "value": "1",
+                          "description": "Número de página.",
+                          "disabled": true
                         },
                         {
-                          "key": "page",
-                          "value": "3"
+                          "key": "page_size",
+                          "value": "20",
+                          "description": "Cantidad de resultados por página (máximo 200).",
+                          "disabled": true
                         }
                       ]
                     },
-                    "description": "Ejemplo para recorrer una pagina adicional del listado y validar navegacion paginada sobre el padron completo de centros."
+                    "description": "Catálogo geográfico de municipios.\n\nEndpoint de solo lectura. Autenticación: Authorization: Api-Key <clave>.\n\nLos filtros opcionales están cargados y deshabilitados."
                   },
                   "event": [
                     {
@@ -3852,15 +3718,15 @@
                       "script": {
                         "type": "text/javascript",
                         "exec": [
-                          "pm.test('Status code is 200', function () {",
-                          "  pm.response.to.have.status(200);",
-                          "});",
+                          "pm.test('Status code 200', function () { pm.response.to.have.status(200); });",
                           "const body = pm.response.json();",
-                          "pm.test('La respuesta paginada contiene previous y results', function () {",
-                          "  pm.expect(body).to.have.property('results');",
-                          "  pm.expect(Array.isArray(body.results)).to.eql(true);",
-                          "  pm.expect(body).to.have.property('previous');",
-                          "});"
+                          "const rows = Array.isArray(body) ? body : (body.results || []);",
+                          "pm.test('La respuesta contiene una lista', function () { pm.expect(Array.isArray(rows)).to.eql(true); });",
+                          "if (rows.length && rows[0].id !== undefined) {",
+                          "  const value = String(rows[0].id);",
+                          "  pm.collectionVariables.set('municipio_id', value);",
+                          "  if (pm.environment && pm.environment.name) { pm.environment.set('municipio_id', value); }",
+                          "}"
                         ]
                       }
                     }
@@ -3868,41 +3734,106 @@
                   "response": []
                 },
                 {
-                  "name": "Listar centros por provincia_id y municipio_id",
+                  "name": "Obtener municipio por ID",
                   "request": {
                     "method": "GET",
                     "header": [
                       {
                         "key": "Authorization",
                         "value": "Api-Key {{apiKey}}",
-                        "type": "text"
+                        "type": "text",
+                        "description": "API key VAT. En los endpoints web también puede reemplazarse por Token <token>."
                       }
                     ],
                     "url": {
-                      "raw": "{{vatBaseUrl}}{{apiPrefix}}/vat/centros/?activo=true&provincia_id={{provincia_id}}&municipio_id={{municipio_id}}",
+                      "raw": "{{vatBaseUrl}}{{apiPrefix}}/vat/municipios/{{municipio_id}}/",
                       "host": [
                         "{{vatBaseUrl}}{{apiPrefix}}"
                       ],
                       "path": [
                         "vat",
-                        "centros",
+                        "municipios",
+                        "{{municipio_id}}",
+                        ""
+                      ]
+                    },
+                    "description": "Catálogo geográfico de municipios.\n\nEndpoint de solo lectura. Autenticación: Authorization: Api-Key <clave>."
+                  },
+                  "event": [
+                    {
+                      "listen": "test",
+                      "script": {
+                        "type": "text/javascript",
+                        "exec": [
+                          "pm.test('Status code 200', function () { pm.response.to.have.status(200); });",
+                          "const body = pm.response.json();",
+                          "if (body.id !== undefined) {",
+                          "  const value = String(body.id);",
+                          "  pm.collectionVariables.set('municipio_id', value);",
+                          "  if (pm.environment && pm.environment.name) { pm.environment.set('municipio_id', value); }",
+                          "}"
+                        ]
+                      }
+                    }
+                  ],
+                  "response": []
+                }
+              ]
+            },
+            {
+              "name": "Localidades",
+              "description": "Catálogo geográfico de localidades.\n\nEndpoint de solo lectura. Autenticación: Authorization: Api-Key <clave>.",
+              "item": [
+                {
+                  "name": "Listar localidades",
+                  "request": {
+                    "method": "GET",
+                    "header": [
+                      {
+                        "key": "Authorization",
+                        "value": "Api-Key {{apiKey}}",
+                        "type": "text",
+                        "description": "API key VAT. En los endpoints web también puede reemplazarse por Token <token>."
+                      }
+                    ],
+                    "url": {
+                      "raw": "{{vatBaseUrl}}{{apiPrefix}}/vat/localidades/",
+                      "host": [
+                        "{{vatBaseUrl}}{{apiPrefix}}"
+                      ],
+                      "path": [
+                        "vat",
+                        "localidades",
                         ""
                       ],
                       "query": [
                         {
-                          "key": "activo",
-                          "value": "true"
+                          "key": "municipio_id",
+                          "value": "{{municipio_id}}",
+                          "description": "Filtra por municipio.",
+                          "disabled": true
                         },
                         {
                           "key": "provincia_id",
-                          "value": "{{provincia_id}}"
+                          "value": "{{provincia_id}}",
+                          "description": "Filtra por provincia.",
+                          "disabled": true
                         },
                         {
-                          "key": "municipio_id",
-                          "value": "{{municipio_id}}"
+                          "key": "page",
+                          "value": "1",
+                          "description": "Número de página.",
+                          "disabled": true
+                        },
+                        {
+                          "key": "page_size",
+                          "value": "20",
+                          "description": "Cantidad de resultados por página (máximo 200).",
+                          "disabled": true
                         }
                       ]
-                    }
+                    },
+                    "description": "Catálogo geográfico de localidades.\n\nEndpoint de solo lectura. Autenticación: Authorization: Api-Key <clave>.\n\nLos filtros opcionales están cargados y deshabilitados."
                   },
                   "event": [
                     {
@@ -3910,13 +3841,514 @@
                       "script": {
                         "type": "text/javascript",
                         "exec": [
-                          "pm.test('Status code is 200', function () {",
-                          "  pm.response.to.have.status(200);",
-                          "});",
+                          "pm.test('Status code 200', function () { pm.response.to.have.status(200); });",
                           "const body = pm.response.json();",
                           "const rows = Array.isArray(body) ? body : (body.results || []);",
-                          "if (rows.length && rows[0].id) {",
-                          "  pm.collectionVariables.set('centro_id', String(rows[0].id));",
+                          "pm.test('La respuesta contiene una lista', function () { pm.expect(Array.isArray(rows)).to.eql(true); });",
+                          "if (rows.length && rows[0].id !== undefined) {",
+                          "  const value = String(rows[0].id);",
+                          "  pm.collectionVariables.set('localidad_id', value);",
+                          "  if (pm.environment && pm.environment.name) { pm.environment.set('localidad_id', value); }",
+                          "}"
+                        ]
+                      }
+                    }
+                  ],
+                  "response": []
+                },
+                {
+                  "name": "Obtener localidad por ID",
+                  "request": {
+                    "method": "GET",
+                    "header": [
+                      {
+                        "key": "Authorization",
+                        "value": "Api-Key {{apiKey}}",
+                        "type": "text",
+                        "description": "API key VAT. En los endpoints web también puede reemplazarse por Token <token>."
+                      }
+                    ],
+                    "url": {
+                      "raw": "{{vatBaseUrl}}{{apiPrefix}}/vat/localidades/{{localidad_id}}/",
+                      "host": [
+                        "{{vatBaseUrl}}{{apiPrefix}}"
+                      ],
+                      "path": [
+                        "vat",
+                        "localidades",
+                        "{{localidad_id}}",
+                        ""
+                      ]
+                    },
+                    "description": "Catálogo geográfico de localidades.\n\nEndpoint de solo lectura. Autenticación: Authorization: Api-Key <clave>."
+                  },
+                  "event": [
+                    {
+                      "listen": "test",
+                      "script": {
+                        "type": "text/javascript",
+                        "exec": [
+                          "pm.test('Status code 200', function () { pm.response.to.have.status(200); });",
+                          "const body = pm.response.json();",
+                          "if (body.id !== undefined) {",
+                          "  const value = String(body.id);",
+                          "  pm.collectionVariables.set('localidad_id', value);",
+                          "  if (pm.environment && pm.environment.name) { pm.environment.set('localidad_id', value); }",
+                          "}"
+                        ]
+                      }
+                    }
+                  ],
+                  "response": []
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "name": "2 - API operativa - Centros e institución",
+          "description": "Centros y datos institucionales relacionados.",
+          "item": [
+            {
+              "name": "Centros",
+              "description": "Centros de formación VAT/INET y su información institucional básica.\n\nAutenticación: Authorization: Api-Key <clave>.\n\nEste ViewSet expone list, retrieve, create, update, partial_update y destroy.",
+              "item": [
+                {
+                  "name": "Listar centros",
+                  "request": {
+                    "method": "GET",
+                    "header": [
+                      {
+                        "key": "Authorization",
+                        "value": "Api-Key {{apiKey}}",
+                        "type": "text",
+                        "description": "API key VAT. En los endpoints web también puede reemplazarse por Token <token>."
+                      }
+                    ],
+                    "url": {
+                      "raw": "{{vatBaseUrl}}{{apiPrefix}}/vat/centros/",
+                      "host": [
+                        "{{vatBaseUrl}}{{apiPrefix}}"
+                      ],
+                      "path": [
+                        "vat",
+                        "centros",
+                        ""
+                      ],
+                      "query": [
+                        {
+                          "key": "activo",
+                          "value": "true",
+                          "description": "Filtra centros activos o inactivos.",
+                          "disabled": true
+                        },
+                        {
+                          "key": "provincia_id",
+                          "value": "{{provincia_id}}",
+                          "description": "Filtra por provincia.",
+                          "disabled": true
+                        },
+                        {
+                          "key": "municipio_id",
+                          "value": "{{municipio_id}}",
+                          "description": "Filtra por municipio.",
+                          "disabled": true
+                        },
+                        {
+                          "key": "localidad_id",
+                          "value": "{{localidad_id}}",
+                          "description": "Filtra por localidad.",
+                          "disabled": true
+                        },
+                        {
+                          "key": "page",
+                          "value": "1",
+                          "description": "Número de página.",
+                          "disabled": true
+                        },
+                        {
+                          "key": "page_size",
+                          "value": "20",
+                          "description": "Cantidad de resultados por página (máximo 200).",
+                          "disabled": true
+                        }
+                      ]
+                    },
+                    "description": "Centros de formación VAT/INET y su información institucional básica.\n\nAutenticación: Authorization: Api-Key <clave>.\n\nLos filtros opcionales están cargados y deshabilitados para activarlos según el caso."
+                  },
+                  "event": [
+                    {
+                      "listen": "test",
+                      "script": {
+                        "type": "text/javascript",
+                        "exec": [
+                          "pm.test('Status code 200', function () { pm.response.to.have.status(200); });",
+                          "const body = pm.response.json();",
+                          "const rows = Array.isArray(body) ? body : (body.results || []);",
+                          "pm.test('La respuesta contiene una lista', function () { pm.expect(Array.isArray(rows)).to.eql(true); });",
+                          "if (rows.length && rows[0].id !== undefined) {",
+                          "  const value = String(rows[0].id);",
+                          "  pm.collectionVariables.set('centro_id', value);",
+                          "  if (pm.environment && pm.environment.name) { pm.environment.set('centro_id', value); }",
+                          "}"
+                        ]
+                      }
+                    }
+                  ],
+                  "response": []
+                },
+                {
+                  "name": "Crear centro",
+                  "request": {
+                    "method": "POST",
+                    "header": [
+                      {
+                        "key": "Authorization",
+                        "value": "Api-Key {{apiKey}}",
+                        "type": "text",
+                        "description": "API key VAT. En los endpoints web también puede reemplazarse por Token <token>."
+                      },
+                      {
+                        "key": "Content-Type",
+                        "value": "application/json",
+                        "type": "text"
+                      }
+                    ],
+                    "body": {
+                      "mode": "raw",
+                      "raw": "{\n  \"nombre\": \"Centro INET de ejemplo\",\n  \"referente\": null,\n  \"referentes\": [],\n  \"codigo\": \"INET-{{$randomInt}}\",\n  \"activo\": true,\n  \"provincia\": {{provincia_id}},\n  \"municipio\": {{municipio_id}},\n  \"localidad\": {{localidad_id}},\n  \"domicilio_actividad\": \"Av. Ejemplo 123\",\n  \"telefono\": \"+54 11 4000-0000\",\n  \"celular\": \"+54 9 11 5000-0000\",\n  \"correo\": \"centro.inet@example.org\",\n  \"nombre_referente\": \"Nombre\",\n  \"apellido_referente\": \"Apellido\",\n  \"tipo_gestion\": \"Estatal\",\n  \"clase_institucion\": \"CFP\",\n  \"situacion\": \"Activa\"\n}",
+                      "options": {
+                        "raw": {
+                          "language": "json"
+                        }
+                      }
+                    },
+                    "url": {
+                      "raw": "{{vatBaseUrl}}{{apiPrefix}}/vat/centros/",
+                      "host": [
+                        "{{vatBaseUrl}}{{apiPrefix}}"
+                      ],
+                      "path": [
+                        "vat",
+                        "centros",
+                        ""
+                      ]
+                    },
+                    "description": "Centros de formación VAT/INET y su información institucional básica.\n\nAutenticación: Authorization: Api-Key <clave>.\n\nOperación de escritura bloqueada por defecto. Para enviarla debe configurar explícitamente `allowVatMutations=true` en el ambiente activo; verifique los identificadores y el ambiente y no la ejecute contra producción como prueba exploratoria."
+                  },
+                  "event": [
+                    {
+                      "listen": "prerequest",
+                      "script": {
+                        "type": "text/javascript",
+                        "exec": [
+                          "const allowMutations = String(pm.variables.get('allowVatMutations') || '').toLowerCase() === 'true';",
+                          "if (!allowMutations) {",
+                          "  console.warn('Request VAT de escritura omitido. Configure allowVatMutations=true sólo para una ejecución controlada.');",
+                          "  pm.execution.skipRequest();",
+                          "}"
+                        ]
+                      }
+                    },
+                    {
+                      "listen": "test",
+                      "script": {
+                        "type": "text/javascript",
+                        "exec": [
+                          "pm.test('Status code 201', function () { pm.response.to.have.status(201); });",
+                          "const body = pm.response.json();",
+                          "if (body.id !== undefined) {",
+                          "  const value = String(body.id);",
+                          "  pm.collectionVariables.set('centro_id', value);",
+                          "  if (pm.environment && pm.environment.name) { pm.environment.set('centro_id', value); }",
+                          "}"
+                        ]
+                      }
+                    }
+                  ],
+                  "response": []
+                },
+                {
+                  "name": "Obtener centro por ID",
+                  "request": {
+                    "method": "GET",
+                    "header": [
+                      {
+                        "key": "Authorization",
+                        "value": "Api-Key {{apiKey}}",
+                        "type": "text",
+                        "description": "API key VAT. En los endpoints web también puede reemplazarse por Token <token>."
+                      }
+                    ],
+                    "url": {
+                      "raw": "{{vatBaseUrl}}{{apiPrefix}}/vat/centros/{{centro_id}}/",
+                      "host": [
+                        "{{vatBaseUrl}}{{apiPrefix}}"
+                      ],
+                      "path": [
+                        "vat",
+                        "centros",
+                        "{{centro_id}}",
+                        ""
+                      ]
+                    },
+                    "description": "Centros de formación VAT/INET y su información institucional básica.\n\nAutenticación: Authorization: Api-Key <clave>."
+                  },
+                  "event": [
+                    {
+                      "listen": "test",
+                      "script": {
+                        "type": "text/javascript",
+                        "exec": [
+                          "pm.test('Status code 200', function () { pm.response.to.have.status(200); });",
+                          "const body = pm.response.json();",
+                          "if (body.id !== undefined) {",
+                          "  const value = String(body.id);",
+                          "  pm.collectionVariables.set('centro_id', value);",
+                          "  if (pm.environment && pm.environment.name) { pm.environment.set('centro_id', value); }",
+                          "}"
+                        ]
+                      }
+                    }
+                  ],
+                  "response": []
+                },
+                {
+                  "name": "Reemplazar centro (PUT)",
+                  "request": {
+                    "method": "PUT",
+                    "header": [
+                      {
+                        "key": "Authorization",
+                        "value": "Api-Key {{apiKey}}",
+                        "type": "text",
+                        "description": "API key VAT. En los endpoints web también puede reemplazarse por Token <token>."
+                      },
+                      {
+                        "key": "Content-Type",
+                        "value": "application/json",
+                        "type": "text"
+                      }
+                    ],
+                    "body": {
+                      "mode": "raw",
+                      "raw": "{\n  \"nombre\": \"Centro INET de ejemplo\",\n  \"referente\": null,\n  \"referentes\": [],\n  \"codigo\": \"INET-{{$randomInt}}\",\n  \"activo\": true,\n  \"provincia\": {{provincia_id}},\n  \"municipio\": {{municipio_id}},\n  \"localidad\": {{localidad_id}},\n  \"domicilio_actividad\": \"Av. Ejemplo 123\",\n  \"telefono\": \"+54 11 4000-0000\",\n  \"celular\": \"+54 9 11 5000-0000\",\n  \"correo\": \"centro.inet@example.org\",\n  \"nombre_referente\": \"Nombre\",\n  \"apellido_referente\": \"Apellido\",\n  \"tipo_gestion\": \"Estatal\",\n  \"clase_institucion\": \"CFP\",\n  \"situacion\": \"Activa\"\n}",
+                      "options": {
+                        "raw": {
+                          "language": "json"
+                        }
+                      }
+                    },
+                    "url": {
+                      "raw": "{{vatBaseUrl}}{{apiPrefix}}/vat/centros/{{centro_id}}/",
+                      "host": [
+                        "{{vatBaseUrl}}{{apiPrefix}}"
+                      ],
+                      "path": [
+                        "vat",
+                        "centros",
+                        "{{centro_id}}",
+                        ""
+                      ]
+                    },
+                    "description": "Centros de formación VAT/INET y su información institucional básica.\n\nAutenticación: Authorization: Api-Key <clave>.\n\nPUT requiere el cuerpo completo. Operación de escritura bloqueada por defecto. Para enviarla debe configurar explícitamente `allowVatMutations=true` en el ambiente activo; verifique los identificadores y el ambiente y no la ejecute contra producción como prueba exploratoria."
+                  },
+                  "event": [
+                    {
+                      "listen": "prerequest",
+                      "script": {
+                        "type": "text/javascript",
+                        "exec": [
+                          "const allowMutations = String(pm.variables.get('allowVatMutations') || '').toLowerCase() === 'true';",
+                          "if (!allowMutations) {",
+                          "  console.warn('Request VAT de escritura omitido. Configure allowVatMutations=true sólo para una ejecución controlada.');",
+                          "  pm.execution.skipRequest();",
+                          "}"
+                        ]
+                      }
+                    },
+                    {
+                      "listen": "test",
+                      "script": {
+                        "type": "text/javascript",
+                        "exec": [
+                          "pm.test('Status code 200', function () { pm.response.to.have.status(200); });",
+                          "const body = pm.response.json();",
+                          "if (body.id !== undefined) {",
+                          "  const value = String(body.id);",
+                          "  pm.collectionVariables.set('centro_id', value);",
+                          "  if (pm.environment && pm.environment.name) { pm.environment.set('centro_id', value); }",
+                          "}"
+                        ]
+                      }
+                    }
+                  ],
+                  "response": []
+                },
+                {
+                  "name": "Actualizar parcialmente centro (PATCH)",
+                  "request": {
+                    "method": "PATCH",
+                    "header": [
+                      {
+                        "key": "Authorization",
+                        "value": "Api-Key {{apiKey}}",
+                        "type": "text",
+                        "description": "API key VAT. En los endpoints web también puede reemplazarse por Token <token>."
+                      },
+                      {
+                        "key": "Content-Type",
+                        "value": "application/json",
+                        "type": "text"
+                      }
+                    ],
+                    "body": {
+                      "mode": "raw",
+                      "raw": "{\n  \"activo\": true,\n  \"situacion\": \"Activa\"\n}",
+                      "options": {
+                        "raw": {
+                          "language": "json"
+                        }
+                      }
+                    },
+                    "url": {
+                      "raw": "{{vatBaseUrl}}{{apiPrefix}}/vat/centros/{{centro_id}}/",
+                      "host": [
+                        "{{vatBaseUrl}}{{apiPrefix}}"
+                      ],
+                      "path": [
+                        "vat",
+                        "centros",
+                        "{{centro_id}}",
+                        ""
+                      ]
+                    },
+                    "description": "Centros de formación VAT/INET y su información institucional básica.\n\nAutenticación: Authorization: Api-Key <clave>.\n\nOperación de escritura bloqueada por defecto. Para enviarla debe configurar explícitamente `allowVatMutations=true` en el ambiente activo; verifique los identificadores y el ambiente y no la ejecute contra producción como prueba exploratoria."
+                  },
+                  "event": [
+                    {
+                      "listen": "prerequest",
+                      "script": {
+                        "type": "text/javascript",
+                        "exec": [
+                          "const allowMutations = String(pm.variables.get('allowVatMutations') || '').toLowerCase() === 'true';",
+                          "if (!allowMutations) {",
+                          "  console.warn('Request VAT de escritura omitido. Configure allowVatMutations=true sólo para una ejecución controlada.');",
+                          "  pm.execution.skipRequest();",
+                          "}"
+                        ]
+                      }
+                    },
+                    {
+                      "listen": "test",
+                      "script": {
+                        "type": "text/javascript",
+                        "exec": [
+                          "pm.test('Status code 200', function () { pm.response.to.have.status(200); });",
+                          "const body = pm.response.json();",
+                          "if (body.id !== undefined) {",
+                          "  const value = String(body.id);",
+                          "  pm.collectionVariables.set('centro_id', value);",
+                          "  if (pm.environment && pm.environment.name) { pm.environment.set('centro_id', value); }",
+                          "}"
+                        ]
+                      }
+                    }
+                  ],
+                  "response": []
+                },
+                {
+                  "name": "Eliminar centro (DELETE)",
+                  "request": {
+                    "method": "DELETE",
+                    "header": [
+                      {
+                        "key": "Authorization",
+                        "value": "Api-Key {{apiKey}}",
+                        "type": "text",
+                        "description": "API key VAT. En los endpoints web también puede reemplazarse por Token <token>."
+                      }
+                    ],
+                    "url": {
+                      "raw": "{{vatBaseUrl}}{{apiPrefix}}/vat/centros/{{centro_id}}/",
+                      "host": [
+                        "{{vatBaseUrl}}{{apiPrefix}}"
+                      ],
+                      "path": [
+                        "vat",
+                        "centros",
+                        "{{centro_id}}",
+                        ""
+                      ]
+                    },
+                    "description": "Centros de formación VAT/INET y su información institucional básica.\n\nAutenticación: Authorization: Api-Key <clave>.\n\nOperación de escritura bloqueada por defecto. Para enviarla debe configurar explícitamente `allowVatMutations=true` en el ambiente activo; verifique los identificadores y el ambiente y no la ejecute contra producción como prueba exploratoria. En los modelos con borrado lógico, el registro se desactiva o cambia a un estado operativo cerrado/cancelado."
+                  },
+                  "event": [
+                    {
+                      "listen": "prerequest",
+                      "script": {
+                        "type": "text/javascript",
+                        "exec": [
+                          "const allowMutations = String(pm.variables.get('allowVatMutations') || '').toLowerCase() === 'true';",
+                          "if (!allowMutations) {",
+                          "  console.warn('Request VAT de escritura omitido. Configure allowVatMutations=true sólo para una ejecución controlada.');",
+                          "  pm.execution.skipRequest();",
+                          "}"
+                        ]
+                      }
+                    },
+                    {
+                      "listen": "test",
+                      "script": {
+                        "type": "text/javascript",
+                        "exec": [
+                          "pm.test('Status code 204', function () { pm.response.to.have.status(204); });"
+                        ]
+                      }
+                    }
+                  ],
+                  "response": []
+                },
+                {
+                  "name": "Listar centros activos (acción)",
+                  "request": {
+                    "method": "GET",
+                    "header": [
+                      {
+                        "key": "Authorization",
+                        "value": "Api-Key {{apiKey}}",
+                        "type": "text",
+                        "description": "API key VAT. En los endpoints web también puede reemplazarse por Token <token>."
+                      }
+                    ],
+                    "url": {
+                      "raw": "{{vatBaseUrl}}{{apiPrefix}}/vat/centros/activos/",
+                      "host": [
+                        "{{vatBaseUrl}}{{apiPrefix}}"
+                      ],
+                      "path": [
+                        "vat",
+                        "centros",
+                        "activos",
+                        ""
+                      ]
+                    },
+                    "description": "Acción custom `activos`: devuelve centros con activo=true."
+                  },
+                  "event": [
+                    {
+                      "listen": "test",
+                      "script": {
+                        "type": "text/javascript",
+                        "exec": [
+                          "pm.test('Status code 200', function () { pm.response.to.have.status(200); });",
+                          "const body = pm.response.json();",
+                          "const rows = Array.isArray(body) ? body : (body.results || []);",
+                          "pm.test('La respuesta contiene una lista', function () { pm.expect(Array.isArray(rows)).to.eql(true); });",
+                          "if (rows.length && rows[0].id !== undefined) {",
+                          "  const value = String(rows[0].id);",
+                          "  pm.collectionVariables.set('centro_id', value);",
+                          "  if (pm.environment && pm.environment.name) { pm.environment.set('centro_id', value); }",
                           "}"
                         ]
                       }
@@ -3927,37 +4359,59 @@
               ]
             },
             {
-              "name": "4 - Cursos por Centro",
-              "description": "Consulta cursos operativos filtrados por centro_id o por ubicacion geografica. Guarda curso_id con el primer registro devuelto.",
+              "name": "Contactos institucionales",
+              "description": "Responsables y canales de contacto asociados a un centro.\n\nAutenticación: Authorization: Api-Key <clave>.\n\nEste ViewSet expone list, retrieve, create, update, partial_update y destroy.",
               "item": [
                 {
-                  "name": "Listar cursos por centro_id",
+                  "name": "Listar contactos institucionales",
                   "request": {
                     "method": "GET",
                     "header": [
                       {
                         "key": "Authorization",
                         "value": "Api-Key {{apiKey}}",
-                        "type": "text"
+                        "type": "text",
+                        "description": "API key VAT. En los endpoints web también puede reemplazarse por Token <token>."
                       }
                     ],
                     "url": {
-                      "raw": "{{vatBaseUrl}}{{apiPrefix}}/vat/cursos/?centro_id={{centro_id}}",
+                      "raw": "{{vatBaseUrl}}{{apiPrefix}}/vat/institucion-contactos/",
                       "host": [
                         "{{vatBaseUrl}}{{apiPrefix}}"
                       ],
                       "path": [
                         "vat",
-                        "cursos",
+                        "institucion-contactos",
                         ""
                       ],
                       "query": [
                         {
                           "key": "centro_id",
-                          "value": "{{centro_id}}"
+                          "value": "{{centro_id}}",
+                          "description": "Filtra por centro.",
+                          "disabled": true
+                        },
+                        {
+                          "key": "tipo",
+                          "value": "email",
+                          "description": "Filtra por tipo: email, telefono, celular, sitio_web o redes_sociales.",
+                          "disabled": true
+                        },
+                        {
+                          "key": "page",
+                          "value": "1",
+                          "description": "Número de página.",
+                          "disabled": true
+                        },
+                        {
+                          "key": "page_size",
+                          "value": "20",
+                          "description": "Cantidad de resultados por página (máximo 200).",
+                          "disabled": true
                         }
                       ]
-                    }
+                    },
+                    "description": "Responsables y canales de contacto asociados a un centro.\n\nAutenticación: Authorization: Api-Key <clave>.\n\nLos filtros opcionales están cargados y deshabilitados para activarlos según el caso."
                   },
                   "event": [
                     {
@@ -3965,16 +4419,14 @@
                       "script": {
                         "type": "text/javascript",
                         "exec": [
-                          "pm.test('Status code is 200', function () {",
-                          "  pm.response.to.have.status(200);",
-                          "});",
+                          "pm.test('Status code 200', function () { pm.response.to.have.status(200); });",
                           "const body = pm.response.json();",
                           "const rows = Array.isArray(body) ? body : (body.results || []);",
-                          "pm.test('La respuesta contiene una lista', function () {",
-                          "  pm.expect(Array.isArray(rows)).to.eql(true);",
-                          "});",
-                          "if (rows.length && rows[0].id) {",
-                          "  pm.collectionVariables.set('curso_id', String(rows[0].id));",
+                          "pm.test('La respuesta contiene una lista', function () { pm.expect(Array.isArray(rows)).to.eql(true); });",
+                          "if (rows.length && rows[0].id !== undefined) {",
+                          "  const value = String(rows[0].id);",
+                          "  pm.collectionVariables.set('institucion_contacto_id', value);",
+                          "  if (pm.environment && pm.environment.name) { pm.environment.set('institucion_contacto_id', value); }",
                           "}"
                         ]
                       }
@@ -3983,18 +4435,3463 @@
                   "response": []
                 },
                 {
-                  "name": "Listar cursos por centro_id y estado",
+                  "name": "Crear contacto institucional",
+                  "request": {
+                    "method": "POST",
+                    "header": [
+                      {
+                        "key": "Authorization",
+                        "value": "Api-Key {{apiKey}}",
+                        "type": "text",
+                        "description": "API key VAT. En los endpoints web también puede reemplazarse por Token <token>."
+                      },
+                      {
+                        "key": "Content-Type",
+                        "value": "application/json",
+                        "type": "text"
+                      }
+                    ],
+                    "body": {
+                      "mode": "raw",
+                      "raw": "{\n  \"centro\": {{centro_id}},\n  \"nombre_contacto\": \"Responsable INET\",\n  \"rol_area\": \"Coordinación\",\n  \"documento\": \"30111222\",\n  \"telefono_contacto\": \"+54 11 4000-0000\",\n  \"email_contacto\": \"responsable@example.org\",\n  \"tipo\": \"email\",\n  \"valor\": \"responsable@example.org\",\n  \"es_principal\": true,\n  \"observaciones\": \"Contacto creado desde Postman\",\n  \"vigencia_hasta\": null\n}",
+                      "options": {
+                        "raw": {
+                          "language": "json"
+                        }
+                      }
+                    },
+                    "url": {
+                      "raw": "{{vatBaseUrl}}{{apiPrefix}}/vat/institucion-contactos/",
+                      "host": [
+                        "{{vatBaseUrl}}{{apiPrefix}}"
+                      ],
+                      "path": [
+                        "vat",
+                        "institucion-contactos",
+                        ""
+                      ]
+                    },
+                    "description": "Responsables y canales de contacto asociados a un centro.\n\nAutenticación: Authorization: Api-Key <clave>.\n\nOperación de escritura bloqueada por defecto. Para enviarla debe configurar explícitamente `allowVatMutations=true` en el ambiente activo; verifique los identificadores y el ambiente y no la ejecute contra producción como prueba exploratoria."
+                  },
+                  "event": [
+                    {
+                      "listen": "prerequest",
+                      "script": {
+                        "type": "text/javascript",
+                        "exec": [
+                          "const allowMutations = String(pm.variables.get('allowVatMutations') || '').toLowerCase() === 'true';",
+                          "if (!allowMutations) {",
+                          "  console.warn('Request VAT de escritura omitido. Configure allowVatMutations=true sólo para una ejecución controlada.');",
+                          "  pm.execution.skipRequest();",
+                          "}"
+                        ]
+                      }
+                    },
+                    {
+                      "listen": "test",
+                      "script": {
+                        "type": "text/javascript",
+                        "exec": [
+                          "pm.test('Status code 201', function () { pm.response.to.have.status(201); });",
+                          "const body = pm.response.json();",
+                          "if (body.id !== undefined) {",
+                          "  const value = String(body.id);",
+                          "  pm.collectionVariables.set('institucion_contacto_id', value);",
+                          "  if (pm.environment && pm.environment.name) { pm.environment.set('institucion_contacto_id', value); }",
+                          "}"
+                        ]
+                      }
+                    }
+                  ],
+                  "response": []
+                },
+                {
+                  "name": "Obtener contacto institucional por ID",
                   "request": {
                     "method": "GET",
                     "header": [
                       {
                         "key": "Authorization",
                         "value": "Api-Key {{apiKey}}",
-                        "type": "text"
+                        "type": "text",
+                        "description": "API key VAT. En los endpoints web también puede reemplazarse por Token <token>."
                       }
                     ],
                     "url": {
-                      "raw": "{{vatBaseUrl}}{{apiPrefix}}/vat/cursos/?centro_id={{centro_id}}&estado=activo",
+                      "raw": "{{vatBaseUrl}}{{apiPrefix}}/vat/institucion-contactos/{{institucion_contacto_id}}/",
+                      "host": [
+                        "{{vatBaseUrl}}{{apiPrefix}}"
+                      ],
+                      "path": [
+                        "vat",
+                        "institucion-contactos",
+                        "{{institucion_contacto_id}}",
+                        ""
+                      ]
+                    },
+                    "description": "Responsables y canales de contacto asociados a un centro.\n\nAutenticación: Authorization: Api-Key <clave>."
+                  },
+                  "event": [
+                    {
+                      "listen": "test",
+                      "script": {
+                        "type": "text/javascript",
+                        "exec": [
+                          "pm.test('Status code 200', function () { pm.response.to.have.status(200); });",
+                          "const body = pm.response.json();",
+                          "if (body.id !== undefined) {",
+                          "  const value = String(body.id);",
+                          "  pm.collectionVariables.set('institucion_contacto_id', value);",
+                          "  if (pm.environment && pm.environment.name) { pm.environment.set('institucion_contacto_id', value); }",
+                          "}"
+                        ]
+                      }
+                    }
+                  ],
+                  "response": []
+                },
+                {
+                  "name": "Reemplazar contacto institucional (PUT)",
+                  "request": {
+                    "method": "PUT",
+                    "header": [
+                      {
+                        "key": "Authorization",
+                        "value": "Api-Key {{apiKey}}",
+                        "type": "text",
+                        "description": "API key VAT. En los endpoints web también puede reemplazarse por Token <token>."
+                      },
+                      {
+                        "key": "Content-Type",
+                        "value": "application/json",
+                        "type": "text"
+                      }
+                    ],
+                    "body": {
+                      "mode": "raw",
+                      "raw": "{\n  \"centro\": {{centro_id}},\n  \"nombre_contacto\": \"Responsable INET\",\n  \"rol_area\": \"Coordinación\",\n  \"documento\": \"30111222\",\n  \"telefono_contacto\": \"+54 11 4000-0000\",\n  \"email_contacto\": \"responsable@example.org\",\n  \"tipo\": \"email\",\n  \"valor\": \"responsable@example.org\",\n  \"es_principal\": true,\n  \"observaciones\": \"Contacto creado desde Postman\",\n  \"vigencia_hasta\": null\n}",
+                      "options": {
+                        "raw": {
+                          "language": "json"
+                        }
+                      }
+                    },
+                    "url": {
+                      "raw": "{{vatBaseUrl}}{{apiPrefix}}/vat/institucion-contactos/{{institucion_contacto_id}}/",
+                      "host": [
+                        "{{vatBaseUrl}}{{apiPrefix}}"
+                      ],
+                      "path": [
+                        "vat",
+                        "institucion-contactos",
+                        "{{institucion_contacto_id}}",
+                        ""
+                      ]
+                    },
+                    "description": "Responsables y canales de contacto asociados a un centro.\n\nAutenticación: Authorization: Api-Key <clave>.\n\nPUT requiere el cuerpo completo. Operación de escritura bloqueada por defecto. Para enviarla debe configurar explícitamente `allowVatMutations=true` en el ambiente activo; verifique los identificadores y el ambiente y no la ejecute contra producción como prueba exploratoria."
+                  },
+                  "event": [
+                    {
+                      "listen": "prerequest",
+                      "script": {
+                        "type": "text/javascript",
+                        "exec": [
+                          "const allowMutations = String(pm.variables.get('allowVatMutations') || '').toLowerCase() === 'true';",
+                          "if (!allowMutations) {",
+                          "  console.warn('Request VAT de escritura omitido. Configure allowVatMutations=true sólo para una ejecución controlada.');",
+                          "  pm.execution.skipRequest();",
+                          "}"
+                        ]
+                      }
+                    },
+                    {
+                      "listen": "test",
+                      "script": {
+                        "type": "text/javascript",
+                        "exec": [
+                          "pm.test('Status code 200', function () { pm.response.to.have.status(200); });",
+                          "const body = pm.response.json();",
+                          "if (body.id !== undefined) {",
+                          "  const value = String(body.id);",
+                          "  pm.collectionVariables.set('institucion_contacto_id', value);",
+                          "  if (pm.environment && pm.environment.name) { pm.environment.set('institucion_contacto_id', value); }",
+                          "}"
+                        ]
+                      }
+                    }
+                  ],
+                  "response": []
+                },
+                {
+                  "name": "Actualizar parcialmente contacto institucional (PATCH)",
+                  "request": {
+                    "method": "PATCH",
+                    "header": [
+                      {
+                        "key": "Authorization",
+                        "value": "Api-Key {{apiKey}}",
+                        "type": "text",
+                        "description": "API key VAT. En los endpoints web también puede reemplazarse por Token <token>."
+                      },
+                      {
+                        "key": "Content-Type",
+                        "value": "application/json",
+                        "type": "text"
+                      }
+                    ],
+                    "body": {
+                      "mode": "raw",
+                      "raw": "{\n  \"es_principal\": true,\n  \"observaciones\": \"Contacto actualizado desde Postman\"\n}",
+                      "options": {
+                        "raw": {
+                          "language": "json"
+                        }
+                      }
+                    },
+                    "url": {
+                      "raw": "{{vatBaseUrl}}{{apiPrefix}}/vat/institucion-contactos/{{institucion_contacto_id}}/",
+                      "host": [
+                        "{{vatBaseUrl}}{{apiPrefix}}"
+                      ],
+                      "path": [
+                        "vat",
+                        "institucion-contactos",
+                        "{{institucion_contacto_id}}",
+                        ""
+                      ]
+                    },
+                    "description": "Responsables y canales de contacto asociados a un centro.\n\nAutenticación: Authorization: Api-Key <clave>.\n\nOperación de escritura bloqueada por defecto. Para enviarla debe configurar explícitamente `allowVatMutations=true` en el ambiente activo; verifique los identificadores y el ambiente y no la ejecute contra producción como prueba exploratoria."
+                  },
+                  "event": [
+                    {
+                      "listen": "prerequest",
+                      "script": {
+                        "type": "text/javascript",
+                        "exec": [
+                          "const allowMutations = String(pm.variables.get('allowVatMutations') || '').toLowerCase() === 'true';",
+                          "if (!allowMutations) {",
+                          "  console.warn('Request VAT de escritura omitido. Configure allowVatMutations=true sólo para una ejecución controlada.');",
+                          "  pm.execution.skipRequest();",
+                          "}"
+                        ]
+                      }
+                    },
+                    {
+                      "listen": "test",
+                      "script": {
+                        "type": "text/javascript",
+                        "exec": [
+                          "pm.test('Status code 200', function () { pm.response.to.have.status(200); });",
+                          "const body = pm.response.json();",
+                          "if (body.id !== undefined) {",
+                          "  const value = String(body.id);",
+                          "  pm.collectionVariables.set('institucion_contacto_id', value);",
+                          "  if (pm.environment && pm.environment.name) { pm.environment.set('institucion_contacto_id', value); }",
+                          "}"
+                        ]
+                      }
+                    }
+                  ],
+                  "response": []
+                },
+                {
+                  "name": "Eliminar contacto institucional (DELETE)",
+                  "request": {
+                    "method": "DELETE",
+                    "header": [
+                      {
+                        "key": "Authorization",
+                        "value": "Api-Key {{apiKey}}",
+                        "type": "text",
+                        "description": "API key VAT. En los endpoints web también puede reemplazarse por Token <token>."
+                      }
+                    ],
+                    "url": {
+                      "raw": "{{vatBaseUrl}}{{apiPrefix}}/vat/institucion-contactos/{{institucion_contacto_id}}/",
+                      "host": [
+                        "{{vatBaseUrl}}{{apiPrefix}}"
+                      ],
+                      "path": [
+                        "vat",
+                        "institucion-contactos",
+                        "{{institucion_contacto_id}}",
+                        ""
+                      ]
+                    },
+                    "description": "Responsables y canales de contacto asociados a un centro.\n\nAutenticación: Authorization: Api-Key <clave>.\n\nOperación de escritura bloqueada por defecto. Para enviarla debe configurar explícitamente `allowVatMutations=true` en el ambiente activo; verifique los identificadores y el ambiente y no la ejecute contra producción como prueba exploratoria. En los modelos con borrado lógico, el registro se desactiva o cambia a un estado operativo cerrado/cancelado."
+                  },
+                  "event": [
+                    {
+                      "listen": "prerequest",
+                      "script": {
+                        "type": "text/javascript",
+                        "exec": [
+                          "const allowMutations = String(pm.variables.get('allowVatMutations') || '').toLowerCase() === 'true';",
+                          "if (!allowMutations) {",
+                          "  console.warn('Request VAT de escritura omitido. Configure allowVatMutations=true sólo para una ejecución controlada.');",
+                          "  pm.execution.skipRequest();",
+                          "}"
+                        ]
+                      }
+                    },
+                    {
+                      "listen": "test",
+                      "script": {
+                        "type": "text/javascript",
+                        "exec": [
+                          "pm.test('Status code 204', function () { pm.response.to.have.status(204); });"
+                        ]
+                      }
+                    }
+                  ],
+                  "response": []
+                }
+              ]
+            },
+            {
+              "name": "Identificadores institucionales",
+              "description": "Historial de CUE, CUIE y otros identificadores de un centro.\n\nAutenticación: Authorization: Api-Key <clave>.\n\nEste ViewSet expone list, retrieve, create, update, partial_update y destroy.",
+              "item": [
+                {
+                  "name": "Listar identificadores institucionales",
+                  "request": {
+                    "method": "GET",
+                    "header": [
+                      {
+                        "key": "Authorization",
+                        "value": "Api-Key {{apiKey}}",
+                        "type": "text",
+                        "description": "API key VAT. En los endpoints web también puede reemplazarse por Token <token>."
+                      }
+                    ],
+                    "url": {
+                      "raw": "{{vatBaseUrl}}{{apiPrefix}}/vat/institucion-identificadores/",
+                      "host": [
+                        "{{vatBaseUrl}}{{apiPrefix}}"
+                      ],
+                      "path": [
+                        "vat",
+                        "institucion-identificadores",
+                        ""
+                      ],
+                      "query": [
+                        {
+                          "key": "centro_id",
+                          "value": "{{centro_id}}",
+                          "description": "Filtra por centro.",
+                          "disabled": true
+                        },
+                        {
+                          "key": "tipo_identificador",
+                          "value": "cue",
+                          "description": "Filtra por tipo de identificador.",
+                          "disabled": true
+                        },
+                        {
+                          "key": "page",
+                          "value": "1",
+                          "description": "Número de página.",
+                          "disabled": true
+                        },
+                        {
+                          "key": "page_size",
+                          "value": "20",
+                          "description": "Cantidad de resultados por página (máximo 200).",
+                          "disabled": true
+                        }
+                      ]
+                    },
+                    "description": "Historial de CUE, CUIE y otros identificadores de un centro.\n\nAutenticación: Authorization: Api-Key <clave>.\n\nLos filtros opcionales están cargados y deshabilitados para activarlos según el caso."
+                  },
+                  "event": [
+                    {
+                      "listen": "test",
+                      "script": {
+                        "type": "text/javascript",
+                        "exec": [
+                          "pm.test('Status code 200', function () { pm.response.to.have.status(200); });",
+                          "const body = pm.response.json();",
+                          "const rows = Array.isArray(body) ? body : (body.results || []);",
+                          "pm.test('La respuesta contiene una lista', function () { pm.expect(Array.isArray(rows)).to.eql(true); });",
+                          "if (rows.length && rows[0].id !== undefined) {",
+                          "  const value = String(rows[0].id);",
+                          "  pm.collectionVariables.set('institucion_identificador_id', value);",
+                          "  if (pm.environment && pm.environment.name) { pm.environment.set('institucion_identificador_id', value); }",
+                          "}"
+                        ]
+                      }
+                    }
+                  ],
+                  "response": []
+                },
+                {
+                  "name": "Crear identificador institucional",
+                  "request": {
+                    "method": "POST",
+                    "header": [
+                      {
+                        "key": "Authorization",
+                        "value": "Api-Key {{apiKey}}",
+                        "type": "text",
+                        "description": "API key VAT. En los endpoints web también puede reemplazarse por Token <token>."
+                      },
+                      {
+                        "key": "Content-Type",
+                        "value": "application/json",
+                        "type": "text"
+                      }
+                    ],
+                    "body": {
+                      "mode": "raw",
+                      "raw": "{\n  \"centro\": {{centro_id}},\n  \"tipo_identificador\": \"cue\",\n  \"valor_identificador\": \"CUE-{{$randomInt}}\",\n  \"rol_institucional\": \"centro_de_formacion\",\n  \"es_actual\": true,\n  \"vigencia_hasta\": null,\n  \"motivo\": \"Alta desde Postman\"\n}",
+                      "options": {
+                        "raw": {
+                          "language": "json"
+                        }
+                      }
+                    },
+                    "url": {
+                      "raw": "{{vatBaseUrl}}{{apiPrefix}}/vat/institucion-identificadores/",
+                      "host": [
+                        "{{vatBaseUrl}}{{apiPrefix}}"
+                      ],
+                      "path": [
+                        "vat",
+                        "institucion-identificadores",
+                        ""
+                      ]
+                    },
+                    "description": "Historial de CUE, CUIE y otros identificadores de un centro.\n\nAutenticación: Authorization: Api-Key <clave>.\n\nOperación de escritura bloqueada por defecto. Para enviarla debe configurar explícitamente `allowVatMutations=true` en el ambiente activo; verifique los identificadores y el ambiente y no la ejecute contra producción como prueba exploratoria."
+                  },
+                  "event": [
+                    {
+                      "listen": "prerequest",
+                      "script": {
+                        "type": "text/javascript",
+                        "exec": [
+                          "const allowMutations = String(pm.variables.get('allowVatMutations') || '').toLowerCase() === 'true';",
+                          "if (!allowMutations) {",
+                          "  console.warn('Request VAT de escritura omitido. Configure allowVatMutations=true sólo para una ejecución controlada.');",
+                          "  pm.execution.skipRequest();",
+                          "}"
+                        ]
+                      }
+                    },
+                    {
+                      "listen": "test",
+                      "script": {
+                        "type": "text/javascript",
+                        "exec": [
+                          "pm.test('Status code 201', function () { pm.response.to.have.status(201); });",
+                          "const body = pm.response.json();",
+                          "if (body.id !== undefined) {",
+                          "  const value = String(body.id);",
+                          "  pm.collectionVariables.set('institucion_identificador_id', value);",
+                          "  if (pm.environment && pm.environment.name) { pm.environment.set('institucion_identificador_id', value); }",
+                          "}"
+                        ]
+                      }
+                    }
+                  ],
+                  "response": []
+                },
+                {
+                  "name": "Obtener identificador institucional por ID",
+                  "request": {
+                    "method": "GET",
+                    "header": [
+                      {
+                        "key": "Authorization",
+                        "value": "Api-Key {{apiKey}}",
+                        "type": "text",
+                        "description": "API key VAT. En los endpoints web también puede reemplazarse por Token <token>."
+                      }
+                    ],
+                    "url": {
+                      "raw": "{{vatBaseUrl}}{{apiPrefix}}/vat/institucion-identificadores/{{institucion_identificador_id}}/",
+                      "host": [
+                        "{{vatBaseUrl}}{{apiPrefix}}"
+                      ],
+                      "path": [
+                        "vat",
+                        "institucion-identificadores",
+                        "{{institucion_identificador_id}}",
+                        ""
+                      ]
+                    },
+                    "description": "Historial de CUE, CUIE y otros identificadores de un centro.\n\nAutenticación: Authorization: Api-Key <clave>."
+                  },
+                  "event": [
+                    {
+                      "listen": "test",
+                      "script": {
+                        "type": "text/javascript",
+                        "exec": [
+                          "pm.test('Status code 200', function () { pm.response.to.have.status(200); });",
+                          "const body = pm.response.json();",
+                          "if (body.id !== undefined) {",
+                          "  const value = String(body.id);",
+                          "  pm.collectionVariables.set('institucion_identificador_id', value);",
+                          "  if (pm.environment && pm.environment.name) { pm.environment.set('institucion_identificador_id', value); }",
+                          "}"
+                        ]
+                      }
+                    }
+                  ],
+                  "response": []
+                },
+                {
+                  "name": "Reemplazar identificador institucional (PUT)",
+                  "request": {
+                    "method": "PUT",
+                    "header": [
+                      {
+                        "key": "Authorization",
+                        "value": "Api-Key {{apiKey}}",
+                        "type": "text",
+                        "description": "API key VAT. En los endpoints web también puede reemplazarse por Token <token>."
+                      },
+                      {
+                        "key": "Content-Type",
+                        "value": "application/json",
+                        "type": "text"
+                      }
+                    ],
+                    "body": {
+                      "mode": "raw",
+                      "raw": "{\n  \"centro\": {{centro_id}},\n  \"tipo_identificador\": \"cue\",\n  \"valor_identificador\": \"CUE-{{$randomInt}}\",\n  \"rol_institucional\": \"centro_de_formacion\",\n  \"es_actual\": true,\n  \"vigencia_hasta\": null,\n  \"motivo\": \"Alta desde Postman\"\n}",
+                      "options": {
+                        "raw": {
+                          "language": "json"
+                        }
+                      }
+                    },
+                    "url": {
+                      "raw": "{{vatBaseUrl}}{{apiPrefix}}/vat/institucion-identificadores/{{institucion_identificador_id}}/",
+                      "host": [
+                        "{{vatBaseUrl}}{{apiPrefix}}"
+                      ],
+                      "path": [
+                        "vat",
+                        "institucion-identificadores",
+                        "{{institucion_identificador_id}}",
+                        ""
+                      ]
+                    },
+                    "description": "Historial de CUE, CUIE y otros identificadores de un centro.\n\nAutenticación: Authorization: Api-Key <clave>.\n\nPUT requiere el cuerpo completo. Operación de escritura bloqueada por defecto. Para enviarla debe configurar explícitamente `allowVatMutations=true` en el ambiente activo; verifique los identificadores y el ambiente y no la ejecute contra producción como prueba exploratoria."
+                  },
+                  "event": [
+                    {
+                      "listen": "prerequest",
+                      "script": {
+                        "type": "text/javascript",
+                        "exec": [
+                          "const allowMutations = String(pm.variables.get('allowVatMutations') || '').toLowerCase() === 'true';",
+                          "if (!allowMutations) {",
+                          "  console.warn('Request VAT de escritura omitido. Configure allowVatMutations=true sólo para una ejecución controlada.');",
+                          "  pm.execution.skipRequest();",
+                          "}"
+                        ]
+                      }
+                    },
+                    {
+                      "listen": "test",
+                      "script": {
+                        "type": "text/javascript",
+                        "exec": [
+                          "pm.test('Status code 200', function () { pm.response.to.have.status(200); });",
+                          "const body = pm.response.json();",
+                          "if (body.id !== undefined) {",
+                          "  const value = String(body.id);",
+                          "  pm.collectionVariables.set('institucion_identificador_id', value);",
+                          "  if (pm.environment && pm.environment.name) { pm.environment.set('institucion_identificador_id', value); }",
+                          "}"
+                        ]
+                      }
+                    }
+                  ],
+                  "response": []
+                },
+                {
+                  "name": "Actualizar parcialmente identificador institucional (PATCH)",
+                  "request": {
+                    "method": "PATCH",
+                    "header": [
+                      {
+                        "key": "Authorization",
+                        "value": "Api-Key {{apiKey}}",
+                        "type": "text",
+                        "description": "API key VAT. En los endpoints web también puede reemplazarse por Token <token>."
+                      },
+                      {
+                        "key": "Content-Type",
+                        "value": "application/json",
+                        "type": "text"
+                      }
+                    ],
+                    "body": {
+                      "mode": "raw",
+                      "raw": "{\n  \"es_actual\": true,\n  \"motivo\": \"Actualizado desde Postman\"\n}",
+                      "options": {
+                        "raw": {
+                          "language": "json"
+                        }
+                      }
+                    },
+                    "url": {
+                      "raw": "{{vatBaseUrl}}{{apiPrefix}}/vat/institucion-identificadores/{{institucion_identificador_id}}/",
+                      "host": [
+                        "{{vatBaseUrl}}{{apiPrefix}}"
+                      ],
+                      "path": [
+                        "vat",
+                        "institucion-identificadores",
+                        "{{institucion_identificador_id}}",
+                        ""
+                      ]
+                    },
+                    "description": "Historial de CUE, CUIE y otros identificadores de un centro.\n\nAutenticación: Authorization: Api-Key <clave>.\n\nOperación de escritura bloqueada por defecto. Para enviarla debe configurar explícitamente `allowVatMutations=true` en el ambiente activo; verifique los identificadores y el ambiente y no la ejecute contra producción como prueba exploratoria."
+                  },
+                  "event": [
+                    {
+                      "listen": "prerequest",
+                      "script": {
+                        "type": "text/javascript",
+                        "exec": [
+                          "const allowMutations = String(pm.variables.get('allowVatMutations') || '').toLowerCase() === 'true';",
+                          "if (!allowMutations) {",
+                          "  console.warn('Request VAT de escritura omitido. Configure allowVatMutations=true sólo para una ejecución controlada.');",
+                          "  pm.execution.skipRequest();",
+                          "}"
+                        ]
+                      }
+                    },
+                    {
+                      "listen": "test",
+                      "script": {
+                        "type": "text/javascript",
+                        "exec": [
+                          "pm.test('Status code 200', function () { pm.response.to.have.status(200); });",
+                          "const body = pm.response.json();",
+                          "if (body.id !== undefined) {",
+                          "  const value = String(body.id);",
+                          "  pm.collectionVariables.set('institucion_identificador_id', value);",
+                          "  if (pm.environment && pm.environment.name) { pm.environment.set('institucion_identificador_id', value); }",
+                          "}"
+                        ]
+                      }
+                    }
+                  ],
+                  "response": []
+                },
+                {
+                  "name": "Eliminar identificador institucional (DELETE)",
+                  "request": {
+                    "method": "DELETE",
+                    "header": [
+                      {
+                        "key": "Authorization",
+                        "value": "Api-Key {{apiKey}}",
+                        "type": "text",
+                        "description": "API key VAT. En los endpoints web también puede reemplazarse por Token <token>."
+                      }
+                    ],
+                    "url": {
+                      "raw": "{{vatBaseUrl}}{{apiPrefix}}/vat/institucion-identificadores/{{institucion_identificador_id}}/",
+                      "host": [
+                        "{{vatBaseUrl}}{{apiPrefix}}"
+                      ],
+                      "path": [
+                        "vat",
+                        "institucion-identificadores",
+                        "{{institucion_identificador_id}}",
+                        ""
+                      ]
+                    },
+                    "description": "Historial de CUE, CUIE y otros identificadores de un centro.\n\nAutenticación: Authorization: Api-Key <clave>.\n\nOperación de escritura bloqueada por defecto. Para enviarla debe configurar explícitamente `allowVatMutations=true` en el ambiente activo; verifique los identificadores y el ambiente y no la ejecute contra producción como prueba exploratoria. En los modelos con borrado lógico, el registro se desactiva o cambia a un estado operativo cerrado/cancelado."
+                  },
+                  "event": [
+                    {
+                      "listen": "prerequest",
+                      "script": {
+                        "type": "text/javascript",
+                        "exec": [
+                          "const allowMutations = String(pm.variables.get('allowVatMutations') || '').toLowerCase() === 'true';",
+                          "if (!allowMutations) {",
+                          "  console.warn('Request VAT de escritura omitido. Configure allowVatMutations=true sólo para una ejecución controlada.');",
+                          "  pm.execution.skipRequest();",
+                          "}"
+                        ]
+                      }
+                    },
+                    {
+                      "listen": "test",
+                      "script": {
+                        "type": "text/javascript",
+                        "exec": [
+                          "pm.test('Status code 204', function () { pm.response.to.have.status(204); });"
+                        ]
+                      }
+                    }
+                  ],
+                  "response": []
+                }
+              ]
+            },
+            {
+              "name": "Ubicaciones institucionales",
+              "description": "Sedes, anexos y puntos de atención de un centro.\n\nAutenticación: Authorization: Api-Key <clave>.\n\nEste ViewSet expone list, retrieve, create, update, partial_update y destroy.",
+              "item": [
+                {
+                  "name": "Listar ubicaciones institucionales",
+                  "request": {
+                    "method": "GET",
+                    "header": [
+                      {
+                        "key": "Authorization",
+                        "value": "Api-Key {{apiKey}}",
+                        "type": "text",
+                        "description": "API key VAT. En los endpoints web también puede reemplazarse por Token <token>."
+                      }
+                    ],
+                    "url": {
+                      "raw": "{{vatBaseUrl}}{{apiPrefix}}/vat/institucion-ubicaciones/",
+                      "host": [
+                        "{{vatBaseUrl}}{{apiPrefix}}"
+                      ],
+                      "path": [
+                        "vat",
+                        "institucion-ubicaciones",
+                        ""
+                      ],
+                      "query": [
+                        {
+                          "key": "centro_id",
+                          "value": "{{centro_id}}",
+                          "description": "Filtra por centro.",
+                          "disabled": true
+                        },
+                        {
+                          "key": "rol_ubicacion",
+                          "value": "sede_principal",
+                          "description": "Filtra por rol de ubicación.",
+                          "disabled": true
+                        },
+                        {
+                          "key": "page",
+                          "value": "1",
+                          "description": "Número de página.",
+                          "disabled": true
+                        },
+                        {
+                          "key": "page_size",
+                          "value": "20",
+                          "description": "Cantidad de resultados por página (máximo 200).",
+                          "disabled": true
+                        }
+                      ]
+                    },
+                    "description": "Sedes, anexos y puntos de atención de un centro.\n\nAutenticación: Authorization: Api-Key <clave>.\n\nLos filtros opcionales están cargados y deshabilitados para activarlos según el caso."
+                  },
+                  "event": [
+                    {
+                      "listen": "test",
+                      "script": {
+                        "type": "text/javascript",
+                        "exec": [
+                          "pm.test('Status code 200', function () { pm.response.to.have.status(200); });",
+                          "const body = pm.response.json();",
+                          "const rows = Array.isArray(body) ? body : (body.results || []);",
+                          "pm.test('La respuesta contiene una lista', function () { pm.expect(Array.isArray(rows)).to.eql(true); });",
+                          "if (rows.length && rows[0].id !== undefined) {",
+                          "  const value = String(rows[0].id);",
+                          "  pm.collectionVariables.set('institucion_ubicacion_id', value);",
+                          "  if (pm.environment && pm.environment.name) { pm.environment.set('institucion_ubicacion_id', value); }",
+                          "}"
+                        ]
+                      }
+                    }
+                  ],
+                  "response": []
+                },
+                {
+                  "name": "Crear ubicación institucional",
+                  "request": {
+                    "method": "POST",
+                    "header": [
+                      {
+                        "key": "Authorization",
+                        "value": "Api-Key {{apiKey}}",
+                        "type": "text",
+                        "description": "API key VAT. En los endpoints web también puede reemplazarse por Token <token>."
+                      },
+                      {
+                        "key": "Content-Type",
+                        "value": "application/json",
+                        "type": "text"
+                      }
+                    ],
+                    "body": {
+                      "mode": "raw",
+                      "raw": "{\n  \"centro\": {{centro_id}},\n  \"localidad\": {{localidad_id}},\n  \"rol_ubicacion\": \"sede_principal\",\n  \"domicilio\": \"Av. Ejemplo 123\",\n  \"es_principal\": true,\n  \"latitud\": \"-34.603722\",\n  \"longitud\": \"-58.381592\",\n  \"observaciones\": \"Ubicación creada desde Postman\",\n  \"vigencia_hasta\": null\n}",
+                      "options": {
+                        "raw": {
+                          "language": "json"
+                        }
+                      }
+                    },
+                    "url": {
+                      "raw": "{{vatBaseUrl}}{{apiPrefix}}/vat/institucion-ubicaciones/",
+                      "host": [
+                        "{{vatBaseUrl}}{{apiPrefix}}"
+                      ],
+                      "path": [
+                        "vat",
+                        "institucion-ubicaciones",
+                        ""
+                      ]
+                    },
+                    "description": "Sedes, anexos y puntos de atención de un centro.\n\nAutenticación: Authorization: Api-Key <clave>.\n\nOperación de escritura bloqueada por defecto. Para enviarla debe configurar explícitamente `allowVatMutations=true` en el ambiente activo; verifique los identificadores y el ambiente y no la ejecute contra producción como prueba exploratoria."
+                  },
+                  "event": [
+                    {
+                      "listen": "prerequest",
+                      "script": {
+                        "type": "text/javascript",
+                        "exec": [
+                          "const allowMutations = String(pm.variables.get('allowVatMutations') || '').toLowerCase() === 'true';",
+                          "if (!allowMutations) {",
+                          "  console.warn('Request VAT de escritura omitido. Configure allowVatMutations=true sólo para una ejecución controlada.');",
+                          "  pm.execution.skipRequest();",
+                          "}"
+                        ]
+                      }
+                    },
+                    {
+                      "listen": "test",
+                      "script": {
+                        "type": "text/javascript",
+                        "exec": [
+                          "pm.test('Status code 201', function () { pm.response.to.have.status(201); });",
+                          "const body = pm.response.json();",
+                          "if (body.id !== undefined) {",
+                          "  const value = String(body.id);",
+                          "  pm.collectionVariables.set('institucion_ubicacion_id', value);",
+                          "  if (pm.environment && pm.environment.name) { pm.environment.set('institucion_ubicacion_id', value); }",
+                          "}"
+                        ]
+                      }
+                    }
+                  ],
+                  "response": []
+                },
+                {
+                  "name": "Obtener ubicación institucional por ID",
+                  "request": {
+                    "method": "GET",
+                    "header": [
+                      {
+                        "key": "Authorization",
+                        "value": "Api-Key {{apiKey}}",
+                        "type": "text",
+                        "description": "API key VAT. En los endpoints web también puede reemplazarse por Token <token>."
+                      }
+                    ],
+                    "url": {
+                      "raw": "{{vatBaseUrl}}{{apiPrefix}}/vat/institucion-ubicaciones/{{institucion_ubicacion_id}}/",
+                      "host": [
+                        "{{vatBaseUrl}}{{apiPrefix}}"
+                      ],
+                      "path": [
+                        "vat",
+                        "institucion-ubicaciones",
+                        "{{institucion_ubicacion_id}}",
+                        ""
+                      ]
+                    },
+                    "description": "Sedes, anexos y puntos de atención de un centro.\n\nAutenticación: Authorization: Api-Key <clave>."
+                  },
+                  "event": [
+                    {
+                      "listen": "test",
+                      "script": {
+                        "type": "text/javascript",
+                        "exec": [
+                          "pm.test('Status code 200', function () { pm.response.to.have.status(200); });",
+                          "const body = pm.response.json();",
+                          "if (body.id !== undefined) {",
+                          "  const value = String(body.id);",
+                          "  pm.collectionVariables.set('institucion_ubicacion_id', value);",
+                          "  if (pm.environment && pm.environment.name) { pm.environment.set('institucion_ubicacion_id', value); }",
+                          "}"
+                        ]
+                      }
+                    }
+                  ],
+                  "response": []
+                },
+                {
+                  "name": "Reemplazar ubicación institucional (PUT)",
+                  "request": {
+                    "method": "PUT",
+                    "header": [
+                      {
+                        "key": "Authorization",
+                        "value": "Api-Key {{apiKey}}",
+                        "type": "text",
+                        "description": "API key VAT. En los endpoints web también puede reemplazarse por Token <token>."
+                      },
+                      {
+                        "key": "Content-Type",
+                        "value": "application/json",
+                        "type": "text"
+                      }
+                    ],
+                    "body": {
+                      "mode": "raw",
+                      "raw": "{\n  \"centro\": {{centro_id}},\n  \"localidad\": {{localidad_id}},\n  \"rol_ubicacion\": \"sede_principal\",\n  \"domicilio\": \"Av. Ejemplo 123\",\n  \"es_principal\": true,\n  \"latitud\": \"-34.603722\",\n  \"longitud\": \"-58.381592\",\n  \"observaciones\": \"Ubicación creada desde Postman\",\n  \"vigencia_hasta\": null\n}",
+                      "options": {
+                        "raw": {
+                          "language": "json"
+                        }
+                      }
+                    },
+                    "url": {
+                      "raw": "{{vatBaseUrl}}{{apiPrefix}}/vat/institucion-ubicaciones/{{institucion_ubicacion_id}}/",
+                      "host": [
+                        "{{vatBaseUrl}}{{apiPrefix}}"
+                      ],
+                      "path": [
+                        "vat",
+                        "institucion-ubicaciones",
+                        "{{institucion_ubicacion_id}}",
+                        ""
+                      ]
+                    },
+                    "description": "Sedes, anexos y puntos de atención de un centro.\n\nAutenticación: Authorization: Api-Key <clave>.\n\nPUT requiere el cuerpo completo. Operación de escritura bloqueada por defecto. Para enviarla debe configurar explícitamente `allowVatMutations=true` en el ambiente activo; verifique los identificadores y el ambiente y no la ejecute contra producción como prueba exploratoria."
+                  },
+                  "event": [
+                    {
+                      "listen": "prerequest",
+                      "script": {
+                        "type": "text/javascript",
+                        "exec": [
+                          "const allowMutations = String(pm.variables.get('allowVatMutations') || '').toLowerCase() === 'true';",
+                          "if (!allowMutations) {",
+                          "  console.warn('Request VAT de escritura omitido. Configure allowVatMutations=true sólo para una ejecución controlada.');",
+                          "  pm.execution.skipRequest();",
+                          "}"
+                        ]
+                      }
+                    },
+                    {
+                      "listen": "test",
+                      "script": {
+                        "type": "text/javascript",
+                        "exec": [
+                          "pm.test('Status code 200', function () { pm.response.to.have.status(200); });",
+                          "const body = pm.response.json();",
+                          "if (body.id !== undefined) {",
+                          "  const value = String(body.id);",
+                          "  pm.collectionVariables.set('institucion_ubicacion_id', value);",
+                          "  if (pm.environment && pm.environment.name) { pm.environment.set('institucion_ubicacion_id', value); }",
+                          "}"
+                        ]
+                      }
+                    }
+                  ],
+                  "response": []
+                },
+                {
+                  "name": "Actualizar parcialmente ubicación institucional (PATCH)",
+                  "request": {
+                    "method": "PATCH",
+                    "header": [
+                      {
+                        "key": "Authorization",
+                        "value": "Api-Key {{apiKey}}",
+                        "type": "text",
+                        "description": "API key VAT. En los endpoints web también puede reemplazarse por Token <token>."
+                      },
+                      {
+                        "key": "Content-Type",
+                        "value": "application/json",
+                        "type": "text"
+                      }
+                    ],
+                    "body": {
+                      "mode": "raw",
+                      "raw": "{\n  \"es_principal\": true,\n  \"observaciones\": \"Ubicación actualizada desde Postman\"\n}",
+                      "options": {
+                        "raw": {
+                          "language": "json"
+                        }
+                      }
+                    },
+                    "url": {
+                      "raw": "{{vatBaseUrl}}{{apiPrefix}}/vat/institucion-ubicaciones/{{institucion_ubicacion_id}}/",
+                      "host": [
+                        "{{vatBaseUrl}}{{apiPrefix}}"
+                      ],
+                      "path": [
+                        "vat",
+                        "institucion-ubicaciones",
+                        "{{institucion_ubicacion_id}}",
+                        ""
+                      ]
+                    },
+                    "description": "Sedes, anexos y puntos de atención de un centro.\n\nAutenticación: Authorization: Api-Key <clave>.\n\nOperación de escritura bloqueada por defecto. Para enviarla debe configurar explícitamente `allowVatMutations=true` en el ambiente activo; verifique los identificadores y el ambiente y no la ejecute contra producción como prueba exploratoria."
+                  },
+                  "event": [
+                    {
+                      "listen": "prerequest",
+                      "script": {
+                        "type": "text/javascript",
+                        "exec": [
+                          "const allowMutations = String(pm.variables.get('allowVatMutations') || '').toLowerCase() === 'true';",
+                          "if (!allowMutations) {",
+                          "  console.warn('Request VAT de escritura omitido. Configure allowVatMutations=true sólo para una ejecución controlada.');",
+                          "  pm.execution.skipRequest();",
+                          "}"
+                        ]
+                      }
+                    },
+                    {
+                      "listen": "test",
+                      "script": {
+                        "type": "text/javascript",
+                        "exec": [
+                          "pm.test('Status code 200', function () { pm.response.to.have.status(200); });",
+                          "const body = pm.response.json();",
+                          "if (body.id !== undefined) {",
+                          "  const value = String(body.id);",
+                          "  pm.collectionVariables.set('institucion_ubicacion_id', value);",
+                          "  if (pm.environment && pm.environment.name) { pm.environment.set('institucion_ubicacion_id', value); }",
+                          "}"
+                        ]
+                      }
+                    }
+                  ],
+                  "response": []
+                },
+                {
+                  "name": "Eliminar ubicación institucional (DELETE)",
+                  "request": {
+                    "method": "DELETE",
+                    "header": [
+                      {
+                        "key": "Authorization",
+                        "value": "Api-Key {{apiKey}}",
+                        "type": "text",
+                        "description": "API key VAT. En los endpoints web también puede reemplazarse por Token <token>."
+                      }
+                    ],
+                    "url": {
+                      "raw": "{{vatBaseUrl}}{{apiPrefix}}/vat/institucion-ubicaciones/{{institucion_ubicacion_id}}/",
+                      "host": [
+                        "{{vatBaseUrl}}{{apiPrefix}}"
+                      ],
+                      "path": [
+                        "vat",
+                        "institucion-ubicaciones",
+                        "{{institucion_ubicacion_id}}",
+                        ""
+                      ]
+                    },
+                    "description": "Sedes, anexos y puntos de atención de un centro.\n\nAutenticación: Authorization: Api-Key <clave>.\n\nOperación de escritura bloqueada por defecto. Para enviarla debe configurar explícitamente `allowVatMutations=true` en el ambiente activo; verifique los identificadores y el ambiente y no la ejecute contra producción como prueba exploratoria. En los modelos con borrado lógico, el registro se desactiva o cambia a un estado operativo cerrado/cancelado."
+                  },
+                  "event": [
+                    {
+                      "listen": "prerequest",
+                      "script": {
+                        "type": "text/javascript",
+                        "exec": [
+                          "const allowMutations = String(pm.variables.get('allowVatMutations') || '').toLowerCase() === 'true';",
+                          "if (!allowMutations) {",
+                          "  console.warn('Request VAT de escritura omitido. Configure allowVatMutations=true sólo para una ejecución controlada.');",
+                          "  pm.execution.skipRequest();",
+                          "}"
+                        ]
+                      }
+                    },
+                    {
+                      "listen": "test",
+                      "script": {
+                        "type": "text/javascript",
+                        "exec": [
+                          "pm.test('Status code 204', function () { pm.response.to.have.status(204); });"
+                        ]
+                      }
+                    }
+                  ],
+                  "response": []
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "name": "3 - API operativa - Catálogos y planes",
+          "description": "Catálogos formativos y estructura curricular.",
+          "item": [
+            {
+              "name": "Modalidades institucionales",
+              "description": "Catálogo administrable de modalidades institucionales.\n\nAutenticación: Authorization: Api-Key <clave>.\n\nEste ViewSet expone list, retrieve, create, update, partial_update y destroy.",
+              "item": [
+                {
+                  "name": "Listar modalidades institucionales",
+                  "request": {
+                    "method": "GET",
+                    "header": [
+                      {
+                        "key": "Authorization",
+                        "value": "Api-Key {{apiKey}}",
+                        "type": "text",
+                        "description": "API key VAT. En los endpoints web también puede reemplazarse por Token <token>."
+                      }
+                    ],
+                    "url": {
+                      "raw": "{{vatBaseUrl}}{{apiPrefix}}/vat/modalidades-institucionales/",
+                      "host": [
+                        "{{vatBaseUrl}}{{apiPrefix}}"
+                      ],
+                      "path": [
+                        "vat",
+                        "modalidades-institucionales",
+                        ""
+                      ],
+                      "query": [
+                        {
+                          "key": "activo",
+                          "value": "true",
+                          "description": "Filtra por estado activo.",
+                          "disabled": true
+                        },
+                        {
+                          "key": "page",
+                          "value": "1",
+                          "description": "Número de página.",
+                          "disabled": true
+                        },
+                        {
+                          "key": "page_size",
+                          "value": "20",
+                          "description": "Cantidad de resultados por página (máximo 200).",
+                          "disabled": true
+                        }
+                      ]
+                    },
+                    "description": "Catálogo administrable de modalidades institucionales.\n\nAutenticación: Authorization: Api-Key <clave>.\n\nLos filtros opcionales están cargados y deshabilitados para activarlos según el caso."
+                  },
+                  "event": [
+                    {
+                      "listen": "test",
+                      "script": {
+                        "type": "text/javascript",
+                        "exec": [
+                          "pm.test('Status code 200', function () { pm.response.to.have.status(200); });",
+                          "const body = pm.response.json();",
+                          "const rows = Array.isArray(body) ? body : (body.results || []);",
+                          "pm.test('La respuesta contiene una lista', function () { pm.expect(Array.isArray(rows)).to.eql(true); });",
+                          "if (rows.length && rows[0].id !== undefined) {",
+                          "  const value = String(rows[0].id);",
+                          "  pm.collectionVariables.set('modalidad_institucional_id', value);",
+                          "  if (pm.environment && pm.environment.name) { pm.environment.set('modalidad_institucional_id', value); }",
+                          "}"
+                        ]
+                      }
+                    }
+                  ],
+                  "response": []
+                },
+                {
+                  "name": "Crear modalidad institucional",
+                  "request": {
+                    "method": "POST",
+                    "header": [
+                      {
+                        "key": "Authorization",
+                        "value": "Api-Key {{apiKey}}",
+                        "type": "text",
+                        "description": "API key VAT. En los endpoints web también puede reemplazarse por Token <token>."
+                      },
+                      {
+                        "key": "Content-Type",
+                        "value": "application/json",
+                        "type": "text"
+                      }
+                    ],
+                    "body": {
+                      "mode": "raw",
+                      "raw": "{\n  \"nombre\": \"Modalidad institucional Postman\",\n  \"descripcion\": \"Ejemplo VAT/INET\",\n  \"activo\": true\n}",
+                      "options": {
+                        "raw": {
+                          "language": "json"
+                        }
+                      }
+                    },
+                    "url": {
+                      "raw": "{{vatBaseUrl}}{{apiPrefix}}/vat/modalidades-institucionales/",
+                      "host": [
+                        "{{vatBaseUrl}}{{apiPrefix}}"
+                      ],
+                      "path": [
+                        "vat",
+                        "modalidades-institucionales",
+                        ""
+                      ]
+                    },
+                    "description": "Catálogo administrable de modalidades institucionales.\n\nAutenticación: Authorization: Api-Key <clave>.\n\nOperación de escritura bloqueada por defecto. Para enviarla debe configurar explícitamente `allowVatMutations=true` en el ambiente activo; verifique los identificadores y el ambiente y no la ejecute contra producción como prueba exploratoria."
+                  },
+                  "event": [
+                    {
+                      "listen": "prerequest",
+                      "script": {
+                        "type": "text/javascript",
+                        "exec": [
+                          "const allowMutations = String(pm.variables.get('allowVatMutations') || '').toLowerCase() === 'true';",
+                          "if (!allowMutations) {",
+                          "  console.warn('Request VAT de escritura omitido. Configure allowVatMutations=true sólo para una ejecución controlada.');",
+                          "  pm.execution.skipRequest();",
+                          "}"
+                        ]
+                      }
+                    },
+                    {
+                      "listen": "test",
+                      "script": {
+                        "type": "text/javascript",
+                        "exec": [
+                          "pm.test('Status code 201', function () { pm.response.to.have.status(201); });",
+                          "const body = pm.response.json();",
+                          "if (body.id !== undefined) {",
+                          "  const value = String(body.id);",
+                          "  pm.collectionVariables.set('modalidad_institucional_id', value);",
+                          "  if (pm.environment && pm.environment.name) { pm.environment.set('modalidad_institucional_id', value); }",
+                          "}"
+                        ]
+                      }
+                    }
+                  ],
+                  "response": []
+                },
+                {
+                  "name": "Obtener modalidad institucional por ID",
+                  "request": {
+                    "method": "GET",
+                    "header": [
+                      {
+                        "key": "Authorization",
+                        "value": "Api-Key {{apiKey}}",
+                        "type": "text",
+                        "description": "API key VAT. En los endpoints web también puede reemplazarse por Token <token>."
+                      }
+                    ],
+                    "url": {
+                      "raw": "{{vatBaseUrl}}{{apiPrefix}}/vat/modalidades-institucionales/{{modalidad_institucional_id}}/",
+                      "host": [
+                        "{{vatBaseUrl}}{{apiPrefix}}"
+                      ],
+                      "path": [
+                        "vat",
+                        "modalidades-institucionales",
+                        "{{modalidad_institucional_id}}",
+                        ""
+                      ]
+                    },
+                    "description": "Catálogo administrable de modalidades institucionales.\n\nAutenticación: Authorization: Api-Key <clave>."
+                  },
+                  "event": [
+                    {
+                      "listen": "test",
+                      "script": {
+                        "type": "text/javascript",
+                        "exec": [
+                          "pm.test('Status code 200', function () { pm.response.to.have.status(200); });",
+                          "const body = pm.response.json();",
+                          "if (body.id !== undefined) {",
+                          "  const value = String(body.id);",
+                          "  pm.collectionVariables.set('modalidad_institucional_id', value);",
+                          "  if (pm.environment && pm.environment.name) { pm.environment.set('modalidad_institucional_id', value); }",
+                          "}"
+                        ]
+                      }
+                    }
+                  ],
+                  "response": []
+                },
+                {
+                  "name": "Reemplazar modalidad institucional (PUT)",
+                  "request": {
+                    "method": "PUT",
+                    "header": [
+                      {
+                        "key": "Authorization",
+                        "value": "Api-Key {{apiKey}}",
+                        "type": "text",
+                        "description": "API key VAT. En los endpoints web también puede reemplazarse por Token <token>."
+                      },
+                      {
+                        "key": "Content-Type",
+                        "value": "application/json",
+                        "type": "text"
+                      }
+                    ],
+                    "body": {
+                      "mode": "raw",
+                      "raw": "{\n  \"nombre\": \"Modalidad institucional Postman\",\n  \"descripcion\": \"Ejemplo VAT/INET\",\n  \"activo\": true\n}",
+                      "options": {
+                        "raw": {
+                          "language": "json"
+                        }
+                      }
+                    },
+                    "url": {
+                      "raw": "{{vatBaseUrl}}{{apiPrefix}}/vat/modalidades-institucionales/{{modalidad_institucional_id}}/",
+                      "host": [
+                        "{{vatBaseUrl}}{{apiPrefix}}"
+                      ],
+                      "path": [
+                        "vat",
+                        "modalidades-institucionales",
+                        "{{modalidad_institucional_id}}",
+                        ""
+                      ]
+                    },
+                    "description": "Catálogo administrable de modalidades institucionales.\n\nAutenticación: Authorization: Api-Key <clave>.\n\nPUT requiere el cuerpo completo. Operación de escritura bloqueada por defecto. Para enviarla debe configurar explícitamente `allowVatMutations=true` en el ambiente activo; verifique los identificadores y el ambiente y no la ejecute contra producción como prueba exploratoria."
+                  },
+                  "event": [
+                    {
+                      "listen": "prerequest",
+                      "script": {
+                        "type": "text/javascript",
+                        "exec": [
+                          "const allowMutations = String(pm.variables.get('allowVatMutations') || '').toLowerCase() === 'true';",
+                          "if (!allowMutations) {",
+                          "  console.warn('Request VAT de escritura omitido. Configure allowVatMutations=true sólo para una ejecución controlada.');",
+                          "  pm.execution.skipRequest();",
+                          "}"
+                        ]
+                      }
+                    },
+                    {
+                      "listen": "test",
+                      "script": {
+                        "type": "text/javascript",
+                        "exec": [
+                          "pm.test('Status code 200', function () { pm.response.to.have.status(200); });",
+                          "const body = pm.response.json();",
+                          "if (body.id !== undefined) {",
+                          "  const value = String(body.id);",
+                          "  pm.collectionVariables.set('modalidad_institucional_id', value);",
+                          "  if (pm.environment && pm.environment.name) { pm.environment.set('modalidad_institucional_id', value); }",
+                          "}"
+                        ]
+                      }
+                    }
+                  ],
+                  "response": []
+                },
+                {
+                  "name": "Actualizar parcialmente modalidad institucional (PATCH)",
+                  "request": {
+                    "method": "PATCH",
+                    "header": [
+                      {
+                        "key": "Authorization",
+                        "value": "Api-Key {{apiKey}}",
+                        "type": "text",
+                        "description": "API key VAT. En los endpoints web también puede reemplazarse por Token <token>."
+                      },
+                      {
+                        "key": "Content-Type",
+                        "value": "application/json",
+                        "type": "text"
+                      }
+                    ],
+                    "body": {
+                      "mode": "raw",
+                      "raw": "{\n  \"activo\": true,\n  \"descripcion\": \"Actualizada desde Postman\"\n}",
+                      "options": {
+                        "raw": {
+                          "language": "json"
+                        }
+                      }
+                    },
+                    "url": {
+                      "raw": "{{vatBaseUrl}}{{apiPrefix}}/vat/modalidades-institucionales/{{modalidad_institucional_id}}/",
+                      "host": [
+                        "{{vatBaseUrl}}{{apiPrefix}}"
+                      ],
+                      "path": [
+                        "vat",
+                        "modalidades-institucionales",
+                        "{{modalidad_institucional_id}}",
+                        ""
+                      ]
+                    },
+                    "description": "Catálogo administrable de modalidades institucionales.\n\nAutenticación: Authorization: Api-Key <clave>.\n\nOperación de escritura bloqueada por defecto. Para enviarla debe configurar explícitamente `allowVatMutations=true` en el ambiente activo; verifique los identificadores y el ambiente y no la ejecute contra producción como prueba exploratoria."
+                  },
+                  "event": [
+                    {
+                      "listen": "prerequest",
+                      "script": {
+                        "type": "text/javascript",
+                        "exec": [
+                          "const allowMutations = String(pm.variables.get('allowVatMutations') || '').toLowerCase() === 'true';",
+                          "if (!allowMutations) {",
+                          "  console.warn('Request VAT de escritura omitido. Configure allowVatMutations=true sólo para una ejecución controlada.');",
+                          "  pm.execution.skipRequest();",
+                          "}"
+                        ]
+                      }
+                    },
+                    {
+                      "listen": "test",
+                      "script": {
+                        "type": "text/javascript",
+                        "exec": [
+                          "pm.test('Status code 200', function () { pm.response.to.have.status(200); });",
+                          "const body = pm.response.json();",
+                          "if (body.id !== undefined) {",
+                          "  const value = String(body.id);",
+                          "  pm.collectionVariables.set('modalidad_institucional_id', value);",
+                          "  if (pm.environment && pm.environment.name) { pm.environment.set('modalidad_institucional_id', value); }",
+                          "}"
+                        ]
+                      }
+                    }
+                  ],
+                  "response": []
+                },
+                {
+                  "name": "Eliminar modalidad institucional (DELETE)",
+                  "request": {
+                    "method": "DELETE",
+                    "header": [
+                      {
+                        "key": "Authorization",
+                        "value": "Api-Key {{apiKey}}",
+                        "type": "text",
+                        "description": "API key VAT. En los endpoints web también puede reemplazarse por Token <token>."
+                      }
+                    ],
+                    "url": {
+                      "raw": "{{vatBaseUrl}}{{apiPrefix}}/vat/modalidades-institucionales/{{modalidad_institucional_id}}/",
+                      "host": [
+                        "{{vatBaseUrl}}{{apiPrefix}}"
+                      ],
+                      "path": [
+                        "vat",
+                        "modalidades-institucionales",
+                        "{{modalidad_institucional_id}}",
+                        ""
+                      ]
+                    },
+                    "description": "Catálogo administrable de modalidades institucionales.\n\nAutenticación: Authorization: Api-Key <clave>.\n\nOperación de escritura bloqueada por defecto. Para enviarla debe configurar explícitamente `allowVatMutations=true` en el ambiente activo; verifique los identificadores y el ambiente y no la ejecute contra producción como prueba exploratoria. En los modelos con borrado lógico, el registro se desactiva o cambia a un estado operativo cerrado/cancelado."
+                  },
+                  "event": [
+                    {
+                      "listen": "prerequest",
+                      "script": {
+                        "type": "text/javascript",
+                        "exec": [
+                          "const allowMutations = String(pm.variables.get('allowVatMutations') || '').toLowerCase() === 'true';",
+                          "if (!allowMutations) {",
+                          "  console.warn('Request VAT de escritura omitido. Configure allowVatMutations=true sólo para una ejecución controlada.');",
+                          "  pm.execution.skipRequest();",
+                          "}"
+                        ]
+                      }
+                    },
+                    {
+                      "listen": "test",
+                      "script": {
+                        "type": "text/javascript",
+                        "exec": [
+                          "pm.test('Status code 204', function () { pm.response.to.have.status(204); });"
+                        ]
+                      }
+                    }
+                  ],
+                  "response": []
+                }
+              ]
+            },
+            {
+              "name": "Sectores",
+              "description": "Sectores formativos de VAT/INET.\n\nAutenticación: Authorization: Api-Key <clave>.\n\nEste ViewSet expone list, retrieve, create, update, partial_update y destroy.",
+              "item": [
+                {
+                  "name": "Listar sectores",
+                  "request": {
+                    "method": "GET",
+                    "header": [
+                      {
+                        "key": "Authorization",
+                        "value": "Api-Key {{apiKey}}",
+                        "type": "text",
+                        "description": "API key VAT. En los endpoints web también puede reemplazarse por Token <token>."
+                      }
+                    ],
+                    "url": {
+                      "raw": "{{vatBaseUrl}}{{apiPrefix}}/vat/sectores/",
+                      "host": [
+                        "{{vatBaseUrl}}{{apiPrefix}}"
+                      ],
+                      "path": [
+                        "vat",
+                        "sectores",
+                        ""
+                      ],
+                      "query": [
+                        {
+                          "key": "page",
+                          "value": "1",
+                          "description": "Número de página.",
+                          "disabled": true
+                        },
+                        {
+                          "key": "page_size",
+                          "value": "20",
+                          "description": "Cantidad de resultados por página (máximo 200).",
+                          "disabled": true
+                        }
+                      ]
+                    },
+                    "description": "Sectores formativos de VAT/INET.\n\nAutenticación: Authorization: Api-Key <clave>.\n\nLos filtros opcionales están cargados y deshabilitados para activarlos según el caso."
+                  },
+                  "event": [
+                    {
+                      "listen": "test",
+                      "script": {
+                        "type": "text/javascript",
+                        "exec": [
+                          "pm.test('Status code 200', function () { pm.response.to.have.status(200); });",
+                          "const body = pm.response.json();",
+                          "const rows = Array.isArray(body) ? body : (body.results || []);",
+                          "pm.test('La respuesta contiene una lista', function () { pm.expect(Array.isArray(rows)).to.eql(true); });",
+                          "if (rows.length && rows[0].id !== undefined) {",
+                          "  const value = String(rows[0].id);",
+                          "  pm.collectionVariables.set('sector_id', value);",
+                          "  if (pm.environment && pm.environment.name) { pm.environment.set('sector_id', value); }",
+                          "}"
+                        ]
+                      }
+                    }
+                  ],
+                  "response": []
+                },
+                {
+                  "name": "Crear sector",
+                  "request": {
+                    "method": "POST",
+                    "header": [
+                      {
+                        "key": "Authorization",
+                        "value": "Api-Key {{apiKey}}",
+                        "type": "text",
+                        "description": "API key VAT. En los endpoints web también puede reemplazarse por Token <token>."
+                      },
+                      {
+                        "key": "Content-Type",
+                        "value": "application/json",
+                        "type": "text"
+                      }
+                    ],
+                    "body": {
+                      "mode": "raw",
+                      "raw": "{\n  \"nombre\": \"Sector Postman {{$randomInt}}\",\n  \"descripcion\": \"Ejemplo VAT/INET\"\n}",
+                      "options": {
+                        "raw": {
+                          "language": "json"
+                        }
+                      }
+                    },
+                    "url": {
+                      "raw": "{{vatBaseUrl}}{{apiPrefix}}/vat/sectores/",
+                      "host": [
+                        "{{vatBaseUrl}}{{apiPrefix}}"
+                      ],
+                      "path": [
+                        "vat",
+                        "sectores",
+                        ""
+                      ]
+                    },
+                    "description": "Sectores formativos de VAT/INET.\n\nAutenticación: Authorization: Api-Key <clave>.\n\nOperación de escritura bloqueada por defecto. Para enviarla debe configurar explícitamente `allowVatMutations=true` en el ambiente activo; verifique los identificadores y el ambiente y no la ejecute contra producción como prueba exploratoria."
+                  },
+                  "event": [
+                    {
+                      "listen": "prerequest",
+                      "script": {
+                        "type": "text/javascript",
+                        "exec": [
+                          "const allowMutations = String(pm.variables.get('allowVatMutations') || '').toLowerCase() === 'true';",
+                          "if (!allowMutations) {",
+                          "  console.warn('Request VAT de escritura omitido. Configure allowVatMutations=true sólo para una ejecución controlada.');",
+                          "  pm.execution.skipRequest();",
+                          "}"
+                        ]
+                      }
+                    },
+                    {
+                      "listen": "test",
+                      "script": {
+                        "type": "text/javascript",
+                        "exec": [
+                          "pm.test('Status code 201', function () { pm.response.to.have.status(201); });",
+                          "const body = pm.response.json();",
+                          "if (body.id !== undefined) {",
+                          "  const value = String(body.id);",
+                          "  pm.collectionVariables.set('sector_id', value);",
+                          "  if (pm.environment && pm.environment.name) { pm.environment.set('sector_id', value); }",
+                          "}"
+                        ]
+                      }
+                    }
+                  ],
+                  "response": []
+                },
+                {
+                  "name": "Obtener sector por ID",
+                  "request": {
+                    "method": "GET",
+                    "header": [
+                      {
+                        "key": "Authorization",
+                        "value": "Api-Key {{apiKey}}",
+                        "type": "text",
+                        "description": "API key VAT. En los endpoints web también puede reemplazarse por Token <token>."
+                      }
+                    ],
+                    "url": {
+                      "raw": "{{vatBaseUrl}}{{apiPrefix}}/vat/sectores/{{sector_id}}/",
+                      "host": [
+                        "{{vatBaseUrl}}{{apiPrefix}}"
+                      ],
+                      "path": [
+                        "vat",
+                        "sectores",
+                        "{{sector_id}}",
+                        ""
+                      ]
+                    },
+                    "description": "Sectores formativos de VAT/INET.\n\nAutenticación: Authorization: Api-Key <clave>."
+                  },
+                  "event": [
+                    {
+                      "listen": "test",
+                      "script": {
+                        "type": "text/javascript",
+                        "exec": [
+                          "pm.test('Status code 200', function () { pm.response.to.have.status(200); });",
+                          "const body = pm.response.json();",
+                          "if (body.id !== undefined) {",
+                          "  const value = String(body.id);",
+                          "  pm.collectionVariables.set('sector_id', value);",
+                          "  if (pm.environment && pm.environment.name) { pm.environment.set('sector_id', value); }",
+                          "}"
+                        ]
+                      }
+                    }
+                  ],
+                  "response": []
+                },
+                {
+                  "name": "Reemplazar sector (PUT)",
+                  "request": {
+                    "method": "PUT",
+                    "header": [
+                      {
+                        "key": "Authorization",
+                        "value": "Api-Key {{apiKey}}",
+                        "type": "text",
+                        "description": "API key VAT. En los endpoints web también puede reemplazarse por Token <token>."
+                      },
+                      {
+                        "key": "Content-Type",
+                        "value": "application/json",
+                        "type": "text"
+                      }
+                    ],
+                    "body": {
+                      "mode": "raw",
+                      "raw": "{\n  \"nombre\": \"Sector Postman {{$randomInt}}\",\n  \"descripcion\": \"Ejemplo VAT/INET\"\n}",
+                      "options": {
+                        "raw": {
+                          "language": "json"
+                        }
+                      }
+                    },
+                    "url": {
+                      "raw": "{{vatBaseUrl}}{{apiPrefix}}/vat/sectores/{{sector_id}}/",
+                      "host": [
+                        "{{vatBaseUrl}}{{apiPrefix}}"
+                      ],
+                      "path": [
+                        "vat",
+                        "sectores",
+                        "{{sector_id}}",
+                        ""
+                      ]
+                    },
+                    "description": "Sectores formativos de VAT/INET.\n\nAutenticación: Authorization: Api-Key <clave>.\n\nPUT requiere el cuerpo completo. Operación de escritura bloqueada por defecto. Para enviarla debe configurar explícitamente `allowVatMutations=true` en el ambiente activo; verifique los identificadores y el ambiente y no la ejecute contra producción como prueba exploratoria."
+                  },
+                  "event": [
+                    {
+                      "listen": "prerequest",
+                      "script": {
+                        "type": "text/javascript",
+                        "exec": [
+                          "const allowMutations = String(pm.variables.get('allowVatMutations') || '').toLowerCase() === 'true';",
+                          "if (!allowMutations) {",
+                          "  console.warn('Request VAT de escritura omitido. Configure allowVatMutations=true sólo para una ejecución controlada.');",
+                          "  pm.execution.skipRequest();",
+                          "}"
+                        ]
+                      }
+                    },
+                    {
+                      "listen": "test",
+                      "script": {
+                        "type": "text/javascript",
+                        "exec": [
+                          "pm.test('Status code 200', function () { pm.response.to.have.status(200); });",
+                          "const body = pm.response.json();",
+                          "if (body.id !== undefined) {",
+                          "  const value = String(body.id);",
+                          "  pm.collectionVariables.set('sector_id', value);",
+                          "  if (pm.environment && pm.environment.name) { pm.environment.set('sector_id', value); }",
+                          "}"
+                        ]
+                      }
+                    }
+                  ],
+                  "response": []
+                },
+                {
+                  "name": "Actualizar parcialmente sector (PATCH)",
+                  "request": {
+                    "method": "PATCH",
+                    "header": [
+                      {
+                        "key": "Authorization",
+                        "value": "Api-Key {{apiKey}}",
+                        "type": "text",
+                        "description": "API key VAT. En los endpoints web también puede reemplazarse por Token <token>."
+                      },
+                      {
+                        "key": "Content-Type",
+                        "value": "application/json",
+                        "type": "text"
+                      }
+                    ],
+                    "body": {
+                      "mode": "raw",
+                      "raw": "{\n  \"descripcion\": \"Sector actualizado desde Postman\"\n}",
+                      "options": {
+                        "raw": {
+                          "language": "json"
+                        }
+                      }
+                    },
+                    "url": {
+                      "raw": "{{vatBaseUrl}}{{apiPrefix}}/vat/sectores/{{sector_id}}/",
+                      "host": [
+                        "{{vatBaseUrl}}{{apiPrefix}}"
+                      ],
+                      "path": [
+                        "vat",
+                        "sectores",
+                        "{{sector_id}}",
+                        ""
+                      ]
+                    },
+                    "description": "Sectores formativos de VAT/INET.\n\nAutenticación: Authorization: Api-Key <clave>.\n\nOperación de escritura bloqueada por defecto. Para enviarla debe configurar explícitamente `allowVatMutations=true` en el ambiente activo; verifique los identificadores y el ambiente y no la ejecute contra producción como prueba exploratoria."
+                  },
+                  "event": [
+                    {
+                      "listen": "prerequest",
+                      "script": {
+                        "type": "text/javascript",
+                        "exec": [
+                          "const allowMutations = String(pm.variables.get('allowVatMutations') || '').toLowerCase() === 'true';",
+                          "if (!allowMutations) {",
+                          "  console.warn('Request VAT de escritura omitido. Configure allowVatMutations=true sólo para una ejecución controlada.');",
+                          "  pm.execution.skipRequest();",
+                          "}"
+                        ]
+                      }
+                    },
+                    {
+                      "listen": "test",
+                      "script": {
+                        "type": "text/javascript",
+                        "exec": [
+                          "pm.test('Status code 200', function () { pm.response.to.have.status(200); });",
+                          "const body = pm.response.json();",
+                          "if (body.id !== undefined) {",
+                          "  const value = String(body.id);",
+                          "  pm.collectionVariables.set('sector_id', value);",
+                          "  if (pm.environment && pm.environment.name) { pm.environment.set('sector_id', value); }",
+                          "}"
+                        ]
+                      }
+                    }
+                  ],
+                  "response": []
+                },
+                {
+                  "name": "Eliminar sector (DELETE)",
+                  "request": {
+                    "method": "DELETE",
+                    "header": [
+                      {
+                        "key": "Authorization",
+                        "value": "Api-Key {{apiKey}}",
+                        "type": "text",
+                        "description": "API key VAT. En los endpoints web también puede reemplazarse por Token <token>."
+                      }
+                    ],
+                    "url": {
+                      "raw": "{{vatBaseUrl}}{{apiPrefix}}/vat/sectores/{{sector_id}}/",
+                      "host": [
+                        "{{vatBaseUrl}}{{apiPrefix}}"
+                      ],
+                      "path": [
+                        "vat",
+                        "sectores",
+                        "{{sector_id}}",
+                        ""
+                      ]
+                    },
+                    "description": "Sectores formativos de VAT/INET.\n\nAutenticación: Authorization: Api-Key <clave>.\n\nOperación de escritura bloqueada por defecto. Para enviarla debe configurar explícitamente `allowVatMutations=true` en el ambiente activo; verifique los identificadores y el ambiente y no la ejecute contra producción como prueba exploratoria. En los modelos con borrado lógico, el registro se desactiva o cambia a un estado operativo cerrado/cancelado."
+                  },
+                  "event": [
+                    {
+                      "listen": "prerequest",
+                      "script": {
+                        "type": "text/javascript",
+                        "exec": [
+                          "const allowMutations = String(pm.variables.get('allowVatMutations') || '').toLowerCase() === 'true';",
+                          "if (!allowMutations) {",
+                          "  console.warn('Request VAT de escritura omitido. Configure allowVatMutations=true sólo para una ejecución controlada.');",
+                          "  pm.execution.skipRequest();",
+                          "}"
+                        ]
+                      }
+                    },
+                    {
+                      "listen": "test",
+                      "script": {
+                        "type": "text/javascript",
+                        "exec": [
+                          "pm.test('Status code 204', function () { pm.response.to.have.status(204); });"
+                        ]
+                      }
+                    }
+                  ],
+                  "response": []
+                }
+              ]
+            },
+            {
+              "name": "Subsectores",
+              "description": "Subsectores vinculados a un sector formativo.\n\nAutenticación: Authorization: Api-Key <clave>.\n\nEste ViewSet expone list, retrieve, create, update, partial_update y destroy.",
+              "item": [
+                {
+                  "name": "Listar subsectores",
+                  "request": {
+                    "method": "GET",
+                    "header": [
+                      {
+                        "key": "Authorization",
+                        "value": "Api-Key {{apiKey}}",
+                        "type": "text",
+                        "description": "API key VAT. En los endpoints web también puede reemplazarse por Token <token>."
+                      }
+                    ],
+                    "url": {
+                      "raw": "{{vatBaseUrl}}{{apiPrefix}}/vat/subsectores/",
+                      "host": [
+                        "{{vatBaseUrl}}{{apiPrefix}}"
+                      ],
+                      "path": [
+                        "vat",
+                        "subsectores",
+                        ""
+                      ],
+                      "query": [
+                        {
+                          "key": "sector_id",
+                          "value": "{{sector_id}}",
+                          "description": "Filtra por sector.",
+                          "disabled": true
+                        },
+                        {
+                          "key": "page",
+                          "value": "1",
+                          "description": "Número de página.",
+                          "disabled": true
+                        },
+                        {
+                          "key": "page_size",
+                          "value": "20",
+                          "description": "Cantidad de resultados por página (máximo 200).",
+                          "disabled": true
+                        }
+                      ]
+                    },
+                    "description": "Subsectores vinculados a un sector formativo.\n\nAutenticación: Authorization: Api-Key <clave>.\n\nLos filtros opcionales están cargados y deshabilitados para activarlos según el caso."
+                  },
+                  "event": [
+                    {
+                      "listen": "test",
+                      "script": {
+                        "type": "text/javascript",
+                        "exec": [
+                          "pm.test('Status code 200', function () { pm.response.to.have.status(200); });",
+                          "const body = pm.response.json();",
+                          "const rows = Array.isArray(body) ? body : (body.results || []);",
+                          "pm.test('La respuesta contiene una lista', function () { pm.expect(Array.isArray(rows)).to.eql(true); });",
+                          "if (rows.length && rows[0].id !== undefined) {",
+                          "  const value = String(rows[0].id);",
+                          "  pm.collectionVariables.set('subsector_id', value);",
+                          "  if (pm.environment && pm.environment.name) { pm.environment.set('subsector_id', value); }",
+                          "}"
+                        ]
+                      }
+                    }
+                  ],
+                  "response": []
+                },
+                {
+                  "name": "Crear subsector",
+                  "request": {
+                    "method": "POST",
+                    "header": [
+                      {
+                        "key": "Authorization",
+                        "value": "Api-Key {{apiKey}}",
+                        "type": "text",
+                        "description": "API key VAT. En los endpoints web también puede reemplazarse por Token <token>."
+                      },
+                      {
+                        "key": "Content-Type",
+                        "value": "application/json",
+                        "type": "text"
+                      }
+                    ],
+                    "body": {
+                      "mode": "raw",
+                      "raw": "{\n  \"sector\": {{sector_id}},\n  \"nombre\": \"Subsector Postman {{$randomInt}}\",\n  \"descripcion\": \"Ejemplo VAT/INET\"\n}",
+                      "options": {
+                        "raw": {
+                          "language": "json"
+                        }
+                      }
+                    },
+                    "url": {
+                      "raw": "{{vatBaseUrl}}{{apiPrefix}}/vat/subsectores/",
+                      "host": [
+                        "{{vatBaseUrl}}{{apiPrefix}}"
+                      ],
+                      "path": [
+                        "vat",
+                        "subsectores",
+                        ""
+                      ]
+                    },
+                    "description": "Subsectores vinculados a un sector formativo.\n\nAutenticación: Authorization: Api-Key <clave>.\n\nOperación de escritura bloqueada por defecto. Para enviarla debe configurar explícitamente `allowVatMutations=true` en el ambiente activo; verifique los identificadores y el ambiente y no la ejecute contra producción como prueba exploratoria."
+                  },
+                  "event": [
+                    {
+                      "listen": "prerequest",
+                      "script": {
+                        "type": "text/javascript",
+                        "exec": [
+                          "const allowMutations = String(pm.variables.get('allowVatMutations') || '').toLowerCase() === 'true';",
+                          "if (!allowMutations) {",
+                          "  console.warn('Request VAT de escritura omitido. Configure allowVatMutations=true sólo para una ejecución controlada.');",
+                          "  pm.execution.skipRequest();",
+                          "}"
+                        ]
+                      }
+                    },
+                    {
+                      "listen": "test",
+                      "script": {
+                        "type": "text/javascript",
+                        "exec": [
+                          "pm.test('Status code 201', function () { pm.response.to.have.status(201); });",
+                          "const body = pm.response.json();",
+                          "if (body.id !== undefined) {",
+                          "  const value = String(body.id);",
+                          "  pm.collectionVariables.set('subsector_id', value);",
+                          "  if (pm.environment && pm.environment.name) { pm.environment.set('subsector_id', value); }",
+                          "}"
+                        ]
+                      }
+                    }
+                  ],
+                  "response": []
+                },
+                {
+                  "name": "Obtener subsector por ID",
+                  "request": {
+                    "method": "GET",
+                    "header": [
+                      {
+                        "key": "Authorization",
+                        "value": "Api-Key {{apiKey}}",
+                        "type": "text",
+                        "description": "API key VAT. En los endpoints web también puede reemplazarse por Token <token>."
+                      }
+                    ],
+                    "url": {
+                      "raw": "{{vatBaseUrl}}{{apiPrefix}}/vat/subsectores/{{subsector_id}}/",
+                      "host": [
+                        "{{vatBaseUrl}}{{apiPrefix}}"
+                      ],
+                      "path": [
+                        "vat",
+                        "subsectores",
+                        "{{subsector_id}}",
+                        ""
+                      ]
+                    },
+                    "description": "Subsectores vinculados a un sector formativo.\n\nAutenticación: Authorization: Api-Key <clave>."
+                  },
+                  "event": [
+                    {
+                      "listen": "test",
+                      "script": {
+                        "type": "text/javascript",
+                        "exec": [
+                          "pm.test('Status code 200', function () { pm.response.to.have.status(200); });",
+                          "const body = pm.response.json();",
+                          "if (body.id !== undefined) {",
+                          "  const value = String(body.id);",
+                          "  pm.collectionVariables.set('subsector_id', value);",
+                          "  if (pm.environment && pm.environment.name) { pm.environment.set('subsector_id', value); }",
+                          "}"
+                        ]
+                      }
+                    }
+                  ],
+                  "response": []
+                },
+                {
+                  "name": "Reemplazar subsector (PUT)",
+                  "request": {
+                    "method": "PUT",
+                    "header": [
+                      {
+                        "key": "Authorization",
+                        "value": "Api-Key {{apiKey}}",
+                        "type": "text",
+                        "description": "API key VAT. En los endpoints web también puede reemplazarse por Token <token>."
+                      },
+                      {
+                        "key": "Content-Type",
+                        "value": "application/json",
+                        "type": "text"
+                      }
+                    ],
+                    "body": {
+                      "mode": "raw",
+                      "raw": "{\n  \"sector\": {{sector_id}},\n  \"nombre\": \"Subsector Postman {{$randomInt}}\",\n  \"descripcion\": \"Ejemplo VAT/INET\"\n}",
+                      "options": {
+                        "raw": {
+                          "language": "json"
+                        }
+                      }
+                    },
+                    "url": {
+                      "raw": "{{vatBaseUrl}}{{apiPrefix}}/vat/subsectores/{{subsector_id}}/",
+                      "host": [
+                        "{{vatBaseUrl}}{{apiPrefix}}"
+                      ],
+                      "path": [
+                        "vat",
+                        "subsectores",
+                        "{{subsector_id}}",
+                        ""
+                      ]
+                    },
+                    "description": "Subsectores vinculados a un sector formativo.\n\nAutenticación: Authorization: Api-Key <clave>.\n\nPUT requiere el cuerpo completo. Operación de escritura bloqueada por defecto. Para enviarla debe configurar explícitamente `allowVatMutations=true` en el ambiente activo; verifique los identificadores y el ambiente y no la ejecute contra producción como prueba exploratoria."
+                  },
+                  "event": [
+                    {
+                      "listen": "prerequest",
+                      "script": {
+                        "type": "text/javascript",
+                        "exec": [
+                          "const allowMutations = String(pm.variables.get('allowVatMutations') || '').toLowerCase() === 'true';",
+                          "if (!allowMutations) {",
+                          "  console.warn('Request VAT de escritura omitido. Configure allowVatMutations=true sólo para una ejecución controlada.');",
+                          "  pm.execution.skipRequest();",
+                          "}"
+                        ]
+                      }
+                    },
+                    {
+                      "listen": "test",
+                      "script": {
+                        "type": "text/javascript",
+                        "exec": [
+                          "pm.test('Status code 200', function () { pm.response.to.have.status(200); });",
+                          "const body = pm.response.json();",
+                          "if (body.id !== undefined) {",
+                          "  const value = String(body.id);",
+                          "  pm.collectionVariables.set('subsector_id', value);",
+                          "  if (pm.environment && pm.environment.name) { pm.environment.set('subsector_id', value); }",
+                          "}"
+                        ]
+                      }
+                    }
+                  ],
+                  "response": []
+                },
+                {
+                  "name": "Actualizar parcialmente subsector (PATCH)",
+                  "request": {
+                    "method": "PATCH",
+                    "header": [
+                      {
+                        "key": "Authorization",
+                        "value": "Api-Key {{apiKey}}",
+                        "type": "text",
+                        "description": "API key VAT. En los endpoints web también puede reemplazarse por Token <token>."
+                      },
+                      {
+                        "key": "Content-Type",
+                        "value": "application/json",
+                        "type": "text"
+                      }
+                    ],
+                    "body": {
+                      "mode": "raw",
+                      "raw": "{\n  \"descripcion\": \"Subsector actualizado desde Postman\"\n}",
+                      "options": {
+                        "raw": {
+                          "language": "json"
+                        }
+                      }
+                    },
+                    "url": {
+                      "raw": "{{vatBaseUrl}}{{apiPrefix}}/vat/subsectores/{{subsector_id}}/",
+                      "host": [
+                        "{{vatBaseUrl}}{{apiPrefix}}"
+                      ],
+                      "path": [
+                        "vat",
+                        "subsectores",
+                        "{{subsector_id}}",
+                        ""
+                      ]
+                    },
+                    "description": "Subsectores vinculados a un sector formativo.\n\nAutenticación: Authorization: Api-Key <clave>.\n\nOperación de escritura bloqueada por defecto. Para enviarla debe configurar explícitamente `allowVatMutations=true` en el ambiente activo; verifique los identificadores y el ambiente y no la ejecute contra producción como prueba exploratoria."
+                  },
+                  "event": [
+                    {
+                      "listen": "prerequest",
+                      "script": {
+                        "type": "text/javascript",
+                        "exec": [
+                          "const allowMutations = String(pm.variables.get('allowVatMutations') || '').toLowerCase() === 'true';",
+                          "if (!allowMutations) {",
+                          "  console.warn('Request VAT de escritura omitido. Configure allowVatMutations=true sólo para una ejecución controlada.');",
+                          "  pm.execution.skipRequest();",
+                          "}"
+                        ]
+                      }
+                    },
+                    {
+                      "listen": "test",
+                      "script": {
+                        "type": "text/javascript",
+                        "exec": [
+                          "pm.test('Status code 200', function () { pm.response.to.have.status(200); });",
+                          "const body = pm.response.json();",
+                          "if (body.id !== undefined) {",
+                          "  const value = String(body.id);",
+                          "  pm.collectionVariables.set('subsector_id', value);",
+                          "  if (pm.environment && pm.environment.name) { pm.environment.set('subsector_id', value); }",
+                          "}"
+                        ]
+                      }
+                    }
+                  ],
+                  "response": []
+                },
+                {
+                  "name": "Eliminar subsector (DELETE)",
+                  "request": {
+                    "method": "DELETE",
+                    "header": [
+                      {
+                        "key": "Authorization",
+                        "value": "Api-Key {{apiKey}}",
+                        "type": "text",
+                        "description": "API key VAT. En los endpoints web también puede reemplazarse por Token <token>."
+                      }
+                    ],
+                    "url": {
+                      "raw": "{{vatBaseUrl}}{{apiPrefix}}/vat/subsectores/{{subsector_id}}/",
+                      "host": [
+                        "{{vatBaseUrl}}{{apiPrefix}}"
+                      ],
+                      "path": [
+                        "vat",
+                        "subsectores",
+                        "{{subsector_id}}",
+                        ""
+                      ]
+                    },
+                    "description": "Subsectores vinculados a un sector formativo.\n\nAutenticación: Authorization: Api-Key <clave>.\n\nOperación de escritura bloqueada por defecto. Para enviarla debe configurar explícitamente `allowVatMutations=true` en el ambiente activo; verifique los identificadores y el ambiente y no la ejecute contra producción como prueba exploratoria. En los modelos con borrado lógico, el registro se desactiva o cambia a un estado operativo cerrado/cancelado."
+                  },
+                  "event": [
+                    {
+                      "listen": "prerequest",
+                      "script": {
+                        "type": "text/javascript",
+                        "exec": [
+                          "const allowMutations = String(pm.variables.get('allowVatMutations') || '').toLowerCase() === 'true';",
+                          "if (!allowMutations) {",
+                          "  console.warn('Request VAT de escritura omitido. Configure allowVatMutations=true sólo para una ejecución controlada.');",
+                          "  pm.execution.skipRequest();",
+                          "}"
+                        ]
+                      }
+                    },
+                    {
+                      "listen": "test",
+                      "script": {
+                        "type": "text/javascript",
+                        "exec": [
+                          "pm.test('Status code 204', function () { pm.response.to.have.status(204); });"
+                        ]
+                      }
+                    }
+                  ],
+                  "response": []
+                }
+              ]
+            },
+            {
+              "name": "Títulos de referencia",
+              "description": "Títulos de referencia asociados opcionalmente a un plan curricular.\n\nAutenticación: Authorization: Api-Key <clave>.\n\nEste ViewSet expone list, retrieve, create, update, partial_update y destroy.",
+              "item": [
+                {
+                  "name": "Listar títulos de referencia",
+                  "request": {
+                    "method": "GET",
+                    "header": [
+                      {
+                        "key": "Authorization",
+                        "value": "Api-Key {{apiKey}}",
+                        "type": "text",
+                        "description": "API key VAT. En los endpoints web también puede reemplazarse por Token <token>."
+                      }
+                    ],
+                    "url": {
+                      "raw": "{{vatBaseUrl}}{{apiPrefix}}/vat/titulos-referencia/",
+                      "host": [
+                        "{{vatBaseUrl}}{{apiPrefix}}"
+                      ],
+                      "path": [
+                        "vat",
+                        "titulos-referencia",
+                        ""
+                      ],
+                      "query": [
+                        {
+                          "key": "sector_id",
+                          "value": "{{sector_id}}",
+                          "description": "Filtra por sector del plan.",
+                          "disabled": true
+                        },
+                        {
+                          "key": "subsector_id",
+                          "value": "{{subsector_id}}",
+                          "description": "Filtra por subsector del plan.",
+                          "disabled": true
+                        },
+                        {
+                          "key": "activo",
+                          "value": "true",
+                          "description": "Filtra por estado activo.",
+                          "disabled": true
+                        },
+                        {
+                          "key": "page",
+                          "value": "1",
+                          "description": "Número de página.",
+                          "disabled": true
+                        },
+                        {
+                          "key": "page_size",
+                          "value": "20",
+                          "description": "Cantidad de resultados por página (máximo 200).",
+                          "disabled": true
+                        }
+                      ]
+                    },
+                    "description": "Títulos de referencia asociados opcionalmente a un plan curricular.\n\nAutenticación: Authorization: Api-Key <clave>.\n\nLos filtros opcionales están cargados y deshabilitados para activarlos según el caso."
+                  },
+                  "event": [
+                    {
+                      "listen": "test",
+                      "script": {
+                        "type": "text/javascript",
+                        "exec": [
+                          "pm.test('Status code 200', function () { pm.response.to.have.status(200); });",
+                          "const body = pm.response.json();",
+                          "const rows = Array.isArray(body) ? body : (body.results || []);",
+                          "pm.test('La respuesta contiene una lista', function () { pm.expect(Array.isArray(rows)).to.eql(true); });",
+                          "if (rows.length && rows[0].id !== undefined) {",
+                          "  const value = String(rows[0].id);",
+                          "  pm.collectionVariables.set('titulo_id', value);",
+                          "  if (pm.environment && pm.environment.name) { pm.environment.set('titulo_id', value); }",
+                          "}"
+                        ]
+                      }
+                    }
+                  ],
+                  "response": []
+                },
+                {
+                  "name": "Crear título de referencia",
+                  "request": {
+                    "method": "POST",
+                    "header": [
+                      {
+                        "key": "Authorization",
+                        "value": "Api-Key {{apiKey}}",
+                        "type": "text",
+                        "description": "API key VAT. En los endpoints web también puede reemplazarse por Token <token>."
+                      },
+                      {
+                        "key": "Content-Type",
+                        "value": "application/json",
+                        "type": "text"
+                      }
+                    ],
+                    "body": {
+                      "mode": "raw",
+                      "raw": "{\n  \"plan_estudio\": null,\n  \"codigo_referencia\": \"TIT-{{$randomInt}}\",\n  \"nombre\": \"Título de referencia Postman\",\n  \"descripcion\": \"Ejemplo VAT/INET\",\n  \"activo\": true\n}",
+                      "options": {
+                        "raw": {
+                          "language": "json"
+                        }
+                      }
+                    },
+                    "url": {
+                      "raw": "{{vatBaseUrl}}{{apiPrefix}}/vat/titulos-referencia/",
+                      "host": [
+                        "{{vatBaseUrl}}{{apiPrefix}}"
+                      ],
+                      "path": [
+                        "vat",
+                        "titulos-referencia",
+                        ""
+                      ]
+                    },
+                    "description": "Títulos de referencia asociados opcionalmente a un plan curricular.\n\nAutenticación: Authorization: Api-Key <clave>.\n\nOperación de escritura bloqueada por defecto. Para enviarla debe configurar explícitamente `allowVatMutations=true` en el ambiente activo; verifique los identificadores y el ambiente y no la ejecute contra producción como prueba exploratoria."
+                  },
+                  "event": [
+                    {
+                      "listen": "prerequest",
+                      "script": {
+                        "type": "text/javascript",
+                        "exec": [
+                          "const allowMutations = String(pm.variables.get('allowVatMutations') || '').toLowerCase() === 'true';",
+                          "if (!allowMutations) {",
+                          "  console.warn('Request VAT de escritura omitido. Configure allowVatMutations=true sólo para una ejecución controlada.');",
+                          "  pm.execution.skipRequest();",
+                          "}"
+                        ]
+                      }
+                    },
+                    {
+                      "listen": "test",
+                      "script": {
+                        "type": "text/javascript",
+                        "exec": [
+                          "pm.test('Status code 201', function () { pm.response.to.have.status(201); });",
+                          "const body = pm.response.json();",
+                          "if (body.id !== undefined) {",
+                          "  const value = String(body.id);",
+                          "  pm.collectionVariables.set('titulo_id', value);",
+                          "  if (pm.environment && pm.environment.name) { pm.environment.set('titulo_id', value); }",
+                          "}"
+                        ]
+                      }
+                    }
+                  ],
+                  "response": []
+                },
+                {
+                  "name": "Obtener título de referencia por ID",
+                  "request": {
+                    "method": "GET",
+                    "header": [
+                      {
+                        "key": "Authorization",
+                        "value": "Api-Key {{apiKey}}",
+                        "type": "text",
+                        "description": "API key VAT. En los endpoints web también puede reemplazarse por Token <token>."
+                      }
+                    ],
+                    "url": {
+                      "raw": "{{vatBaseUrl}}{{apiPrefix}}/vat/titulos-referencia/{{titulo_id}}/",
+                      "host": [
+                        "{{vatBaseUrl}}{{apiPrefix}}"
+                      ],
+                      "path": [
+                        "vat",
+                        "titulos-referencia",
+                        "{{titulo_id}}",
+                        ""
+                      ]
+                    },
+                    "description": "Títulos de referencia asociados opcionalmente a un plan curricular.\n\nAutenticación: Authorization: Api-Key <clave>."
+                  },
+                  "event": [
+                    {
+                      "listen": "test",
+                      "script": {
+                        "type": "text/javascript",
+                        "exec": [
+                          "pm.test('Status code 200', function () { pm.response.to.have.status(200); });",
+                          "const body = pm.response.json();",
+                          "if (body.id !== undefined) {",
+                          "  const value = String(body.id);",
+                          "  pm.collectionVariables.set('titulo_id', value);",
+                          "  if (pm.environment && pm.environment.name) { pm.environment.set('titulo_id', value); }",
+                          "}"
+                        ]
+                      }
+                    }
+                  ],
+                  "response": []
+                },
+                {
+                  "name": "Reemplazar título de referencia (PUT)",
+                  "request": {
+                    "method": "PUT",
+                    "header": [
+                      {
+                        "key": "Authorization",
+                        "value": "Api-Key {{apiKey}}",
+                        "type": "text",
+                        "description": "API key VAT. En los endpoints web también puede reemplazarse por Token <token>."
+                      },
+                      {
+                        "key": "Content-Type",
+                        "value": "application/json",
+                        "type": "text"
+                      }
+                    ],
+                    "body": {
+                      "mode": "raw",
+                      "raw": "{\n  \"plan_estudio\": null,\n  \"codigo_referencia\": \"TIT-{{$randomInt}}\",\n  \"nombre\": \"Título de referencia Postman\",\n  \"descripcion\": \"Ejemplo VAT/INET\",\n  \"activo\": true\n}",
+                      "options": {
+                        "raw": {
+                          "language": "json"
+                        }
+                      }
+                    },
+                    "url": {
+                      "raw": "{{vatBaseUrl}}{{apiPrefix}}/vat/titulos-referencia/{{titulo_id}}/",
+                      "host": [
+                        "{{vatBaseUrl}}{{apiPrefix}}"
+                      ],
+                      "path": [
+                        "vat",
+                        "titulos-referencia",
+                        "{{titulo_id}}",
+                        ""
+                      ]
+                    },
+                    "description": "Títulos de referencia asociados opcionalmente a un plan curricular.\n\nAutenticación: Authorization: Api-Key <clave>.\n\nPUT requiere el cuerpo completo. Operación de escritura bloqueada por defecto. Para enviarla debe configurar explícitamente `allowVatMutations=true` en el ambiente activo; verifique los identificadores y el ambiente y no la ejecute contra producción como prueba exploratoria."
+                  },
+                  "event": [
+                    {
+                      "listen": "prerequest",
+                      "script": {
+                        "type": "text/javascript",
+                        "exec": [
+                          "const allowMutations = String(pm.variables.get('allowVatMutations') || '').toLowerCase() === 'true';",
+                          "if (!allowMutations) {",
+                          "  console.warn('Request VAT de escritura omitido. Configure allowVatMutations=true sólo para una ejecución controlada.');",
+                          "  pm.execution.skipRequest();",
+                          "}"
+                        ]
+                      }
+                    },
+                    {
+                      "listen": "test",
+                      "script": {
+                        "type": "text/javascript",
+                        "exec": [
+                          "pm.test('Status code 200', function () { pm.response.to.have.status(200); });",
+                          "const body = pm.response.json();",
+                          "if (body.id !== undefined) {",
+                          "  const value = String(body.id);",
+                          "  pm.collectionVariables.set('titulo_id', value);",
+                          "  if (pm.environment && pm.environment.name) { pm.environment.set('titulo_id', value); }",
+                          "}"
+                        ]
+                      }
+                    }
+                  ],
+                  "response": []
+                },
+                {
+                  "name": "Actualizar parcialmente título de referencia (PATCH)",
+                  "request": {
+                    "method": "PATCH",
+                    "header": [
+                      {
+                        "key": "Authorization",
+                        "value": "Api-Key {{apiKey}}",
+                        "type": "text",
+                        "description": "API key VAT. En los endpoints web también puede reemplazarse por Token <token>."
+                      },
+                      {
+                        "key": "Content-Type",
+                        "value": "application/json",
+                        "type": "text"
+                      }
+                    ],
+                    "body": {
+                      "mode": "raw",
+                      "raw": "{\n  \"plan_estudio\": {{plan_id}},\n  \"activo\": true,\n  \"descripcion\": \"Título actualizado desde Postman\"\n}",
+                      "options": {
+                        "raw": {
+                          "language": "json"
+                        }
+                      }
+                    },
+                    "url": {
+                      "raw": "{{vatBaseUrl}}{{apiPrefix}}/vat/titulos-referencia/{{titulo_id}}/",
+                      "host": [
+                        "{{vatBaseUrl}}{{apiPrefix}}"
+                      ],
+                      "path": [
+                        "vat",
+                        "titulos-referencia",
+                        "{{titulo_id}}",
+                        ""
+                      ]
+                    },
+                    "description": "Títulos de referencia asociados opcionalmente a un plan curricular.\n\nAutenticación: Authorization: Api-Key <clave>.\n\nOperación de escritura bloqueada por defecto. Para enviarla debe configurar explícitamente `allowVatMutations=true` en el ambiente activo; verifique los identificadores y el ambiente y no la ejecute contra producción como prueba exploratoria."
+                  },
+                  "event": [
+                    {
+                      "listen": "prerequest",
+                      "script": {
+                        "type": "text/javascript",
+                        "exec": [
+                          "const allowMutations = String(pm.variables.get('allowVatMutations') || '').toLowerCase() === 'true';",
+                          "if (!allowMutations) {",
+                          "  console.warn('Request VAT de escritura omitido. Configure allowVatMutations=true sólo para una ejecución controlada.');",
+                          "  pm.execution.skipRequest();",
+                          "}"
+                        ]
+                      }
+                    },
+                    {
+                      "listen": "test",
+                      "script": {
+                        "type": "text/javascript",
+                        "exec": [
+                          "pm.test('Status code 200', function () { pm.response.to.have.status(200); });",
+                          "const body = pm.response.json();",
+                          "if (body.id !== undefined) {",
+                          "  const value = String(body.id);",
+                          "  pm.collectionVariables.set('titulo_id', value);",
+                          "  if (pm.environment && pm.environment.name) { pm.environment.set('titulo_id', value); }",
+                          "}"
+                        ]
+                      }
+                    }
+                  ],
+                  "response": []
+                },
+                {
+                  "name": "Eliminar título de referencia (DELETE)",
+                  "request": {
+                    "method": "DELETE",
+                    "header": [
+                      {
+                        "key": "Authorization",
+                        "value": "Api-Key {{apiKey}}",
+                        "type": "text",
+                        "description": "API key VAT. En los endpoints web también puede reemplazarse por Token <token>."
+                      }
+                    ],
+                    "url": {
+                      "raw": "{{vatBaseUrl}}{{apiPrefix}}/vat/titulos-referencia/{{titulo_id}}/",
+                      "host": [
+                        "{{vatBaseUrl}}{{apiPrefix}}"
+                      ],
+                      "path": [
+                        "vat",
+                        "titulos-referencia",
+                        "{{titulo_id}}",
+                        ""
+                      ]
+                    },
+                    "description": "Títulos de referencia asociados opcionalmente a un plan curricular.\n\nAutenticación: Authorization: Api-Key <clave>.\n\nOperación de escritura bloqueada por defecto. Para enviarla debe configurar explícitamente `allowVatMutations=true` en el ambiente activo; verifique los identificadores y el ambiente y no la ejecute contra producción como prueba exploratoria. En los modelos con borrado lógico, el registro se desactiva o cambia a un estado operativo cerrado/cancelado."
+                  },
+                  "event": [
+                    {
+                      "listen": "prerequest",
+                      "script": {
+                        "type": "text/javascript",
+                        "exec": [
+                          "const allowMutations = String(pm.variables.get('allowVatMutations') || '').toLowerCase() === 'true';",
+                          "if (!allowMutations) {",
+                          "  console.warn('Request VAT de escritura omitido. Configure allowVatMutations=true sólo para una ejecución controlada.');",
+                          "  pm.execution.skipRequest();",
+                          "}"
+                        ]
+                      }
+                    },
+                    {
+                      "listen": "test",
+                      "script": {
+                        "type": "text/javascript",
+                        "exec": [
+                          "pm.test('Status code 204', function () { pm.response.to.have.status(204); });"
+                        ]
+                      }
+                    }
+                  ],
+                  "response": []
+                }
+              ]
+            },
+            {
+              "name": "Modalidades de cursada",
+              "description": "Catálogo administrable de modalidades de cursada.\n\nAutenticación: Authorization: Api-Key <clave>.\n\nEste ViewSet expone list, retrieve, create, update, partial_update y destroy.",
+              "item": [
+                {
+                  "name": "Listar modalidades de cursada",
+                  "request": {
+                    "method": "GET",
+                    "header": [
+                      {
+                        "key": "Authorization",
+                        "value": "Api-Key {{apiKey}}",
+                        "type": "text",
+                        "description": "API key VAT. En los endpoints web también puede reemplazarse por Token <token>."
+                      }
+                    ],
+                    "url": {
+                      "raw": "{{vatBaseUrl}}{{apiPrefix}}/vat/modalidades-cursadas/",
+                      "host": [
+                        "{{vatBaseUrl}}{{apiPrefix}}"
+                      ],
+                      "path": [
+                        "vat",
+                        "modalidades-cursadas",
+                        ""
+                      ],
+                      "query": [
+                        {
+                          "key": "activo",
+                          "value": "true",
+                          "description": "Filtra por estado activo.",
+                          "disabled": true
+                        },
+                        {
+                          "key": "page",
+                          "value": "1",
+                          "description": "Número de página.",
+                          "disabled": true
+                        },
+                        {
+                          "key": "page_size",
+                          "value": "20",
+                          "description": "Cantidad de resultados por página (máximo 200).",
+                          "disabled": true
+                        }
+                      ]
+                    },
+                    "description": "Catálogo administrable de modalidades de cursada.\n\nAutenticación: Authorization: Api-Key <clave>.\n\nLos filtros opcionales están cargados y deshabilitados para activarlos según el caso."
+                  },
+                  "event": [
+                    {
+                      "listen": "test",
+                      "script": {
+                        "type": "text/javascript",
+                        "exec": [
+                          "pm.test('Status code 200', function () { pm.response.to.have.status(200); });",
+                          "const body = pm.response.json();",
+                          "const rows = Array.isArray(body) ? body : (body.results || []);",
+                          "pm.test('La respuesta contiene una lista', function () { pm.expect(Array.isArray(rows)).to.eql(true); });",
+                          "if (rows.length && rows[0].id !== undefined) {",
+                          "  const value = String(rows[0].id);",
+                          "  pm.collectionVariables.set('modalidad_cursada_id', value);",
+                          "  if (pm.environment && pm.environment.name) { pm.environment.set('modalidad_cursada_id', value); }",
+                          "}"
+                        ]
+                      }
+                    }
+                  ],
+                  "response": []
+                },
+                {
+                  "name": "Crear modalidad de cursada",
+                  "request": {
+                    "method": "POST",
+                    "header": [
+                      {
+                        "key": "Authorization",
+                        "value": "Api-Key {{apiKey}}",
+                        "type": "text",
+                        "description": "API key VAT. En los endpoints web también puede reemplazarse por Token <token>."
+                      },
+                      {
+                        "key": "Content-Type",
+                        "value": "application/json",
+                        "type": "text"
+                      }
+                    ],
+                    "body": {
+                      "mode": "raw",
+                      "raw": "{\n  \"nombre\": \"Presencial Postman {{$randomInt}}\",\n  \"descripcion\": \"Ejemplo VAT/INET\",\n  \"activo\": true\n}",
+                      "options": {
+                        "raw": {
+                          "language": "json"
+                        }
+                      }
+                    },
+                    "url": {
+                      "raw": "{{vatBaseUrl}}{{apiPrefix}}/vat/modalidades-cursadas/",
+                      "host": [
+                        "{{vatBaseUrl}}{{apiPrefix}}"
+                      ],
+                      "path": [
+                        "vat",
+                        "modalidades-cursadas",
+                        ""
+                      ]
+                    },
+                    "description": "Catálogo administrable de modalidades de cursada.\n\nAutenticación: Authorization: Api-Key <clave>.\n\nOperación de escritura bloqueada por defecto. Para enviarla debe configurar explícitamente `allowVatMutations=true` en el ambiente activo; verifique los identificadores y el ambiente y no la ejecute contra producción como prueba exploratoria."
+                  },
+                  "event": [
+                    {
+                      "listen": "prerequest",
+                      "script": {
+                        "type": "text/javascript",
+                        "exec": [
+                          "const allowMutations = String(pm.variables.get('allowVatMutations') || '').toLowerCase() === 'true';",
+                          "if (!allowMutations) {",
+                          "  console.warn('Request VAT de escritura omitido. Configure allowVatMutations=true sólo para una ejecución controlada.');",
+                          "  pm.execution.skipRequest();",
+                          "}"
+                        ]
+                      }
+                    },
+                    {
+                      "listen": "test",
+                      "script": {
+                        "type": "text/javascript",
+                        "exec": [
+                          "pm.test('Status code 201', function () { pm.response.to.have.status(201); });",
+                          "const body = pm.response.json();",
+                          "if (body.id !== undefined) {",
+                          "  const value = String(body.id);",
+                          "  pm.collectionVariables.set('modalidad_cursada_id', value);",
+                          "  if (pm.environment && pm.environment.name) { pm.environment.set('modalidad_cursada_id', value); }",
+                          "}"
+                        ]
+                      }
+                    }
+                  ],
+                  "response": []
+                },
+                {
+                  "name": "Obtener modalidad de cursada por ID",
+                  "request": {
+                    "method": "GET",
+                    "header": [
+                      {
+                        "key": "Authorization",
+                        "value": "Api-Key {{apiKey}}",
+                        "type": "text",
+                        "description": "API key VAT. En los endpoints web también puede reemplazarse por Token <token>."
+                      }
+                    ],
+                    "url": {
+                      "raw": "{{vatBaseUrl}}{{apiPrefix}}/vat/modalidades-cursadas/{{modalidad_cursada_id}}/",
+                      "host": [
+                        "{{vatBaseUrl}}{{apiPrefix}}"
+                      ],
+                      "path": [
+                        "vat",
+                        "modalidades-cursadas",
+                        "{{modalidad_cursada_id}}",
+                        ""
+                      ]
+                    },
+                    "description": "Catálogo administrable de modalidades de cursada.\n\nAutenticación: Authorization: Api-Key <clave>."
+                  },
+                  "event": [
+                    {
+                      "listen": "test",
+                      "script": {
+                        "type": "text/javascript",
+                        "exec": [
+                          "pm.test('Status code 200', function () { pm.response.to.have.status(200); });",
+                          "const body = pm.response.json();",
+                          "if (body.id !== undefined) {",
+                          "  const value = String(body.id);",
+                          "  pm.collectionVariables.set('modalidad_cursada_id', value);",
+                          "  if (pm.environment && pm.environment.name) { pm.environment.set('modalidad_cursada_id', value); }",
+                          "}"
+                        ]
+                      }
+                    }
+                  ],
+                  "response": []
+                },
+                {
+                  "name": "Reemplazar modalidad de cursada (PUT)",
+                  "request": {
+                    "method": "PUT",
+                    "header": [
+                      {
+                        "key": "Authorization",
+                        "value": "Api-Key {{apiKey}}",
+                        "type": "text",
+                        "description": "API key VAT. En los endpoints web también puede reemplazarse por Token <token>."
+                      },
+                      {
+                        "key": "Content-Type",
+                        "value": "application/json",
+                        "type": "text"
+                      }
+                    ],
+                    "body": {
+                      "mode": "raw",
+                      "raw": "{\n  \"nombre\": \"Presencial Postman {{$randomInt}}\",\n  \"descripcion\": \"Ejemplo VAT/INET\",\n  \"activo\": true\n}",
+                      "options": {
+                        "raw": {
+                          "language": "json"
+                        }
+                      }
+                    },
+                    "url": {
+                      "raw": "{{vatBaseUrl}}{{apiPrefix}}/vat/modalidades-cursadas/{{modalidad_cursada_id}}/",
+                      "host": [
+                        "{{vatBaseUrl}}{{apiPrefix}}"
+                      ],
+                      "path": [
+                        "vat",
+                        "modalidades-cursadas",
+                        "{{modalidad_cursada_id}}",
+                        ""
+                      ]
+                    },
+                    "description": "Catálogo administrable de modalidades de cursada.\n\nAutenticación: Authorization: Api-Key <clave>.\n\nPUT requiere el cuerpo completo. Operación de escritura bloqueada por defecto. Para enviarla debe configurar explícitamente `allowVatMutations=true` en el ambiente activo; verifique los identificadores y el ambiente y no la ejecute contra producción como prueba exploratoria."
+                  },
+                  "event": [
+                    {
+                      "listen": "prerequest",
+                      "script": {
+                        "type": "text/javascript",
+                        "exec": [
+                          "const allowMutations = String(pm.variables.get('allowVatMutations') || '').toLowerCase() === 'true';",
+                          "if (!allowMutations) {",
+                          "  console.warn('Request VAT de escritura omitido. Configure allowVatMutations=true sólo para una ejecución controlada.');",
+                          "  pm.execution.skipRequest();",
+                          "}"
+                        ]
+                      }
+                    },
+                    {
+                      "listen": "test",
+                      "script": {
+                        "type": "text/javascript",
+                        "exec": [
+                          "pm.test('Status code 200', function () { pm.response.to.have.status(200); });",
+                          "const body = pm.response.json();",
+                          "if (body.id !== undefined) {",
+                          "  const value = String(body.id);",
+                          "  pm.collectionVariables.set('modalidad_cursada_id', value);",
+                          "  if (pm.environment && pm.environment.name) { pm.environment.set('modalidad_cursada_id', value); }",
+                          "}"
+                        ]
+                      }
+                    }
+                  ],
+                  "response": []
+                },
+                {
+                  "name": "Actualizar parcialmente modalidad de cursada (PATCH)",
+                  "request": {
+                    "method": "PATCH",
+                    "header": [
+                      {
+                        "key": "Authorization",
+                        "value": "Api-Key {{apiKey}}",
+                        "type": "text",
+                        "description": "API key VAT. En los endpoints web también puede reemplazarse por Token <token>."
+                      },
+                      {
+                        "key": "Content-Type",
+                        "value": "application/json",
+                        "type": "text"
+                      }
+                    ],
+                    "body": {
+                      "mode": "raw",
+                      "raw": "{\n  \"activo\": true,\n  \"descripcion\": \"Modalidad actualizada desde Postman\"\n}",
+                      "options": {
+                        "raw": {
+                          "language": "json"
+                        }
+                      }
+                    },
+                    "url": {
+                      "raw": "{{vatBaseUrl}}{{apiPrefix}}/vat/modalidades-cursadas/{{modalidad_cursada_id}}/",
+                      "host": [
+                        "{{vatBaseUrl}}{{apiPrefix}}"
+                      ],
+                      "path": [
+                        "vat",
+                        "modalidades-cursadas",
+                        "{{modalidad_cursada_id}}",
+                        ""
+                      ]
+                    },
+                    "description": "Catálogo administrable de modalidades de cursada.\n\nAutenticación: Authorization: Api-Key <clave>.\n\nOperación de escritura bloqueada por defecto. Para enviarla debe configurar explícitamente `allowVatMutations=true` en el ambiente activo; verifique los identificadores y el ambiente y no la ejecute contra producción como prueba exploratoria."
+                  },
+                  "event": [
+                    {
+                      "listen": "prerequest",
+                      "script": {
+                        "type": "text/javascript",
+                        "exec": [
+                          "const allowMutations = String(pm.variables.get('allowVatMutations') || '').toLowerCase() === 'true';",
+                          "if (!allowMutations) {",
+                          "  console.warn('Request VAT de escritura omitido. Configure allowVatMutations=true sólo para una ejecución controlada.');",
+                          "  pm.execution.skipRequest();",
+                          "}"
+                        ]
+                      }
+                    },
+                    {
+                      "listen": "test",
+                      "script": {
+                        "type": "text/javascript",
+                        "exec": [
+                          "pm.test('Status code 200', function () { pm.response.to.have.status(200); });",
+                          "const body = pm.response.json();",
+                          "if (body.id !== undefined) {",
+                          "  const value = String(body.id);",
+                          "  pm.collectionVariables.set('modalidad_cursada_id', value);",
+                          "  if (pm.environment && pm.environment.name) { pm.environment.set('modalidad_cursada_id', value); }",
+                          "}"
+                        ]
+                      }
+                    }
+                  ],
+                  "response": []
+                },
+                {
+                  "name": "Eliminar modalidad de cursada (DELETE)",
+                  "request": {
+                    "method": "DELETE",
+                    "header": [
+                      {
+                        "key": "Authorization",
+                        "value": "Api-Key {{apiKey}}",
+                        "type": "text",
+                        "description": "API key VAT. En los endpoints web también puede reemplazarse por Token <token>."
+                      }
+                    ],
+                    "url": {
+                      "raw": "{{vatBaseUrl}}{{apiPrefix}}/vat/modalidades-cursadas/{{modalidad_cursada_id}}/",
+                      "host": [
+                        "{{vatBaseUrl}}{{apiPrefix}}"
+                      ],
+                      "path": [
+                        "vat",
+                        "modalidades-cursadas",
+                        "{{modalidad_cursada_id}}",
+                        ""
+                      ]
+                    },
+                    "description": "Catálogo administrable de modalidades de cursada.\n\nAutenticación: Authorization: Api-Key <clave>.\n\nOperación de escritura bloqueada por defecto. Para enviarla debe configurar explícitamente `allowVatMutations=true` en el ambiente activo; verifique los identificadores y el ambiente y no la ejecute contra producción como prueba exploratoria. En los modelos con borrado lógico, el registro se desactiva o cambia a un estado operativo cerrado/cancelado."
+                  },
+                  "event": [
+                    {
+                      "listen": "prerequest",
+                      "script": {
+                        "type": "text/javascript",
+                        "exec": [
+                          "const allowMutations = String(pm.variables.get('allowVatMutations') || '').toLowerCase() === 'true';",
+                          "if (!allowMutations) {",
+                          "  console.warn('Request VAT de escritura omitido. Configure allowVatMutations=true sólo para una ejecución controlada.');",
+                          "  pm.execution.skipRequest();",
+                          "}"
+                        ]
+                      }
+                    },
+                    {
+                      "listen": "test",
+                      "script": {
+                        "type": "text/javascript",
+                        "exec": [
+                          "pm.test('Status code 204', function () { pm.response.to.have.status(204); });"
+                        ]
+                      }
+                    }
+                  ],
+                  "response": []
+                }
+              ]
+            },
+            {
+              "name": "Planes curriculares",
+              "description": "Planes curriculares con sector, subsector y modalidad de cursada.\n\nAutenticación: Authorization: Api-Key <clave>.\n\nEste ViewSet expone list, retrieve, create, update, partial_update y destroy.",
+              "item": [
+                {
+                  "name": "Listar planes curriculares",
+                  "request": {
+                    "method": "GET",
+                    "header": [
+                      {
+                        "key": "Authorization",
+                        "value": "Api-Key {{apiKey}}",
+                        "type": "text",
+                        "description": "API key VAT. En los endpoints web también puede reemplazarse por Token <token>."
+                      }
+                    ],
+                    "url": {
+                      "raw": "{{vatBaseUrl}}{{apiPrefix}}/vat/planes-curriculares/",
+                      "host": [
+                        "{{vatBaseUrl}}{{apiPrefix}}"
+                      ],
+                      "path": [
+                        "vat",
+                        "planes-curriculares",
+                        ""
+                      ],
+                      "query": [
+                        {
+                          "key": "sector_id",
+                          "value": "{{sector_id}}",
+                          "description": "Filtra por sector.",
+                          "disabled": true
+                        },
+                        {
+                          "key": "subsector_id",
+                          "value": "{{subsector_id}}",
+                          "description": "Filtra por subsector.",
+                          "disabled": true
+                        },
+                        {
+                          "key": "titulo_referencia_id",
+                          "value": "{{titulo_id}}",
+                          "description": "Filtra por título de referencia.",
+                          "disabled": true
+                        },
+                        {
+                          "key": "modalidad_cursada_id",
+                          "value": "{{modalidad_cursada_id}}",
+                          "description": "Filtra por modalidad de cursada.",
+                          "disabled": true
+                        },
+                        {
+                          "key": "activo",
+                          "value": "true",
+                          "description": "Filtra por estado activo.",
+                          "disabled": true
+                        },
+                        {
+                          "key": "page",
+                          "value": "1",
+                          "description": "Número de página.",
+                          "disabled": true
+                        },
+                        {
+                          "key": "page_size",
+                          "value": "20",
+                          "description": "Cantidad de resultados por página (máximo 200).",
+                          "disabled": true
+                        }
+                      ]
+                    },
+                    "description": "Planes curriculares con sector, subsector y modalidad de cursada.\n\nAutenticación: Authorization: Api-Key <clave>.\n\nLos filtros opcionales están cargados y deshabilitados para activarlos según el caso."
+                  },
+                  "event": [
+                    {
+                      "listen": "test",
+                      "script": {
+                        "type": "text/javascript",
+                        "exec": [
+                          "pm.test('Status code 200', function () { pm.response.to.have.status(200); });",
+                          "const body = pm.response.json();",
+                          "const rows = Array.isArray(body) ? body : (body.results || []);",
+                          "pm.test('La respuesta contiene una lista', function () { pm.expect(Array.isArray(rows)).to.eql(true); });",
+                          "if (rows.length && rows[0].id !== undefined) {",
+                          "  const value = String(rows[0].id);",
+                          "  pm.collectionVariables.set('plan_id', value);",
+                          "  if (pm.environment && pm.environment.name) { pm.environment.set('plan_id', value); }",
+                          "}"
+                        ]
+                      }
+                    }
+                  ],
+                  "response": []
+                },
+                {
+                  "name": "Crear plan curricular",
+                  "request": {
+                    "method": "POST",
+                    "header": [
+                      {
+                        "key": "Authorization",
+                        "value": "Api-Key {{apiKey}}",
+                        "type": "text",
+                        "description": "API key VAT. En los endpoints web también puede reemplazarse por Token <token>."
+                      },
+                      {
+                        "key": "Content-Type",
+                        "value": "application/json",
+                        "type": "text"
+                      }
+                    ],
+                    "body": {
+                      "mode": "raw",
+                      "raw": "{\n  \"nombre\": \"Plan curricular Postman\",\n  \"sector\": {{sector_id}},\n  \"subsector\": {{subsector_id}},\n  \"modalidad_cursada\": {{modalidad_cursada_id}},\n  \"normativa\": \"Normativa de ejemplo\",\n  \"horas_reloj\": 120,\n  \"nivel_requerido\": \"Primario completo\",\n  \"nivel_certifica\": \"Formación profesional\",\n  \"activo\": true\n}",
+                      "options": {
+                        "raw": {
+                          "language": "json"
+                        }
+                      }
+                    },
+                    "url": {
+                      "raw": "{{vatBaseUrl}}{{apiPrefix}}/vat/planes-curriculares/",
+                      "host": [
+                        "{{vatBaseUrl}}{{apiPrefix}}"
+                      ],
+                      "path": [
+                        "vat",
+                        "planes-curriculares",
+                        ""
+                      ]
+                    },
+                    "description": "Planes curriculares con sector, subsector y modalidad de cursada.\n\nAutenticación: Authorization: Api-Key <clave>.\n\nOperación de escritura bloqueada por defecto. Para enviarla debe configurar explícitamente `allowVatMutations=true` en el ambiente activo; verifique los identificadores y el ambiente y no la ejecute contra producción como prueba exploratoria."
+                  },
+                  "event": [
+                    {
+                      "listen": "prerequest",
+                      "script": {
+                        "type": "text/javascript",
+                        "exec": [
+                          "const allowMutations = String(pm.variables.get('allowVatMutations') || '').toLowerCase() === 'true';",
+                          "if (!allowMutations) {",
+                          "  console.warn('Request VAT de escritura omitido. Configure allowVatMutations=true sólo para una ejecución controlada.');",
+                          "  pm.execution.skipRequest();",
+                          "}"
+                        ]
+                      }
+                    },
+                    {
+                      "listen": "test",
+                      "script": {
+                        "type": "text/javascript",
+                        "exec": [
+                          "pm.test('Status code 201', function () { pm.response.to.have.status(201); });",
+                          "const body = pm.response.json();",
+                          "if (body.id !== undefined) {",
+                          "  const value = String(body.id);",
+                          "  pm.collectionVariables.set('plan_id', value);",
+                          "  if (pm.environment && pm.environment.name) { pm.environment.set('plan_id', value); }",
+                          "}"
+                        ]
+                      }
+                    }
+                  ],
+                  "response": []
+                },
+                {
+                  "name": "Obtener plan curricular por ID",
+                  "request": {
+                    "method": "GET",
+                    "header": [
+                      {
+                        "key": "Authorization",
+                        "value": "Api-Key {{apiKey}}",
+                        "type": "text",
+                        "description": "API key VAT. En los endpoints web también puede reemplazarse por Token <token>."
+                      }
+                    ],
+                    "url": {
+                      "raw": "{{vatBaseUrl}}{{apiPrefix}}/vat/planes-curriculares/{{plan_id}}/",
+                      "host": [
+                        "{{vatBaseUrl}}{{apiPrefix}}"
+                      ],
+                      "path": [
+                        "vat",
+                        "planes-curriculares",
+                        "{{plan_id}}",
+                        ""
+                      ]
+                    },
+                    "description": "Planes curriculares con sector, subsector y modalidad de cursada.\n\nAutenticación: Authorization: Api-Key <clave>."
+                  },
+                  "event": [
+                    {
+                      "listen": "test",
+                      "script": {
+                        "type": "text/javascript",
+                        "exec": [
+                          "pm.test('Status code 200', function () { pm.response.to.have.status(200); });",
+                          "const body = pm.response.json();",
+                          "if (body.id !== undefined) {",
+                          "  const value = String(body.id);",
+                          "  pm.collectionVariables.set('plan_id', value);",
+                          "  if (pm.environment && pm.environment.name) { pm.environment.set('plan_id', value); }",
+                          "}"
+                        ]
+                      }
+                    }
+                  ],
+                  "response": []
+                },
+                {
+                  "name": "Reemplazar plan curricular (PUT)",
+                  "request": {
+                    "method": "PUT",
+                    "header": [
+                      {
+                        "key": "Authorization",
+                        "value": "Api-Key {{apiKey}}",
+                        "type": "text",
+                        "description": "API key VAT. En los endpoints web también puede reemplazarse por Token <token>."
+                      },
+                      {
+                        "key": "Content-Type",
+                        "value": "application/json",
+                        "type": "text"
+                      }
+                    ],
+                    "body": {
+                      "mode": "raw",
+                      "raw": "{\n  \"nombre\": \"Plan curricular Postman\",\n  \"sector\": {{sector_id}},\n  \"subsector\": {{subsector_id}},\n  \"modalidad_cursada\": {{modalidad_cursada_id}},\n  \"normativa\": \"Normativa de ejemplo\",\n  \"horas_reloj\": 120,\n  \"nivel_requerido\": \"Primario completo\",\n  \"nivel_certifica\": \"Formación profesional\",\n  \"activo\": true\n}",
+                      "options": {
+                        "raw": {
+                          "language": "json"
+                        }
+                      }
+                    },
+                    "url": {
+                      "raw": "{{vatBaseUrl}}{{apiPrefix}}/vat/planes-curriculares/{{plan_id}}/",
+                      "host": [
+                        "{{vatBaseUrl}}{{apiPrefix}}"
+                      ],
+                      "path": [
+                        "vat",
+                        "planes-curriculares",
+                        "{{plan_id}}",
+                        ""
+                      ]
+                    },
+                    "description": "Planes curriculares con sector, subsector y modalidad de cursada.\n\nAutenticación: Authorization: Api-Key <clave>.\n\nPUT requiere el cuerpo completo. Operación de escritura bloqueada por defecto. Para enviarla debe configurar explícitamente `allowVatMutations=true` en el ambiente activo; verifique los identificadores y el ambiente y no la ejecute contra producción como prueba exploratoria."
+                  },
+                  "event": [
+                    {
+                      "listen": "prerequest",
+                      "script": {
+                        "type": "text/javascript",
+                        "exec": [
+                          "const allowMutations = String(pm.variables.get('allowVatMutations') || '').toLowerCase() === 'true';",
+                          "if (!allowMutations) {",
+                          "  console.warn('Request VAT de escritura omitido. Configure allowVatMutations=true sólo para una ejecución controlada.');",
+                          "  pm.execution.skipRequest();",
+                          "}"
+                        ]
+                      }
+                    },
+                    {
+                      "listen": "test",
+                      "script": {
+                        "type": "text/javascript",
+                        "exec": [
+                          "pm.test('Status code 200', function () { pm.response.to.have.status(200); });",
+                          "const body = pm.response.json();",
+                          "if (body.id !== undefined) {",
+                          "  const value = String(body.id);",
+                          "  pm.collectionVariables.set('plan_id', value);",
+                          "  if (pm.environment && pm.environment.name) { pm.environment.set('plan_id', value); }",
+                          "}"
+                        ]
+                      }
+                    }
+                  ],
+                  "response": []
+                },
+                {
+                  "name": "Actualizar parcialmente plan curricular (PATCH)",
+                  "request": {
+                    "method": "PATCH",
+                    "header": [
+                      {
+                        "key": "Authorization",
+                        "value": "Api-Key {{apiKey}}",
+                        "type": "text",
+                        "description": "API key VAT. En los endpoints web también puede reemplazarse por Token <token>."
+                      },
+                      {
+                        "key": "Content-Type",
+                        "value": "application/json",
+                        "type": "text"
+                      }
+                    ],
+                    "body": {
+                      "mode": "raw",
+                      "raw": "{\n  \"activo\": true,\n  \"horas_reloj\": 120\n}",
+                      "options": {
+                        "raw": {
+                          "language": "json"
+                        }
+                      }
+                    },
+                    "url": {
+                      "raw": "{{vatBaseUrl}}{{apiPrefix}}/vat/planes-curriculares/{{plan_id}}/",
+                      "host": [
+                        "{{vatBaseUrl}}{{apiPrefix}}"
+                      ],
+                      "path": [
+                        "vat",
+                        "planes-curriculares",
+                        "{{plan_id}}",
+                        ""
+                      ]
+                    },
+                    "description": "Planes curriculares con sector, subsector y modalidad de cursada.\n\nAutenticación: Authorization: Api-Key <clave>.\n\nOperación de escritura bloqueada por defecto. Para enviarla debe configurar explícitamente `allowVatMutations=true` en el ambiente activo; verifique los identificadores y el ambiente y no la ejecute contra producción como prueba exploratoria."
+                  },
+                  "event": [
+                    {
+                      "listen": "prerequest",
+                      "script": {
+                        "type": "text/javascript",
+                        "exec": [
+                          "const allowMutations = String(pm.variables.get('allowVatMutations') || '').toLowerCase() === 'true';",
+                          "if (!allowMutations) {",
+                          "  console.warn('Request VAT de escritura omitido. Configure allowVatMutations=true sólo para una ejecución controlada.');",
+                          "  pm.execution.skipRequest();",
+                          "}"
+                        ]
+                      }
+                    },
+                    {
+                      "listen": "test",
+                      "script": {
+                        "type": "text/javascript",
+                        "exec": [
+                          "pm.test('Status code 200', function () { pm.response.to.have.status(200); });",
+                          "const body = pm.response.json();",
+                          "if (body.id !== undefined) {",
+                          "  const value = String(body.id);",
+                          "  pm.collectionVariables.set('plan_id', value);",
+                          "  if (pm.environment && pm.environment.name) { pm.environment.set('plan_id', value); }",
+                          "}"
+                        ]
+                      }
+                    }
+                  ],
+                  "response": []
+                },
+                {
+                  "name": "Eliminar plan curricular (DELETE)",
+                  "request": {
+                    "method": "DELETE",
+                    "header": [
+                      {
+                        "key": "Authorization",
+                        "value": "Api-Key {{apiKey}}",
+                        "type": "text",
+                        "description": "API key VAT. En los endpoints web también puede reemplazarse por Token <token>."
+                      }
+                    ],
+                    "url": {
+                      "raw": "{{vatBaseUrl}}{{apiPrefix}}/vat/planes-curriculares/{{plan_id}}/",
+                      "host": [
+                        "{{vatBaseUrl}}{{apiPrefix}}"
+                      ],
+                      "path": [
+                        "vat",
+                        "planes-curriculares",
+                        "{{plan_id}}",
+                        ""
+                      ]
+                    },
+                    "description": "Planes curriculares con sector, subsector y modalidad de cursada.\n\nAutenticación: Authorization: Api-Key <clave>.\n\nOperación de escritura bloqueada por defecto. Para enviarla debe configurar explícitamente `allowVatMutations=true` en el ambiente activo; verifique los identificadores y el ambiente y no la ejecute contra producción como prueba exploratoria. En los modelos con borrado lógico, el registro se desactiva o cambia a un estado operativo cerrado/cancelado."
+                  },
+                  "event": [
+                    {
+                      "listen": "prerequest",
+                      "script": {
+                        "type": "text/javascript",
+                        "exec": [
+                          "const allowMutations = String(pm.variables.get('allowVatMutations') || '').toLowerCase() === 'true';",
+                          "if (!allowMutations) {",
+                          "  console.warn('Request VAT de escritura omitido. Configure allowVatMutations=true sólo para una ejecución controlada.');",
+                          "  pm.execution.skipRequest();",
+                          "}"
+                        ]
+                      }
+                    },
+                    {
+                      "listen": "test",
+                      "script": {
+                        "type": "text/javascript",
+                        "exec": [
+                          "pm.test('Status code 204', function () { pm.response.to.have.status(204); });"
+                        ]
+                      }
+                    }
+                  ],
+                  "response": []
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "name": "4 - API operativa - Cursos y comisiones",
+          "description": "Flujo operativo actual basado en Curso y ComisionCurso.",
+          "item": [
+            {
+              "name": "Cursos operativos",
+              "description": "Cursos operativos asociados a centros, planes y modalidades.\n\nAutenticación: Authorization: Api-Key <clave>.\n\nEste ViewSet expone list, retrieve, create, update, partial_update y destroy.",
+              "item": [
+                {
+                  "name": "Listar cursos operativos",
+                  "request": {
+                    "method": "GET",
+                    "header": [
+                      {
+                        "key": "Authorization",
+                        "value": "Api-Key {{apiKey}}",
+                        "type": "text",
+                        "description": "API key VAT. En los endpoints web también puede reemplazarse por Token <token>."
+                      }
+                    ],
+                    "url": {
+                      "raw": "{{vatBaseUrl}}{{apiPrefix}}/vat/cursos/",
                       "host": [
                         "{{vatBaseUrl}}{{apiPrefix}}"
                       ],
@@ -4006,49 +7903,55 @@
                       "query": [
                         {
                           "key": "centro_id",
-                          "value": "{{centro_id}}"
+                          "value": "{{centro_id}}",
+                          "description": "Filtra por centro.",
+                          "disabled": true
+                        },
+                        {
+                          "key": "provincia_id",
+                          "value": "{{provincia_id}}",
+                          "description": "Filtra por provincia del centro.",
+                          "disabled": true
+                        },
+                        {
+                          "key": "municipio_id",
+                          "value": "{{municipio_id}}",
+                          "description": "Filtra por municipio del centro.",
+                          "disabled": true
+                        },
+                        {
+                          "key": "modalidad_id",
+                          "value": "{{modalidad_cursada_id}}",
+                          "description": "Filtra por modalidad de cursada.",
+                          "disabled": true
+                        },
+                        {
+                          "key": "programa_id",
+                          "value": "{{programa_id}}",
+                          "description": "Filtra por programa derivado de parametrías de voucher.",
+                          "disabled": true
                         },
                         {
                           "key": "estado",
-                          "value": "activo"
-                        }
-                      ]
-                    }
-                  },
-                  "response": []
-                },
-                {
-                  "name": "Listar cursos por provincia_id y municipio_id",
-                  "request": {
-                    "method": "GET",
-                    "header": [
-                      {
-                        "key": "Authorization",
-                        "value": "Api-Key {{apiKey}}",
-                        "type": "text"
-                      }
-                    ],
-                    "url": {
-                      "raw": "{{vatBaseUrl}}{{apiPrefix}}/vat/cursos/?provincia_id={{provincia_id}}&municipio_id={{municipio_id}}",
-                      "host": [
-                        "{{vatBaseUrl}}{{apiPrefix}}"
-                      ],
-                      "path": [
-                        "vat",
-                        "cursos",
-                        ""
-                      ],
-                      "query": [
-                        {
-                          "key": "provincia_id",
-                          "value": "{{provincia_id}}"
+                          "value": "{{estado_curso}}",
+                          "description": "Filtra por estado del curso.",
+                          "disabled": true
                         },
                         {
-                          "key": "municipio_id",
-                          "value": "{{municipio_id}}"
+                          "key": "page",
+                          "value": "1",
+                          "description": "Número de página.",
+                          "disabled": true
+                        },
+                        {
+                          "key": "page_size",
+                          "value": "20",
+                          "description": "Cantidad de resultados por página (máximo 200).",
+                          "disabled": true
                         }
                       ]
-                    }
+                    },
+                    "description": "Cursos operativos asociados a centros, planes y modalidades.\n\nAutenticación: Authorization: Api-Key <clave>.\n\nLos filtros opcionales están cargados y deshabilitados para activarlos según el caso."
                   },
                   "event": [
                     {
@@ -4056,13 +7959,14 @@
                       "script": {
                         "type": "text/javascript",
                         "exec": [
-                          "pm.test('Status code is 200', function () {",
-                          "  pm.response.to.have.status(200);",
-                          "});",
+                          "pm.test('Status code 200', function () { pm.response.to.have.status(200); });",
                           "const body = pm.response.json();",
                           "const rows = Array.isArray(body) ? body : (body.results || []);",
-                          "if (rows.length && rows[0].id) {",
-                          "  pm.collectionVariables.set('curso_id', String(rows[0].id));",
+                          "pm.test('La respuesta contiene una lista', function () { pm.expect(Array.isArray(rows)).to.eql(true); });",
+                          "if (rows.length && rows[0].id !== undefined) {",
+                          "  const value = String(rows[0].id);",
+                          "  pm.collectionVariables.set('curso_id', value);",
+                          "  if (pm.environment && pm.environment.name) { pm.environment.set('curso_id', value); }",
                           "}"
                         ]
                       }
@@ -4071,18 +7975,331 @@
                   "response": []
                 },
                 {
-                  "name": "Buscar cursos por texto",
+                  "name": "Crear curso operativo",
+                  "request": {
+                    "method": "POST",
+                    "header": [
+                      {
+                        "key": "Authorization",
+                        "value": "Api-Key {{apiKey}}",
+                        "type": "text",
+                        "description": "API key VAT. En los endpoints web también puede reemplazarse por Token <token>."
+                      },
+                      {
+                        "key": "Content-Type",
+                        "value": "application/json",
+                        "type": "text"
+                      }
+                    ],
+                    "body": {
+                      "mode": "raw",
+                      "raw": "{\n  \"centro\": {{centro_id}},\n  \"plan_estudio\": {{plan_id}},\n  \"nombre\": \"Curso INET Postman {{$randomInt}}\",\n  \"tipo\": [\n    \"inet\"\n  ],\n  \"prioritario\": false,\n  \"modalidad\": {{modalidad_cursada_id}},\n  \"estado\": \"planificado\",\n  \"usa_voucher\": false,\n  \"inscripcion_libre\": false,\n  \"costo_creditos\": 0,\n  \"observaciones\": \"Curso creado desde Postman\"\n}",
+                      "options": {
+                        "raw": {
+                          "language": "json"
+                        }
+                      }
+                    },
+                    "url": {
+                      "raw": "{{vatBaseUrl}}{{apiPrefix}}/vat/cursos/",
+                      "host": [
+                        "{{vatBaseUrl}}{{apiPrefix}}"
+                      ],
+                      "path": [
+                        "vat",
+                        "cursos",
+                        ""
+                      ]
+                    },
+                    "description": "Cursos operativos asociados a centros, planes y modalidades.\n\nAutenticación: Authorization: Api-Key <clave>.\n\nOperación de escritura bloqueada por defecto. Para enviarla debe configurar explícitamente `allowVatMutations=true` en el ambiente activo; verifique los identificadores y el ambiente y no la ejecute contra producción como prueba exploratoria."
+                  },
+                  "event": [
+                    {
+                      "listen": "prerequest",
+                      "script": {
+                        "type": "text/javascript",
+                        "exec": [
+                          "const allowMutations = String(pm.variables.get('allowVatMutations') || '').toLowerCase() === 'true';",
+                          "if (!allowMutations) {",
+                          "  console.warn('Request VAT de escritura omitido. Configure allowVatMutations=true sólo para una ejecución controlada.');",
+                          "  pm.execution.skipRequest();",
+                          "}"
+                        ]
+                      }
+                    },
+                    {
+                      "listen": "test",
+                      "script": {
+                        "type": "text/javascript",
+                        "exec": [
+                          "pm.test('Status code 201', function () { pm.response.to.have.status(201); });",
+                          "const body = pm.response.json();",
+                          "if (body.id !== undefined) {",
+                          "  const value = String(body.id);",
+                          "  pm.collectionVariables.set('curso_id', value);",
+                          "  if (pm.environment && pm.environment.name) { pm.environment.set('curso_id', value); }",
+                          "}"
+                        ]
+                      }
+                    }
+                  ],
+                  "response": []
+                },
+                {
+                  "name": "Obtener curso operativo por ID",
                   "request": {
                     "method": "GET",
                     "header": [
                       {
                         "key": "Authorization",
                         "value": "Api-Key {{apiKey}}",
-                        "type": "text"
+                        "type": "text",
+                        "description": "API key VAT. En los endpoints web también puede reemplazarse por Token <token>."
                       }
                     ],
                     "url": {
-                      "raw": "{{vatBaseUrl}}{{apiPrefix}}/vat/cursos/buscar/?q={{curso_busqueda}}",
+                      "raw": "{{vatBaseUrl}}{{apiPrefix}}/vat/cursos/{{curso_id}}/",
+                      "host": [
+                        "{{vatBaseUrl}}{{apiPrefix}}"
+                      ],
+                      "path": [
+                        "vat",
+                        "cursos",
+                        "{{curso_id}}",
+                        ""
+                      ]
+                    },
+                    "description": "Cursos operativos asociados a centros, planes y modalidades.\n\nAutenticación: Authorization: Api-Key <clave>."
+                  },
+                  "event": [
+                    {
+                      "listen": "test",
+                      "script": {
+                        "type": "text/javascript",
+                        "exec": [
+                          "pm.test('Status code 200', function () { pm.response.to.have.status(200); });",
+                          "const body = pm.response.json();",
+                          "if (body.id !== undefined) {",
+                          "  const value = String(body.id);",
+                          "  pm.collectionVariables.set('curso_id', value);",
+                          "  if (pm.environment && pm.environment.name) { pm.environment.set('curso_id', value); }",
+                          "}"
+                        ]
+                      }
+                    }
+                  ],
+                  "response": []
+                },
+                {
+                  "name": "Reemplazar curso operativo (PUT)",
+                  "request": {
+                    "method": "PUT",
+                    "header": [
+                      {
+                        "key": "Authorization",
+                        "value": "Api-Key {{apiKey}}",
+                        "type": "text",
+                        "description": "API key VAT. En los endpoints web también puede reemplazarse por Token <token>."
+                      },
+                      {
+                        "key": "Content-Type",
+                        "value": "application/json",
+                        "type": "text"
+                      }
+                    ],
+                    "body": {
+                      "mode": "raw",
+                      "raw": "{\n  \"centro\": {{centro_id}},\n  \"plan_estudio\": {{plan_id}},\n  \"nombre\": \"Curso INET Postman {{$randomInt}}\",\n  \"tipo\": [\n    \"inet\"\n  ],\n  \"prioritario\": false,\n  \"modalidad\": {{modalidad_cursada_id}},\n  \"estado\": \"planificado\",\n  \"usa_voucher\": false,\n  \"inscripcion_libre\": false,\n  \"costo_creditos\": 0,\n  \"observaciones\": \"Curso creado desde Postman\"\n}",
+                      "options": {
+                        "raw": {
+                          "language": "json"
+                        }
+                      }
+                    },
+                    "url": {
+                      "raw": "{{vatBaseUrl}}{{apiPrefix}}/vat/cursos/{{curso_id}}/",
+                      "host": [
+                        "{{vatBaseUrl}}{{apiPrefix}}"
+                      ],
+                      "path": [
+                        "vat",
+                        "cursos",
+                        "{{curso_id}}",
+                        ""
+                      ]
+                    },
+                    "description": "Cursos operativos asociados a centros, planes y modalidades.\n\nAutenticación: Authorization: Api-Key <clave>.\n\nPUT requiere el cuerpo completo. Operación de escritura bloqueada por defecto. Para enviarla debe configurar explícitamente `allowVatMutations=true` en el ambiente activo; verifique los identificadores y el ambiente y no la ejecute contra producción como prueba exploratoria."
+                  },
+                  "event": [
+                    {
+                      "listen": "prerequest",
+                      "script": {
+                        "type": "text/javascript",
+                        "exec": [
+                          "const allowMutations = String(pm.variables.get('allowVatMutations') || '').toLowerCase() === 'true';",
+                          "if (!allowMutations) {",
+                          "  console.warn('Request VAT de escritura omitido. Configure allowVatMutations=true sólo para una ejecución controlada.');",
+                          "  pm.execution.skipRequest();",
+                          "}"
+                        ]
+                      }
+                    },
+                    {
+                      "listen": "test",
+                      "script": {
+                        "type": "text/javascript",
+                        "exec": [
+                          "pm.test('Status code 200', function () { pm.response.to.have.status(200); });",
+                          "const body = pm.response.json();",
+                          "if (body.id !== undefined) {",
+                          "  const value = String(body.id);",
+                          "  pm.collectionVariables.set('curso_id', value);",
+                          "  if (pm.environment && pm.environment.name) { pm.environment.set('curso_id', value); }",
+                          "}"
+                        ]
+                      }
+                    }
+                  ],
+                  "response": []
+                },
+                {
+                  "name": "Actualizar parcialmente curso operativo (PATCH)",
+                  "request": {
+                    "method": "PATCH",
+                    "header": [
+                      {
+                        "key": "Authorization",
+                        "value": "Api-Key {{apiKey}}",
+                        "type": "text",
+                        "description": "API key VAT. En los endpoints web también puede reemplazarse por Token <token>."
+                      },
+                      {
+                        "key": "Content-Type",
+                        "value": "application/json",
+                        "type": "text"
+                      }
+                    ],
+                    "body": {
+                      "mode": "raw",
+                      "raw": "{\n  \"prioritario\": true,\n  \"observaciones\": \"Curso actualizado desde Postman\"\n}",
+                      "options": {
+                        "raw": {
+                          "language": "json"
+                        }
+                      }
+                    },
+                    "url": {
+                      "raw": "{{vatBaseUrl}}{{apiPrefix}}/vat/cursos/{{curso_id}}/",
+                      "host": [
+                        "{{vatBaseUrl}}{{apiPrefix}}"
+                      ],
+                      "path": [
+                        "vat",
+                        "cursos",
+                        "{{curso_id}}",
+                        ""
+                      ]
+                    },
+                    "description": "Cursos operativos asociados a centros, planes y modalidades.\n\nAutenticación: Authorization: Api-Key <clave>.\n\nOperación de escritura bloqueada por defecto. Para enviarla debe configurar explícitamente `allowVatMutations=true` en el ambiente activo; verifique los identificadores y el ambiente y no la ejecute contra producción como prueba exploratoria."
+                  },
+                  "event": [
+                    {
+                      "listen": "prerequest",
+                      "script": {
+                        "type": "text/javascript",
+                        "exec": [
+                          "const allowMutations = String(pm.variables.get('allowVatMutations') || '').toLowerCase() === 'true';",
+                          "if (!allowMutations) {",
+                          "  console.warn('Request VAT de escritura omitido. Configure allowVatMutations=true sólo para una ejecución controlada.');",
+                          "  pm.execution.skipRequest();",
+                          "}"
+                        ]
+                      }
+                    },
+                    {
+                      "listen": "test",
+                      "script": {
+                        "type": "text/javascript",
+                        "exec": [
+                          "pm.test('Status code 200', function () { pm.response.to.have.status(200); });",
+                          "const body = pm.response.json();",
+                          "if (body.id !== undefined) {",
+                          "  const value = String(body.id);",
+                          "  pm.collectionVariables.set('curso_id', value);",
+                          "  if (pm.environment && pm.environment.name) { pm.environment.set('curso_id', value); }",
+                          "}"
+                        ]
+                      }
+                    }
+                  ],
+                  "response": []
+                },
+                {
+                  "name": "Eliminar curso operativo (DELETE)",
+                  "request": {
+                    "method": "DELETE",
+                    "header": [
+                      {
+                        "key": "Authorization",
+                        "value": "Api-Key {{apiKey}}",
+                        "type": "text",
+                        "description": "API key VAT. En los endpoints web también puede reemplazarse por Token <token>."
+                      }
+                    ],
+                    "url": {
+                      "raw": "{{vatBaseUrl}}{{apiPrefix}}/vat/cursos/{{curso_id}}/",
+                      "host": [
+                        "{{vatBaseUrl}}{{apiPrefix}}"
+                      ],
+                      "path": [
+                        "vat",
+                        "cursos",
+                        "{{curso_id}}",
+                        ""
+                      ]
+                    },
+                    "description": "Cursos operativos asociados a centros, planes y modalidades.\n\nAutenticación: Authorization: Api-Key <clave>.\n\nOperación de escritura bloqueada por defecto. Para enviarla debe configurar explícitamente `allowVatMutations=true` en el ambiente activo; verifique los identificadores y el ambiente y no la ejecute contra producción como prueba exploratoria. En los modelos con borrado lógico, el registro se desactiva o cambia a un estado operativo cerrado/cancelado."
+                  },
+                  "event": [
+                    {
+                      "listen": "prerequest",
+                      "script": {
+                        "type": "text/javascript",
+                        "exec": [
+                          "const allowMutations = String(pm.variables.get('allowVatMutations') || '').toLowerCase() === 'true';",
+                          "if (!allowMutations) {",
+                          "  console.warn('Request VAT de escritura omitido. Configure allowVatMutations=true sólo para una ejecución controlada.');",
+                          "  pm.execution.skipRequest();",
+                          "}"
+                        ]
+                      }
+                    },
+                    {
+                      "listen": "test",
+                      "script": {
+                        "type": "text/javascript",
+                        "exec": [
+                          "pm.test('Status code 204', function () { pm.response.to.have.status(204); });"
+                        ]
+                      }
+                    }
+                  ],
+                  "response": []
+                },
+                {
+                  "name": "Buscar cursos operativos (acción)",
+                  "request": {
+                    "method": "GET",
+                    "header": [
+                      {
+                        "key": "Authorization",
+                        "value": "Api-Key {{apiKey}}",
+                        "type": "text",
+                        "description": "API key VAT. En los endpoints web también puede reemplazarse por Token <token>."
+                      }
+                    ],
+                    "url": {
+                      "raw": "{{vatBaseUrl}}{{apiPrefix}}/vat/cursos/buscar/",
                       "host": [
                         "{{vatBaseUrl}}{{apiPrefix}}"
                       ],
@@ -4095,10 +8312,61 @@
                       "query": [
                         {
                           "key": "q",
-                          "value": "{{curso_busqueda}}"
+                          "value": "{{curso_busqueda_minima}}",
+                          "description": "Texto opcional; si se usa debe tener al menos 3 caracteres.",
+                          "disabled": true
+                        },
+                        {
+                          "key": "centro_id",
+                          "value": "{{centro_id}}",
+                          "description": "Filtra por centro.",
+                          "disabled": true
+                        },
+                        {
+                          "key": "provincia_id",
+                          "value": "{{provincia_id}}",
+                          "description": "Filtra por provincia del centro.",
+                          "disabled": true
+                        },
+                        {
+                          "key": "municipio_id",
+                          "value": "{{municipio_id}}",
+                          "description": "Filtra por municipio del centro.",
+                          "disabled": true
+                        },
+                        {
+                          "key": "modalidad_id",
+                          "value": "{{modalidad_cursada_id}}",
+                          "description": "Filtra por modalidad de cursada.",
+                          "disabled": true
+                        },
+                        {
+                          "key": "programa_id",
+                          "value": "{{programa_id}}",
+                          "description": "Filtra por programa derivado de parametrías de voucher.",
+                          "disabled": true
+                        },
+                        {
+                          "key": "estado",
+                          "value": "{{estado_curso}}",
+                          "description": "Filtra por estado del curso.",
+                          "disabled": true
+                        },
+                        {
+                          "key": "page",
+                          "value": "1",
+                          "description": "Número de página.",
+                          "disabled": true
+                        },
+                        {
+                          "key": "page_size",
+                          "value": "20",
+                          "description": "Cantidad de resultados por página (máximo 200).",
+                          "disabled": true
                         }
                       ]
-                    }
+                    },
+                    "description": "Acción custom `buscar`. Devuelve cursos activos con al menos una comisión activa; `q` busca por curso, plan o título y es opcional."
                   },
                   "event": [
                     {
@@ -4106,16 +8374,14 @@
                       "script": {
                         "type": "text/javascript",
                         "exec": [
-                          "pm.test('Status code is 200', function () {",
-                          "  pm.response.to.have.status(200);",
-                          "});",
+                          "pm.test('Status code 200', function () { pm.response.to.have.status(200); });",
                           "const body = pm.response.json();",
                           "const rows = Array.isArray(body) ? body : (body.results || []);",
-                          "pm.test('La respuesta contiene resultados paginados', function () {",
-                          "  pm.expect(Array.isArray(rows)).to.eql(true);",
-                          "});",
-                          "if (rows.length && rows[0].id) {",
-                          "  pm.collectionVariables.set('curso_id', String(rows[0].id));",
+                          "pm.test('La respuesta contiene una lista', function () { pm.expect(Array.isArray(rows)).to.eql(true); });",
+                          "if (rows.length && rows[0].id !== undefined) {",
+                          "  const value = String(rows[0].id);",
+                          "  pm.collectionVariables.set('curso_id', value);",
+                          "  if (pm.environment && pm.environment.name) { pm.environment.set('curso_id', value); }",
                           "}"
                         ]
                       }
@@ -4124,14 +8390,15 @@
                   "response": []
                 },
                 {
-                  "name": "Listar cursos prioritarios",
+                  "name": "Listar cursos prioritarios (acción)",
                   "request": {
                     "method": "GET",
                     "header": [
                       {
                         "key": "Authorization",
                         "value": "Api-Key {{apiKey}}",
-                        "type": "text"
+                        "type": "text",
+                        "description": "API key VAT. En los endpoints web también puede reemplazarse por Token <token>."
                       }
                     ],
                     "url": {
@@ -4144,8 +8411,59 @@
                         "cursos",
                         "prioritarios",
                         ""
+                      ],
+                      "query": [
+                        {
+                          "key": "centro_id",
+                          "value": "{{centro_id}}",
+                          "description": "Filtra por centro.",
+                          "disabled": true
+                        },
+                        {
+                          "key": "provincia_id",
+                          "value": "{{provincia_id}}",
+                          "description": "Filtra por provincia del centro.",
+                          "disabled": true
+                        },
+                        {
+                          "key": "municipio_id",
+                          "value": "{{municipio_id}}",
+                          "description": "Filtra por municipio del centro.",
+                          "disabled": true
+                        },
+                        {
+                          "key": "modalidad_id",
+                          "value": "{{modalidad_cursada_id}}",
+                          "description": "Filtra por modalidad de cursada.",
+                          "disabled": true
+                        },
+                        {
+                          "key": "programa_id",
+                          "value": "{{programa_id}}",
+                          "description": "Filtra por programa derivado de parametrías de voucher.",
+                          "disabled": true
+                        },
+                        {
+                          "key": "estado",
+                          "value": "{{estado_curso}}",
+                          "description": "Filtra por estado del curso.",
+                          "disabled": true
+                        },
+                        {
+                          "key": "page",
+                          "value": "1",
+                          "description": "Número de página.",
+                          "disabled": true
+                        },
+                        {
+                          "key": "page_size",
+                          "value": "20",
+                          "description": "Cantidad de resultados por página (máximo 200).",
+                          "disabled": true
+                        }
                       ]
-                    }
+                    },
+                    "description": "Acción custom `prioritarios`. Devuelve cursos activos, prioritarios y con al menos una comisión activa."
                   },
                   "event": [
                     {
@@ -4153,16 +8471,14 @@
                       "script": {
                         "type": "text/javascript",
                         "exec": [
-                          "pm.test('Status code is 200', function () {",
-                          "  pm.response.to.have.status(200);",
-                          "});",
+                          "pm.test('Status code 200', function () { pm.response.to.have.status(200); });",
                           "const body = pm.response.json();",
                           "const rows = Array.isArray(body) ? body : (body.results || []);",
-                          "pm.test('La respuesta contiene resultados paginados', function () {",
-                          "  pm.expect(Array.isArray(rows)).to.eql(true);",
-                          "});",
-                          "if (rows.length && rows[0].id) {",
-                          "  pm.collectionVariables.set('curso_id', String(rows[0].id));",
+                          "pm.test('La respuesta contiene una lista', function () { pm.expect(Array.isArray(rows)).to.eql(true); });",
+                          "if (rows.length && rows[0].id !== undefined) {",
+                          "  const value = String(rows[0].id);",
+                          "  pm.collectionVariables.set('curso_id', value);",
+                          "  if (pm.environment && pm.environment.name) { pm.environment.set('curso_id', value); }",
                           "}"
                         ]
                       }
@@ -4173,22 +8489,23 @@
               ]
             },
             {
-              "name": "5 - Comisiones de Curso por Curso",
-              "description": "Consulta comisiones operativas filtradas por curso_id, centro_id o ubicacion geografica.",
+              "name": "Comisiones de curso",
+              "description": "Aperturas concretas de cursos operativos. Es la comisión del flujo actual de cursos.\n\nAutenticación: Authorization: Api-Key <clave>.\n\nEste ViewSet expone list, retrieve, create, update, partial_update y destroy.",
               "item": [
                 {
-                  "name": "Listar comisiones de curso por curso_id",
+                  "name": "Listar comisiones de curso",
                   "request": {
                     "method": "GET",
                     "header": [
                       {
                         "key": "Authorization",
                         "value": "Api-Key {{apiKey}}",
-                        "type": "text"
+                        "type": "text",
+                        "description": "API key VAT. En los endpoints web también puede reemplazarse por Token <token>."
                       }
                     ],
                     "url": {
-                      "raw": "{{vatBaseUrl}}{{apiPrefix}}/vat/comisiones-curso/?curso_id={{curso_id}}",
+                      "raw": "{{vatBaseUrl}}{{apiPrefix}}/vat/comisiones-curso/",
                       "host": [
                         "{{vatBaseUrl}}{{apiPrefix}}"
                       ],
@@ -4200,125 +8517,49 @@
                       "query": [
                         {
                           "key": "curso_id",
-                          "value": "{{curso_id}}"
-                        }
-                      ]
-                    }
-                  },
-                  "event": [
-                    {
-                      "listen": "test",
-                      "script": {
-                        "type": "text/javascript",
-                        "exec": [
-                          "pm.test('Status code is 200', function () {",
-                          "  pm.response.to.have.status(200);",
-                          "});",
-                          "const body = pm.response.json();",
-                          "const rows = Array.isArray(body) ? body : (body.results || []);",
-                          "pm.test('La respuesta contiene una lista', function () {",
-                          "  pm.expect(Array.isArray(rows)).to.eql(true);",
-                          "});"
-                        ]
-                      }
-                    }
-                  ],
-                  "response": []
-                },
-                {
-                  "name": "Listar comisiones de curso por centro_id",
-                  "request": {
-                    "method": "GET",
-                    "header": [
-                      {
-                        "key": "Authorization",
-                        "value": "Api-Key {{apiKey}}",
-                        "type": "text"
-                      }
-                    ],
-                    "url": {
-                      "raw": "{{vatBaseUrl}}{{apiPrefix}}/vat/comisiones-curso/?centro_id={{centro_id}}",
-                      "host": [
-                        "{{vatBaseUrl}}{{apiPrefix}}"
-                      ],
-                      "path": [
-                        "vat",
-                        "comisiones-curso",
-                        ""
-                      ],
-                      "query": [
+                          "value": "{{curso_id}}",
+                          "description": "Filtra por curso.",
+                          "disabled": true
+                        },
                         {
                           "key": "centro_id",
-                          "value": "{{centro_id}}"
-                        }
-                      ]
-                    }
-                  },
-                  "response": []
-                },
-                {
-                  "name": "Listar comisiones de curso por provincia_id y municipio_id",
-                  "request": {
-                    "method": "GET",
-                    "header": [
-                      {
-                        "key": "Authorization",
-                        "value": "Api-Key {{apiKey}}",
-                        "type": "text"
-                      }
-                    ],
-                    "url": {
-                      "raw": "{{vatBaseUrl}}{{apiPrefix}}/vat/comisiones-curso/?provincia_id={{provincia_id}}&municipio_id={{municipio_id}}",
-                      "host": [
-                        "{{vatBaseUrl}}{{apiPrefix}}"
-                      ],
-                      "path": [
-                        "vat",
-                        "comisiones-curso",
-                        ""
-                      ],
-                      "query": [
+                          "value": "{{centro_id}}",
+                          "description": "Filtra por centro vía curso.",
+                          "disabled": true
+                        },
                         {
                           "key": "provincia_id",
-                          "value": "{{provincia_id}}"
+                          "value": "{{provincia_id}}",
+                          "description": "Filtra por provincia del centro.",
+                          "disabled": true
                         },
                         {
                           "key": "municipio_id",
-                          "value": "{{municipio_id}}"
+                          "value": "{{municipio_id}}",
+                          "description": "Filtra por municipio del centro.",
+                          "disabled": true
+                        },
+                        {
+                          "key": "estado",
+                          "value": "activa",
+                          "description": "Filtra por estado de comisión de curso.",
+                          "disabled": true
+                        },
+                        {
+                          "key": "page",
+                          "value": "1",
+                          "description": "Número de página.",
+                          "disabled": true
+                        },
+                        {
+                          "key": "page_size",
+                          "value": "20",
+                          "description": "Cantidad de resultados por página (máximo 200).",
+                          "disabled": true
                         }
                       ]
-                    }
-                  },
-                  "response": []
-                }
-              ]
-            },
-            {
-              "name": "6 - Catalogos",
-              "description": "Endpoints de solo lectura para poblar selectores: sectores, subsectores, localidades, modalidades y titulos de referencia.",
-              "item": [
-                {
-                  "name": "Listar sectores",
-                  "request": {
-                    "method": "GET",
-                    "header": [
-                      {
-                        "key": "Authorization",
-                        "value": "Api-Key {{apiKey}}",
-                        "type": "text"
-                      }
-                    ],
-                    "url": {
-                      "raw": "{{vatBaseUrl}}{{apiPrefix}}/vat/sectores/",
-                      "host": [
-                        "{{vatBaseUrl}}{{apiPrefix}}"
-                      ],
-                      "path": [
-                        "vat",
-                        "sectores",
-                        ""
-                      ]
-                    }
+                    },
+                    "description": "Aperturas concretas de cursos operativos. Es la comisión del flujo actual de cursos.\n\nAutenticación: Authorization: Api-Key <clave>.\n\nLos filtros opcionales están cargados y deshabilitados para activarlos según el caso."
                   },
                   "event": [
                     {
@@ -4326,9 +8567,15 @@
                       "script": {
                         "type": "text/javascript",
                         "exec": [
-                          "pm.test('Status code is 200', function () { pm.response.to.have.status(200); });",
-                          "const body = pm.response.json(); const rows = Array.isArray(body) ? body : (body.results || []);",
-                          "if (rows.length && rows[0].id) { pm.collectionVariables.set('sector_id', String(rows[0].id)); }"
+                          "pm.test('Status code 200', function () { pm.response.to.have.status(200); });",
+                          "const body = pm.response.json();",
+                          "const rows = Array.isArray(body) ? body : (body.results || []);",
+                          "pm.test('La respuesta contiene una lista', function () { pm.expect(Array.isArray(rows)).to.eql(true); });",
+                          "if (rows.length && rows[0].id !== undefined) {",
+                          "  const value = String(rows[0].id);",
+                          "  pm.collectionVariables.set('comision_curso_id', value);",
+                          "  if (pm.environment && pm.environment.name) { pm.environment.set('comision_curso_id', value); }",
+                          "}"
                         ]
                       }
                     }
@@ -4336,259 +8583,328 @@
                   "response": []
                 },
                 {
-                  "name": "Listar subsectores",
+                  "name": "Crear comisión de curso",
                   "request": {
-                    "method": "GET",
+                    "method": "POST",
                     "header": [
                       {
                         "key": "Authorization",
                         "value": "Api-Key {{apiKey}}",
+                        "type": "text",
+                        "description": "API key VAT. En los endpoints web también puede reemplazarse por Token <token>."
+                      },
+                      {
+                        "key": "Content-Type",
+                        "value": "application/json",
                         "type": "text"
                       }
                     ],
-                    "url": {
-                      "raw": "{{vatBaseUrl}}{{apiPrefix}}/vat/subsectores/?sector_id={{sector_id}}",
-                      "host": [
-                        "{{vatBaseUrl}}{{apiPrefix}}"
-                      ],
-                      "path": [
-                        "vat",
-                        "subsectores",
-                        ""
-                      ],
-                      "query": [
-                        {
-                          "key": "sector_id",
-                          "value": "{{sector_id}}"
+                    "body": {
+                      "mode": "raw",
+                      "raw": "{\n  \"curso\": {{curso_id}},\n  \"ubicacion\": {{institucion_ubicacion_id}},\n  \"codigo_comision\": \"INET-COM-{{$randomInt}}\",\n  \"nombre\": \"Comisión INET Postman\",\n  \"cupo_total\": 30,\n  \"acepta_lista_espera\": true,\n  \"cupo_lista_espera\": 10,\n  \"fecha_inicio\": \"2026-09-01\",\n  \"fecha_fin\": \"2026-12-15\",\n  \"estado\": \"planificada\",\n  \"observaciones\": \"Comisión creada desde Postman\"\n}",
+                      "options": {
+                        "raw": {
+                          "language": "json"
                         }
+                      }
+                    },
+                    "url": {
+                      "raw": "{{vatBaseUrl}}{{apiPrefix}}/vat/comisiones-curso/",
+                      "host": [
+                        "{{vatBaseUrl}}{{apiPrefix}}"
+                      ],
+                      "path": [
+                        "vat",
+                        "comisiones-curso",
+                        ""
                       ]
-                    }
+                    },
+                    "description": "Aperturas concretas de cursos operativos. Es la comisión del flujo actual de cursos.\n\nAutenticación: Authorization: Api-Key <clave>.\n\nOperación de escritura bloqueada por defecto. Para enviarla debe configurar explícitamente `allowVatMutations=true` en el ambiente activo; verifique los identificadores y el ambiente y no la ejecute contra producción como prueba exploratoria."
                   },
+                  "event": [
+                    {
+                      "listen": "prerequest",
+                      "script": {
+                        "type": "text/javascript",
+                        "exec": [
+                          "const allowMutations = String(pm.variables.get('allowVatMutations') || '').toLowerCase() === 'true';",
+                          "if (!allowMutations) {",
+                          "  console.warn('Request VAT de escritura omitido. Configure allowVatMutations=true sólo para una ejecución controlada.');",
+                          "  pm.execution.skipRequest();",
+                          "}"
+                        ]
+                      }
+                    },
+                    {
+                      "listen": "test",
+                      "script": {
+                        "type": "text/javascript",
+                        "exec": [
+                          "pm.test('Status code 201', function () { pm.response.to.have.status(201); });",
+                          "const body = pm.response.json();",
+                          "if (body.id !== undefined) {",
+                          "  const value = String(body.id);",
+                          "  pm.collectionVariables.set('comision_curso_id', value);",
+                          "  if (pm.environment && pm.environment.name) { pm.environment.set('comision_curso_id', value); }",
+                          "}"
+                        ]
+                      }
+                    }
+                  ],
                   "response": []
                 },
                 {
-                  "name": "Listar localidades",
+                  "name": "Obtener comisión de curso por ID",
                   "request": {
                     "method": "GET",
                     "header": [
                       {
                         "key": "Authorization",
                         "value": "Api-Key {{apiKey}}",
-                        "type": "text"
+                        "type": "text",
+                        "description": "API key VAT. En los endpoints web también puede reemplazarse por Token <token>."
                       }
                     ],
                     "url": {
-                      "raw": "{{vatBaseUrl}}{{apiPrefix}}/vat/localidades/?municipio_id={{municipio_id}}",
+                      "raw": "{{vatBaseUrl}}{{apiPrefix}}/vat/comisiones-curso/{{comision_curso_id}}/",
                       "host": [
                         "{{vatBaseUrl}}{{apiPrefix}}"
                       ],
                       "path": [
                         "vat",
-                        "localidades",
+                        "comisiones-curso",
+                        "{{comision_curso_id}}",
                         ""
-                      ],
-                      "query": [
-                        {
-                          "key": "municipio_id",
-                          "value": "{{municipio_id}}"
+                      ]
+                    },
+                    "description": "Aperturas concretas de cursos operativos. Es la comisión del flujo actual de cursos.\n\nAutenticación: Authorization: Api-Key <clave>."
+                  },
+                  "event": [
+                    {
+                      "listen": "test",
+                      "script": {
+                        "type": "text/javascript",
+                        "exec": [
+                          "pm.test('Status code 200', function () { pm.response.to.have.status(200); });",
+                          "const body = pm.response.json();",
+                          "if (body.id !== undefined) {",
+                          "  const value = String(body.id);",
+                          "  pm.collectionVariables.set('comision_curso_id', value);",
+                          "  if (pm.environment && pm.environment.name) { pm.environment.set('comision_curso_id', value); }",
+                          "}"
+                        ]
+                      }
+                    }
+                  ],
+                  "response": []
+                },
+                {
+                  "name": "Reemplazar comisión de curso (PUT)",
+                  "request": {
+                    "method": "PUT",
+                    "header": [
+                      {
+                        "key": "Authorization",
+                        "value": "Api-Key {{apiKey}}",
+                        "type": "text",
+                        "description": "API key VAT. En los endpoints web también puede reemplazarse por Token <token>."
+                      },
+                      {
+                        "key": "Content-Type",
+                        "value": "application/json",
+                        "type": "text"
+                      }
+                    ],
+                    "body": {
+                      "mode": "raw",
+                      "raw": "{\n  \"curso\": {{curso_id}},\n  \"ubicacion\": {{institucion_ubicacion_id}},\n  \"codigo_comision\": \"INET-COM-{{$randomInt}}\",\n  \"nombre\": \"Comisión INET Postman\",\n  \"cupo_total\": 30,\n  \"acepta_lista_espera\": true,\n  \"cupo_lista_espera\": 10,\n  \"fecha_inicio\": \"2026-09-01\",\n  \"fecha_fin\": \"2026-12-15\",\n  \"estado\": \"planificada\",\n  \"observaciones\": \"Comisión creada desde Postman\"\n}",
+                      "options": {
+                        "raw": {
+                          "language": "json"
                         }
-                      ]
-                    }
-                  },
-                  "response": []
-                },
-                {
-                  "name": "Listar modalidades institucionales",
-                  "request": {
-                    "method": "GET",
-                    "header": [
-                      {
-                        "key": "Authorization",
-                        "value": "Api-Key {{apiKey}}",
-                        "type": "text"
                       }
-                    ],
+                    },
                     "url": {
-                      "raw": "{{vatBaseUrl}}{{apiPrefix}}/vat/modalidades-institucionales/",
+                      "raw": "{{vatBaseUrl}}{{apiPrefix}}/vat/comisiones-curso/{{comision_curso_id}}/",
                       "host": [
                         "{{vatBaseUrl}}{{apiPrefix}}"
                       ],
                       "path": [
                         "vat",
-                        "modalidades-institucionales",
+                        "comisiones-curso",
+                        "{{comision_curso_id}}",
                         ""
                       ]
-                    }
+                    },
+                    "description": "Aperturas concretas de cursos operativos. Es la comisión del flujo actual de cursos.\n\nAutenticación: Authorization: Api-Key <clave>.\n\nPUT requiere el cuerpo completo. Operación de escritura bloqueada por defecto. Para enviarla debe configurar explícitamente `allowVatMutations=true` en el ambiente activo; verifique los identificadores y el ambiente y no la ejecute contra producción como prueba exploratoria."
                   },
+                  "event": [
+                    {
+                      "listen": "prerequest",
+                      "script": {
+                        "type": "text/javascript",
+                        "exec": [
+                          "const allowMutations = String(pm.variables.get('allowVatMutations') || '').toLowerCase() === 'true';",
+                          "if (!allowMutations) {",
+                          "  console.warn('Request VAT de escritura omitido. Configure allowVatMutations=true sólo para una ejecución controlada.');",
+                          "  pm.execution.skipRequest();",
+                          "}"
+                        ]
+                      }
+                    },
+                    {
+                      "listen": "test",
+                      "script": {
+                        "type": "text/javascript",
+                        "exec": [
+                          "pm.test('Status code 200', function () { pm.response.to.have.status(200); });",
+                          "const body = pm.response.json();",
+                          "if (body.id !== undefined) {",
+                          "  const value = String(body.id);",
+                          "  pm.collectionVariables.set('comision_curso_id', value);",
+                          "  if (pm.environment && pm.environment.name) { pm.environment.set('comision_curso_id', value); }",
+                          "}"
+                        ]
+                      }
+                    }
+                  ],
                   "response": []
                 },
                 {
-                  "name": "Listar modalidades de cursado",
+                  "name": "Actualizar parcialmente comisión de curso (PATCH)",
                   "request": {
-                    "method": "GET",
+                    "method": "PATCH",
                     "header": [
                       {
                         "key": "Authorization",
                         "value": "Api-Key {{apiKey}}",
-                        "type": "text"
-                      }
-                    ],
-                    "url": {
-                      "raw": "{{vatBaseUrl}}{{apiPrefix}}/vat/modalidades-cursadas/",
-                      "host": [
-                        "{{vatBaseUrl}}{{apiPrefix}}"
-                      ],
-                      "path": [
-                        "vat",
-                        "modalidades-cursadas",
-                        ""
-                      ]
-                    }
-                  },
-                  "response": []
-                },
-                {
-                  "name": "Listar titulos de referencia",
-                  "request": {
-                    "method": "GET",
-                    "header": [
+                        "type": "text",
+                        "description": "API key VAT. En los endpoints web también puede reemplazarse por Token <token>."
+                      },
                       {
-                        "key": "Authorization",
-                        "value": "Api-Key {{apiKey}}",
+                        "key": "Content-Type",
+                        "value": "application/json",
                         "type": "text"
                       }
                     ],
-                    "url": {
-                      "raw": "{{vatBaseUrl}}{{apiPrefix}}/vat/titulos-referencia/?activo=true&sector_id={{sector_id}}",
-                      "host": [
-                        "{{vatBaseUrl}}{{apiPrefix}}"
-                      ],
-                      "path": [
-                        "vat",
-                        "titulos-referencia",
-                        ""
-                      ],
-                      "query": [
-                        {
-                          "key": "activo",
-                          "value": "true"
-                        },
-                        {
-                          "key": "sector_id",
-                          "value": "{{sector_id}}"
+                    "body": {
+                      "mode": "raw",
+                      "raw": "{\n  \"estado\": \"activa\",\n  \"observaciones\": \"Comisión actualizada desde Postman\"\n}",
+                      "options": {
+                        "raw": {
+                          "language": "json"
                         }
+                      }
+                    },
+                    "url": {
+                      "raw": "{{vatBaseUrl}}{{apiPrefix}}/vat/comisiones-curso/{{comision_curso_id}}/",
+                      "host": [
+                        "{{vatBaseUrl}}{{apiPrefix}}"
+                      ],
+                      "path": [
+                        "vat",
+                        "comisiones-curso",
+                        "{{comision_curso_id}}",
+                        ""
                       ]
-                    }
+                    },
+                    "description": "Aperturas concretas de cursos operativos. Es la comisión del flujo actual de cursos.\n\nAutenticación: Authorization: Api-Key <clave>.\n\nOperación de escritura bloqueada por defecto. Para enviarla debe configurar explícitamente `allowVatMutations=true` en el ambiente activo; verifique los identificadores y el ambiente y no la ejecute contra producción como prueba exploratoria."
                   },
+                  "event": [
+                    {
+                      "listen": "prerequest",
+                      "script": {
+                        "type": "text/javascript",
+                        "exec": [
+                          "const allowMutations = String(pm.variables.get('allowVatMutations') || '').toLowerCase() === 'true';",
+                          "if (!allowMutations) {",
+                          "  console.warn('Request VAT de escritura omitido. Configure allowVatMutations=true sólo para una ejecución controlada.');",
+                          "  pm.execution.skipRequest();",
+                          "}"
+                        ]
+                      }
+                    },
+                    {
+                      "listen": "test",
+                      "script": {
+                        "type": "text/javascript",
+                        "exec": [
+                          "pm.test('Status code 200', function () { pm.response.to.have.status(200); });",
+                          "const body = pm.response.json();",
+                          "if (body.id !== undefined) {",
+                          "  const value = String(body.id);",
+                          "  pm.collectionVariables.set('comision_curso_id', value);",
+                          "  if (pm.environment && pm.environment.name) { pm.environment.set('comision_curso_id', value); }",
+                          "}"
+                        ]
+                      }
+                    }
+                  ],
+                  "response": []
+                },
+                {
+                  "name": "Eliminar comisión de curso (DELETE)",
+                  "request": {
+                    "method": "DELETE",
+                    "header": [
+                      {
+                        "key": "Authorization",
+                        "value": "Api-Key {{apiKey}}",
+                        "type": "text",
+                        "description": "API key VAT. En los endpoints web también puede reemplazarse por Token <token>."
+                      }
+                    ],
+                    "url": {
+                      "raw": "{{vatBaseUrl}}{{apiPrefix}}/vat/comisiones-curso/{{comision_curso_id}}/",
+                      "host": [
+                        "{{vatBaseUrl}}{{apiPrefix}}"
+                      ],
+                      "path": [
+                        "vat",
+                        "comisiones-curso",
+                        "{{comision_curso_id}}",
+                        ""
+                      ]
+                    },
+                    "description": "Aperturas concretas de cursos operativos. Es la comisión del flujo actual de cursos.\n\nAutenticación: Authorization: Api-Key <clave>.\n\nOperación de escritura bloqueada por defecto. Para enviarla debe configurar explícitamente `allowVatMutations=true` en el ambiente activo; verifique los identificadores y el ambiente y no la ejecute contra producción como prueba exploratoria. En los modelos con borrado lógico, el registro se desactiva o cambia a un estado operativo cerrado/cancelado."
+                  },
+                  "event": [
+                    {
+                      "listen": "prerequest",
+                      "script": {
+                        "type": "text/javascript",
+                        "exec": [
+                          "const allowMutations = String(pm.variables.get('allowVatMutations') || '').toLowerCase() === 'true';",
+                          "if (!allowMutations) {",
+                          "  console.warn('Request VAT de escritura omitido. Configure allowVatMutations=true sólo para una ejecución controlada.');",
+                          "  pm.execution.skipRequest();",
+                          "}"
+                        ]
+                      }
+                    },
+                    {
+                      "listen": "test",
+                      "script": {
+                        "type": "text/javascript",
+                        "exec": [
+                          "pm.test('Status code 204', function () { pm.response.to.have.status(204); });"
+                        ]
+                      }
+                    }
+                  ],
                   "response": []
                 }
               ]
-            },
+            }
+          ]
+        },
+        {
+          "name": "5 - API operativa - Oferta institucional",
+          "description": "Flujo legacy basado en OfertaInstitucional y Comision, conservado por compatibilidad.",
+          "item": [
             {
-              "name": "7 - Institucion",
-              "description": "Datos institucionales de los centros VAT: contactos, identificadores fiscales/legales y ubicaciones.",
-              "item": [
-                {
-                  "name": "Listar contactos institucion",
-                  "request": {
-                    "method": "GET",
-                    "header": [
-                      {
-                        "key": "Authorization",
-                        "value": "Api-Key {{apiKey}}",
-                        "type": "text"
-                      }
-                    ],
-                    "url": {
-                      "raw": "{{vatBaseUrl}}{{apiPrefix}}/vat/institucion-contactos/?centro_id={{centro_id}}",
-                      "host": [
-                        "{{vatBaseUrl}}{{apiPrefix}}"
-                      ],
-                      "path": [
-                        "vat",
-                        "institucion-contactos",
-                        ""
-                      ],
-                      "query": [
-                        {
-                          "key": "centro_id",
-                          "value": "{{centro_id}}"
-                        }
-                      ]
-                    },
-                    "description": "Lista contactos institucionales del centro. Filtrar por `centro_id`."
-                  },
-                  "response": []
-                },
-                {
-                  "name": "Listar identificadores institucion",
-                  "request": {
-                    "method": "GET",
-                    "header": [
-                      {
-                        "key": "Authorization",
-                        "value": "Api-Key {{apiKey}}",
-                        "type": "text"
-                      }
-                    ],
-                    "url": {
-                      "raw": "{{vatBaseUrl}}{{apiPrefix}}/vat/institucion-identificadores/?centro_id={{centro_id}}",
-                      "host": [
-                        "{{vatBaseUrl}}{{apiPrefix}}"
-                      ],
-                      "path": [
-                        "vat",
-                        "institucion-identificadores",
-                        ""
-                      ],
-                      "query": [
-                        {
-                          "key": "centro_id",
-                          "value": "{{centro_id}}"
-                        }
-                      ]
-                    },
-                    "description": "Lista identificadores (CUIT, codigo CUEANEXO, etc.) del centro."
-                  },
-                  "response": []
-                },
-                {
-                  "name": "Listar ubicaciones institucion",
-                  "request": {
-                    "method": "GET",
-                    "header": [
-                      {
-                        "key": "Authorization",
-                        "value": "Api-Key {{apiKey}}",
-                        "type": "text"
-                      }
-                    ],
-                    "url": {
-                      "raw": "{{vatBaseUrl}}{{apiPrefix}}/vat/institucion-ubicaciones/?centro_id={{centro_id}}",
-                      "host": [
-                        "{{vatBaseUrl}}{{apiPrefix}}"
-                      ],
-                      "path": [
-                        "vat",
-                        "institucion-ubicaciones",
-                        ""
-                      ],
-                      "query": [
-                        {
-                          "key": "centro_id",
-                          "value": "{{centro_id}}"
-                        }
-                      ]
-                    },
-                    "description": "Lista ubicaciones fisicas registradas para el centro."
-                  },
-                  "response": []
-                }
-              ]
-            },
-            {
-              "name": "8 - Oferta Institucional",
-              "description": "Oferta formativa institucional: ofertas, comisiones y horarios de comision.",
+              "name": "Ofertas institucionales",
+              "description": "Oferta institucional legacy basada en un plan curricular. No confundir con Curso/ComisionCurso.\n\nAutenticación: Authorization: Api-Key <clave>.\n\nEste ViewSet expone list, retrieve, create, update, partial_update y destroy.",
               "item": [
                 {
                   "name": "Listar ofertas institucionales",
@@ -4598,11 +8914,12 @@
                       {
                         "key": "Authorization",
                         "value": "Api-Key {{apiKey}}",
-                        "type": "text"
+                        "type": "text",
+                        "description": "API key VAT. En los endpoints web también puede reemplazarse por Token <token>."
                       }
                     ],
                     "url": {
-                      "raw": "{{vatBaseUrl}}{{apiPrefix}}/vat/ofertas-institucionales/?centro_id={{centro_id}}",
+                      "raw": "{{vatBaseUrl}}{{apiPrefix}}/vat/ofertas-institucionales/",
                       "host": [
                         "{{vatBaseUrl}}{{apiPrefix}}"
                       ],
@@ -4614,11 +8931,31 @@
                       "query": [
                         {
                           "key": "centro_id",
-                          "value": "{{centro_id}}"
+                          "value": "{{centro_id}}",
+                          "description": "Filtra por centro.",
+                          "disabled": true
+                        },
+                        {
+                          "key": "estado",
+                          "value": "planificada",
+                          "description": "Filtra por estado de oferta.",
+                          "disabled": true
+                        },
+                        {
+                          "key": "page",
+                          "value": "1",
+                          "description": "Número de página.",
+                          "disabled": true
+                        },
+                        {
+                          "key": "page_size",
+                          "value": "20",
+                          "description": "Cantidad de resultados por página (máximo 200).",
+                          "disabled": true
                         }
                       ]
                     },
-                    "description": "Lista las ofertas institucionales de un centro."
+                    "description": "Oferta institucional legacy basada en un plan curricular. No confundir con Curso/ComisionCurso.\n\nAutenticación: Authorization: Api-Key <clave>.\n\nLos filtros opcionales están cargados y deshabilitados para activarlos según el caso."
                   },
                   "event": [
                     {
@@ -4626,7 +8963,15 @@
                       "script": {
                         "type": "text/javascript",
                         "exec": [
-                          "pm.test('Status code is 200', function () { pm.response.to.have.status(200); });"
+                          "pm.test('Status code 200', function () { pm.response.to.have.status(200); });",
+                          "const body = pm.response.json();",
+                          "const rows = Array.isArray(body) ? body : (body.results || []);",
+                          "pm.test('La respuesta contiene una lista', function () { pm.expect(Array.isArray(rows)).to.eql(true); });",
+                          "if (rows.length && rows[0].id !== undefined) {",
+                          "  const value = String(rows[0].id);",
+                          "  pm.collectionVariables.set('oferta_institucional_id', value);",
+                          "  if (pm.environment && pm.environment.name) { pm.environment.set('oferta_institucional_id', value); }",
+                          "}"
                         ]
                       }
                     }
@@ -4634,18 +8979,337 @@
                   "response": []
                 },
                 {
-                  "name": "Listar comisiones (oferta institucional)",
+                  "name": "Crear oferta institucional",
+                  "request": {
+                    "method": "POST",
+                    "header": [
+                      {
+                        "key": "Authorization",
+                        "value": "Api-Key {{apiKey}}",
+                        "type": "text",
+                        "description": "API key VAT. En los endpoints web también puede reemplazarse por Token <token>."
+                      },
+                      {
+                        "key": "Content-Type",
+                        "value": "application/json",
+                        "type": "text"
+                      }
+                    ],
+                    "body": {
+                      "mode": "raw",
+                      "raw": "{\n  \"centro\": {{centro_id}},\n  \"plan_curricular\": {{plan_id}},\n  \"programa\": {{programa_id}},\n  \"nombre_local\": \"Oferta INET Postman\",\n  \"ciclo_lectivo\": 2026,\n  \"plan_externo_id\": \"PLAN-{{$randomInt}}\",\n  \"estado\": \"planificada\",\n  \"costo\": \"0.00\",\n  \"usa_voucher\": false,\n  \"fecha_publicacion\": null,\n  \"observaciones\": \"Oferta creada desde Postman\"\n}",
+                      "options": {
+                        "raw": {
+                          "language": "json"
+                        }
+                      }
+                    },
+                    "url": {
+                      "raw": "{{vatBaseUrl}}{{apiPrefix}}/vat/ofertas-institucionales/",
+                      "host": [
+                        "{{vatBaseUrl}}{{apiPrefix}}"
+                      ],
+                      "path": [
+                        "vat",
+                        "ofertas-institucionales",
+                        ""
+                      ]
+                    },
+                    "description": "Oferta institucional legacy basada en un plan curricular. No confundir con Curso/ComisionCurso.\n\nAutenticación: Authorization: Api-Key <clave>.\n\nOperación de escritura bloqueada por defecto. Para enviarla debe configurar explícitamente `allowVatMutations=true` en el ambiente activo; verifique los identificadores y el ambiente y no la ejecute contra producción como prueba exploratoria."
+                  },
+                  "event": [
+                    {
+                      "listen": "prerequest",
+                      "script": {
+                        "type": "text/javascript",
+                        "exec": [
+                          "const allowMutations = String(pm.variables.get('allowVatMutations') || '').toLowerCase() === 'true';",
+                          "if (!allowMutations) {",
+                          "  console.warn('Request VAT de escritura omitido. Configure allowVatMutations=true sólo para una ejecución controlada.');",
+                          "  pm.execution.skipRequest();",
+                          "}"
+                        ]
+                      }
+                    },
+                    {
+                      "listen": "test",
+                      "script": {
+                        "type": "text/javascript",
+                        "exec": [
+                          "pm.test('Status code 201', function () { pm.response.to.have.status(201); });",
+                          "const body = pm.response.json();",
+                          "if (body.id !== undefined) {",
+                          "  const value = String(body.id);",
+                          "  pm.collectionVariables.set('oferta_institucional_id', value);",
+                          "  if (pm.environment && pm.environment.name) { pm.environment.set('oferta_institucional_id', value); }",
+                          "}"
+                        ]
+                      }
+                    }
+                  ],
+                  "response": []
+                },
+                {
+                  "name": "Obtener oferta institucional por ID",
                   "request": {
                     "method": "GET",
                     "header": [
                       {
                         "key": "Authorization",
                         "value": "Api-Key {{apiKey}}",
-                        "type": "text"
+                        "type": "text",
+                        "description": "API key VAT. En los endpoints web también puede reemplazarse por Token <token>."
                       }
                     ],
                     "url": {
-                      "raw": "{{vatBaseUrl}}{{apiPrefix}}/vat/comisiones/?centro_id={{centro_id}}",
+                      "raw": "{{vatBaseUrl}}{{apiPrefix}}/vat/ofertas-institucionales/{{oferta_institucional_id}}/",
+                      "host": [
+                        "{{vatBaseUrl}}{{apiPrefix}}"
+                      ],
+                      "path": [
+                        "vat",
+                        "ofertas-institucionales",
+                        "{{oferta_institucional_id}}",
+                        ""
+                      ]
+                    },
+                    "description": "Oferta institucional legacy basada en un plan curricular. No confundir con Curso/ComisionCurso.\n\nAutenticación: Authorization: Api-Key <clave>."
+                  },
+                  "event": [
+                    {
+                      "listen": "test",
+                      "script": {
+                        "type": "text/javascript",
+                        "exec": [
+                          "pm.test('Status code 200', function () { pm.response.to.have.status(200); });",
+                          "const body = pm.response.json();",
+                          "if (body.id !== undefined) {",
+                          "  const value = String(body.id);",
+                          "  pm.collectionVariables.set('oferta_institucional_id', value);",
+                          "  if (pm.environment && pm.environment.name) { pm.environment.set('oferta_institucional_id', value); }",
+                          "}"
+                        ]
+                      }
+                    }
+                  ],
+                  "response": []
+                },
+                {
+                  "name": "Reemplazar oferta institucional (PUT)",
+                  "request": {
+                    "method": "PUT",
+                    "header": [
+                      {
+                        "key": "Authorization",
+                        "value": "Api-Key {{apiKey}}",
+                        "type": "text",
+                        "description": "API key VAT. En los endpoints web también puede reemplazarse por Token <token>."
+                      },
+                      {
+                        "key": "Content-Type",
+                        "value": "application/json",
+                        "type": "text"
+                      }
+                    ],
+                    "body": {
+                      "mode": "raw",
+                      "raw": "{\n  \"centro\": {{centro_id}},\n  \"plan_curricular\": {{plan_id}},\n  \"programa\": {{programa_id}},\n  \"nombre_local\": \"Oferta INET Postman\",\n  \"ciclo_lectivo\": 2026,\n  \"plan_externo_id\": \"PLAN-{{$randomInt}}\",\n  \"estado\": \"planificada\",\n  \"costo\": \"0.00\",\n  \"usa_voucher\": false,\n  \"fecha_publicacion\": null,\n  \"observaciones\": \"Oferta creada desde Postman\"\n}",
+                      "options": {
+                        "raw": {
+                          "language": "json"
+                        }
+                      }
+                    },
+                    "url": {
+                      "raw": "{{vatBaseUrl}}{{apiPrefix}}/vat/ofertas-institucionales/{{oferta_institucional_id}}/",
+                      "host": [
+                        "{{vatBaseUrl}}{{apiPrefix}}"
+                      ],
+                      "path": [
+                        "vat",
+                        "ofertas-institucionales",
+                        "{{oferta_institucional_id}}",
+                        ""
+                      ]
+                    },
+                    "description": "Oferta institucional legacy basada en un plan curricular. No confundir con Curso/ComisionCurso.\n\nAutenticación: Authorization: Api-Key <clave>.\n\nPUT requiere el cuerpo completo. Operación de escritura bloqueada por defecto. Para enviarla debe configurar explícitamente `allowVatMutations=true` en el ambiente activo; verifique los identificadores y el ambiente y no la ejecute contra producción como prueba exploratoria."
+                  },
+                  "event": [
+                    {
+                      "listen": "prerequest",
+                      "script": {
+                        "type": "text/javascript",
+                        "exec": [
+                          "const allowMutations = String(pm.variables.get('allowVatMutations') || '').toLowerCase() === 'true';",
+                          "if (!allowMutations) {",
+                          "  console.warn('Request VAT de escritura omitido. Configure allowVatMutations=true sólo para una ejecución controlada.');",
+                          "  pm.execution.skipRequest();",
+                          "}"
+                        ]
+                      }
+                    },
+                    {
+                      "listen": "test",
+                      "script": {
+                        "type": "text/javascript",
+                        "exec": [
+                          "pm.test('Status code 200', function () { pm.response.to.have.status(200); });",
+                          "const body = pm.response.json();",
+                          "if (body.id !== undefined) {",
+                          "  const value = String(body.id);",
+                          "  pm.collectionVariables.set('oferta_institucional_id', value);",
+                          "  if (pm.environment && pm.environment.name) { pm.environment.set('oferta_institucional_id', value); }",
+                          "}"
+                        ]
+                      }
+                    }
+                  ],
+                  "response": []
+                },
+                {
+                  "name": "Actualizar parcialmente oferta institucional (PATCH)",
+                  "request": {
+                    "method": "PATCH",
+                    "header": [
+                      {
+                        "key": "Authorization",
+                        "value": "Api-Key {{apiKey}}",
+                        "type": "text",
+                        "description": "API key VAT. En los endpoints web también puede reemplazarse por Token <token>."
+                      },
+                      {
+                        "key": "Content-Type",
+                        "value": "application/json",
+                        "type": "text"
+                      }
+                    ],
+                    "body": {
+                      "mode": "raw",
+                      "raw": "{\n  \"estado\": \"aprobada\",\n  \"observaciones\": \"Oferta actualizada desde Postman\"\n}",
+                      "options": {
+                        "raw": {
+                          "language": "json"
+                        }
+                      }
+                    },
+                    "url": {
+                      "raw": "{{vatBaseUrl}}{{apiPrefix}}/vat/ofertas-institucionales/{{oferta_institucional_id}}/",
+                      "host": [
+                        "{{vatBaseUrl}}{{apiPrefix}}"
+                      ],
+                      "path": [
+                        "vat",
+                        "ofertas-institucionales",
+                        "{{oferta_institucional_id}}",
+                        ""
+                      ]
+                    },
+                    "description": "Oferta institucional legacy basada en un plan curricular. No confundir con Curso/ComisionCurso.\n\nAutenticación: Authorization: Api-Key <clave>.\n\nOperación de escritura bloqueada por defecto. Para enviarla debe configurar explícitamente `allowVatMutations=true` en el ambiente activo; verifique los identificadores y el ambiente y no la ejecute contra producción como prueba exploratoria."
+                  },
+                  "event": [
+                    {
+                      "listen": "prerequest",
+                      "script": {
+                        "type": "text/javascript",
+                        "exec": [
+                          "const allowMutations = String(pm.variables.get('allowVatMutations') || '').toLowerCase() === 'true';",
+                          "if (!allowMutations) {",
+                          "  console.warn('Request VAT de escritura omitido. Configure allowVatMutations=true sólo para una ejecución controlada.');",
+                          "  pm.execution.skipRequest();",
+                          "}"
+                        ]
+                      }
+                    },
+                    {
+                      "listen": "test",
+                      "script": {
+                        "type": "text/javascript",
+                        "exec": [
+                          "pm.test('Status code 200', function () { pm.response.to.have.status(200); });",
+                          "const body = pm.response.json();",
+                          "if (body.id !== undefined) {",
+                          "  const value = String(body.id);",
+                          "  pm.collectionVariables.set('oferta_institucional_id', value);",
+                          "  if (pm.environment && pm.environment.name) { pm.environment.set('oferta_institucional_id', value); }",
+                          "}"
+                        ]
+                      }
+                    }
+                  ],
+                  "response": []
+                },
+                {
+                  "name": "Eliminar oferta institucional (DELETE)",
+                  "request": {
+                    "method": "DELETE",
+                    "header": [
+                      {
+                        "key": "Authorization",
+                        "value": "Api-Key {{apiKey}}",
+                        "type": "text",
+                        "description": "API key VAT. En los endpoints web también puede reemplazarse por Token <token>."
+                      }
+                    ],
+                    "url": {
+                      "raw": "{{vatBaseUrl}}{{apiPrefix}}/vat/ofertas-institucionales/{{oferta_institucional_id}}/",
+                      "host": [
+                        "{{vatBaseUrl}}{{apiPrefix}}"
+                      ],
+                      "path": [
+                        "vat",
+                        "ofertas-institucionales",
+                        "{{oferta_institucional_id}}",
+                        ""
+                      ]
+                    },
+                    "description": "Oferta institucional legacy basada en un plan curricular. No confundir con Curso/ComisionCurso.\n\nAutenticación: Authorization: Api-Key <clave>.\n\nOperación de escritura bloqueada por defecto. Para enviarla debe configurar explícitamente `allowVatMutations=true` en el ambiente activo; verifique los identificadores y el ambiente y no la ejecute contra producción como prueba exploratoria. En los modelos con borrado lógico, el registro se desactiva o cambia a un estado operativo cerrado/cancelado."
+                  },
+                  "event": [
+                    {
+                      "listen": "prerequest",
+                      "script": {
+                        "type": "text/javascript",
+                        "exec": [
+                          "const allowMutations = String(pm.variables.get('allowVatMutations') || '').toLowerCase() === 'true';",
+                          "if (!allowMutations) {",
+                          "  console.warn('Request VAT de escritura omitido. Configure allowVatMutations=true sólo para una ejecución controlada.');",
+                          "  pm.execution.skipRequest();",
+                          "}"
+                        ]
+                      }
+                    },
+                    {
+                      "listen": "test",
+                      "script": {
+                        "type": "text/javascript",
+                        "exec": [
+                          "pm.test('Status code 204', function () { pm.response.to.have.status(204); });"
+                        ]
+                      }
+                    }
+                  ],
+                  "response": []
+                }
+              ]
+            },
+            {
+              "name": "Comisiones de oferta institucional",
+              "description": "Comisiones del flujo legacy de oferta institucional. No confundir con `/comisiones-curso/`.\n\nAutenticación: Authorization: Api-Key <clave>.\n\nEste ViewSet expone list, retrieve, create, update, partial_update y destroy.",
+              "item": [
+                {
+                  "name": "Listar comisiones de oferta institucional",
+                  "request": {
+                    "method": "GET",
+                    "header": [
+                      {
+                        "key": "Authorization",
+                        "value": "Api-Key {{apiKey}}",
+                        "type": "text",
+                        "description": "API key VAT. En los endpoints web también puede reemplazarse por Token <token>."
+                      }
+                    ],
+                    "url": {
+                      "raw": "{{vatBaseUrl}}{{apiPrefix}}/vat/comisiones/",
                       "host": [
                         "{{vatBaseUrl}}{{apiPrefix}}"
                       ],
@@ -4656,24 +9320,382 @@
                       ],
                       "query": [
                         {
-                          "key": "centro_id",
-                          "value": "{{centro_id}}"
+                          "key": "oferta_id",
+                          "value": "{{oferta_institucional_id}}",
+                          "description": "Filtra por oferta institucional.",
+                          "disabled": true
+                        },
+                        {
+                          "key": "estado",
+                          "value": "activa",
+                          "description": "Filtra por estado de comisión.",
+                          "disabled": true
+                        },
+                        {
+                          "key": "page",
+                          "value": "1",
+                          "description": "Número de página.",
+                          "disabled": true
+                        },
+                        {
+                          "key": "page_size",
+                          "value": "20",
+                          "description": "Cantidad de resultados por página (máximo 200).",
+                          "disabled": true
                         }
                       ]
                     },
-                    "description": "Lista comisiones de oferta institucional (distinto de `comisiones-curso`). Filtrar por `centro_id`."
+                    "description": "Comisiones del flujo legacy de oferta institucional. No confundir con `/comisiones-curso/`.\n\nAutenticación: Authorization: Api-Key <clave>.\n\nLos filtros opcionales están cargados y deshabilitados para activarlos según el caso."
                   },
+                  "event": [
+                    {
+                      "listen": "test",
+                      "script": {
+                        "type": "text/javascript",
+                        "exec": [
+                          "pm.test('Status code 200', function () { pm.response.to.have.status(200); });",
+                          "const body = pm.response.json();",
+                          "const rows = Array.isArray(body) ? body : (body.results || []);",
+                          "pm.test('La respuesta contiene una lista', function () { pm.expect(Array.isArray(rows)).to.eql(true); });",
+                          "if (rows.length && rows[0].id !== undefined) {",
+                          "  const value = String(rows[0].id);",
+                          "  pm.collectionVariables.set('comision_id', value);",
+                          "  if (pm.environment && pm.environment.name) { pm.environment.set('comision_id', value); }",
+                          "}"
+                        ]
+                      }
+                    }
+                  ],
                   "response": []
                 },
                 {
-                  "name": "Listar horarios de comision",
+                  "name": "Crear comisión de oferta institucional",
+                  "request": {
+                    "method": "POST",
+                    "header": [
+                      {
+                        "key": "Authorization",
+                        "value": "Api-Key {{apiKey}}",
+                        "type": "text",
+                        "description": "API key VAT. En los endpoints web también puede reemplazarse por Token <token>."
+                      },
+                      {
+                        "key": "Content-Type",
+                        "value": "application/json",
+                        "type": "text"
+                      }
+                    ],
+                    "body": {
+                      "mode": "raw",
+                      "raw": "{\n  \"oferta\": {{oferta_institucional_id}},\n  \"ubicacion\": {{institucion_ubicacion_id}},\n  \"codigo_comision\": \"OFE-COM-{{$randomInt}}\",\n  \"nombre\": \"Comisión de oferta Postman\",\n  \"fecha_inicio\": \"2026-09-01\",\n  \"fecha_fin\": \"2026-12-15\",\n  \"cupo\": 30,\n  \"acepta_lista_espera\": true,\n  \"estado\": \"planificada\",\n  \"observaciones\": \"Comisión creada desde Postman\"\n}",
+                      "options": {
+                        "raw": {
+                          "language": "json"
+                        }
+                      }
+                    },
+                    "url": {
+                      "raw": "{{vatBaseUrl}}{{apiPrefix}}/vat/comisiones/",
+                      "host": [
+                        "{{vatBaseUrl}}{{apiPrefix}}"
+                      ],
+                      "path": [
+                        "vat",
+                        "comisiones",
+                        ""
+                      ]
+                    },
+                    "description": "Comisiones del flujo legacy de oferta institucional. No confundir con `/comisiones-curso/`.\n\nAutenticación: Authorization: Api-Key <clave>.\n\nOperación de escritura bloqueada por defecto. Para enviarla debe configurar explícitamente `allowVatMutations=true` en el ambiente activo; verifique los identificadores y el ambiente y no la ejecute contra producción como prueba exploratoria."
+                  },
+                  "event": [
+                    {
+                      "listen": "prerequest",
+                      "script": {
+                        "type": "text/javascript",
+                        "exec": [
+                          "const allowMutations = String(pm.variables.get('allowVatMutations') || '').toLowerCase() === 'true';",
+                          "if (!allowMutations) {",
+                          "  console.warn('Request VAT de escritura omitido. Configure allowVatMutations=true sólo para una ejecución controlada.');",
+                          "  pm.execution.skipRequest();",
+                          "}"
+                        ]
+                      }
+                    },
+                    {
+                      "listen": "test",
+                      "script": {
+                        "type": "text/javascript",
+                        "exec": [
+                          "pm.test('Status code 201', function () { pm.response.to.have.status(201); });",
+                          "const body = pm.response.json();",
+                          "if (body.id !== undefined) {",
+                          "  const value = String(body.id);",
+                          "  pm.collectionVariables.set('comision_id', value);",
+                          "  if (pm.environment && pm.environment.name) { pm.environment.set('comision_id', value); }",
+                          "}"
+                        ]
+                      }
+                    }
+                  ],
+                  "response": []
+                },
+                {
+                  "name": "Obtener comisión de oferta institucional por ID",
                   "request": {
                     "method": "GET",
                     "header": [
                       {
                         "key": "Authorization",
                         "value": "Api-Key {{apiKey}}",
+                        "type": "text",
+                        "description": "API key VAT. En los endpoints web también puede reemplazarse por Token <token>."
+                      }
+                    ],
+                    "url": {
+                      "raw": "{{vatBaseUrl}}{{apiPrefix}}/vat/comisiones/{{comision_id}}/",
+                      "host": [
+                        "{{vatBaseUrl}}{{apiPrefix}}"
+                      ],
+                      "path": [
+                        "vat",
+                        "comisiones",
+                        "{{comision_id}}",
+                        ""
+                      ]
+                    },
+                    "description": "Comisiones del flujo legacy de oferta institucional. No confundir con `/comisiones-curso/`.\n\nAutenticación: Authorization: Api-Key <clave>."
+                  },
+                  "event": [
+                    {
+                      "listen": "test",
+                      "script": {
+                        "type": "text/javascript",
+                        "exec": [
+                          "pm.test('Status code 200', function () { pm.response.to.have.status(200); });",
+                          "const body = pm.response.json();",
+                          "if (body.id !== undefined) {",
+                          "  const value = String(body.id);",
+                          "  pm.collectionVariables.set('comision_id', value);",
+                          "  if (pm.environment && pm.environment.name) { pm.environment.set('comision_id', value); }",
+                          "}"
+                        ]
+                      }
+                    }
+                  ],
+                  "response": []
+                },
+                {
+                  "name": "Reemplazar comisión de oferta institucional (PUT)",
+                  "request": {
+                    "method": "PUT",
+                    "header": [
+                      {
+                        "key": "Authorization",
+                        "value": "Api-Key {{apiKey}}",
+                        "type": "text",
+                        "description": "API key VAT. En los endpoints web también puede reemplazarse por Token <token>."
+                      },
+                      {
+                        "key": "Content-Type",
+                        "value": "application/json",
                         "type": "text"
+                      }
+                    ],
+                    "body": {
+                      "mode": "raw",
+                      "raw": "{\n  \"oferta\": {{oferta_institucional_id}},\n  \"ubicacion\": {{institucion_ubicacion_id}},\n  \"codigo_comision\": \"OFE-COM-{{$randomInt}}\",\n  \"nombre\": \"Comisión de oferta Postman\",\n  \"fecha_inicio\": \"2026-09-01\",\n  \"fecha_fin\": \"2026-12-15\",\n  \"cupo\": 30,\n  \"acepta_lista_espera\": true,\n  \"estado\": \"planificada\",\n  \"observaciones\": \"Comisión creada desde Postman\"\n}",
+                      "options": {
+                        "raw": {
+                          "language": "json"
+                        }
+                      }
+                    },
+                    "url": {
+                      "raw": "{{vatBaseUrl}}{{apiPrefix}}/vat/comisiones/{{comision_id}}/",
+                      "host": [
+                        "{{vatBaseUrl}}{{apiPrefix}}"
+                      ],
+                      "path": [
+                        "vat",
+                        "comisiones",
+                        "{{comision_id}}",
+                        ""
+                      ]
+                    },
+                    "description": "Comisiones del flujo legacy de oferta institucional. No confundir con `/comisiones-curso/`.\n\nAutenticación: Authorization: Api-Key <clave>.\n\nPUT requiere el cuerpo completo. Operación de escritura bloqueada por defecto. Para enviarla debe configurar explícitamente `allowVatMutations=true` en el ambiente activo; verifique los identificadores y el ambiente y no la ejecute contra producción como prueba exploratoria."
+                  },
+                  "event": [
+                    {
+                      "listen": "prerequest",
+                      "script": {
+                        "type": "text/javascript",
+                        "exec": [
+                          "const allowMutations = String(pm.variables.get('allowVatMutations') || '').toLowerCase() === 'true';",
+                          "if (!allowMutations) {",
+                          "  console.warn('Request VAT de escritura omitido. Configure allowVatMutations=true sólo para una ejecución controlada.');",
+                          "  pm.execution.skipRequest();",
+                          "}"
+                        ]
+                      }
+                    },
+                    {
+                      "listen": "test",
+                      "script": {
+                        "type": "text/javascript",
+                        "exec": [
+                          "pm.test('Status code 200', function () { pm.response.to.have.status(200); });",
+                          "const body = pm.response.json();",
+                          "if (body.id !== undefined) {",
+                          "  const value = String(body.id);",
+                          "  pm.collectionVariables.set('comision_id', value);",
+                          "  if (pm.environment && pm.environment.name) { pm.environment.set('comision_id', value); }",
+                          "}"
+                        ]
+                      }
+                    }
+                  ],
+                  "response": []
+                },
+                {
+                  "name": "Actualizar parcialmente comisión de oferta institucional (PATCH)",
+                  "request": {
+                    "method": "PATCH",
+                    "header": [
+                      {
+                        "key": "Authorization",
+                        "value": "Api-Key {{apiKey}}",
+                        "type": "text",
+                        "description": "API key VAT. En los endpoints web también puede reemplazarse por Token <token>."
+                      },
+                      {
+                        "key": "Content-Type",
+                        "value": "application/json",
+                        "type": "text"
+                      }
+                    ],
+                    "body": {
+                      "mode": "raw",
+                      "raw": "{\n  \"estado\": \"activa\",\n  \"observaciones\": \"Comisión actualizada desde Postman\"\n}",
+                      "options": {
+                        "raw": {
+                          "language": "json"
+                        }
+                      }
+                    },
+                    "url": {
+                      "raw": "{{vatBaseUrl}}{{apiPrefix}}/vat/comisiones/{{comision_id}}/",
+                      "host": [
+                        "{{vatBaseUrl}}{{apiPrefix}}"
+                      ],
+                      "path": [
+                        "vat",
+                        "comisiones",
+                        "{{comision_id}}",
+                        ""
+                      ]
+                    },
+                    "description": "Comisiones del flujo legacy de oferta institucional. No confundir con `/comisiones-curso/`.\n\nAutenticación: Authorization: Api-Key <clave>.\n\nOperación de escritura bloqueada por defecto. Para enviarla debe configurar explícitamente `allowVatMutations=true` en el ambiente activo; verifique los identificadores y el ambiente y no la ejecute contra producción como prueba exploratoria."
+                  },
+                  "event": [
+                    {
+                      "listen": "prerequest",
+                      "script": {
+                        "type": "text/javascript",
+                        "exec": [
+                          "const allowMutations = String(pm.variables.get('allowVatMutations') || '').toLowerCase() === 'true';",
+                          "if (!allowMutations) {",
+                          "  console.warn('Request VAT de escritura omitido. Configure allowVatMutations=true sólo para una ejecución controlada.');",
+                          "  pm.execution.skipRequest();",
+                          "}"
+                        ]
+                      }
+                    },
+                    {
+                      "listen": "test",
+                      "script": {
+                        "type": "text/javascript",
+                        "exec": [
+                          "pm.test('Status code 200', function () { pm.response.to.have.status(200); });",
+                          "const body = pm.response.json();",
+                          "if (body.id !== undefined) {",
+                          "  const value = String(body.id);",
+                          "  pm.collectionVariables.set('comision_id', value);",
+                          "  if (pm.environment && pm.environment.name) { pm.environment.set('comision_id', value); }",
+                          "}"
+                        ]
+                      }
+                    }
+                  ],
+                  "response": []
+                },
+                {
+                  "name": "Eliminar comisión de oferta institucional (DELETE)",
+                  "request": {
+                    "method": "DELETE",
+                    "header": [
+                      {
+                        "key": "Authorization",
+                        "value": "Api-Key {{apiKey}}",
+                        "type": "text",
+                        "description": "API key VAT. En los endpoints web también puede reemplazarse por Token <token>."
+                      }
+                    ],
+                    "url": {
+                      "raw": "{{vatBaseUrl}}{{apiPrefix}}/vat/comisiones/{{comision_id}}/",
+                      "host": [
+                        "{{vatBaseUrl}}{{apiPrefix}}"
+                      ],
+                      "path": [
+                        "vat",
+                        "comisiones",
+                        "{{comision_id}}",
+                        ""
+                      ]
+                    },
+                    "description": "Comisiones del flujo legacy de oferta institucional. No confundir con `/comisiones-curso/`.\n\nAutenticación: Authorization: Api-Key <clave>.\n\nOperación de escritura bloqueada por defecto. Para enviarla debe configurar explícitamente `allowVatMutations=true` en el ambiente activo; verifique los identificadores y el ambiente y no la ejecute contra producción como prueba exploratoria. En los modelos con borrado lógico, el registro se desactiva o cambia a un estado operativo cerrado/cancelado."
+                  },
+                  "event": [
+                    {
+                      "listen": "prerequest",
+                      "script": {
+                        "type": "text/javascript",
+                        "exec": [
+                          "const allowMutations = String(pm.variables.get('allowVatMutations') || '').toLowerCase() === 'true';",
+                          "if (!allowMutations) {",
+                          "  console.warn('Request VAT de escritura omitido. Configure allowVatMutations=true sólo para una ejecución controlada.');",
+                          "  pm.execution.skipRequest();",
+                          "}"
+                        ]
+                      }
+                    },
+                    {
+                      "listen": "test",
+                      "script": {
+                        "type": "text/javascript",
+                        "exec": [
+                          "pm.test('Status code 204', function () { pm.response.to.have.status(204); });"
+                        ]
+                      }
+                    }
+                  ],
+                  "response": []
+                }
+              ]
+            },
+            {
+              "name": "Horarios de comisión",
+              "description": "Horarios asociados a una comisión de oferta institucional.\n\nAutenticación: Authorization: Api-Key <clave>.\n\nEste ViewSet expone list, retrieve, create, update, partial_update y destroy.",
+              "item": [
+                {
+                  "name": "Listar horarios de comisión",
+                  "request": {
+                    "method": "GET",
+                    "header": [
+                      {
+                        "key": "Authorization",
+                        "value": "Api-Key {{apiKey}}",
+                        "type": "text",
+                        "description": "API key VAT. En los endpoints web también puede reemplazarse por Token <token>."
                       }
                     ],
                     "url": {
@@ -4685,53 +9707,385 @@
                         "vat",
                         "comision-horarios",
                         ""
+                      ],
+                      "query": [
+                        {
+                          "key": "comision_id",
+                          "value": "{{comision_id}}",
+                          "description": "Filtra por comisión de oferta institucional.",
+                          "disabled": true
+                        },
+                        {
+                          "key": "page",
+                          "value": "1",
+                          "description": "Número de página.",
+                          "disabled": true
+                        },
+                        {
+                          "key": "page_size",
+                          "value": "20",
+                          "description": "Cantidad de resultados por página (máximo 200).",
+                          "disabled": true
+                        }
                       ]
                     },
-                    "description": "Lista los horarios configurados para las comisiones."
+                    "description": "Horarios asociados a una comisión de oferta institucional.\n\nAutenticación: Authorization: Api-Key <clave>.\n\nLos filtros opcionales están cargados y deshabilitados para activarlos según el caso."
                   },
+                  "event": [
+                    {
+                      "listen": "test",
+                      "script": {
+                        "type": "text/javascript",
+                        "exec": [
+                          "pm.test('Status code 200', function () { pm.response.to.have.status(200); });",
+                          "const body = pm.response.json();",
+                          "const rows = Array.isArray(body) ? body : (body.results || []);",
+                          "pm.test('La respuesta contiene una lista', function () { pm.expect(Array.isArray(rows)).to.eql(true); });",
+                          "if (rows.length && rows[0].id !== undefined) {",
+                          "  const value = String(rows[0].id);",
+                          "  pm.collectionVariables.set('comision_horario_id', value);",
+                          "  if (pm.environment && pm.environment.name) { pm.environment.set('comision_horario_id', value); }",
+                          "}"
+                        ]
+                      }
+                    }
+                  ],
                   "response": []
-                }
-              ]
-            },
-            {
-              "name": "9 - Inscripciones y Evaluaciones",
-              "description": "Inscripciones a oferta institucional, inscripciones a cursos, evaluaciones y resultados.",
-              "item": [
+                },
                 {
-                  "name": "Listar inscripciones (oferta institucional)",
+                  "name": "Crear horario de comisión",
                   "request": {
-                    "method": "GET",
+                    "method": "POST",
                     "header": [
                       {
                         "key": "Authorization",
                         "value": "Api-Key {{apiKey}}",
+                        "type": "text",
+                        "description": "API key VAT. En los endpoints web también puede reemplazarse por Token <token>."
+                      },
+                      {
+                        "key": "Content-Type",
+                        "value": "application/json",
                         "type": "text"
                       }
                     ],
+                    "body": {
+                      "mode": "raw",
+                      "raw": "{\n  \"comision\": {{comision_id}},\n  \"dia_semana\": {{dia_semana_id}},\n  \"hora_desde\": \"18:00:00\",\n  \"hora_hasta\": \"21:00:00\",\n  \"aula_espacio\": \"Aula 1\",\n  \"vigente\": true\n}",
+                      "options": {
+                        "raw": {
+                          "language": "json"
+                        }
+                      }
+                    },
                     "url": {
-                      "raw": "{{vatBaseUrl}}{{apiPrefix}}/vat/inscripciones/",
+                      "raw": "{{vatBaseUrl}}{{apiPrefix}}/vat/comision-horarios/",
                       "host": [
                         "{{vatBaseUrl}}{{apiPrefix}}"
                       ],
                       "path": [
                         "vat",
-                        "inscripciones",
+                        "comision-horarios",
                         ""
                       ]
                     },
-                    "description": "Lista inscripciones a ofertas institucionales. Filtrar por `centro_id`, `estado`, etc."
+                    "description": "Horarios asociados a una comisión de oferta institucional.\n\nAutenticación: Authorization: Api-Key <clave>.\n\nOperación de escritura bloqueada por defecto. Para enviarla debe configurar explícitamente `allowVatMutations=true` en el ambiente activo; verifique los identificadores y el ambiente y no la ejecute contra producción como prueba exploratoria."
                   },
+                  "event": [
+                    {
+                      "listen": "prerequest",
+                      "script": {
+                        "type": "text/javascript",
+                        "exec": [
+                          "const allowMutations = String(pm.variables.get('allowVatMutations') || '').toLowerCase() === 'true';",
+                          "if (!allowMutations) {",
+                          "  console.warn('Request VAT de escritura omitido. Configure allowVatMutations=true sólo para una ejecución controlada.');",
+                          "  pm.execution.skipRequest();",
+                          "}"
+                        ]
+                      }
+                    },
+                    {
+                      "listen": "test",
+                      "script": {
+                        "type": "text/javascript",
+                        "exec": [
+                          "pm.test('Status code 201', function () { pm.response.to.have.status(201); });",
+                          "const body = pm.response.json();",
+                          "if (body.id !== undefined) {",
+                          "  const value = String(body.id);",
+                          "  pm.collectionVariables.set('comision_horario_id', value);",
+                          "  if (pm.environment && pm.environment.name) { pm.environment.set('comision_horario_id', value); }",
+                          "}"
+                        ]
+                      }
+                    }
+                  ],
                   "response": []
                 },
                 {
-                  "name": "Listar inscripciones a oferta",
+                  "name": "Obtener horario de comisión por ID",
                   "request": {
                     "method": "GET",
                     "header": [
                       {
                         "key": "Authorization",
                         "value": "Api-Key {{apiKey}}",
+                        "type": "text",
+                        "description": "API key VAT. En los endpoints web también puede reemplazarse por Token <token>."
+                      }
+                    ],
+                    "url": {
+                      "raw": "{{vatBaseUrl}}{{apiPrefix}}/vat/comision-horarios/{{comision_horario_id}}/",
+                      "host": [
+                        "{{vatBaseUrl}}{{apiPrefix}}"
+                      ],
+                      "path": [
+                        "vat",
+                        "comision-horarios",
+                        "{{comision_horario_id}}",
+                        ""
+                      ]
+                    },
+                    "description": "Horarios asociados a una comisión de oferta institucional.\n\nAutenticación: Authorization: Api-Key <clave>."
+                  },
+                  "event": [
+                    {
+                      "listen": "test",
+                      "script": {
+                        "type": "text/javascript",
+                        "exec": [
+                          "pm.test('Status code 200', function () { pm.response.to.have.status(200); });",
+                          "const body = pm.response.json();",
+                          "if (body.id !== undefined) {",
+                          "  const value = String(body.id);",
+                          "  pm.collectionVariables.set('comision_horario_id', value);",
+                          "  if (pm.environment && pm.environment.name) { pm.environment.set('comision_horario_id', value); }",
+                          "}"
+                        ]
+                      }
+                    }
+                  ],
+                  "response": []
+                },
+                {
+                  "name": "Reemplazar horario de comisión (PUT)",
+                  "request": {
+                    "method": "PUT",
+                    "header": [
+                      {
+                        "key": "Authorization",
+                        "value": "Api-Key {{apiKey}}",
+                        "type": "text",
+                        "description": "API key VAT. En los endpoints web también puede reemplazarse por Token <token>."
+                      },
+                      {
+                        "key": "Content-Type",
+                        "value": "application/json",
                         "type": "text"
+                      }
+                    ],
+                    "body": {
+                      "mode": "raw",
+                      "raw": "{\n  \"comision\": {{comision_id}},\n  \"dia_semana\": {{dia_semana_id}},\n  \"hora_desde\": \"18:00:00\",\n  \"hora_hasta\": \"21:00:00\",\n  \"aula_espacio\": \"Aula 1\",\n  \"vigente\": true\n}",
+                      "options": {
+                        "raw": {
+                          "language": "json"
+                        }
+                      }
+                    },
+                    "url": {
+                      "raw": "{{vatBaseUrl}}{{apiPrefix}}/vat/comision-horarios/{{comision_horario_id}}/",
+                      "host": [
+                        "{{vatBaseUrl}}{{apiPrefix}}"
+                      ],
+                      "path": [
+                        "vat",
+                        "comision-horarios",
+                        "{{comision_horario_id}}",
+                        ""
+                      ]
+                    },
+                    "description": "Horarios asociados a una comisión de oferta institucional.\n\nAutenticación: Authorization: Api-Key <clave>.\n\nPUT requiere el cuerpo completo. Operación de escritura bloqueada por defecto. Para enviarla debe configurar explícitamente `allowVatMutations=true` en el ambiente activo; verifique los identificadores y el ambiente y no la ejecute contra producción como prueba exploratoria."
+                  },
+                  "event": [
+                    {
+                      "listen": "prerequest",
+                      "script": {
+                        "type": "text/javascript",
+                        "exec": [
+                          "const allowMutations = String(pm.variables.get('allowVatMutations') || '').toLowerCase() === 'true';",
+                          "if (!allowMutations) {",
+                          "  console.warn('Request VAT de escritura omitido. Configure allowVatMutations=true sólo para una ejecución controlada.');",
+                          "  pm.execution.skipRequest();",
+                          "}"
+                        ]
+                      }
+                    },
+                    {
+                      "listen": "test",
+                      "script": {
+                        "type": "text/javascript",
+                        "exec": [
+                          "pm.test('Status code 200', function () { pm.response.to.have.status(200); });",
+                          "const body = pm.response.json();",
+                          "if (body.id !== undefined) {",
+                          "  const value = String(body.id);",
+                          "  pm.collectionVariables.set('comision_horario_id', value);",
+                          "  if (pm.environment && pm.environment.name) { pm.environment.set('comision_horario_id', value); }",
+                          "}"
+                        ]
+                      }
+                    }
+                  ],
+                  "response": []
+                },
+                {
+                  "name": "Actualizar parcialmente horario de comisión (PATCH)",
+                  "request": {
+                    "method": "PATCH",
+                    "header": [
+                      {
+                        "key": "Authorization",
+                        "value": "Api-Key {{apiKey}}",
+                        "type": "text",
+                        "description": "API key VAT. En los endpoints web también puede reemplazarse por Token <token>."
+                      },
+                      {
+                        "key": "Content-Type",
+                        "value": "application/json",
+                        "type": "text"
+                      }
+                    ],
+                    "body": {
+                      "mode": "raw",
+                      "raw": "{\n  \"hora_hasta\": \"21:30:00\",\n  \"vigente\": true\n}",
+                      "options": {
+                        "raw": {
+                          "language": "json"
+                        }
+                      }
+                    },
+                    "url": {
+                      "raw": "{{vatBaseUrl}}{{apiPrefix}}/vat/comision-horarios/{{comision_horario_id}}/",
+                      "host": [
+                        "{{vatBaseUrl}}{{apiPrefix}}"
+                      ],
+                      "path": [
+                        "vat",
+                        "comision-horarios",
+                        "{{comision_horario_id}}",
+                        ""
+                      ]
+                    },
+                    "description": "Horarios asociados a una comisión de oferta institucional.\n\nAutenticación: Authorization: Api-Key <clave>.\n\nOperación de escritura bloqueada por defecto. Para enviarla debe configurar explícitamente `allowVatMutations=true` en el ambiente activo; verifique los identificadores y el ambiente y no la ejecute contra producción como prueba exploratoria."
+                  },
+                  "event": [
+                    {
+                      "listen": "prerequest",
+                      "script": {
+                        "type": "text/javascript",
+                        "exec": [
+                          "const allowMutations = String(pm.variables.get('allowVatMutations') || '').toLowerCase() === 'true';",
+                          "if (!allowMutations) {",
+                          "  console.warn('Request VAT de escritura omitido. Configure allowVatMutations=true sólo para una ejecución controlada.');",
+                          "  pm.execution.skipRequest();",
+                          "}"
+                        ]
+                      }
+                    },
+                    {
+                      "listen": "test",
+                      "script": {
+                        "type": "text/javascript",
+                        "exec": [
+                          "pm.test('Status code 200', function () { pm.response.to.have.status(200); });",
+                          "const body = pm.response.json();",
+                          "if (body.id !== undefined) {",
+                          "  const value = String(body.id);",
+                          "  pm.collectionVariables.set('comision_horario_id', value);",
+                          "  if (pm.environment && pm.environment.name) { pm.environment.set('comision_horario_id', value); }",
+                          "}"
+                        ]
+                      }
+                    }
+                  ],
+                  "response": []
+                },
+                {
+                  "name": "Eliminar horario de comisión (DELETE)",
+                  "request": {
+                    "method": "DELETE",
+                    "header": [
+                      {
+                        "key": "Authorization",
+                        "value": "Api-Key {{apiKey}}",
+                        "type": "text",
+                        "description": "API key VAT. En los endpoints web también puede reemplazarse por Token <token>."
+                      }
+                    ],
+                    "url": {
+                      "raw": "{{vatBaseUrl}}{{apiPrefix}}/vat/comision-horarios/{{comision_horario_id}}/",
+                      "host": [
+                        "{{vatBaseUrl}}{{apiPrefix}}"
+                      ],
+                      "path": [
+                        "vat",
+                        "comision-horarios",
+                        "{{comision_horario_id}}",
+                        ""
+                      ]
+                    },
+                    "description": "Horarios asociados a una comisión de oferta institucional.\n\nAutenticación: Authorization: Api-Key <clave>.\n\nOperación de escritura bloqueada por defecto. Para enviarla debe configurar explícitamente `allowVatMutations=true` en el ambiente activo; verifique los identificadores y el ambiente y no la ejecute contra producción como prueba exploratoria. En los modelos con borrado lógico, el registro se desactiva o cambia a un estado operativo cerrado/cancelado."
+                  },
+                  "event": [
+                    {
+                      "listen": "prerequest",
+                      "script": {
+                        "type": "text/javascript",
+                        "exec": [
+                          "const allowMutations = String(pm.variables.get('allowVatMutations') || '').toLowerCase() === 'true';",
+                          "if (!allowMutations) {",
+                          "  console.warn('Request VAT de escritura omitido. Configure allowVatMutations=true sólo para una ejecución controlada.');",
+                          "  pm.execution.skipRequest();",
+                          "}"
+                        ]
+                      }
+                    },
+                    {
+                      "listen": "test",
+                      "script": {
+                        "type": "text/javascript",
+                        "exec": [
+                          "pm.test('Status code 204', function () { pm.response.to.have.status(204); });"
+                        ]
+                      }
+                    }
+                  ],
+                  "response": []
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "name": "6 - API operativa - Inscripciones y vouchers",
+          "description": "Altas, consultas y administración de inscripciones y vouchers.",
+          "item": [
+            {
+              "name": "Inscripciones a oferta institucional",
+              "description": "Inscripciones del flujo legacy sobre una Comisión de oferta institucional.\n\nAutenticación: Authorization: Api-Key <clave>.\n\nEste ViewSet expone list, retrieve, create, update, partial_update y destroy.",
+              "item": [
+                {
+                  "name": "Listar inscripciones a oferta institucional",
+                  "request": {
+                    "method": "GET",
+                    "header": [
+                      {
+                        "key": "Authorization",
+                        "value": "Api-Key {{apiKey}}",
+                        "type": "text",
+                        "description": "API key VAT. En los endpoints web también puede reemplazarse por Token <token>."
                       }
                     ],
                     "url": {
@@ -4743,101 +10097,374 @@
                         "vat",
                         "inscripciones-oferta",
                         ""
-                      ]
-                    },
-                    "description": "Lista el registro de inscripciones a oferta."
-                  },
-                  "response": []
-                },
-                {
-                  "name": "Listar inscripciones a curso",
-                  "request": {
-                    "method": "GET",
-                    "header": [
-                      {
-                        "key": "Authorization",
-                        "value": "Api-Key {{apiKey}}",
-                        "type": "text"
-                      }
-                    ],
-                    "url": {
-                      "raw": "{{vatBaseUrl}}{{apiPrefix}}/vat/inscripciones-curso/?comision_curso_id={{curso_id}}",
-                      "host": [
-                        "{{vatBaseUrl}}{{apiPrefix}}"
-                      ],
-                      "path": [
-                        "vat",
-                        "inscripciones-curso",
-                        ""
                       ],
                       "query": [
                         {
-                          "key": "comision_curso_id",
-                          "value": "{{curso_id}}"
+                          "key": "oferta_id",
+                          "value": "{{comision_id}}",
+                          "description": "Filtra por comisión de oferta institucional.",
+                          "disabled": true
+                        },
+                        {
+                          "key": "estado",
+                          "value": "inscrito",
+                          "description": "Filtra por estado.",
+                          "disabled": true
+                        },
+                        {
+                          "key": "page",
+                          "value": "1",
+                          "description": "Número de página.",
+                          "disabled": true
+                        },
+                        {
+                          "key": "page_size",
+                          "value": "20",
+                          "description": "Cantidad de resultados por página (máximo 200).",
+                          "disabled": true
                         }
                       ]
                     },
-                    "description": "Lista inscripciones a comisiones de curso. Filtrar por `comision_curso_id`."
+                    "description": "Inscripciones del flujo legacy sobre una Comisión de oferta institucional.\n\nAutenticación: Authorization: Api-Key <clave>.\n\nLos filtros opcionales están cargados y deshabilitados para activarlos según el caso."
                   },
+                  "event": [
+                    {
+                      "listen": "test",
+                      "script": {
+                        "type": "text/javascript",
+                        "exec": [
+                          "pm.test('Status code 200', function () { pm.response.to.have.status(200); });",
+                          "const body = pm.response.json();",
+                          "const rows = Array.isArray(body) ? body : (body.results || []);",
+                          "pm.test('La respuesta contiene una lista', function () { pm.expect(Array.isArray(rows)).to.eql(true); });",
+                          "if (rows.length && rows[0].id !== undefined) {",
+                          "  const value = String(rows[0].id);",
+                          "  pm.collectionVariables.set('inscripcion_oferta_id', value);",
+                          "  if (pm.environment && pm.environment.name) { pm.environment.set('inscripcion_oferta_id', value); }",
+                          "}"
+                        ]
+                      }
+                    }
+                  ],
                   "response": []
                 },
                 {
-                  "name": "Listar evaluaciones",
+                  "name": "Crear inscripción a oferta institucional",
+                  "request": {
+                    "method": "POST",
+                    "header": [
+                      {
+                        "key": "Authorization",
+                        "value": "Api-Key {{apiKey}}",
+                        "type": "text",
+                        "description": "API key VAT. En los endpoints web también puede reemplazarse por Token <token>."
+                      },
+                      {
+                        "key": "Content-Type",
+                        "value": "application/json",
+                        "type": "text"
+                      }
+                    ],
+                    "body": {
+                      "mode": "raw",
+                      "raw": "{\n  \"oferta\": {{comision_id}},\n  \"ciudadano\": {{ciudadano_id}},\n  \"estado\": \"inscrito\"\n}",
+                      "options": {
+                        "raw": {
+                          "language": "json"
+                        }
+                      }
+                    },
+                    "url": {
+                      "raw": "{{vatBaseUrl}}{{apiPrefix}}/vat/inscripciones-oferta/",
+                      "host": [
+                        "{{vatBaseUrl}}{{apiPrefix}}"
+                      ],
+                      "path": [
+                        "vat",
+                        "inscripciones-oferta",
+                        ""
+                      ]
+                    },
+                    "description": "Inscripciones del flujo legacy sobre una Comisión de oferta institucional.\n\nAutenticación: Authorization: Api-Key <clave>.\n\nOperación de escritura bloqueada por defecto. Para enviarla debe configurar explícitamente `allowVatMutations=true` en el ambiente activo; verifique los identificadores y el ambiente y no la ejecute contra producción como prueba exploratoria.\n\nEl alta usa InscripcionService y requiere que la API key pueda resolverse a un usuario válido para `inscrito_por`."
+                  },
+                  "event": [
+                    {
+                      "listen": "prerequest",
+                      "script": {
+                        "type": "text/javascript",
+                        "exec": [
+                          "const allowMutations = String(pm.variables.get('allowVatMutations') || '').toLowerCase() === 'true';",
+                          "if (!allowMutations) {",
+                          "  console.warn('Request VAT de escritura omitido. Configure allowVatMutations=true sólo para una ejecución controlada.');",
+                          "  pm.execution.skipRequest();",
+                          "}"
+                        ]
+                      }
+                    },
+                    {
+                      "listen": "test",
+                      "script": {
+                        "type": "text/javascript",
+                        "exec": [
+                          "pm.test('Status code 201', function () { pm.response.to.have.status(201); });",
+                          "const body = pm.response.json();",
+                          "if (body.id !== undefined) {",
+                          "  const value = String(body.id);",
+                          "  pm.collectionVariables.set('inscripcion_oferta_id', value);",
+                          "  if (pm.environment && pm.environment.name) { pm.environment.set('inscripcion_oferta_id', value); }",
+                          "}"
+                        ]
+                      }
+                    }
+                  ],
+                  "response": []
+                },
+                {
+                  "name": "Obtener inscripción a oferta institucional por ID",
                   "request": {
                     "method": "GET",
                     "header": [
                       {
                         "key": "Authorization",
                         "value": "Api-Key {{apiKey}}",
-                        "type": "text"
+                        "type": "text",
+                        "description": "API key VAT. En los endpoints web también puede reemplazarse por Token <token>."
                       }
                     ],
                     "url": {
-                      "raw": "{{vatBaseUrl}}{{apiPrefix}}/vat/evaluaciones/",
+                      "raw": "{{vatBaseUrl}}{{apiPrefix}}/vat/inscripciones-oferta/{{inscripcion_oferta_id}}/",
                       "host": [
                         "{{vatBaseUrl}}{{apiPrefix}}"
                       ],
                       "path": [
                         "vat",
-                        "evaluaciones",
+                        "inscripciones-oferta",
+                        "{{inscripcion_oferta_id}}",
                         ""
                       ]
                     },
-                    "description": "Lista evaluaciones registradas para comisiones."
+                    "description": "Inscripciones del flujo legacy sobre una Comisión de oferta institucional.\n\nAutenticación: Authorization: Api-Key <clave>."
                   },
+                  "event": [
+                    {
+                      "listen": "test",
+                      "script": {
+                        "type": "text/javascript",
+                        "exec": [
+                          "pm.test('Status code 200', function () { pm.response.to.have.status(200); });",
+                          "const body = pm.response.json();",
+                          "if (body.id !== undefined) {",
+                          "  const value = String(body.id);",
+                          "  pm.collectionVariables.set('inscripcion_oferta_id', value);",
+                          "  if (pm.environment && pm.environment.name) { pm.environment.set('inscripcion_oferta_id', value); }",
+                          "}"
+                        ]
+                      }
+                    }
+                  ],
                   "response": []
                 },
                 {
-                  "name": "Listar resultados de evaluaciones",
+                  "name": "Reemplazar inscripción a oferta institucional (PUT)",
                   "request": {
-                    "method": "GET",
+                    "method": "PUT",
                     "header": [
                       {
                         "key": "Authorization",
                         "value": "Api-Key {{apiKey}}",
+                        "type": "text",
+                        "description": "API key VAT. En los endpoints web también puede reemplazarse por Token <token>."
+                      },
+                      {
+                        "key": "Content-Type",
+                        "value": "application/json",
                         "type": "text"
                       }
                     ],
+                    "body": {
+                      "mode": "raw",
+                      "raw": "{\n  \"oferta\": {{comision_id}},\n  \"ciudadano\": {{ciudadano_id}},\n  \"estado\": \"inscrito\"\n}",
+                      "options": {
+                        "raw": {
+                          "language": "json"
+                        }
+                      }
+                    },
                     "url": {
-                      "raw": "{{vatBaseUrl}}{{apiPrefix}}/vat/resultado-evaluaciones/",
+                      "raw": "{{vatBaseUrl}}{{apiPrefix}}/vat/inscripciones-oferta/{{inscripcion_oferta_id}}/",
                       "host": [
                         "{{vatBaseUrl}}{{apiPrefix}}"
                       ],
                       "path": [
                         "vat",
-                        "resultado-evaluaciones",
+                        "inscripciones-oferta",
+                        "{{inscripcion_oferta_id}}",
                         ""
                       ]
                     },
-                    "description": "Lista los resultados de evaluaciones por participante."
+                    "description": "Inscripciones del flujo legacy sobre una Comisión de oferta institucional.\n\nAutenticación: Authorization: Api-Key <clave>.\n\nPUT requiere el cuerpo completo. Operación de escritura bloqueada por defecto. Para enviarla debe configurar explícitamente `allowVatMutations=true` en el ambiente activo; verifique los identificadores y el ambiente y no la ejecute contra producción como prueba exploratoria.\n\nEl alta usa InscripcionService y requiere que la API key pueda resolverse a un usuario válido para `inscrito_por`."
                   },
+                  "event": [
+                    {
+                      "listen": "prerequest",
+                      "script": {
+                        "type": "text/javascript",
+                        "exec": [
+                          "const allowMutations = String(pm.variables.get('allowVatMutations') || '').toLowerCase() === 'true';",
+                          "if (!allowMutations) {",
+                          "  console.warn('Request VAT de escritura omitido. Configure allowVatMutations=true sólo para una ejecución controlada.');",
+                          "  pm.execution.skipRequest();",
+                          "}"
+                        ]
+                      }
+                    },
+                    {
+                      "listen": "test",
+                      "script": {
+                        "type": "text/javascript",
+                        "exec": [
+                          "pm.test('Status code 200', function () { pm.response.to.have.status(200); });",
+                          "const body = pm.response.json();",
+                          "if (body.id !== undefined) {",
+                          "  const value = String(body.id);",
+                          "  pm.collectionVariables.set('inscripcion_oferta_id', value);",
+                          "  if (pm.environment && pm.environment.name) { pm.environment.set('inscripcion_oferta_id', value); }",
+                          "}"
+                        ]
+                      }
+                    }
+                  ],
+                  "response": []
+                },
+                {
+                  "name": "Actualizar parcialmente inscripción a oferta institucional (PATCH)",
+                  "request": {
+                    "method": "PATCH",
+                    "header": [
+                      {
+                        "key": "Authorization",
+                        "value": "Api-Key {{apiKey}}",
+                        "type": "text",
+                        "description": "API key VAT. En los endpoints web también puede reemplazarse por Token <token>."
+                      },
+                      {
+                        "key": "Content-Type",
+                        "value": "application/json",
+                        "type": "text"
+                      }
+                    ],
+                    "body": {
+                      "mode": "raw",
+                      "raw": "{\n  \"estado\": \"completado\"\n}",
+                      "options": {
+                        "raw": {
+                          "language": "json"
+                        }
+                      }
+                    },
+                    "url": {
+                      "raw": "{{vatBaseUrl}}{{apiPrefix}}/vat/inscripciones-oferta/{{inscripcion_oferta_id}}/",
+                      "host": [
+                        "{{vatBaseUrl}}{{apiPrefix}}"
+                      ],
+                      "path": [
+                        "vat",
+                        "inscripciones-oferta",
+                        "{{inscripcion_oferta_id}}",
+                        ""
+                      ]
+                    },
+                    "description": "Inscripciones del flujo legacy sobre una Comisión de oferta institucional.\n\nAutenticación: Authorization: Api-Key <clave>.\n\nOperación de escritura bloqueada por defecto. Para enviarla debe configurar explícitamente `allowVatMutations=true` en el ambiente activo; verifique los identificadores y el ambiente y no la ejecute contra producción como prueba exploratoria.\n\nEl alta usa InscripcionService y requiere que la API key pueda resolverse a un usuario válido para `inscrito_por`."
+                  },
+                  "event": [
+                    {
+                      "listen": "prerequest",
+                      "script": {
+                        "type": "text/javascript",
+                        "exec": [
+                          "const allowMutations = String(pm.variables.get('allowVatMutations') || '').toLowerCase() === 'true';",
+                          "if (!allowMutations) {",
+                          "  console.warn('Request VAT de escritura omitido. Configure allowVatMutations=true sólo para una ejecución controlada.');",
+                          "  pm.execution.skipRequest();",
+                          "}"
+                        ]
+                      }
+                    },
+                    {
+                      "listen": "test",
+                      "script": {
+                        "type": "text/javascript",
+                        "exec": [
+                          "pm.test('Status code 200', function () { pm.response.to.have.status(200); });",
+                          "const body = pm.response.json();",
+                          "if (body.id !== undefined) {",
+                          "  const value = String(body.id);",
+                          "  pm.collectionVariables.set('inscripcion_oferta_id', value);",
+                          "  if (pm.environment && pm.environment.name) { pm.environment.set('inscripcion_oferta_id', value); }",
+                          "}"
+                        ]
+                      }
+                    }
+                  ],
+                  "response": []
+                },
+                {
+                  "name": "Eliminar inscripción a oferta institucional (DELETE)",
+                  "request": {
+                    "method": "DELETE",
+                    "header": [
+                      {
+                        "key": "Authorization",
+                        "value": "Api-Key {{apiKey}}",
+                        "type": "text",
+                        "description": "API key VAT. En los endpoints web también puede reemplazarse por Token <token>."
+                      }
+                    ],
+                    "url": {
+                      "raw": "{{vatBaseUrl}}{{apiPrefix}}/vat/inscripciones-oferta/{{inscripcion_oferta_id}}/",
+                      "host": [
+                        "{{vatBaseUrl}}{{apiPrefix}}"
+                      ],
+                      "path": [
+                        "vat",
+                        "inscripciones-oferta",
+                        "{{inscripcion_oferta_id}}",
+                        ""
+                      ]
+                    },
+                    "description": "Inscripciones del flujo legacy sobre una Comisión de oferta institucional.\n\nAutenticación: Authorization: Api-Key <clave>.\n\nOperación de escritura bloqueada por defecto. Para enviarla debe configurar explícitamente `allowVatMutations=true` en el ambiente activo; verifique los identificadores y el ambiente y no la ejecute contra producción como prueba exploratoria. En los modelos con borrado lógico, el registro se desactiva o cambia a un estado operativo cerrado/cancelado."
+                  },
+                  "event": [
+                    {
+                      "listen": "prerequest",
+                      "script": {
+                        "type": "text/javascript",
+                        "exec": [
+                          "const allowMutations = String(pm.variables.get('allowVatMutations') || '').toLowerCase() === 'true';",
+                          "if (!allowMutations) {",
+                          "  console.warn('Request VAT de escritura omitido. Configure allowVatMutations=true sólo para una ejecución controlada.');",
+                          "  pm.execution.skipRequest();",
+                          "}"
+                        ]
+                      }
+                    },
+                    {
+                      "listen": "test",
+                      "script": {
+                        "type": "text/javascript",
+                        "exec": [
+                          "pm.test('Status code 204', function () { pm.response.to.have.status(204); });"
+                        ]
+                      }
+                    }
+                  ],
                   "response": []
                 }
               ]
             },
             {
-              "name": "10 - Vouchers",
-              "description": "Gestion de vouchers VAT.",
+              "name": "Vouchers",
+              "description": "Asignaciones de créditos de formación a ciudadanos.\n\nAutenticación: Authorization: Api-Key <clave>.\n\nEste ViewSet expone list, retrieve, create, update, partial_update y destroy.",
               "item": [
                 {
                   "name": "Listar vouchers",
@@ -4847,7 +10474,8 @@
                       {
                         "key": "Authorization",
                         "value": "Api-Key {{apiKey}}",
-                        "type": "text"
+                        "type": "text",
+                        "description": "API key VAT. En los endpoints web también puede reemplazarse por Token <token>."
                       }
                     ],
                     "url": {
@@ -4859,25 +10487,414 @@
                         "vat",
                         "vouchers",
                         ""
+                      ],
+                      "query": [
+                        {
+                          "key": "ciudadano_id",
+                          "value": "{{ciudadano_id}}",
+                          "description": "Filtra por ciudadano.",
+                          "disabled": true
+                        },
+                        {
+                          "key": "estado",
+                          "value": "activo",
+                          "description": "Filtra por estado.",
+                          "disabled": true
+                        },
+                        {
+                          "key": "programa_id",
+                          "value": "{{programa_id}}",
+                          "description": "Filtra por programa.",
+                          "disabled": true
+                        },
+                        {
+                          "key": "page",
+                          "value": "1",
+                          "description": "Número de página.",
+                          "disabled": true
+                        },
+                        {
+                          "key": "page_size",
+                          "value": "20",
+                          "description": "Cantidad de resultados por página (máximo 200).",
+                          "disabled": true
+                        }
                       ]
                     },
-                    "description": "Lista todos los vouchers. Filtrar por `ciudadano_id`, `programa_id` o `estado`."
+                    "description": "Asignaciones de créditos de formación a ciudadanos.\n\nAutenticación: Authorization: Api-Key <clave>.\n\nLos filtros opcionales están cargados y deshabilitados para activarlos según el caso."
                   },
+                  "event": [
+                    {
+                      "listen": "test",
+                      "script": {
+                        "type": "text/javascript",
+                        "exec": [
+                          "pm.test('Status code 200', function () { pm.response.to.have.status(200); });",
+                          "const body = pm.response.json();",
+                          "const rows = Array.isArray(body) ? body : (body.results || []);",
+                          "pm.test('La respuesta contiene una lista', function () { pm.expect(Array.isArray(rows)).to.eql(true); });",
+                          "if (rows.length && rows[0].id !== undefined) {",
+                          "  const value = String(rows[0].id);",
+                          "  pm.collectionVariables.set('voucher_id', value);",
+                          "  if (pm.environment && pm.environment.name) { pm.environment.set('voucher_id', value); }",
+                          "}"
+                        ]
+                      }
+                    }
+                  ],
                   "response": []
                 },
                 {
-                  "name": "Vouchers por ciudadano",
+                  "name": "Crear voucher",
+                  "request": {
+                    "method": "POST",
+                    "header": [
+                      {
+                        "key": "Authorization",
+                        "value": "Api-Key {{apiKey}}",
+                        "type": "text",
+                        "description": "API key VAT. En los endpoints web también puede reemplazarse por Token <token>."
+                      },
+                      {
+                        "key": "Content-Type",
+                        "value": "application/json",
+                        "type": "text"
+                      }
+                    ],
+                    "body": {
+                      "mode": "raw",
+                      "raw": "{\n  \"ciudadano\": {{ciudadano_id}},\n  \"programa\": {{programa_id}},\n  \"cantidad_inicial\": 100,\n  \"fecha_vencimiento\": \"2027-12-31\",\n  \"estado\": \"activo\"\n}",
+                      "options": {
+                        "raw": {
+                          "language": "json"
+                        }
+                      }
+                    },
+                    "url": {
+                      "raw": "{{vatBaseUrl}}{{apiPrefix}}/vat/vouchers/",
+                      "host": [
+                        "{{vatBaseUrl}}{{apiPrefix}}"
+                      ],
+                      "path": [
+                        "vat",
+                        "vouchers",
+                        ""
+                      ]
+                    },
+                    "description": "Asignaciones de créditos de formación a ciudadanos.\n\nAutenticación: Authorization: Api-Key <clave>.\n\nOperación de escritura bloqueada por defecto. Para enviarla debe configurar explícitamente `allowVatMutations=true` en el ambiente activo; verifique los identificadores y el ambiente y no la ejecute contra producción como prueba exploratoria.\n\nRIESGO CONOCIDO: POST no es ejecutable con el contrato actual. `cantidad_disponible` es obligatoria en el modelo, pero de solo lectura en el serializer y el ViewSet no la completa. El request se conserva para representar fielmente el método expuesto por el router; requiere corregir la API antes de utilizarlo. PUT/PATCH conservan el saldo existente."
+                  },
+                  "event": [
+                    {
+                      "listen": "prerequest",
+                      "script": {
+                        "type": "text/javascript",
+                        "exec": [
+                          "const allowMutations = String(pm.variables.get('allowVatMutations') || '').toLowerCase() === 'true';",
+                          "if (!allowMutations) {",
+                          "  console.warn('Request VAT de escritura omitido. Configure allowVatMutations=true sólo para una ejecución controlada.');",
+                          "  pm.execution.skipRequest();",
+                          "}"
+                        ]
+                      }
+                    }
+                  ],
+                  "response": []
+                },
+                {
+                  "name": "Obtener voucher por ID",
                   "request": {
                     "method": "GET",
                     "header": [
                       {
                         "key": "Authorization",
                         "value": "Api-Key {{apiKey}}",
-                        "type": "text"
+                        "type": "text",
+                        "description": "API key VAT. En los endpoints web también puede reemplazarse por Token <token>."
                       }
                     ],
                     "url": {
-                      "raw": "{{vatBaseUrl}}{{apiPrefix}}/vat/vouchers/por_ciudadano/?ciudadano_id={{centro_id}}",
+                      "raw": "{{vatBaseUrl}}{{apiPrefix}}/vat/vouchers/{{voucher_id}}/",
+                      "host": [
+                        "{{vatBaseUrl}}{{apiPrefix}}"
+                      ],
+                      "path": [
+                        "vat",
+                        "vouchers",
+                        "{{voucher_id}}",
+                        ""
+                      ]
+                    },
+                    "description": "Asignaciones de créditos de formación a ciudadanos.\n\nAutenticación: Authorization: Api-Key <clave>."
+                  },
+                  "event": [
+                    {
+                      "listen": "test",
+                      "script": {
+                        "type": "text/javascript",
+                        "exec": [
+                          "pm.test('Status code 200', function () { pm.response.to.have.status(200); });",
+                          "const body = pm.response.json();",
+                          "if (body.id !== undefined) {",
+                          "  const value = String(body.id);",
+                          "  pm.collectionVariables.set('voucher_id', value);",
+                          "  if (pm.environment && pm.environment.name) { pm.environment.set('voucher_id', value); }",
+                          "}"
+                        ]
+                      }
+                    }
+                  ],
+                  "response": []
+                },
+                {
+                  "name": "Reemplazar voucher (PUT)",
+                  "request": {
+                    "method": "PUT",
+                    "header": [
+                      {
+                        "key": "Authorization",
+                        "value": "Api-Key {{apiKey}}",
+                        "type": "text",
+                        "description": "API key VAT. En los endpoints web también puede reemplazarse por Token <token>."
+                      },
+                      {
+                        "key": "Content-Type",
+                        "value": "application/json",
+                        "type": "text"
+                      }
+                    ],
+                    "body": {
+                      "mode": "raw",
+                      "raw": "{\n  \"ciudadano\": {{ciudadano_id}},\n  \"programa\": {{programa_id}},\n  \"cantidad_inicial\": 100,\n  \"fecha_vencimiento\": \"2027-12-31\",\n  \"estado\": \"activo\"\n}",
+                      "options": {
+                        "raw": {
+                          "language": "json"
+                        }
+                      }
+                    },
+                    "url": {
+                      "raw": "{{vatBaseUrl}}{{apiPrefix}}/vat/vouchers/{{voucher_id}}/",
+                      "host": [
+                        "{{vatBaseUrl}}{{apiPrefix}}"
+                      ],
+                      "path": [
+                        "vat",
+                        "vouchers",
+                        "{{voucher_id}}",
+                        ""
+                      ]
+                    },
+                    "description": "Asignaciones de créditos de formación a ciudadanos.\n\nAutenticación: Authorization: Api-Key <clave>.\n\nPUT requiere el cuerpo completo. Operación de escritura bloqueada por defecto. Para enviarla debe configurar explícitamente `allowVatMutations=true` en el ambiente activo; verifique los identificadores y el ambiente y no la ejecute contra producción como prueba exploratoria.\n\nRIESGO CONOCIDO: POST no es ejecutable con el contrato actual. `cantidad_disponible` es obligatoria en el modelo, pero de solo lectura en el serializer y el ViewSet no la completa. El request se conserva para representar fielmente el método expuesto por el router; requiere corregir la API antes de utilizarlo. PUT/PATCH conservan el saldo existente."
+                  },
+                  "event": [
+                    {
+                      "listen": "prerequest",
+                      "script": {
+                        "type": "text/javascript",
+                        "exec": [
+                          "const allowMutations = String(pm.variables.get('allowVatMutations') || '').toLowerCase() === 'true';",
+                          "if (!allowMutations) {",
+                          "  console.warn('Request VAT de escritura omitido. Configure allowVatMutations=true sólo para una ejecución controlada.');",
+                          "  pm.execution.skipRequest();",
+                          "}"
+                        ]
+                      }
+                    },
+                    {
+                      "listen": "test",
+                      "script": {
+                        "type": "text/javascript",
+                        "exec": [
+                          "pm.test('Status code 200', function () { pm.response.to.have.status(200); });",
+                          "const body = pm.response.json();",
+                          "if (body.id !== undefined) {",
+                          "  const value = String(body.id);",
+                          "  pm.collectionVariables.set('voucher_id', value);",
+                          "  if (pm.environment && pm.environment.name) { pm.environment.set('voucher_id', value); }",
+                          "}"
+                        ]
+                      }
+                    }
+                  ],
+                  "response": []
+                },
+                {
+                  "name": "Actualizar parcialmente voucher (PATCH)",
+                  "request": {
+                    "method": "PATCH",
+                    "header": [
+                      {
+                        "key": "Authorization",
+                        "value": "Api-Key {{apiKey}}",
+                        "type": "text",
+                        "description": "API key VAT. En los endpoints web también puede reemplazarse por Token <token>."
+                      },
+                      {
+                        "key": "Content-Type",
+                        "value": "application/json",
+                        "type": "text"
+                      }
+                    ],
+                    "body": {
+                      "mode": "raw",
+                      "raw": "{\n  \"estado\": \"activo\",\n  \"fecha_vencimiento\": \"2027-12-31\"\n}",
+                      "options": {
+                        "raw": {
+                          "language": "json"
+                        }
+                      }
+                    },
+                    "url": {
+                      "raw": "{{vatBaseUrl}}{{apiPrefix}}/vat/vouchers/{{voucher_id}}/",
+                      "host": [
+                        "{{vatBaseUrl}}{{apiPrefix}}"
+                      ],
+                      "path": [
+                        "vat",
+                        "vouchers",
+                        "{{voucher_id}}",
+                        ""
+                      ]
+                    },
+                    "description": "Asignaciones de créditos de formación a ciudadanos.\n\nAutenticación: Authorization: Api-Key <clave>.\n\nOperación de escritura bloqueada por defecto. Para enviarla debe configurar explícitamente `allowVatMutations=true` en el ambiente activo; verifique los identificadores y el ambiente y no la ejecute contra producción como prueba exploratoria.\n\nRIESGO CONOCIDO: POST no es ejecutable con el contrato actual. `cantidad_disponible` es obligatoria en el modelo, pero de solo lectura en el serializer y el ViewSet no la completa. El request se conserva para representar fielmente el método expuesto por el router; requiere corregir la API antes de utilizarlo. PUT/PATCH conservan el saldo existente."
+                  },
+                  "event": [
+                    {
+                      "listen": "prerequest",
+                      "script": {
+                        "type": "text/javascript",
+                        "exec": [
+                          "const allowMutations = String(pm.variables.get('allowVatMutations') || '').toLowerCase() === 'true';",
+                          "if (!allowMutations) {",
+                          "  console.warn('Request VAT de escritura omitido. Configure allowVatMutations=true sólo para una ejecución controlada.');",
+                          "  pm.execution.skipRequest();",
+                          "}"
+                        ]
+                      }
+                    },
+                    {
+                      "listen": "test",
+                      "script": {
+                        "type": "text/javascript",
+                        "exec": [
+                          "pm.test('Status code 200', function () { pm.response.to.have.status(200); });",
+                          "const body = pm.response.json();",
+                          "if (body.id !== undefined) {",
+                          "  const value = String(body.id);",
+                          "  pm.collectionVariables.set('voucher_id', value);",
+                          "  if (pm.environment && pm.environment.name) { pm.environment.set('voucher_id', value); }",
+                          "}"
+                        ]
+                      }
+                    }
+                  ],
+                  "response": []
+                },
+                {
+                  "name": "Eliminar voucher (DELETE)",
+                  "request": {
+                    "method": "DELETE",
+                    "header": [
+                      {
+                        "key": "Authorization",
+                        "value": "Api-Key {{apiKey}}",
+                        "type": "text",
+                        "description": "API key VAT. En los endpoints web también puede reemplazarse por Token <token>."
+                      }
+                    ],
+                    "url": {
+                      "raw": "{{vatBaseUrl}}{{apiPrefix}}/vat/vouchers/{{voucher_id}}/",
+                      "host": [
+                        "{{vatBaseUrl}}{{apiPrefix}}"
+                      ],
+                      "path": [
+                        "vat",
+                        "vouchers",
+                        "{{voucher_id}}",
+                        ""
+                      ]
+                    },
+                    "description": "Asignaciones de créditos de formación a ciudadanos.\n\nAutenticación: Authorization: Api-Key <clave>.\n\nOperación de escritura bloqueada por defecto. Para enviarla debe configurar explícitamente `allowVatMutations=true` en el ambiente activo; verifique los identificadores y el ambiente y no la ejecute contra producción como prueba exploratoria. En los modelos con borrado lógico, el registro se desactiva o cambia a un estado operativo cerrado/cancelado."
+                  },
+                  "event": [
+                    {
+                      "listen": "prerequest",
+                      "script": {
+                        "type": "text/javascript",
+                        "exec": [
+                          "const allowMutations = String(pm.variables.get('allowVatMutations') || '').toLowerCase() === 'true';",
+                          "if (!allowMutations) {",
+                          "  console.warn('Request VAT de escritura omitido. Configure allowVatMutations=true sólo para una ejecución controlada.');",
+                          "  pm.execution.skipRequest();",
+                          "}"
+                        ]
+                      }
+                    },
+                    {
+                      "listen": "test",
+                      "script": {
+                        "type": "text/javascript",
+                        "exec": [
+                          "pm.test('Status code 204', function () { pm.response.to.have.status(204); });"
+                        ]
+                      }
+                    }
+                  ],
+                  "response": []
+                },
+                {
+                  "name": "Consultar disponibilidad de voucher (acción)",
+                  "request": {
+                    "method": "GET",
+                    "header": [
+                      {
+                        "key": "Authorization",
+                        "value": "Api-Key {{apiKey}}",
+                        "type": "text",
+                        "description": "API key VAT. En los endpoints web también puede reemplazarse por Token <token>."
+                      }
+                    ],
+                    "url": {
+                      "raw": "{{vatBaseUrl}}{{apiPrefix}}/vat/vouchers/{{voucher_id}}/disponible/",
+                      "host": [
+                        "{{vatBaseUrl}}{{apiPrefix}}"
+                      ],
+                      "path": [
+                        "vat",
+                        "vouchers",
+                        "{{voucher_id}}",
+                        "disponible",
+                        ""
+                      ]
+                    },
+                    "description": "Acción custom de detalle. Devuelve cantidad inicial, usada, disponible y estado del voucher."
+                  },
+                  "event": [
+                    {
+                      "listen": "test",
+                      "script": {
+                        "type": "text/javascript",
+                        "exec": [
+                          "pm.test('Status code 200', function () { pm.response.to.have.status(200); });"
+                        ]
+                      }
+                    }
+                  ],
+                  "response": []
+                },
+                {
+                  "name": "Listar vouchers por ciudadano (acción)",
+                  "request": {
+                    "method": "GET",
+                    "header": [
+                      {
+                        "key": "Authorization",
+                        "value": "Api-Key {{apiKey}}",
+                        "type": "text",
+                        "description": "API key VAT. En los endpoints web también puede reemplazarse por Token <token>."
+                      }
+                    ],
+                    "url": {
+                      "raw": "{{vatBaseUrl}}{{apiPrefix}}/vat/vouchers/por_ciudadano/?ciudadano_id={{ciudadano_id}}",
                       "host": [
                         "{{vatBaseUrl}}{{apiPrefix}}"
                       ],
@@ -4890,78 +10907,12 @@
                       "query": [
                         {
                           "key": "ciudadano_id",
-                          "value": "{{centro_id}}"
+                          "value": "{{ciudadano_id}}",
+                          "description": "ID obligatorio del ciudadano."
                         }
                       ]
                     },
-                    "description": "Retorna el/los voucher(s) activos de un ciudadano. Accion custom del ViewSet."
-                  },
-                  "response": []
-                }
-              ]
-            },
-            {
-              "name": "11 - Web Ciudadanos",
-              "description": "Endpoint VAT Web para datos de ciudadanos (publico, usado por Mi Argentina y portales externos).",
-              "item": [
-                {
-                  "name": "Listar ciudadanos",
-                  "request": {
-                    "method": "GET",
-                    "header": [
-                      {
-                        "key": "Authorization",
-                        "value": "Api-Key {{apiKey}}",
-                        "type": "text"
-                      }
-                    ],
-                    "url": {
-                      "raw": "{{vatBaseUrl}}{{apiPrefix}}/vat/web/ciudadanos/",
-                      "host": [
-                        "{{vatBaseUrl}}{{apiPrefix}}"
-                      ],
-                      "path": [
-                        "vat",
-                        "web",
-                        "ciudadanos",
-                        ""
-                      ]
-                    },
-                    "description": "Lista ciudadanos registrados en VAT. Filtrar por `documento` o `cuil`."
-                  },
-                  "response": []
-                },
-                {
-                  "name": "Estado de voucher por documento",
-                  "request": {
-                    "method": "GET",
-                    "header": [
-                      {
-                        "key": "Authorization",
-                        "value": "Api-Key {{apiKey}}",
-                        "type": "text"
-                      }
-                    ],
-                    "url": {
-                      "raw": "{{vatBaseUrl}}{{apiPrefix}}/vat/web/ciudadanos/voucher-estado/?documento=40732138",
-                      "host": [
-                        "{{vatBaseUrl}}{{apiPrefix}}"
-                      ],
-                      "path": [
-                        "vat",
-                        "web",
-                        "ciudadanos",
-                        "voucher-estado",
-                        ""
-                      ],
-                      "query": [
-                        {
-                          "key": "documento",
-                          "value": "40732138"
-                        }
-                      ]
-                    },
-                    "description": "Consulta si el ciudadano tiene voucher disponible. Devuelve `estado`, `tiene_voucher` y `esta_inscripto`."
+                    "description": "Acción custom. `ciudadano_id` es obligatorio; sin el parámetro devuelve 400."
                   },
                   "event": [
                     {
@@ -4969,8 +10920,813 @@
                       "script": {
                         "type": "text/javascript",
                         "exec": [
-                          "pm.test('Status code is 200', function () { pm.response.to.have.status(200); });",
-                          "const body = pm.response.json(); pm.test('Devuelve estado de voucher', function () { pm.expect(['Disponible', 'En uso', 'No disponible']).to.include(body.estado); });"
+                          "pm.test('Status code 200', function () { pm.response.to.have.status(200); });",
+                          "const body = pm.response.json();",
+                          "const rows = Array.isArray(body) ? body : (body.results || []);",
+                          "pm.test('La respuesta contiene una lista', function () { pm.expect(Array.isArray(rows)).to.eql(true); });",
+                          "if (rows.length && rows[0].id !== undefined) {",
+                          "  const value = String(rows[0].id);",
+                          "  pm.collectionVariables.set('voucher_id', value);",
+                          "  if (pm.environment && pm.environment.name) { pm.environment.set('voucher_id', value); }",
+                          "}"
+                        ]
+                      }
+                    }
+                  ],
+                  "response": []
+                }
+              ]
+            },
+            {
+              "name": "Inscripciones",
+              "description": "Endpoint general de inscripciones; admite exactamente una comisión legacy o una comisión de curso.\n\nAutenticación: Authorization: Api-Key <clave>.\n\nEste ViewSet expone list, retrieve, create, update, partial_update y destroy.",
+              "item": [
+                {
+                  "name": "Listar inscripciones",
+                  "request": {
+                    "method": "GET",
+                    "header": [
+                      {
+                        "key": "Authorization",
+                        "value": "Api-Key {{apiKey}}",
+                        "type": "text",
+                        "description": "API key VAT. En los endpoints web también puede reemplazarse por Token <token>."
+                      }
+                    ],
+                    "url": {
+                      "raw": "{{vatBaseUrl}}{{apiPrefix}}/vat/inscripciones/",
+                      "host": [
+                        "{{vatBaseUrl}}{{apiPrefix}}"
+                      ],
+                      "path": [
+                        "vat",
+                        "inscripciones",
+                        ""
+                      ],
+                      "query": [
+                        {
+                          "key": "ciudadano_id",
+                          "value": "{{ciudadano_id}}",
+                          "description": "Filtra por ciudadano.",
+                          "disabled": true
+                        },
+                        {
+                          "key": "comision_id",
+                          "value": "{{comision_id}}",
+                          "description": "Filtra por comisión de oferta institucional.",
+                          "disabled": true
+                        },
+                        {
+                          "key": "comision_curso_id",
+                          "value": "{{comision_curso_id}}",
+                          "description": "Filtra por comisión de curso.",
+                          "disabled": true
+                        },
+                        {
+                          "key": "estado",
+                          "value": "{{estado_inscripcion}}",
+                          "description": "Filtra por estado.",
+                          "disabled": true
+                        },
+                        {
+                          "key": "page",
+                          "value": "1",
+                          "description": "Número de página.",
+                          "disabled": true
+                        },
+                        {
+                          "key": "page_size",
+                          "value": "20",
+                          "description": "Cantidad de resultados por página (máximo 200).",
+                          "disabled": true
+                        }
+                      ]
+                    },
+                    "description": "Endpoint general de inscripciones; admite exactamente una comisión legacy o una comisión de curso.\n\nAutenticación: Authorization: Api-Key <clave>.\n\nLos filtros opcionales están cargados y deshabilitados para activarlos según el caso."
+                  },
+                  "event": [
+                    {
+                      "listen": "test",
+                      "script": {
+                        "type": "text/javascript",
+                        "exec": [
+                          "pm.test('Status code 200', function () { pm.response.to.have.status(200); });",
+                          "const body = pm.response.json();",
+                          "const rows = Array.isArray(body) ? body : (body.results || []);",
+                          "pm.test('La respuesta contiene una lista', function () { pm.expect(Array.isArray(rows)).to.eql(true); });",
+                          "if (rows.length && rows[0].id !== undefined) {",
+                          "  const value = String(rows[0].id);",
+                          "  pm.collectionVariables.set('inscripcion_id', value);",
+                          "  if (pm.environment && pm.environment.name) { pm.environment.set('inscripcion_id', value); }",
+                          "}"
+                        ]
+                      }
+                    }
+                  ],
+                  "response": []
+                },
+                {
+                  "name": "Crear inscripción",
+                  "request": {
+                    "method": "POST",
+                    "header": [
+                      {
+                        "key": "Authorization",
+                        "value": "Api-Key {{apiKey}}",
+                        "type": "text",
+                        "description": "API key VAT. En los endpoints web también puede reemplazarse por Token <token>."
+                      },
+                      {
+                        "key": "Content-Type",
+                        "value": "application/json",
+                        "type": "text"
+                      }
+                    ],
+                    "body": {
+                      "mode": "raw",
+                      "raw": "{\n  \"ciudadano\": {{ciudadano_id}},\n  \"comision\": {{comision_id}},\n  \"programa\": {{programa_id}},\n  \"estado\": \"inscripta\",\n  \"origen_canal\": \"api\",\n  \"fecha_validacion_presencial\": null,\n  \"observaciones\": \"Inscripción creada desde Postman\"\n}",
+                      "options": {
+                        "raw": {
+                          "language": "json"
+                        }
+                      }
+                    },
+                    "url": {
+                      "raw": "{{vatBaseUrl}}{{apiPrefix}}/vat/inscripciones/",
+                      "host": [
+                        "{{vatBaseUrl}}{{apiPrefix}}"
+                      ],
+                      "path": [
+                        "vat",
+                        "inscripciones",
+                        ""
+                      ]
+                    },
+                    "description": "Endpoint general de inscripciones; admite exactamente una comisión legacy o una comisión de curso.\n\nAutenticación: Authorization: Api-Key <clave>.\n\nOperación de escritura bloqueada por defecto. Para enviarla debe configurar explícitamente `allowVatMutations=true` en el ambiente activo; verifique los identificadores y el ambiente y no la ejecute contra producción como prueba exploratoria.\n\nNo envíe `comision` y `comision_curso` al mismo tiempo."
+                  },
+                  "event": [
+                    {
+                      "listen": "prerequest",
+                      "script": {
+                        "type": "text/javascript",
+                        "exec": [
+                          "const allowMutations = String(pm.variables.get('allowVatMutations') || '').toLowerCase() === 'true';",
+                          "if (!allowMutations) {",
+                          "  console.warn('Request VAT de escritura omitido. Configure allowVatMutations=true sólo para una ejecución controlada.');",
+                          "  pm.execution.skipRequest();",
+                          "}"
+                        ]
+                      }
+                    },
+                    {
+                      "listen": "test",
+                      "script": {
+                        "type": "text/javascript",
+                        "exec": [
+                          "pm.test('Status code 201', function () { pm.response.to.have.status(201); });",
+                          "const body = pm.response.json();",
+                          "if (body.id !== undefined) {",
+                          "  const value = String(body.id);",
+                          "  pm.collectionVariables.set('inscripcion_id', value);",
+                          "  if (pm.environment && pm.environment.name) { pm.environment.set('inscripcion_id', value); }",
+                          "}"
+                        ]
+                      }
+                    }
+                  ],
+                  "response": []
+                },
+                {
+                  "name": "Obtener inscripción por ID",
+                  "request": {
+                    "method": "GET",
+                    "header": [
+                      {
+                        "key": "Authorization",
+                        "value": "Api-Key {{apiKey}}",
+                        "type": "text",
+                        "description": "API key VAT. En los endpoints web también puede reemplazarse por Token <token>."
+                      }
+                    ],
+                    "url": {
+                      "raw": "{{vatBaseUrl}}{{apiPrefix}}/vat/inscripciones/{{inscripcion_id}}/",
+                      "host": [
+                        "{{vatBaseUrl}}{{apiPrefix}}"
+                      ],
+                      "path": [
+                        "vat",
+                        "inscripciones",
+                        "{{inscripcion_id}}",
+                        ""
+                      ]
+                    },
+                    "description": "Endpoint general de inscripciones; admite exactamente una comisión legacy o una comisión de curso.\n\nAutenticación: Authorization: Api-Key <clave>."
+                  },
+                  "event": [
+                    {
+                      "listen": "test",
+                      "script": {
+                        "type": "text/javascript",
+                        "exec": [
+                          "pm.test('Status code 200', function () { pm.response.to.have.status(200); });",
+                          "const body = pm.response.json();",
+                          "if (body.id !== undefined) {",
+                          "  const value = String(body.id);",
+                          "  pm.collectionVariables.set('inscripcion_id', value);",
+                          "  if (pm.environment && pm.environment.name) { pm.environment.set('inscripcion_id', value); }",
+                          "}"
+                        ]
+                      }
+                    }
+                  ],
+                  "response": []
+                },
+                {
+                  "name": "Reemplazar inscripción (PUT)",
+                  "request": {
+                    "method": "PUT",
+                    "header": [
+                      {
+                        "key": "Authorization",
+                        "value": "Api-Key {{apiKey}}",
+                        "type": "text",
+                        "description": "API key VAT. En los endpoints web también puede reemplazarse por Token <token>."
+                      },
+                      {
+                        "key": "Content-Type",
+                        "value": "application/json",
+                        "type": "text"
+                      }
+                    ],
+                    "body": {
+                      "mode": "raw",
+                      "raw": "{\n  \"ciudadano\": {{ciudadano_id}},\n  \"comision\": {{comision_id}},\n  \"programa\": {{programa_id}},\n  \"estado\": \"inscripta\",\n  \"origen_canal\": \"api\",\n  \"fecha_validacion_presencial\": null,\n  \"observaciones\": \"Inscripción creada desde Postman\"\n}",
+                      "options": {
+                        "raw": {
+                          "language": "json"
+                        }
+                      }
+                    },
+                    "url": {
+                      "raw": "{{vatBaseUrl}}{{apiPrefix}}/vat/inscripciones/{{inscripcion_id}}/",
+                      "host": [
+                        "{{vatBaseUrl}}{{apiPrefix}}"
+                      ],
+                      "path": [
+                        "vat",
+                        "inscripciones",
+                        "{{inscripcion_id}}",
+                        ""
+                      ]
+                    },
+                    "description": "Endpoint general de inscripciones; admite exactamente una comisión legacy o una comisión de curso.\n\nAutenticación: Authorization: Api-Key <clave>.\n\nPUT requiere el cuerpo completo. Operación de escritura bloqueada por defecto. Para enviarla debe configurar explícitamente `allowVatMutations=true` en el ambiente activo; verifique los identificadores y el ambiente y no la ejecute contra producción como prueba exploratoria.\n\nNo envíe `comision` y `comision_curso` al mismo tiempo."
+                  },
+                  "event": [
+                    {
+                      "listen": "prerequest",
+                      "script": {
+                        "type": "text/javascript",
+                        "exec": [
+                          "const allowMutations = String(pm.variables.get('allowVatMutations') || '').toLowerCase() === 'true';",
+                          "if (!allowMutations) {",
+                          "  console.warn('Request VAT de escritura omitido. Configure allowVatMutations=true sólo para una ejecución controlada.');",
+                          "  pm.execution.skipRequest();",
+                          "}"
+                        ]
+                      }
+                    },
+                    {
+                      "listen": "test",
+                      "script": {
+                        "type": "text/javascript",
+                        "exec": [
+                          "pm.test('Status code 200', function () { pm.response.to.have.status(200); });",
+                          "const body = pm.response.json();",
+                          "if (body.id !== undefined) {",
+                          "  const value = String(body.id);",
+                          "  pm.collectionVariables.set('inscripcion_id', value);",
+                          "  if (pm.environment && pm.environment.name) { pm.environment.set('inscripcion_id', value); }",
+                          "}"
+                        ]
+                      }
+                    }
+                  ],
+                  "response": []
+                },
+                {
+                  "name": "Actualizar parcialmente inscripción (PATCH)",
+                  "request": {
+                    "method": "PATCH",
+                    "header": [
+                      {
+                        "key": "Authorization",
+                        "value": "Api-Key {{apiKey}}",
+                        "type": "text",
+                        "description": "API key VAT. En los endpoints web también puede reemplazarse por Token <token>."
+                      },
+                      {
+                        "key": "Content-Type",
+                        "value": "application/json",
+                        "type": "text"
+                      }
+                    ],
+                    "body": {
+                      "mode": "raw",
+                      "raw": "{\n  \"estado\": \"completada\",\n  \"observaciones\": \"Inscripción actualizada desde Postman\"\n}",
+                      "options": {
+                        "raw": {
+                          "language": "json"
+                        }
+                      }
+                    },
+                    "url": {
+                      "raw": "{{vatBaseUrl}}{{apiPrefix}}/vat/inscripciones/{{inscripcion_id}}/",
+                      "host": [
+                        "{{vatBaseUrl}}{{apiPrefix}}"
+                      ],
+                      "path": [
+                        "vat",
+                        "inscripciones",
+                        "{{inscripcion_id}}",
+                        ""
+                      ]
+                    },
+                    "description": "Endpoint general de inscripciones; admite exactamente una comisión legacy o una comisión de curso.\n\nAutenticación: Authorization: Api-Key <clave>.\n\nOperación de escritura bloqueada por defecto. Para enviarla debe configurar explícitamente `allowVatMutations=true` en el ambiente activo; verifique los identificadores y el ambiente y no la ejecute contra producción como prueba exploratoria.\n\nNo envíe `comision` y `comision_curso` al mismo tiempo."
+                  },
+                  "event": [
+                    {
+                      "listen": "prerequest",
+                      "script": {
+                        "type": "text/javascript",
+                        "exec": [
+                          "const allowMutations = String(pm.variables.get('allowVatMutations') || '').toLowerCase() === 'true';",
+                          "if (!allowMutations) {",
+                          "  console.warn('Request VAT de escritura omitido. Configure allowVatMutations=true sólo para una ejecución controlada.');",
+                          "  pm.execution.skipRequest();",
+                          "}"
+                        ]
+                      }
+                    },
+                    {
+                      "listen": "test",
+                      "script": {
+                        "type": "text/javascript",
+                        "exec": [
+                          "pm.test('Status code 200', function () { pm.response.to.have.status(200); });",
+                          "const body = pm.response.json();",
+                          "if (body.id !== undefined) {",
+                          "  const value = String(body.id);",
+                          "  pm.collectionVariables.set('inscripcion_id', value);",
+                          "  if (pm.environment && pm.environment.name) { pm.environment.set('inscripcion_id', value); }",
+                          "}"
+                        ]
+                      }
+                    }
+                  ],
+                  "response": []
+                },
+                {
+                  "name": "Eliminar inscripción (DELETE)",
+                  "request": {
+                    "method": "DELETE",
+                    "header": [
+                      {
+                        "key": "Authorization",
+                        "value": "Api-Key {{apiKey}}",
+                        "type": "text",
+                        "description": "API key VAT. En los endpoints web también puede reemplazarse por Token <token>."
+                      }
+                    ],
+                    "url": {
+                      "raw": "{{vatBaseUrl}}{{apiPrefix}}/vat/inscripciones/{{inscripcion_id}}/",
+                      "host": [
+                        "{{vatBaseUrl}}{{apiPrefix}}"
+                      ],
+                      "path": [
+                        "vat",
+                        "inscripciones",
+                        "{{inscripcion_id}}",
+                        ""
+                      ]
+                    },
+                    "description": "Endpoint general de inscripciones; admite exactamente una comisión legacy o una comisión de curso.\n\nAutenticación: Authorization: Api-Key <clave>.\n\nOperación de escritura bloqueada por defecto. Para enviarla debe configurar explícitamente `allowVatMutations=true` en el ambiente activo; verifique los identificadores y el ambiente y no la ejecute contra producción como prueba exploratoria. En los modelos con borrado lógico, el registro se desactiva o cambia a un estado operativo cerrado/cancelado."
+                  },
+                  "event": [
+                    {
+                      "listen": "prerequest",
+                      "script": {
+                        "type": "text/javascript",
+                        "exec": [
+                          "const allowMutations = String(pm.variables.get('allowVatMutations') || '').toLowerCase() === 'true';",
+                          "if (!allowMutations) {",
+                          "  console.warn('Request VAT de escritura omitido. Configure allowVatMutations=true sólo para una ejecución controlada.');",
+                          "  pm.execution.skipRequest();",
+                          "}"
+                        ]
+                      }
+                    },
+                    {
+                      "listen": "test",
+                      "script": {
+                        "type": "text/javascript",
+                        "exec": [
+                          "pm.test('Status code 204', function () { pm.response.to.have.status(204); });"
+                        ]
+                      }
+                    }
+                  ],
+                  "response": []
+                }
+              ]
+            },
+            {
+              "name": "Inscripciones a comisión de curso",
+              "description": "Endpoint explícito del flujo operativo; solo admite `comision_curso`.\n\nAutenticación: Authorization: Api-Key <clave>.\n\nEste ViewSet expone list, retrieve, create, update, partial_update y destroy.",
+              "item": [
+                {
+                  "name": "Listar inscripciones a comisión de curso",
+                  "request": {
+                    "method": "GET",
+                    "header": [
+                      {
+                        "key": "Authorization",
+                        "value": "Api-Key {{apiKey}}",
+                        "type": "text",
+                        "description": "API key VAT. En los endpoints web también puede reemplazarse por Token <token>."
+                      }
+                    ],
+                    "url": {
+                      "raw": "{{vatBaseUrl}}{{apiPrefix}}/vat/inscripciones-curso/",
+                      "host": [
+                        "{{vatBaseUrl}}{{apiPrefix}}"
+                      ],
+                      "path": [
+                        "vat",
+                        "inscripciones-curso",
+                        ""
+                      ],
+                      "query": [
+                        {
+                          "key": "ciudadano_id",
+                          "value": "{{ciudadano_id}}",
+                          "description": "Filtra por ciudadano.",
+                          "disabled": true
+                        },
+                        {
+                          "key": "comision_curso_id",
+                          "value": "{{comision_curso_id}}",
+                          "description": "Filtra por comisión de curso.",
+                          "disabled": true
+                        },
+                        {
+                          "key": "estado",
+                          "value": "{{estado_inscripcion}}",
+                          "description": "Filtra por estado.",
+                          "disabled": true
+                        },
+                        {
+                          "key": "page",
+                          "value": "1",
+                          "description": "Número de página.",
+                          "disabled": true
+                        },
+                        {
+                          "key": "page_size",
+                          "value": "20",
+                          "description": "Cantidad de resultados por página (máximo 200).",
+                          "disabled": true
+                        }
+                      ]
+                    },
+                    "description": "Endpoint explícito del flujo operativo; solo admite `comision_curso`.\n\nAutenticación: Authorization: Api-Key <clave>.\n\nLos filtros opcionales están cargados y deshabilitados para activarlos según el caso."
+                  },
+                  "event": [
+                    {
+                      "listen": "test",
+                      "script": {
+                        "type": "text/javascript",
+                        "exec": [
+                          "pm.test('Status code 200', function () { pm.response.to.have.status(200); });",
+                          "const body = pm.response.json();",
+                          "const rows = Array.isArray(body) ? body : (body.results || []);",
+                          "pm.test('La respuesta contiene una lista', function () { pm.expect(Array.isArray(rows)).to.eql(true); });",
+                          "if (rows.length && rows[0].id !== undefined) {",
+                          "  const value = String(rows[0].id);",
+                          "  pm.collectionVariables.set('inscripcion_curso_id', value);",
+                          "  if (pm.environment && pm.environment.name) { pm.environment.set('inscripcion_curso_id', value); }",
+                          "}"
+                        ]
+                      }
+                    }
+                  ],
+                  "response": []
+                },
+                {
+                  "name": "Crear inscripción a comisión de curso",
+                  "request": {
+                    "method": "POST",
+                    "header": [
+                      {
+                        "key": "Authorization",
+                        "value": "Api-Key {{apiKey}}",
+                        "type": "text",
+                        "description": "API key VAT. En los endpoints web también puede reemplazarse por Token <token>."
+                      },
+                      {
+                        "key": "Content-Type",
+                        "value": "application/json",
+                        "type": "text"
+                      }
+                    ],
+                    "body": {
+                      "mode": "raw",
+                      "raw": "{\n  \"ciudadano\": {{ciudadano_id}},\n  \"comision_curso\": {{comision_curso_id}},\n  \"programa\": {{programa_id}},\n  \"estado\": \"inscripta\",\n  \"origen_canal\": \"api\",\n  \"fecha_validacion_presencial\": null,\n  \"observaciones\": \"Inscripción operativa creada desde Postman\"\n}",
+                      "options": {
+                        "raw": {
+                          "language": "json"
+                        }
+                      }
+                    },
+                    "url": {
+                      "raw": "{{vatBaseUrl}}{{apiPrefix}}/vat/inscripciones-curso/",
+                      "host": [
+                        "{{vatBaseUrl}}{{apiPrefix}}"
+                      ],
+                      "path": [
+                        "vat",
+                        "inscripciones-curso",
+                        ""
+                      ]
+                    },
+                    "description": "Endpoint explícito del flujo operativo; solo admite `comision_curso`.\n\nAutenticación: Authorization: Api-Key <clave>.\n\nOperación de escritura bloqueada por defecto. Para enviarla debe configurar explícitamente `allowVatMutations=true` en el ambiente activo; verifique los identificadores y el ambiente y no la ejecute contra producción como prueba exploratoria.\n\nEste endpoint rechaza el campo `comision`; use únicamente `comision_curso`."
+                  },
+                  "event": [
+                    {
+                      "listen": "prerequest",
+                      "script": {
+                        "type": "text/javascript",
+                        "exec": [
+                          "const allowMutations = String(pm.variables.get('allowVatMutations') || '').toLowerCase() === 'true';",
+                          "if (!allowMutations) {",
+                          "  console.warn('Request VAT de escritura omitido. Configure allowVatMutations=true sólo para una ejecución controlada.');",
+                          "  pm.execution.skipRequest();",
+                          "}"
+                        ]
+                      }
+                    },
+                    {
+                      "listen": "test",
+                      "script": {
+                        "type": "text/javascript",
+                        "exec": [
+                          "pm.test('Status code 201', function () { pm.response.to.have.status(201); });",
+                          "const body = pm.response.json();",
+                          "if (body.id !== undefined) {",
+                          "  const value = String(body.id);",
+                          "  pm.collectionVariables.set('inscripcion_curso_id', value);",
+                          "  if (pm.environment && pm.environment.name) { pm.environment.set('inscripcion_curso_id', value); }",
+                          "}"
+                        ]
+                      }
+                    }
+                  ],
+                  "response": []
+                },
+                {
+                  "name": "Obtener inscripción a comisión de curso por ID",
+                  "request": {
+                    "method": "GET",
+                    "header": [
+                      {
+                        "key": "Authorization",
+                        "value": "Api-Key {{apiKey}}",
+                        "type": "text",
+                        "description": "API key VAT. En los endpoints web también puede reemplazarse por Token <token>."
+                      }
+                    ],
+                    "url": {
+                      "raw": "{{vatBaseUrl}}{{apiPrefix}}/vat/inscripciones-curso/{{inscripcion_curso_id}}/",
+                      "host": [
+                        "{{vatBaseUrl}}{{apiPrefix}}"
+                      ],
+                      "path": [
+                        "vat",
+                        "inscripciones-curso",
+                        "{{inscripcion_curso_id}}",
+                        ""
+                      ]
+                    },
+                    "description": "Endpoint explícito del flujo operativo; solo admite `comision_curso`.\n\nAutenticación: Authorization: Api-Key <clave>."
+                  },
+                  "event": [
+                    {
+                      "listen": "test",
+                      "script": {
+                        "type": "text/javascript",
+                        "exec": [
+                          "pm.test('Status code 200', function () { pm.response.to.have.status(200); });",
+                          "const body = pm.response.json();",
+                          "if (body.id !== undefined) {",
+                          "  const value = String(body.id);",
+                          "  pm.collectionVariables.set('inscripcion_curso_id', value);",
+                          "  if (pm.environment && pm.environment.name) { pm.environment.set('inscripcion_curso_id', value); }",
+                          "}"
+                        ]
+                      }
+                    }
+                  ],
+                  "response": []
+                },
+                {
+                  "name": "Reemplazar inscripción a comisión de curso (PUT)",
+                  "request": {
+                    "method": "PUT",
+                    "header": [
+                      {
+                        "key": "Authorization",
+                        "value": "Api-Key {{apiKey}}",
+                        "type": "text",
+                        "description": "API key VAT. En los endpoints web también puede reemplazarse por Token <token>."
+                      },
+                      {
+                        "key": "Content-Type",
+                        "value": "application/json",
+                        "type": "text"
+                      }
+                    ],
+                    "body": {
+                      "mode": "raw",
+                      "raw": "{\n  \"ciudadano\": {{ciudadano_id}},\n  \"comision_curso\": {{comision_curso_id}},\n  \"programa\": {{programa_id}},\n  \"estado\": \"inscripta\",\n  \"origen_canal\": \"api\",\n  \"fecha_validacion_presencial\": null,\n  \"observaciones\": \"Inscripción operativa creada desde Postman\"\n}",
+                      "options": {
+                        "raw": {
+                          "language": "json"
+                        }
+                      }
+                    },
+                    "url": {
+                      "raw": "{{vatBaseUrl}}{{apiPrefix}}/vat/inscripciones-curso/{{inscripcion_curso_id}}/",
+                      "host": [
+                        "{{vatBaseUrl}}{{apiPrefix}}"
+                      ],
+                      "path": [
+                        "vat",
+                        "inscripciones-curso",
+                        "{{inscripcion_curso_id}}",
+                        ""
+                      ]
+                    },
+                    "description": "Endpoint explícito del flujo operativo; solo admite `comision_curso`.\n\nAutenticación: Authorization: Api-Key <clave>.\n\nPUT requiere el cuerpo completo. Operación de escritura bloqueada por defecto. Para enviarla debe configurar explícitamente `allowVatMutations=true` en el ambiente activo; verifique los identificadores y el ambiente y no la ejecute contra producción como prueba exploratoria.\n\nEste endpoint rechaza el campo `comision`; use únicamente `comision_curso`."
+                  },
+                  "event": [
+                    {
+                      "listen": "prerequest",
+                      "script": {
+                        "type": "text/javascript",
+                        "exec": [
+                          "const allowMutations = String(pm.variables.get('allowVatMutations') || '').toLowerCase() === 'true';",
+                          "if (!allowMutations) {",
+                          "  console.warn('Request VAT de escritura omitido. Configure allowVatMutations=true sólo para una ejecución controlada.');",
+                          "  pm.execution.skipRequest();",
+                          "}"
+                        ]
+                      }
+                    },
+                    {
+                      "listen": "test",
+                      "script": {
+                        "type": "text/javascript",
+                        "exec": [
+                          "pm.test('Status code 200', function () { pm.response.to.have.status(200); });",
+                          "const body = pm.response.json();",
+                          "if (body.id !== undefined) {",
+                          "  const value = String(body.id);",
+                          "  pm.collectionVariables.set('inscripcion_curso_id', value);",
+                          "  if (pm.environment && pm.environment.name) { pm.environment.set('inscripcion_curso_id', value); }",
+                          "}"
+                        ]
+                      }
+                    }
+                  ],
+                  "response": []
+                },
+                {
+                  "name": "Actualizar parcialmente inscripción a comisión de curso (PATCH)",
+                  "request": {
+                    "method": "PATCH",
+                    "header": [
+                      {
+                        "key": "Authorization",
+                        "value": "Api-Key {{apiKey}}",
+                        "type": "text",
+                        "description": "API key VAT. En los endpoints web también puede reemplazarse por Token <token>."
+                      },
+                      {
+                        "key": "Content-Type",
+                        "value": "application/json",
+                        "type": "text"
+                      }
+                    ],
+                    "body": {
+                      "mode": "raw",
+                      "raw": "{\n  \"estado\": \"completada\",\n  \"observaciones\": \"Inscripción actualizada desde Postman\"\n}",
+                      "options": {
+                        "raw": {
+                          "language": "json"
+                        }
+                      }
+                    },
+                    "url": {
+                      "raw": "{{vatBaseUrl}}{{apiPrefix}}/vat/inscripciones-curso/{{inscripcion_curso_id}}/",
+                      "host": [
+                        "{{vatBaseUrl}}{{apiPrefix}}"
+                      ],
+                      "path": [
+                        "vat",
+                        "inscripciones-curso",
+                        "{{inscripcion_curso_id}}",
+                        ""
+                      ]
+                    },
+                    "description": "Endpoint explícito del flujo operativo; solo admite `comision_curso`.\n\nAutenticación: Authorization: Api-Key <clave>.\n\nOperación de escritura bloqueada por defecto. Para enviarla debe configurar explícitamente `allowVatMutations=true` en el ambiente activo; verifique los identificadores y el ambiente y no la ejecute contra producción como prueba exploratoria.\n\nEste endpoint rechaza el campo `comision`; use únicamente `comision_curso`."
+                  },
+                  "event": [
+                    {
+                      "listen": "prerequest",
+                      "script": {
+                        "type": "text/javascript",
+                        "exec": [
+                          "const allowMutations = String(pm.variables.get('allowVatMutations') || '').toLowerCase() === 'true';",
+                          "if (!allowMutations) {",
+                          "  console.warn('Request VAT de escritura omitido. Configure allowVatMutations=true sólo para una ejecución controlada.');",
+                          "  pm.execution.skipRequest();",
+                          "}"
+                        ]
+                      }
+                    },
+                    {
+                      "listen": "test",
+                      "script": {
+                        "type": "text/javascript",
+                        "exec": [
+                          "pm.test('Status code 200', function () { pm.response.to.have.status(200); });",
+                          "const body = pm.response.json();",
+                          "if (body.id !== undefined) {",
+                          "  const value = String(body.id);",
+                          "  pm.collectionVariables.set('inscripcion_curso_id', value);",
+                          "  if (pm.environment && pm.environment.name) { pm.environment.set('inscripcion_curso_id', value); }",
+                          "}"
+                        ]
+                      }
+                    }
+                  ],
+                  "response": []
+                },
+                {
+                  "name": "Eliminar inscripción a comisión de curso (DELETE)",
+                  "request": {
+                    "method": "DELETE",
+                    "header": [
+                      {
+                        "key": "Authorization",
+                        "value": "Api-Key {{apiKey}}",
+                        "type": "text",
+                        "description": "API key VAT. En los endpoints web también puede reemplazarse por Token <token>."
+                      }
+                    ],
+                    "url": {
+                      "raw": "{{vatBaseUrl}}{{apiPrefix}}/vat/inscripciones-curso/{{inscripcion_curso_id}}/",
+                      "host": [
+                        "{{vatBaseUrl}}{{apiPrefix}}"
+                      ],
+                      "path": [
+                        "vat",
+                        "inscripciones-curso",
+                        "{{inscripcion_curso_id}}",
+                        ""
+                      ]
+                    },
+                    "description": "Endpoint explícito del flujo operativo; solo admite `comision_curso`.\n\nAutenticación: Authorization: Api-Key <clave>.\n\nOperación de escritura bloqueada por defecto. Para enviarla debe configurar explícitamente `allowVatMutations=true` en el ambiente activo; verifique los identificadores y el ambiente y no la ejecute contra producción como prueba exploratoria. En los modelos con borrado lógico, el registro se desactiva o cambia a un estado operativo cerrado/cancelado."
+                  },
+                  "event": [
+                    {
+                      "listen": "prerequest",
+                      "script": {
+                        "type": "text/javascript",
+                        "exec": [
+                          "const allowMutations = String(pm.variables.get('allowVatMutations') || '').toLowerCase() === 'true';",
+                          "if (!allowMutations) {",
+                          "  console.warn('Request VAT de escritura omitido. Configure allowVatMutations=true sólo para una ejecución controlada.');",
+                          "  pm.execution.skipRequest();",
+                          "}"
+                        ]
+                      }
+                    },
+                    {
+                      "listen": "test",
+                      "script": {
+                        "type": "text/javascript",
+                        "exec": [
+                          "pm.test('Status code 204', function () { pm.response.to.have.status(204); });"
                         ]
                       }
                     }
@@ -4982,41 +11738,856 @@
           ]
         },
         {
-          "name": "Operativo - Cursos Busqueda y Prioritarios",
-          "description": "Coleccion dedicada a ejemplos de uso para los endpoints operativos de cursos VAT: busqueda por texto y listado de cursos prioritarios. Incluye casos felices, filtros combinados y errores esperados.",
+          "name": "7 - API operativa - Evaluaciones",
+          "description": "Evaluaciones y resultados del flujo de oferta institucional.",
           "item": [
             {
-              "name": "0 - Auxiliares",
-              "description": "Requests opcionales para poblar variables de filtros antes de probar busqueda o prioritarios.",
+              "name": "Evaluaciones",
+              "description": "Instancias de evaluación asociadas a comisiones de oferta institucional.\n\nAutenticación: Authorization: Api-Key <clave>.\n\nEste ViewSet expone list, retrieve, create, update, partial_update y destroy.",
               "item": [
                 {
-                  "name": "Listar centros activos",
+                  "name": "Listar evaluaciones",
                   "request": {
                     "method": "GET",
                     "header": [
                       {
                         "key": "Authorization",
                         "value": "Api-Key {{apiKey}}",
-                        "type": "text"
+                        "type": "text",
+                        "description": "API key VAT. En los endpoints web también puede reemplazarse por Token <token>."
                       }
                     ],
                     "url": {
-                      "raw": "{{vatBaseUrl}}{{apiPrefix}}/vat/centros/?activo=true",
+                      "raw": "{{vatBaseUrl}}{{apiPrefix}}/vat/evaluaciones/",
                       "host": [
                         "{{vatBaseUrl}}{{apiPrefix}}"
                       ],
                       "path": [
                         "vat",
+                        "evaluaciones",
+                        ""
+                      ],
+                      "query": [
+                        {
+                          "key": "comision_id",
+                          "value": "{{comision_id}}",
+                          "description": "Filtra por comisión.",
+                          "disabled": true
+                        },
+                        {
+                          "key": "tipo",
+                          "value": "final",
+                          "description": "Filtra por tipo: parcial, final, integradora o recuperatorio.",
+                          "disabled": true
+                        },
+                        {
+                          "key": "page",
+                          "value": "1",
+                          "description": "Número de página.",
+                          "disabled": true
+                        },
+                        {
+                          "key": "page_size",
+                          "value": "20",
+                          "description": "Cantidad de resultados por página (máximo 200).",
+                          "disabled": true
+                        }
+                      ]
+                    },
+                    "description": "Instancias de evaluación asociadas a comisiones de oferta institucional.\n\nAutenticación: Authorization: Api-Key <clave>.\n\nLos filtros opcionales están cargados y deshabilitados para activarlos según el caso."
+                  },
+                  "event": [
+                    {
+                      "listen": "test",
+                      "script": {
+                        "type": "text/javascript",
+                        "exec": [
+                          "pm.test('Status code 200', function () { pm.response.to.have.status(200); });",
+                          "const body = pm.response.json();",
+                          "const rows = Array.isArray(body) ? body : (body.results || []);",
+                          "pm.test('La respuesta contiene una lista', function () { pm.expect(Array.isArray(rows)).to.eql(true); });",
+                          "if (rows.length && rows[0].id !== undefined) {",
+                          "  const value = String(rows[0].id);",
+                          "  pm.collectionVariables.set('evaluacion_id', value);",
+                          "  if (pm.environment && pm.environment.name) { pm.environment.set('evaluacion_id', value); }",
+                          "}"
+                        ]
+                      }
+                    }
+                  ],
+                  "response": []
+                },
+                {
+                  "name": "Crear evaluación",
+                  "request": {
+                    "method": "POST",
+                    "header": [
+                      {
+                        "key": "Authorization",
+                        "value": "Api-Key {{apiKey}}",
+                        "type": "text",
+                        "description": "API key VAT. En los endpoints web también puede reemplazarse por Token <token>."
+                      },
+                      {
+                        "key": "Content-Type",
+                        "value": "application/json",
+                        "type": "text"
+                      }
+                    ],
+                    "body": {
+                      "mode": "raw",
+                      "raw": "{\n  \"comision\": {{comision_id}},\n  \"tipo\": \"final\",\n  \"nombre\": \"Evaluación final Postman\",\n  \"descripcion\": \"Ejemplo VAT/INET\",\n  \"fecha\": \"2026-12-10\",\n  \"es_final\": true,\n  \"ponderacion\": \"100.00\",\n  \"observaciones\": \"Evaluación creada desde Postman\"\n}",
+                      "options": {
+                        "raw": {
+                          "language": "json"
+                        }
+                      }
+                    },
+                    "url": {
+                      "raw": "{{vatBaseUrl}}{{apiPrefix}}/vat/evaluaciones/",
+                      "host": [
+                        "{{vatBaseUrl}}{{apiPrefix}}"
+                      ],
+                      "path": [
+                        "vat",
+                        "evaluaciones",
+                        ""
+                      ]
+                    },
+                    "description": "Instancias de evaluación asociadas a comisiones de oferta institucional.\n\nAutenticación: Authorization: Api-Key <clave>.\n\nOperación de escritura bloqueada por defecto. Para enviarla debe configurar explícitamente `allowVatMutations=true` en el ambiente activo; verifique los identificadores y el ambiente y no la ejecute contra producción como prueba exploratoria."
+                  },
+                  "event": [
+                    {
+                      "listen": "prerequest",
+                      "script": {
+                        "type": "text/javascript",
+                        "exec": [
+                          "const allowMutations = String(pm.variables.get('allowVatMutations') || '').toLowerCase() === 'true';",
+                          "if (!allowMutations) {",
+                          "  console.warn('Request VAT de escritura omitido. Configure allowVatMutations=true sólo para una ejecución controlada.');",
+                          "  pm.execution.skipRequest();",
+                          "}"
+                        ]
+                      }
+                    },
+                    {
+                      "listen": "test",
+                      "script": {
+                        "type": "text/javascript",
+                        "exec": [
+                          "pm.test('Status code 201', function () { pm.response.to.have.status(201); });",
+                          "const body = pm.response.json();",
+                          "if (body.id !== undefined) {",
+                          "  const value = String(body.id);",
+                          "  pm.collectionVariables.set('evaluacion_id', value);",
+                          "  if (pm.environment && pm.environment.name) { pm.environment.set('evaluacion_id', value); }",
+                          "}"
+                        ]
+                      }
+                    }
+                  ],
+                  "response": []
+                },
+                {
+                  "name": "Obtener evaluación por ID",
+                  "request": {
+                    "method": "GET",
+                    "header": [
+                      {
+                        "key": "Authorization",
+                        "value": "Api-Key {{apiKey}}",
+                        "type": "text",
+                        "description": "API key VAT. En los endpoints web también puede reemplazarse por Token <token>."
+                      }
+                    ],
+                    "url": {
+                      "raw": "{{vatBaseUrl}}{{apiPrefix}}/vat/evaluaciones/{{evaluacion_id}}/",
+                      "host": [
+                        "{{vatBaseUrl}}{{apiPrefix}}"
+                      ],
+                      "path": [
+                        "vat",
+                        "evaluaciones",
+                        "{{evaluacion_id}}",
+                        ""
+                      ]
+                    },
+                    "description": "Instancias de evaluación asociadas a comisiones de oferta institucional.\n\nAutenticación: Authorization: Api-Key <clave>."
+                  },
+                  "event": [
+                    {
+                      "listen": "test",
+                      "script": {
+                        "type": "text/javascript",
+                        "exec": [
+                          "pm.test('Status code 200', function () { pm.response.to.have.status(200); });",
+                          "const body = pm.response.json();",
+                          "if (body.id !== undefined) {",
+                          "  const value = String(body.id);",
+                          "  pm.collectionVariables.set('evaluacion_id', value);",
+                          "  if (pm.environment && pm.environment.name) { pm.environment.set('evaluacion_id', value); }",
+                          "}"
+                        ]
+                      }
+                    }
+                  ],
+                  "response": []
+                },
+                {
+                  "name": "Reemplazar evaluación (PUT)",
+                  "request": {
+                    "method": "PUT",
+                    "header": [
+                      {
+                        "key": "Authorization",
+                        "value": "Api-Key {{apiKey}}",
+                        "type": "text",
+                        "description": "API key VAT. En los endpoints web también puede reemplazarse por Token <token>."
+                      },
+                      {
+                        "key": "Content-Type",
+                        "value": "application/json",
+                        "type": "text"
+                      }
+                    ],
+                    "body": {
+                      "mode": "raw",
+                      "raw": "{\n  \"comision\": {{comision_id}},\n  \"tipo\": \"final\",\n  \"nombre\": \"Evaluación final Postman\",\n  \"descripcion\": \"Ejemplo VAT/INET\",\n  \"fecha\": \"2026-12-10\",\n  \"es_final\": true,\n  \"ponderacion\": \"100.00\",\n  \"observaciones\": \"Evaluación creada desde Postman\"\n}",
+                      "options": {
+                        "raw": {
+                          "language": "json"
+                        }
+                      }
+                    },
+                    "url": {
+                      "raw": "{{vatBaseUrl}}{{apiPrefix}}/vat/evaluaciones/{{evaluacion_id}}/",
+                      "host": [
+                        "{{vatBaseUrl}}{{apiPrefix}}"
+                      ],
+                      "path": [
+                        "vat",
+                        "evaluaciones",
+                        "{{evaluacion_id}}",
+                        ""
+                      ]
+                    },
+                    "description": "Instancias de evaluación asociadas a comisiones de oferta institucional.\n\nAutenticación: Authorization: Api-Key <clave>.\n\nPUT requiere el cuerpo completo. Operación de escritura bloqueada por defecto. Para enviarla debe configurar explícitamente `allowVatMutations=true` en el ambiente activo; verifique los identificadores y el ambiente y no la ejecute contra producción como prueba exploratoria."
+                  },
+                  "event": [
+                    {
+                      "listen": "prerequest",
+                      "script": {
+                        "type": "text/javascript",
+                        "exec": [
+                          "const allowMutations = String(pm.variables.get('allowVatMutations') || '').toLowerCase() === 'true';",
+                          "if (!allowMutations) {",
+                          "  console.warn('Request VAT de escritura omitido. Configure allowVatMutations=true sólo para una ejecución controlada.');",
+                          "  pm.execution.skipRequest();",
+                          "}"
+                        ]
+                      }
+                    },
+                    {
+                      "listen": "test",
+                      "script": {
+                        "type": "text/javascript",
+                        "exec": [
+                          "pm.test('Status code 200', function () { pm.response.to.have.status(200); });",
+                          "const body = pm.response.json();",
+                          "if (body.id !== undefined) {",
+                          "  const value = String(body.id);",
+                          "  pm.collectionVariables.set('evaluacion_id', value);",
+                          "  if (pm.environment && pm.environment.name) { pm.environment.set('evaluacion_id', value); }",
+                          "}"
+                        ]
+                      }
+                    }
+                  ],
+                  "response": []
+                },
+                {
+                  "name": "Actualizar parcialmente evaluación (PATCH)",
+                  "request": {
+                    "method": "PATCH",
+                    "header": [
+                      {
+                        "key": "Authorization",
+                        "value": "Api-Key {{apiKey}}",
+                        "type": "text",
+                        "description": "API key VAT. En los endpoints web también puede reemplazarse por Token <token>."
+                      },
+                      {
+                        "key": "Content-Type",
+                        "value": "application/json",
+                        "type": "text"
+                      }
+                    ],
+                    "body": {
+                      "mode": "raw",
+                      "raw": "{\n  \"ponderacion\": \"100.00\",\n  \"observaciones\": \"Evaluación actualizada desde Postman\"\n}",
+                      "options": {
+                        "raw": {
+                          "language": "json"
+                        }
+                      }
+                    },
+                    "url": {
+                      "raw": "{{vatBaseUrl}}{{apiPrefix}}/vat/evaluaciones/{{evaluacion_id}}/",
+                      "host": [
+                        "{{vatBaseUrl}}{{apiPrefix}}"
+                      ],
+                      "path": [
+                        "vat",
+                        "evaluaciones",
+                        "{{evaluacion_id}}",
+                        ""
+                      ]
+                    },
+                    "description": "Instancias de evaluación asociadas a comisiones de oferta institucional.\n\nAutenticación: Authorization: Api-Key <clave>.\n\nOperación de escritura bloqueada por defecto. Para enviarla debe configurar explícitamente `allowVatMutations=true` en el ambiente activo; verifique los identificadores y el ambiente y no la ejecute contra producción como prueba exploratoria."
+                  },
+                  "event": [
+                    {
+                      "listen": "prerequest",
+                      "script": {
+                        "type": "text/javascript",
+                        "exec": [
+                          "const allowMutations = String(pm.variables.get('allowVatMutations') || '').toLowerCase() === 'true';",
+                          "if (!allowMutations) {",
+                          "  console.warn('Request VAT de escritura omitido. Configure allowVatMutations=true sólo para una ejecución controlada.');",
+                          "  pm.execution.skipRequest();",
+                          "}"
+                        ]
+                      }
+                    },
+                    {
+                      "listen": "test",
+                      "script": {
+                        "type": "text/javascript",
+                        "exec": [
+                          "pm.test('Status code 200', function () { pm.response.to.have.status(200); });",
+                          "const body = pm.response.json();",
+                          "if (body.id !== undefined) {",
+                          "  const value = String(body.id);",
+                          "  pm.collectionVariables.set('evaluacion_id', value);",
+                          "  if (pm.environment && pm.environment.name) { pm.environment.set('evaluacion_id', value); }",
+                          "}"
+                        ]
+                      }
+                    }
+                  ],
+                  "response": []
+                },
+                {
+                  "name": "Eliminar evaluación (DELETE)",
+                  "request": {
+                    "method": "DELETE",
+                    "header": [
+                      {
+                        "key": "Authorization",
+                        "value": "Api-Key {{apiKey}}",
+                        "type": "text",
+                        "description": "API key VAT. En los endpoints web también puede reemplazarse por Token <token>."
+                      }
+                    ],
+                    "url": {
+                      "raw": "{{vatBaseUrl}}{{apiPrefix}}/vat/evaluaciones/{{evaluacion_id}}/",
+                      "host": [
+                        "{{vatBaseUrl}}{{apiPrefix}}"
+                      ],
+                      "path": [
+                        "vat",
+                        "evaluaciones",
+                        "{{evaluacion_id}}",
+                        ""
+                      ]
+                    },
+                    "description": "Instancias de evaluación asociadas a comisiones de oferta institucional.\n\nAutenticación: Authorization: Api-Key <clave>.\n\nOperación de escritura bloqueada por defecto. Para enviarla debe configurar explícitamente `allowVatMutations=true` en el ambiente activo; verifique los identificadores y el ambiente y no la ejecute contra producción como prueba exploratoria. En los modelos con borrado lógico, el registro se desactiva o cambia a un estado operativo cerrado/cancelado."
+                  },
+                  "event": [
+                    {
+                      "listen": "prerequest",
+                      "script": {
+                        "type": "text/javascript",
+                        "exec": [
+                          "const allowMutations = String(pm.variables.get('allowVatMutations') || '').toLowerCase() === 'true';",
+                          "if (!allowMutations) {",
+                          "  console.warn('Request VAT de escritura omitido. Configure allowVatMutations=true sólo para una ejecución controlada.');",
+                          "  pm.execution.skipRequest();",
+                          "}"
+                        ]
+                      }
+                    },
+                    {
+                      "listen": "test",
+                      "script": {
+                        "type": "text/javascript",
+                        "exec": [
+                          "pm.test('Status code 204', function () { pm.response.to.have.status(204); });"
+                        ]
+                      }
+                    }
+                  ],
+                  "response": []
+                }
+              ]
+            },
+            {
+              "name": "Resultados de evaluación",
+              "description": "Resultados de evaluación asociados a una inscripción.\n\nAutenticación: Authorization: Api-Key <clave>.\n\nEste ViewSet expone list, retrieve, create, update, partial_update y destroy.",
+              "item": [
+                {
+                  "name": "Listar resultados de evaluación",
+                  "request": {
+                    "method": "GET",
+                    "header": [
+                      {
+                        "key": "Authorization",
+                        "value": "Api-Key {{apiKey}}",
+                        "type": "text",
+                        "description": "API key VAT. En los endpoints web también puede reemplazarse por Token <token>."
+                      }
+                    ],
+                    "url": {
+                      "raw": "{{vatBaseUrl}}{{apiPrefix}}/vat/resultado-evaluaciones/",
+                      "host": [
+                        "{{vatBaseUrl}}{{apiPrefix}}"
+                      ],
+                      "path": [
+                        "vat",
+                        "resultado-evaluaciones",
+                        ""
+                      ],
+                      "query": [
+                        {
+                          "key": "evaluacion_id",
+                          "value": "{{evaluacion_id}}",
+                          "description": "Filtra por evaluación.",
+                          "disabled": true
+                        },
+                        {
+                          "key": "calificacion",
+                          "value": "8.00",
+                          "description": "Filtra por calificación exacta.",
+                          "disabled": true
+                        },
+                        {
+                          "key": "page",
+                          "value": "1",
+                          "description": "Número de página.",
+                          "disabled": true
+                        },
+                        {
+                          "key": "page_size",
+                          "value": "20",
+                          "description": "Cantidad de resultados por página (máximo 200).",
+                          "disabled": true
+                        }
+                      ]
+                    },
+                    "description": "Resultados de evaluación asociados a una inscripción.\n\nAutenticación: Authorization: Api-Key <clave>.\n\nLos filtros opcionales están cargados y deshabilitados para activarlos según el caso."
+                  },
+                  "event": [
+                    {
+                      "listen": "test",
+                      "script": {
+                        "type": "text/javascript",
+                        "exec": [
+                          "pm.test('Status code 200', function () { pm.response.to.have.status(200); });",
+                          "const body = pm.response.json();",
+                          "const rows = Array.isArray(body) ? body : (body.results || []);",
+                          "pm.test('La respuesta contiene una lista', function () { pm.expect(Array.isArray(rows)).to.eql(true); });",
+                          "if (rows.length && rows[0].id !== undefined) {",
+                          "  const value = String(rows[0].id);",
+                          "  pm.collectionVariables.set('resultado_evaluacion_id', value);",
+                          "  if (pm.environment && pm.environment.name) { pm.environment.set('resultado_evaluacion_id', value); }",
+                          "}"
+                        ]
+                      }
+                    }
+                  ],
+                  "response": []
+                },
+                {
+                  "name": "Crear resultado de evaluación",
+                  "request": {
+                    "method": "POST",
+                    "header": [
+                      {
+                        "key": "Authorization",
+                        "value": "Api-Key {{apiKey}}",
+                        "type": "text",
+                        "description": "API key VAT. En los endpoints web también puede reemplazarse por Token <token>."
+                      },
+                      {
+                        "key": "Content-Type",
+                        "value": "application/json",
+                        "type": "text"
+                      }
+                    ],
+                    "body": {
+                      "mode": "raw",
+                      "raw": "{\n  \"evaluacion\": {{evaluacion_id}},\n  \"inscripcion\": {{inscripcion_id}},\n  \"calificacion\": \"8.00\",\n  \"aprobo\": true,\n  \"observaciones\": \"Resultado creado desde Postman\",\n  \"registrado_por\": {{usuario_id}}\n}",
+                      "options": {
+                        "raw": {
+                          "language": "json"
+                        }
+                      }
+                    },
+                    "url": {
+                      "raw": "{{vatBaseUrl}}{{apiPrefix}}/vat/resultado-evaluaciones/",
+                      "host": [
+                        "{{vatBaseUrl}}{{apiPrefix}}"
+                      ],
+                      "path": [
+                        "vat",
+                        "resultado-evaluaciones",
+                        ""
+                      ]
+                    },
+                    "description": "Resultados de evaluación asociados a una inscripción.\n\nAutenticación: Authorization: Api-Key <clave>.\n\nOperación de escritura bloqueada por defecto. Para enviarla debe configurar explícitamente `allowVatMutations=true` en el ambiente activo; verifique los identificadores y el ambiente y no la ejecute contra producción como prueba exploratoria."
+                  },
+                  "event": [
+                    {
+                      "listen": "prerequest",
+                      "script": {
+                        "type": "text/javascript",
+                        "exec": [
+                          "const allowMutations = String(pm.variables.get('allowVatMutations') || '').toLowerCase() === 'true';",
+                          "if (!allowMutations) {",
+                          "  console.warn('Request VAT de escritura omitido. Configure allowVatMutations=true sólo para una ejecución controlada.');",
+                          "  pm.execution.skipRequest();",
+                          "}"
+                        ]
+                      }
+                    },
+                    {
+                      "listen": "test",
+                      "script": {
+                        "type": "text/javascript",
+                        "exec": [
+                          "pm.test('Status code 201', function () { pm.response.to.have.status(201); });",
+                          "const body = pm.response.json();",
+                          "if (body.id !== undefined) {",
+                          "  const value = String(body.id);",
+                          "  pm.collectionVariables.set('resultado_evaluacion_id', value);",
+                          "  if (pm.environment && pm.environment.name) { pm.environment.set('resultado_evaluacion_id', value); }",
+                          "}"
+                        ]
+                      }
+                    }
+                  ],
+                  "response": []
+                },
+                {
+                  "name": "Obtener resultado de evaluación por ID",
+                  "request": {
+                    "method": "GET",
+                    "header": [
+                      {
+                        "key": "Authorization",
+                        "value": "Api-Key {{apiKey}}",
+                        "type": "text",
+                        "description": "API key VAT. En los endpoints web también puede reemplazarse por Token <token>."
+                      }
+                    ],
+                    "url": {
+                      "raw": "{{vatBaseUrl}}{{apiPrefix}}/vat/resultado-evaluaciones/{{resultado_evaluacion_id}}/",
+                      "host": [
+                        "{{vatBaseUrl}}{{apiPrefix}}"
+                      ],
+                      "path": [
+                        "vat",
+                        "resultado-evaluaciones",
+                        "{{resultado_evaluacion_id}}",
+                        ""
+                      ]
+                    },
+                    "description": "Resultados de evaluación asociados a una inscripción.\n\nAutenticación: Authorization: Api-Key <clave>."
+                  },
+                  "event": [
+                    {
+                      "listen": "test",
+                      "script": {
+                        "type": "text/javascript",
+                        "exec": [
+                          "pm.test('Status code 200', function () { pm.response.to.have.status(200); });",
+                          "const body = pm.response.json();",
+                          "if (body.id !== undefined) {",
+                          "  const value = String(body.id);",
+                          "  pm.collectionVariables.set('resultado_evaluacion_id', value);",
+                          "  if (pm.environment && pm.environment.name) { pm.environment.set('resultado_evaluacion_id', value); }",
+                          "}"
+                        ]
+                      }
+                    }
+                  ],
+                  "response": []
+                },
+                {
+                  "name": "Reemplazar resultado de evaluación (PUT)",
+                  "request": {
+                    "method": "PUT",
+                    "header": [
+                      {
+                        "key": "Authorization",
+                        "value": "Api-Key {{apiKey}}",
+                        "type": "text",
+                        "description": "API key VAT. En los endpoints web también puede reemplazarse por Token <token>."
+                      },
+                      {
+                        "key": "Content-Type",
+                        "value": "application/json",
+                        "type": "text"
+                      }
+                    ],
+                    "body": {
+                      "mode": "raw",
+                      "raw": "{\n  \"evaluacion\": {{evaluacion_id}},\n  \"inscripcion\": {{inscripcion_id}},\n  \"calificacion\": \"8.00\",\n  \"aprobo\": true,\n  \"observaciones\": \"Resultado creado desde Postman\",\n  \"registrado_por\": {{usuario_id}}\n}",
+                      "options": {
+                        "raw": {
+                          "language": "json"
+                        }
+                      }
+                    },
+                    "url": {
+                      "raw": "{{vatBaseUrl}}{{apiPrefix}}/vat/resultado-evaluaciones/{{resultado_evaluacion_id}}/",
+                      "host": [
+                        "{{vatBaseUrl}}{{apiPrefix}}"
+                      ],
+                      "path": [
+                        "vat",
+                        "resultado-evaluaciones",
+                        "{{resultado_evaluacion_id}}",
+                        ""
+                      ]
+                    },
+                    "description": "Resultados de evaluación asociados a una inscripción.\n\nAutenticación: Authorization: Api-Key <clave>.\n\nPUT requiere el cuerpo completo. Operación de escritura bloqueada por defecto. Para enviarla debe configurar explícitamente `allowVatMutations=true` en el ambiente activo; verifique los identificadores y el ambiente y no la ejecute contra producción como prueba exploratoria."
+                  },
+                  "event": [
+                    {
+                      "listen": "prerequest",
+                      "script": {
+                        "type": "text/javascript",
+                        "exec": [
+                          "const allowMutations = String(pm.variables.get('allowVatMutations') || '').toLowerCase() === 'true';",
+                          "if (!allowMutations) {",
+                          "  console.warn('Request VAT de escritura omitido. Configure allowVatMutations=true sólo para una ejecución controlada.');",
+                          "  pm.execution.skipRequest();",
+                          "}"
+                        ]
+                      }
+                    },
+                    {
+                      "listen": "test",
+                      "script": {
+                        "type": "text/javascript",
+                        "exec": [
+                          "pm.test('Status code 200', function () { pm.response.to.have.status(200); });",
+                          "const body = pm.response.json();",
+                          "if (body.id !== undefined) {",
+                          "  const value = String(body.id);",
+                          "  pm.collectionVariables.set('resultado_evaluacion_id', value);",
+                          "  if (pm.environment && pm.environment.name) { pm.environment.set('resultado_evaluacion_id', value); }",
+                          "}"
+                        ]
+                      }
+                    }
+                  ],
+                  "response": []
+                },
+                {
+                  "name": "Actualizar parcialmente resultado de evaluación (PATCH)",
+                  "request": {
+                    "method": "PATCH",
+                    "header": [
+                      {
+                        "key": "Authorization",
+                        "value": "Api-Key {{apiKey}}",
+                        "type": "text",
+                        "description": "API key VAT. En los endpoints web también puede reemplazarse por Token <token>."
+                      },
+                      {
+                        "key": "Content-Type",
+                        "value": "application/json",
+                        "type": "text"
+                      }
+                    ],
+                    "body": {
+                      "mode": "raw",
+                      "raw": "{\n  \"calificacion\": \"9.00\",\n  \"aprobo\": true,\n  \"observaciones\": \"Resultado actualizado desde Postman\"\n}",
+                      "options": {
+                        "raw": {
+                          "language": "json"
+                        }
+                      }
+                    },
+                    "url": {
+                      "raw": "{{vatBaseUrl}}{{apiPrefix}}/vat/resultado-evaluaciones/{{resultado_evaluacion_id}}/",
+                      "host": [
+                        "{{vatBaseUrl}}{{apiPrefix}}"
+                      ],
+                      "path": [
+                        "vat",
+                        "resultado-evaluaciones",
+                        "{{resultado_evaluacion_id}}",
+                        ""
+                      ]
+                    },
+                    "description": "Resultados de evaluación asociados a una inscripción.\n\nAutenticación: Authorization: Api-Key <clave>.\n\nOperación de escritura bloqueada por defecto. Para enviarla debe configurar explícitamente `allowVatMutations=true` en el ambiente activo; verifique los identificadores y el ambiente y no la ejecute contra producción como prueba exploratoria."
+                  },
+                  "event": [
+                    {
+                      "listen": "prerequest",
+                      "script": {
+                        "type": "text/javascript",
+                        "exec": [
+                          "const allowMutations = String(pm.variables.get('allowVatMutations') || '').toLowerCase() === 'true';",
+                          "if (!allowMutations) {",
+                          "  console.warn('Request VAT de escritura omitido. Configure allowVatMutations=true sólo para una ejecución controlada.');",
+                          "  pm.execution.skipRequest();",
+                          "}"
+                        ]
+                      }
+                    },
+                    {
+                      "listen": "test",
+                      "script": {
+                        "type": "text/javascript",
+                        "exec": [
+                          "pm.test('Status code 200', function () { pm.response.to.have.status(200); });",
+                          "const body = pm.response.json();",
+                          "if (body.id !== undefined) {",
+                          "  const value = String(body.id);",
+                          "  pm.collectionVariables.set('resultado_evaluacion_id', value);",
+                          "  if (pm.environment && pm.environment.name) { pm.environment.set('resultado_evaluacion_id', value); }",
+                          "}"
+                        ]
+                      }
+                    }
+                  ],
+                  "response": []
+                },
+                {
+                  "name": "Eliminar resultado de evaluación (DELETE)",
+                  "request": {
+                    "method": "DELETE",
+                    "header": [
+                      {
+                        "key": "Authorization",
+                        "value": "Api-Key {{apiKey}}",
+                        "type": "text",
+                        "description": "API key VAT. En los endpoints web también puede reemplazarse por Token <token>."
+                      }
+                    ],
+                    "url": {
+                      "raw": "{{vatBaseUrl}}{{apiPrefix}}/vat/resultado-evaluaciones/{{resultado_evaluacion_id}}/",
+                      "host": [
+                        "{{vatBaseUrl}}{{apiPrefix}}"
+                      ],
+                      "path": [
+                        "vat",
+                        "resultado-evaluaciones",
+                        "{{resultado_evaluacion_id}}",
+                        ""
+                      ]
+                    },
+                    "description": "Resultados de evaluación asociados a una inscripción.\n\nAutenticación: Authorization: Api-Key <clave>.\n\nOperación de escritura bloqueada por defecto. Para enviarla debe configurar explícitamente `allowVatMutations=true` en el ambiente activo; verifique los identificadores y el ambiente y no la ejecute contra producción como prueba exploratoria. En los modelos con borrado lógico, el registro se desactiva o cambia a un estado operativo cerrado/cancelado."
+                  },
+                  "event": [
+                    {
+                      "listen": "prerequest",
+                      "script": {
+                        "type": "text/javascript",
+                        "exec": [
+                          "const allowMutations = String(pm.variables.get('allowVatMutations') || '').toLowerCase() === 'true';",
+                          "if (!allowMutations) {",
+                          "  console.warn('Request VAT de escritura omitido. Configure allowVatMutations=true sólo para una ejecución controlada.');",
+                          "  pm.execution.skipRequest();",
+                          "}"
+                        ]
+                      }
+                    },
+                    {
+                      "listen": "test",
+                      "script": {
+                        "type": "text/javascript",
+                        "exec": [
+                          "pm.test('Status code 204', function () { pm.response.to.have.status(204); });"
+                        ]
+                      }
+                    }
+                  ],
+                  "response": []
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "name": "8 - API web",
+          "description": "Superficie para portales y frontends externos; no incluye vistas HTML ni AJAX internos.",
+          "item": [
+            {
+              "name": "Centros web",
+              "description": "Centros visibles para portales y frontends externos.\n\nAcepta Api-Key o token de usuario. La colección usa Api-Key por defecto.",
+              "item": [
+                {
+                  "name": "Listar centros web",
+                  "request": {
+                    "method": "GET",
+                    "header": [
+                      {
+                        "key": "Authorization",
+                        "value": "Api-Key {{apiKey}}",
+                        "type": "text",
+                        "description": "API key VAT. En los endpoints web también puede reemplazarse por Token <token>."
+                      }
+                    ],
+                    "url": {
+                      "raw": "{{baseUrl}}{{apiPrefix}}/vat/web/centros/",
+                      "host": [
+                        "{{baseUrl}}{{apiPrefix}}"
+                      ],
+                      "path": [
+                        "vat",
+                        "web",
                         "centros",
                         ""
                       ],
                       "query": [
                         {
+                          "key": "q",
+                          "value": "CFP",
+                          "description": "Búsqueda por nombre o código.",
+                          "disabled": true
+                        },
+                        {
+                          "key": "provincia_id",
+                          "value": "{{provincia_id}}",
+                          "description": "Filtra por provincia.",
+                          "disabled": true
+                        },
+                        {
+                          "key": "municipio_id",
+                          "value": "{{municipio_id}}",
+                          "description": "Filtra por municipio.",
+                          "disabled": true
+                        },
+                        {
+                          "key": "localidad_id",
+                          "value": "{{localidad_id}}",
+                          "description": "Filtra por localidad.",
+                          "disabled": true
+                        },
+                        {
                           "key": "activo",
-                          "value": "true"
+                          "value": "true",
+                          "description": "Filtra por estado activo.",
+                          "disabled": true
                         }
                       ]
-                    }
+                    },
+                    "description": "Centros visibles para portales y frontends externos.\n\nAcepta Api-Key o token de usuario. La colección usa Api-Key por defecto.\n\nLos filtros opcionales están cargados y deshabilitados."
                   },
                   "event": [
                     {
@@ -5024,15 +12595,60 @@
                       "script": {
                         "type": "text/javascript",
                         "exec": [
-                          "pm.test('Status code is 200', function () {",
-                          "  pm.response.to.have.status(200);",
-                          "});",
+                          "pm.test('Status code 200', function () { pm.response.to.have.status(200); });",
                           "const body = pm.response.json();",
                           "const rows = Array.isArray(body) ? body : (body.results || []);",
-                          "if (rows.length && rows[0].id) {",
-                          "  pm.collectionVariables.set('centro_id', String(rows[0].id));",
-                          "  pm.collectionVariables.set('provincia_id', String(rows[0].provincia || ''));",
-                          "  pm.collectionVariables.set('municipio_id', String(rows[0].municipio || ''));",
+                          "pm.test('La respuesta contiene una lista', function () { pm.expect(Array.isArray(rows)).to.eql(true); });",
+                          "if (rows.length && rows[0].id !== undefined) {",
+                          "  const value = String(rows[0].id);",
+                          "  pm.collectionVariables.set('centro_id', value);",
+                          "  if (pm.environment && pm.environment.name) { pm.environment.set('centro_id', value); }",
+                          "}"
+                        ]
+                      }
+                    }
+                  ],
+                  "response": []
+                },
+                {
+                  "name": "Obtener centro web por ID",
+                  "request": {
+                    "method": "GET",
+                    "header": [
+                      {
+                        "key": "Authorization",
+                        "value": "Api-Key {{apiKey}}",
+                        "type": "text",
+                        "description": "API key VAT. En los endpoints web también puede reemplazarse por Token <token>."
+                      }
+                    ],
+                    "url": {
+                      "raw": "{{baseUrl}}{{apiPrefix}}/vat/web/centros/{{centro_id}}/",
+                      "host": [
+                        "{{baseUrl}}{{apiPrefix}}"
+                      ],
+                      "path": [
+                        "vat",
+                        "web",
+                        "centros",
+                        "{{centro_id}}",
+                        ""
+                      ]
+                    },
+                    "description": "Centros visibles para portales y frontends externos.\n\nAcepta Api-Key o token de usuario. La colección usa Api-Key por defecto."
+                  },
+                  "event": [
+                    {
+                      "listen": "test",
+                      "script": {
+                        "type": "text/javascript",
+                        "exec": [
+                          "pm.test('Status code 200', function () { pm.response.to.have.status(200); });",
+                          "const body = pm.response.json();",
+                          "if (body.id !== undefined) {",
+                          "  const value = String(body.id);",
+                          "  pm.collectionVariables.set('centro_id', value);",
+                          "  if (pm.environment && pm.environment.name) { pm.environment.set('centro_id', value); }",
                           "}"
                         ]
                       }
@@ -5043,82 +12659,60 @@
               ]
             },
             {
-              "name": "1 - Buscar cursos",
-              "description": "Ejemplos del endpoint GET /api/vat/cursos/buscar/ con casos exitosos y errores esperados.",
+              "name": "Títulos web",
+              "description": "Títulos de referencia para navegación del frontend.\n\nAcepta Api-Key o token de usuario. La colección usa Api-Key por defecto.",
               "item": [
                 {
-                  "name": "Listar primera carga sin texto",
+                  "name": "Listar títulos web",
                   "request": {
                     "method": "GET",
                     "header": [
                       {
                         "key": "Authorization",
                         "value": "Api-Key {{apiKey}}",
-                        "type": "text"
+                        "type": "text",
+                        "description": "API key VAT. En los endpoints web también puede reemplazarse por Token <token>."
                       }
                     ],
                     "url": {
-                      "raw": "{{vatBaseUrl}}{{apiPrefix}}/vat/cursos/buscar/",
+                      "raw": "{{baseUrl}}{{apiPrefix}}/vat/web/titulos/",
                       "host": [
-                        "{{vatBaseUrl}}{{apiPrefix}}"
+                        "{{baseUrl}}{{apiPrefix}}"
                       ],
                       "path": [
                         "vat",
-                        "cursos",
-                        "buscar",
-                        ""
-                      ]
-                    }
-                  },
-                  "event": [
-                    {
-                      "listen": "test",
-                      "script": {
-                        "type": "text/javascript",
-                        "exec": [
-                          "pm.test('Status code is 200', function () {",
-                          "  pm.response.to.have.status(200);",
-                          "});",
-                          "const body = pm.response.json();",
-                          "pm.test('La respuesta mantiene paginacion', function () {",
-                          "  pm.expect(body).to.have.property('results');",
-                          "  pm.expect(Array.isArray(body.results)).to.eql(true);",
-                          "});"
-                        ]
-                      }
-                    }
-                  ],
-                  "response": []
-                },
-                {
-                  "name": "Buscar por 3 letras minimo",
-                  "request": {
-                    "method": "GET",
-                    "header": [
-                      {
-                        "key": "Authorization",
-                        "value": "Api-Key {{apiKey}}",
-                        "type": "text"
-                      }
-                    ],
-                    "url": {
-                      "raw": "{{vatBaseUrl}}{{apiPrefix}}/vat/cursos/buscar/?q={{curso_busqueda_minima}}",
-                      "host": [
-                        "{{vatBaseUrl}}{{apiPrefix}}"
-                      ],
-                      "path": [
-                        "vat",
-                        "cursos",
-                        "buscar",
+                        "web",
+                        "titulos",
                         ""
                       ],
                       "query": [
                         {
                           "key": "q",
-                          "value": "{{curso_busqueda_minima}}"
+                          "value": "soldadura",
+                          "description": "Búsqueda por texto.",
+                          "disabled": true
+                        },
+                        {
+                          "key": "sector_id",
+                          "value": "{{sector_id}}",
+                          "description": "Filtra por sector.",
+                          "disabled": true
+                        },
+                        {
+                          "key": "subsector_id",
+                          "value": "{{subsector_id}}",
+                          "description": "Filtra por subsector.",
+                          "disabled": true
+                        },
+                        {
+                          "key": "activo",
+                          "value": "true",
+                          "description": "Filtra por estado activo.",
+                          "disabled": true
                         }
                       ]
-                    }
+                    },
+                    "description": "Títulos de referencia para navegación del frontend.\n\nAcepta Api-Key o token de usuario. La colección usa Api-Key por defecto.\n\nLos filtros opcionales están cargados y deshabilitados."
                   },
                   "event": [
                     {
@@ -5126,16 +12720,14 @@
                       "script": {
                         "type": "text/javascript",
                         "exec": [
-                          "pm.test('Status code is 200', function () {",
-                          "  pm.response.to.have.status(200);",
-                          "});",
+                          "pm.test('Status code 200', function () { pm.response.to.have.status(200); });",
                           "const body = pm.response.json();",
                           "const rows = Array.isArray(body) ? body : (body.results || []);",
-                          "pm.test('La respuesta es paginada', function () {",
-                          "  pm.expect(Array.isArray(rows)).to.eql(true);",
-                          "});",
-                          "if (rows.length && rows[0].id) {",
-                          "  pm.collectionVariables.set('curso_id', String(rows[0].id));",
+                          "pm.test('La respuesta contiene una lista', function () { pm.expect(Array.isArray(rows)).to.eql(true); });",
+                          "if (rows.length && rows[0].id !== undefined) {",
+                          "  const value = String(rows[0].id);",
+                          "  pm.collectionVariables.set('titulo_id', value);",
+                          "  if (pm.environment && pm.environment.name) { pm.environment.set('titulo_id', value); }",
                           "}"
                         ]
                       }
@@ -5144,42 +12736,31 @@
                   "response": []
                 },
                 {
-                  "name": "Buscar por texto con centro y estado",
+                  "name": "Obtener título web por ID",
                   "request": {
                     "method": "GET",
                     "header": [
                       {
                         "key": "Authorization",
                         "value": "Api-Key {{apiKey}}",
-                        "type": "text"
+                        "type": "text",
+                        "description": "API key VAT. En los endpoints web también puede reemplazarse por Token <token>."
                       }
                     ],
                     "url": {
-                      "raw": "{{vatBaseUrl}}{{apiPrefix}}/vat/cursos/buscar/?q={{curso_busqueda_plan}}&centro_id={{centro_id}}&estado={{estado_curso}}",
+                      "raw": "{{baseUrl}}{{apiPrefix}}/vat/web/titulos/{{titulo_id}}/",
                       "host": [
-                        "{{vatBaseUrl}}{{apiPrefix}}"
+                        "{{baseUrl}}{{apiPrefix}}"
                       ],
                       "path": [
                         "vat",
-                        "cursos",
-                        "buscar",
+                        "web",
+                        "titulos",
+                        "{{titulo_id}}",
                         ""
-                      ],
-                      "query": [
-                        {
-                          "key": "q",
-                          "value": "{{curso_busqueda_plan}}"
-                        },
-                        {
-                          "key": "centro_id",
-                          "value": "{{centro_id}}"
-                        },
-                        {
-                          "key": "estado",
-                          "value": "{{estado_curso}}"
-                        }
                       ]
-                    }
+                    },
+                    "description": "Títulos de referencia para navegación del frontend.\n\nAcepta Api-Key o token de usuario. La colección usa Api-Key por defecto."
                   },
                   "event": [
                     {
@@ -5187,146 +12768,13 @@
                       "script": {
                         "type": "text/javascript",
                         "exec": [
-                          "pm.test('Status code is 200', function () {",
-                          "  pm.response.to.have.status(200);",
-                          "});"
-                        ]
-                      }
-                    }
-                  ],
-                  "response": []
-                },
-                {
-                  "name": "Buscar por texto con provincia y municipio",
-                  "request": {
-                    "method": "GET",
-                    "header": [
-                      {
-                        "key": "Authorization",
-                        "value": "Api-Key {{apiKey}}",
-                        "type": "text"
-                      }
-                    ],
-                    "url": {
-                      "raw": "{{vatBaseUrl}}{{apiPrefix}}/vat/cursos/buscar/?q={{curso_busqueda_minima}}&provincia_id={{provincia_id}}&municipio_id={{municipio_id}}",
-                      "host": [
-                        "{{vatBaseUrl}}{{apiPrefix}}"
-                      ],
-                      "path": [
-                        "vat",
-                        "cursos",
-                        "buscar",
-                        ""
-                      ],
-                      "query": [
-                        {
-                          "key": "q",
-                          "value": "{{curso_busqueda_minima}}"
-                        },
-                        {
-                          "key": "provincia_id",
-                          "value": "{{provincia_id}}"
-                        },
-                        {
-                          "key": "municipio_id",
-                          "value": "{{municipio_id}}"
-                        }
-                      ]
-                    }
-                  },
-                  "event": [
-                    {
-                      "listen": "test",
-                      "script": {
-                        "type": "text/javascript",
-                        "exec": [
-                          "pm.test('Status code is 200', function () {",
-                          "  pm.response.to.have.status(200);",
-                          "});"
-                        ]
-                      }
-                    }
-                  ],
-                  "response": []
-                },
-                {
-                  "name": "Error por faltar q",
-                  "request": {
-                    "method": "GET",
-                    "header": [
-                      {
-                        "key": "Authorization",
-                        "value": "Api-Key {{apiKey}}",
-                        "type": "text"
-                      }
-                    ],
-                    "url": {
-                      "raw": "{{vatBaseUrl}}{{apiPrefix}}/vat/cursos/buscar/",
-                      "host": [
-                        "{{vatBaseUrl}}{{apiPrefix}}"
-                      ],
-                      "path": [
-                        "vat",
-                        "cursos",
-                        "buscar",
-                        ""
-                      ]
-                    }
-                  },
-                  "event": [
-                    {
-                      "listen": "test",
-                      "script": {
-                        "type": "text/javascript",
-                        "exec": [
-                          "pm.test('Status code is 400', function () {",
-                          "  pm.response.to.have.status(400);",
-                          "});"
-                        ]
-                      }
-                    }
-                  ],
-                  "response": []
-                },
-                {
-                  "name": "Error por menos de 3 letras",
-                  "request": {
-                    "method": "GET",
-                    "header": [
-                      {
-                        "key": "Authorization",
-                        "value": "Api-Key {{apiKey}}",
-                        "type": "text"
-                      }
-                    ],
-                    "url": {
-                      "raw": "{{vatBaseUrl}}{{apiPrefix}}/vat/cursos/buscar/?q={{curso_busqueda_corta}}",
-                      "host": [
-                        "{{vatBaseUrl}}{{apiPrefix}}"
-                      ],
-                      "path": [
-                        "vat",
-                        "cursos",
-                        "buscar",
-                        ""
-                      ],
-                      "query": [
-                        {
-                          "key": "q",
-                          "value": "{{curso_busqueda_corta}}"
-                        }
-                      ]
-                    }
-                  },
-                  "event": [
-                    {
-                      "listen": "test",
-                      "script": {
-                        "type": "text/javascript",
-                        "exec": [
-                          "pm.test('Status code is 400', function () {",
-                          "  pm.response.to.have.status(400);",
-                          "});"
+                          "pm.test('Status code 200', function () { pm.response.to.have.status(200); });",
+                          "const body = pm.response.json();",
+                          "if (body.id !== undefined) {",
+                          "  const value = String(body.id);",
+                          "  pm.collectionVariables.set('titulo_id', value);",
+                          "  if (pm.environment && pm.environment.name) { pm.environment.set('titulo_id', value); }",
+                          "}"
                         ]
                       }
                     }
@@ -5336,228 +12784,23 @@
               ]
             },
             {
-              "name": "2 - Cursos prioritarios",
-              "description": "Ejemplos del endpoint GET /api/vat/cursos/prioritarios/ con y sin filtros opcionales.",
+              "name": "Cursos web",
+              "description": "Comisiones de curso visibles para inscripción pública; el ID de detalle corresponde a ComisionCurso.\n\nAcepta Api-Key o token de usuario. La colección usa Api-Key por defecto.",
               "item": [
                 {
-                  "name": "Listar todos los prioritarios",
+                  "name": "Listar cursos/comisiones web",
                   "request": {
                     "method": "GET",
                     "header": [
                       {
                         "key": "Authorization",
                         "value": "Api-Key {{apiKey}}",
-                        "type": "text"
+                        "type": "text",
+                        "description": "API key VAT. En los endpoints web también puede reemplazarse por Token <token>."
                       }
                     ],
                     "url": {
-                      "raw": "{{vatBaseUrl}}{{apiPrefix}}/vat/cursos/prioritarios/",
-                      "host": [
-                        "{{vatBaseUrl}}{{apiPrefix}}"
-                      ],
-                      "path": [
-                        "vat",
-                        "cursos",
-                        "prioritarios",
-                        ""
-                      ]
-                    }
-                  },
-                  "event": [
-                    {
-                      "listen": "test",
-                      "script": {
-                        "type": "text/javascript",
-                        "exec": [
-                          "pm.test('Status code is 200', function () {",
-                          "  pm.response.to.have.status(200);",
-                          "});",
-                          "const body = pm.response.json();",
-                          "const rows = Array.isArray(body) ? body : (body.results || []);",
-                          "pm.test('La respuesta es paginada', function () {",
-                          "  pm.expect(Array.isArray(rows)).to.eql(true);",
-                          "});",
-                          "if (rows.length && rows[0].id) {",
-                          "  pm.collectionVariables.set('curso_id', String(rows[0].id));",
-                          "}"
-                        ]
-                      }
-                    }
-                  ],
-                  "response": []
-                },
-                {
-                  "name": "Prioritarios por centro y estado",
-                  "request": {
-                    "method": "GET",
-                    "header": [
-                      {
-                        "key": "Authorization",
-                        "value": "Api-Key {{apiKey}}",
-                        "type": "text"
-                      }
-                    ],
-                    "url": {
-                      "raw": "{{vatBaseUrl}}{{apiPrefix}}/vat/cursos/prioritarios/?centro_id={{centro_id}}&estado={{estado_curso}}",
-                      "host": [
-                        "{{vatBaseUrl}}{{apiPrefix}}"
-                      ],
-                      "path": [
-                        "vat",
-                        "cursos",
-                        "prioritarios",
-                        ""
-                      ],
-                      "query": [
-                        {
-                          "key": "centro_id",
-                          "value": "{{centro_id}}"
-                        },
-                        {
-                          "key": "estado",
-                          "value": "{{estado_curso}}"
-                        }
-                      ]
-                    }
-                  },
-                  "event": [
-                    {
-                      "listen": "test",
-                      "script": {
-                        "type": "text/javascript",
-                        "exec": [
-                          "pm.test('Status code is 200', function () {",
-                          "  pm.response.to.have.status(200);",
-                          "});"
-                        ]
-                      }
-                    }
-                  ],
-                  "response": []
-                },
-                {
-                  "name": "Prioritarios por provincia y municipio",
-                  "request": {
-                    "method": "GET",
-                    "header": [
-                      {
-                        "key": "Authorization",
-                        "value": "Api-Key {{apiKey}}",
-                        "type": "text"
-                      }
-                    ],
-                    "url": {
-                      "raw": "{{vatBaseUrl}}{{apiPrefix}}/vat/cursos/prioritarios/?provincia_id={{provincia_id}}&municipio_id={{municipio_id}}",
-                      "host": [
-                        "{{vatBaseUrl}}{{apiPrefix}}"
-                      ],
-                      "path": [
-                        "vat",
-                        "cursos",
-                        "prioritarios",
-                        ""
-                      ],
-                      "query": [
-                        {
-                          "key": "provincia_id",
-                          "value": "{{provincia_id}}"
-                        },
-                        {
-                          "key": "municipio_id",
-                          "value": "{{municipio_id}}"
-                        }
-                      ]
-                    }
-                  },
-                  "event": [
-                    {
-                      "listen": "test",
-                      "script": {
-                        "type": "text/javascript",
-                        "exec": [
-                          "pm.test('Status code is 200', function () {",
-                          "  pm.response.to.have.status(200);",
-                          "});"
-                        ]
-                      }
-                    }
-                  ],
-                  "response": []
-                },
-                {
-                  "name": "Prioritarios por modalidad y programa",
-                  "request": {
-                    "method": "GET",
-                    "header": [
-                      {
-                        "key": "Authorization",
-                        "value": "Api-Key {{apiKey}}",
-                        "type": "text"
-                      }
-                    ],
-                    "url": {
-                      "raw": "{{vatBaseUrl}}{{apiPrefix}}/vat/cursos/prioritarios/?modalidad_id={{modalidad_id}}&programa_id={{programa_id}}",
-                      "host": [
-                        "{{vatBaseUrl}}{{apiPrefix}}"
-                      ],
-                      "path": [
-                        "vat",
-                        "cursos",
-                        "prioritarios",
-                        ""
-                      ],
-                      "query": [
-                        {
-                          "key": "modalidad_id",
-                          "value": "{{modalidad_id}}"
-                        },
-                        {
-                          "key": "programa_id",
-                          "value": "{{programa_id}}"
-                        }
-                      ]
-                    }
-                  },
-                  "event": [
-                    {
-                      "listen": "test",
-                      "script": {
-                        "type": "text/javascript",
-                        "exec": [
-                          "pm.test('Status code is 200', function () {",
-                          "  pm.response.to.have.status(200);",
-                          "});"
-                        ]
-                      }
-                    }
-                  ],
-                  "response": []
-                }
-              ]
-            }
-          ]
-        },
-        {
-          "name": "Web - Mi Argentina Inscripcion",
-          "description": "Coleccion específica para el flujo Mi Argentina -> SISOC -> VAT Web: centros, cursos/comisiones, prevalidación, inscripción y consulta final.",
-          "item": [
-            {
-              "name": "Paso 1 - Buscar comisión del centro",
-              "description": "Lista las comisiones visibles en VAT Web y agrega un request de diagnóstico contra el endpoint operativo para comparar resultados con el mismo centro.",
-              "item": [
-                {
-                  "name": "Listar comisiones visibles del centro",
-                  "request": {
-                    "method": "GET",
-                    "header": [
-                      {
-                        "key": "Authorization",
-                        "value": "{{authHeader}}",
-                        "type": "text"
-                      }
-                    ],
-                    "url": {
-                      "raw": "{{baseUrl}}{{apiPrefix}}/vat/web/cursos/?centro_id={{centro_id}}",
+                      "raw": "{{baseUrl}}{{apiPrefix}}/vat/web/cursos/",
                       "host": [
                         "{{baseUrl}}{{apiPrefix}}"
                       ],
@@ -5569,11 +12812,50 @@
                       ],
                       "query": [
                         {
+                          "key": "q",
+                          "value": "curso",
+                          "description": "Búsqueda por curso, comisión, centro o título.",
+                          "disabled": true
+                        },
+                        {
                           "key": "centro_id",
-                          "value": "{{centro_id}}"
+                          "value": "{{centro_id}}",
+                          "description": "Filtra por centro.",
+                          "disabled": true
+                        },
+                        {
+                          "key": "titulo_id",
+                          "value": "{{titulo_id}}",
+                          "description": "Filtra por título.",
+                          "disabled": true
+                        },
+                        {
+                          "key": "programa_id",
+                          "value": "{{programa_id}}",
+                          "description": "Filtra por programa.",
+                          "disabled": true
+                        },
+                        {
+                          "key": "ciclo_lectivo",
+                          "value": "2026",
+                          "description": "Filtra por año de inicio.",
+                          "disabled": true
+                        },
+                        {
+                          "key": "estado",
+                          "value": "activa",
+                          "description": "Filtra por estado de comisión.",
+                          "disabled": true
+                        },
+                        {
+                          "key": "usa_voucher",
+                          "value": "true",
+                          "description": "Filtra por uso de voucher.",
+                          "disabled": true
                         }
                       ]
-                    }
+                    },
+                    "description": "Comisiones de curso visibles para inscripción pública; el ID de detalle corresponde a ComisionCurso.\n\nAcepta Api-Key o token de usuario. La colección usa Api-Key por defecto.\n\nLos filtros opcionales están cargados y deshabilitados."
                   },
                   "event": [
                     {
@@ -5581,26 +12863,15 @@
                       "script": {
                         "type": "text/javascript",
                         "exec": [
-                          "pm.test('Status code is 200', function () {",
-                          "  pm.response.to.have.status(200);",
-                          "});",
+                          "pm.test('Status code 200', function () { pm.response.to.have.status(200); });",
                           "const body = pm.response.json();",
                           "const rows = Array.isArray(body) ? body : (body.results || []);",
-                          "pm.test('La respuesta tiene formato de listado', function () {",
-                          "  pm.expect(Array.isArray(rows)).to.eql(true);",
-                          "});",
-                          "const target = rows.find(function (item) {",
-                          "  return String(item.nombre || '').toLowerCase().includes('test api voucher');",
-                          "});",
-                          "if (target && target.id) {",
-                          "  pm.collectionVariables.set('comision_curso_id', String(target.id));",
-                          "}",
-                          "if (target && target.programa_id) {",
-                          "  pm.collectionVariables.set('programa_id', String(target.programa_id));",
-                          "}",
-                          "pm.test('Si existe TEST API Voucher, guarda la comisión', function () {",
-                          "  pm.expect(true).to.eql(true);",
-                          "});"
+                          "pm.test('La respuesta contiene una lista', function () { pm.expect(Array.isArray(rows)).to.eql(true); });",
+                          "if (rows.length && rows[0].id !== undefined) {",
+                          "  const value = String(rows[0].id);",
+                          "  pm.collectionVariables.set('comision_curso_id', value);",
+                          "  if (pm.environment && pm.environment.name) { pm.environment.set('comision_curso_id', value); }",
+                          "}"
                         ]
                       }
                     }
@@ -5608,33 +12879,31 @@
                   "response": []
                 },
                 {
-                  "name": "Diagnóstico operativo - comisiones-curso por centro_id",
+                  "name": "Obtener curso/comisión web por ID",
                   "request": {
                     "method": "GET",
                     "header": [
                       {
                         "key": "Authorization",
-                        "value": "{{authHeader}}",
-                        "type": "text"
+                        "value": "Api-Key {{apiKey}}",
+                        "type": "text",
+                        "description": "API key VAT. En los endpoints web también puede reemplazarse por Token <token>."
                       }
                     ],
                     "url": {
-                      "raw": "{{baseUrl}}{{apiPrefix}}/vat/comisiones-curso/?centro_id={{centro_id}}",
+                      "raw": "{{baseUrl}}{{apiPrefix}}/vat/web/cursos/{{comision_curso_id}}/",
                       "host": [
                         "{{baseUrl}}{{apiPrefix}}"
                       ],
                       "path": [
                         "vat",
-                        "comisiones-curso",
+                        "web",
+                        "cursos",
+                        "{{comision_curso_id}}",
                         ""
-                      ],
-                      "query": [
-                        {
-                          "key": "centro_id",
-                          "value": "{{centro_id}}"
-                        }
                       ]
-                    }
+                    },
+                    "description": "Comisiones de curso visibles para inscripción pública; el ID de detalle corresponde a ComisionCurso.\n\nAcepta Api-Key o token de usuario. La colección usa Api-Key por defecto."
                   },
                   "event": [
                     {
@@ -5642,14 +12911,13 @@
                       "script": {
                         "type": "text/javascript",
                         "exec": [
-                          "pm.test('Status code is 200', function () {",
-                          "  pm.response.to.have.status(200);",
-                          "});",
+                          "pm.test('Status code 200', function () { pm.response.to.have.status(200); });",
                           "const body = pm.response.json();",
-                          "const rows = Array.isArray(body) ? body : (body.results || []);",
-                          "pm.test('La respuesta operativa tiene formato de listado', function () {",
-                          "  pm.expect(Array.isArray(rows)).to.eql(true);",
-                          "});"
+                          "if (body.id !== undefined) {",
+                          "  const value = String(body.id);",
+                          "  pm.collectionVariables.set('comision_curso_id', value);",
+                          "  if (pm.environment && pm.environment.name) { pm.environment.set('comision_curso_id', value); }",
+                          "}"
                         ]
                       }
                     }
@@ -5659,18 +12927,19 @@
               ]
             },
             {
-              "name": "Paso 2 - Consultar estado de voucher",
-              "description": "Consulta por DNI si el voucher esta Disponible, En uso o No disponible, sin requerir una comision.",
+              "name": "Ciudadanos web",
+              "description": "La superficie web de ciudadanos expone únicamente la acción `voucher-estado`; no registra list ni retrieve.",
               "item": [
                 {
-                  "name": "Consultar estado de voucher por documento",
+                  "name": "Consultar estado general de voucher por documento",
                   "request": {
                     "method": "GET",
                     "header": [
                       {
                         "key": "Authorization",
-                        "value": "{{authHeader}}",
-                        "type": "text"
+                        "value": "Api-Key {{apiKey}}",
+                        "type": "text",
+                        "description": "API key VAT. En los endpoints web también puede reemplazarse por Token <token>."
                       }
                     ],
                     "url": {
@@ -5688,10 +12957,12 @@
                       "query": [
                         {
                           "key": "documento",
-                          "value": "{{documento}}"
+                          "value": "{{documento}}",
+                          "description": "DNI numérico obligatorio."
                         }
                       ]
-                    }
+                    },
+                    "description": "Devuelve Disponible, En uso o No disponible junto con los flags `tiene_voucher` y `esta_inscripto`."
                   },
                   "event": [
                     {
@@ -5699,17 +12970,7 @@
                       "script": {
                         "type": "text/javascript",
                         "exec": [
-                          "pm.test('Status code is 200', function () {",
-                          "  pm.response.to.have.status(200);",
-                          "});",
-                          "const body = pm.response.json();",
-                          "pm.test('Devuelve un estado funcional de voucher', function () {",
-                          "  pm.expect(['Disponible', 'En uso', 'No disponible']).to.include(body.estado);",
-                          "});",
-                          "pm.test('Devuelve flags booleanos', function () {",
-                          "  pm.expect(body.tiene_voucher).to.be.a('boolean');",
-                          "  pm.expect(body.esta_inscripto).to.be.a('boolean');",
-                          "});"
+                          "pm.test('Status code 200', function () { pm.response.to.have.status(200); });"
                         ]
                       }
                     }
@@ -5719,18 +12980,86 @@
               ]
             },
             {
-              "name": "Paso 3 - Prevalidar inscripción",
-              "description": "Valida elegibilidad antes de inscribir: ciudadano, comisión, cupo, voucher, parametría y saldo.",
+              "name": "Inscripciones web",
+              "description": "Consulta, prevalidación y alta pública de inscripciones. Acepta Api-Key o token; la colección usa Api-Key por defecto.",
               "item": [
                 {
-                  "name": "Prevalidar inscripción por documento",
+                  "name": "Listar inscripciones web",
+                  "request": {
+                    "method": "GET",
+                    "header": [
+                      {
+                        "key": "Authorization",
+                        "value": "Api-Key {{apiKey}}",
+                        "type": "text",
+                        "description": "API key VAT. En los endpoints web también puede reemplazarse por Token <token>."
+                      }
+                    ],
+                    "url": {
+                      "raw": "{{baseUrl}}{{apiPrefix}}/vat/web/inscripciones/",
+                      "host": [
+                        "{{baseUrl}}{{apiPrefix}}"
+                      ],
+                      "path": [
+                        "vat",
+                        "web",
+                        "inscripciones",
+                        ""
+                      ],
+                      "query": [
+                        {
+                          "key": "ciudadano_id",
+                          "value": "{{ciudadano_id}}",
+                          "description": "Filtra por ciudadano.",
+                          "disabled": true
+                        },
+                        {
+                          "key": "documento",
+                          "value": "{{documento}}",
+                          "description": "Filtra por DNI.",
+                          "disabled": true
+                        },
+                        {
+                          "key": "estado",
+                          "value": "{{estado_inscripcion}}",
+                          "description": "Filtra por estado.",
+                          "disabled": true
+                        }
+                      ]
+                    },
+                    "description": "Consulta inscripciones existentes. Los filtros por ciudadano, documento y estado son opcionales."
+                  },
+                  "event": [
+                    {
+                      "listen": "test",
+                      "script": {
+                        "type": "text/javascript",
+                        "exec": [
+                          "pm.test('Status code 200', function () { pm.response.to.have.status(200); });",
+                          "const body = pm.response.json();",
+                          "const rows = Array.isArray(body) ? body : (body.results || []);",
+                          "pm.test('La respuesta contiene una lista', function () { pm.expect(Array.isArray(rows)).to.eql(true); });",
+                          "if (rows.length && rows[0].id !== undefined) {",
+                          "  const value = String(rows[0].id);",
+                          "  pm.collectionVariables.set('inscripcion_id', value);",
+                          "  if (pm.environment && pm.environment.name) { pm.environment.set('inscripcion_id', value); }",
+                          "}"
+                        ]
+                      }
+                    }
+                  ],
+                  "response": []
+                },
+                {
+                  "name": "Crear inscripción web por documento",
                   "request": {
                     "method": "POST",
                     "header": [
                       {
                         "key": "Authorization",
-                        "value": "{{authHeader}}",
-                        "type": "text"
+                        "value": "Api-Key {{apiKey}}",
+                        "type": "text",
+                        "description": "API key VAT. En los endpoints web también puede reemplazarse por Token <token>."
                       },
                       {
                         "key": "Content-Type",
@@ -5740,7 +13069,90 @@
                     ],
                     "body": {
                       "mode": "raw",
-                      "raw": "{\n  \"documento\": \"{{documento}}\",\n  \"cuil\": \"{{cuil}}\",\n  \"comision_curso_id\": {{comision_curso_id}}\n}"
+                      "raw": "{\n  \"documento\": \"{{documento}}\",\n  \"comision_curso_id\": {{comision_curso_id}},\n  \"estado\": \"pre_inscripta\",\n  \"observaciones\": \"Alta web desde Postman\"\n}",
+                      "options": {
+                        "raw": {
+                          "language": "json"
+                        }
+                      }
+                    },
+                    "url": {
+                      "raw": "{{baseUrl}}{{apiPrefix}}/vat/web/inscripciones/",
+                      "host": [
+                        "{{baseUrl}}{{apiPrefix}}"
+                      ],
+                      "path": [
+                        "vat",
+                        "web",
+                        "inscripciones",
+                        ""
+                      ]
+                    },
+                    "description": "Operación de escritura. Crea una inscripción o solicitud pública según el ciudadano y la configuración del curso. Puede consumir voucher y cupo."
+                  },
+                  "event": [
+                    {
+                      "listen": "prerequest",
+                      "script": {
+                        "type": "text/javascript",
+                        "exec": [
+                          "const allowMutations = String(pm.variables.get('allowVatMutations') || '').toLowerCase() === 'true';",
+                          "if (!allowMutations) {",
+                          "  console.warn('Request VAT de escritura omitido. Configure allowVatMutations=true sólo para una ejecución controlada.');",
+                          "  pm.execution.skipRequest();",
+                          "}"
+                        ]
+                      }
+                    },
+                    {
+                      "listen": "test",
+                      "script": {
+                        "type": "text/javascript",
+                        "exec": [
+                          "pm.test('Status code 201', function () { pm.response.to.have.status(201); });",
+                          "const body = pm.response.json();",
+                          "const isSolicitud = Object.prototype.hasOwnProperty.call(body, 'datos_postulante');",
+                          "const variableName = isSolicitud ? 'solicitud_inscripcion_id' : 'inscripcion_id';",
+                          "if (body.id !== undefined) {",
+                          "  const value = String(body.id);",
+                          "  pm.collectionVariables.set(variableName, value);",
+                          "  if (pm.environment && pm.environment.name) { pm.environment.set(variableName, value); }",
+                          "}",
+                          "pm.test('La respuesta identifica inscripción o solicitud pública', function () {",
+                          "  pm.expect(body).to.have.property('id');",
+                          "  pm.expect(isSolicitud || Object.prototype.hasOwnProperty.call(body, 'en_lista_espera')).to.eql(true);",
+                          "});"
+                        ]
+                      }
+                    }
+                  ],
+                  "response": []
+                },
+                {
+                  "name": "Prevalidar inscripción web por documento",
+                  "request": {
+                    "method": "POST",
+                    "header": [
+                      {
+                        "key": "Authorization",
+                        "value": "Api-Key {{apiKey}}",
+                        "type": "text",
+                        "description": "API key VAT. En los endpoints web también puede reemplazarse por Token <token>."
+                      },
+                      {
+                        "key": "Content-Type",
+                        "value": "application/json",
+                        "type": "text"
+                      }
+                    ],
+                    "body": {
+                      "mode": "raw",
+                      "raw": "{\n  \"documento\": \"{{documento}}\",\n  \"cuil\": \"{{cuil}}\",\n  \"comision_curso_id\": {{comision_curso_id}}\n}",
+                      "options": {
+                        "raw": {
+                          "language": "json"
+                        }
+                      }
                     },
                     "url": {
                       "raw": "{{baseUrl}}{{apiPrefix}}/vat/web/inscripciones/prevalidar/",
@@ -5754,75 +13166,8 @@
                         "prevalidar",
                         ""
                       ]
-                    }
-                  },
-                  "event": [
-                    {
-                      "listen": "test",
-                      "script": {
-                        "type": "text/javascript",
-                        "exec": [
-                          "pm.test('Status code is 200', function () {",
-                          "  pm.response.to.have.status(200);",
-                          "});",
-                          "const body = pm.response.json();",
-                          "pm.test('La respuesta indica si puede inscribirse', function () {",
-                          "  pm.expect(body).to.have.property('puede_inscribirse');",
-                          "  pm.expect(body).to.have.property('motivos');",
-                          "});",
-                          "if (body.ciudadano && body.ciudadano.id) {",
-                          "  pm.collectionVariables.set('ciudadano_id', String(body.ciudadano.id));",
-                          "}",
-                          "if (body.comision && body.comision.programa_id) {",
-                          "  pm.collectionVariables.set('programa_id', String(body.comision.programa_id));",
-                          "}",
-                          "if (body.voucher && body.voucher.voucher_id) {",
-                          "  pm.collectionVariables.set('voucher_id', String(body.voucher.voucher_id));",
-                          "}"
-                        ]
-                      }
-                    }
-                  ],
-                  "response": []
-                }
-              ]
-            },
-            {
-              "name": "Paso 4 - Crear inscripción",
-              "description": "Confirma el alta final luego de la prevalidación positiva.",
-              "item": [
-                {
-                  "name": "Crear inscripción por documento",
-                  "request": {
-                    "method": "POST",
-                    "header": [
-                      {
-                        "key": "Authorization",
-                        "value": "{{authHeader}}",
-                        "type": "text"
-                      },
-                      {
-                        "key": "Content-Type",
-                        "value": "application/json",
-                        "type": "text"
-                      }
-                    ],
-                    "body": {
-                      "mode": "raw",
-                      "raw": "{\n  \"documento\": \"{{documento}}\",\n  \"comision_curso_id\": {{comision_curso_id}},\n  \"estado\": \"{{estado_inscripcion}}\",\n  \"observaciones\": \"{{observaciones}}\"\n}"
                     },
-                    "url": {
-                      "raw": "{{baseUrl}}{{apiPrefix}}/vat/web/inscripciones/",
-                      "host": [
-                        "{{baseUrl}}{{apiPrefix}}"
-                      ],
-                      "path": [
-                        "vat",
-                        "web",
-                        "inscripciones",
-                        ""
-                      ]
-                    }
+                    "description": "No crea la inscripción. Evalúa ciudadano, comisión, cupo, duplicados, voucher y reglas de inscripción antes del alta."
                   },
                   "event": [
                     {
@@ -5830,923 +13175,11 @@
                       "script": {
                         "type": "text/javascript",
                         "exec": [
-                          "pm.test('Status code is 201', function () {",
-                          "  pm.response.to.have.status(201);",
-                          "});",
-                          "const body = pm.response.json();",
-                          "pm.test('La inscripción devuelve la comisión de curso', function () {",
-                          "  pm.expect(String(body.comision_curso)).to.eql(String(pm.collectionVariables.get('comision_curso_id')));",
-                          "});",
-                          "if (body.ciudadano) {",
-                          "  pm.collectionVariables.set('ciudadano_id', String(body.ciudadano));",
-                          "}"
+                          "pm.test('Status code 200', function () { pm.response.to.have.status(200); });"
                         ]
                       }
                     }
                   ],
-                  "response": []
-                }
-              ]
-            },
-            {
-              "name": "Paso 5 - Consultar inscripción",
-              "description": "Consulta el resultado final de la inscripción creada y la lista de inscripciones del ciudadano.",
-              "item": [
-                {
-                  "name": "Listar inscripciones por documento",
-                  "request": {
-                    "method": "GET",
-                    "header": [
-                      {
-                        "key": "Authorization",
-                        "value": "{{authHeader}}",
-                        "type": "text"
-                      }
-                    ],
-                    "url": {
-                      "raw": "{{baseUrl}}{{apiPrefix}}/vat/web/inscripciones/?documento={{documento}}",
-                      "host": [
-                        "{{baseUrl}}{{apiPrefix}}"
-                      ],
-                      "path": [
-                        "vat",
-                        "web",
-                        "inscripciones",
-                        ""
-                      ],
-                      "query": [
-                        {
-                          "key": "documento",
-                          "value": "{{documento}}"
-                        }
-                      ]
-                    }
-                  },
-                  "event": [
-                    {
-                      "listen": "test",
-                      "script": {
-                        "type": "text/javascript",
-                        "exec": [
-                          "pm.test('Status code is 200', function () {",
-                          "  pm.response.to.have.status(200);",
-                          "});",
-                          "const body = pm.response.json();",
-                          "const rows = Array.isArray(body) ? body : (body.results || []);",
-                          "pm.test('La respuesta contiene al menos una inscripción', function () {",
-                          "  pm.expect(rows.length).to.be.greaterThan(0);",
-                          "});",
-                          "pm.test('La primera inscripción corresponde a la comisión esperada', function () {",
-                          "  pm.expect(String(rows[0].comision_curso)).to.eql(String(pm.collectionVariables.get('comision_curso_id')));",
-                          "});"
-                        ]
-                      }
-                    }
-                  ],
-                  "response": []
-                }
-              ]
-            }
-          ]
-        },
-        {
-          "name": "Web - Sectores Subsectores Cursos",
-          "description": "Coleccion para navegar el flujo Sector -> Subsector -> Cursos y validar centros, vouchers e inscripciones usando endpoints VAT Web y los endpoints operativos nuevos de ComisionCurso.",
-          "item": [
-            {
-              "name": "0 - Centros",
-              "item": [
-                {
-                  "name": "Listar centros activos",
-                  "request": {
-                    "method": "GET",
-                    "header": [
-                      {
-                        "key": "Authorization",
-                        "value": "{{authHeader}}",
-                        "type": "text"
-                      }
-                    ],
-                    "url": {
-                      "raw": "{{baseUrl}}{{apiPrefix}}/vat/web/centros/?activo=true",
-                      "host": [
-                        "{{baseUrl}}{{apiPrefix}}"
-                      ],
-                      "path": [
-                        "vat",
-                        "web",
-                        "centros",
-                        ""
-                      ],
-                      "query": [
-                        {
-                          "key": "activo",
-                          "value": "true"
-                        }
-                      ]
-                    }
-                  },
-                  "event": [
-                    {
-                      "listen": "test",
-                      "script": {
-                        "type": "text/javascript",
-                        "exec": [
-                          "pm.test('Status code is 200', function () {",
-                          "  pm.response.to.have.status(200);",
-                          "});",
-                          "const body = pm.response.json();",
-                          "const rows = Array.isArray(body) ? body : (body.results || []);",
-                          "if (rows.length && rows[0].id) {",
-                          "  pm.collectionVariables.set('centro_id', String(rows[0].id));",
-                          "}"
-                        ]
-                      }
-                    }
-                  ],
-                  "response": []
-                },
-                {
-                  "name": "Buscar centros por q",
-                  "request": {
-                    "method": "GET",
-                    "header": [
-                      {
-                        "key": "Authorization",
-                        "value": "{{authHeader}}",
-                        "type": "text"
-                      }
-                    ],
-                    "url": {
-                      "raw": "{{baseUrl}}{{apiPrefix}}/vat/web/centros/?q=CFP",
-                      "host": [
-                        "{{baseUrl}}{{apiPrefix}}"
-                      ],
-                      "path": [
-                        "vat",
-                        "web",
-                        "centros",
-                        ""
-                      ],
-                      "query": [
-                        {
-                          "key": "q",
-                          "value": "CFP"
-                        }
-                      ]
-                    }
-                  },
-                  "response": []
-                }
-              ]
-            },
-            {
-              "name": "1 - Sectores",
-              "item": [
-                {
-                  "name": "Listar titulos (activo=true)",
-                  "request": {
-                    "method": "GET",
-                    "header": [
-                      {
-                        "key": "Authorization",
-                        "value": "{{authHeader}}",
-                        "type": "text"
-                      }
-                    ],
-                    "url": {
-                      "raw": "{{baseUrl}}{{apiPrefix}}/vat/web/titulos/?activo=true",
-                      "host": [
-                        "{{baseUrl}}{{apiPrefix}}"
-                      ],
-                      "path": [
-                        "vat",
-                        "web",
-                        "titulos",
-                        ""
-                      ],
-                      "query": [
-                        {
-                          "key": "activo",
-                          "value": "true"
-                        }
-                      ]
-                    }
-                  },
-                  "event": [
-                    {
-                      "listen": "test",
-                      "script": {
-                        "type": "text/javascript",
-                        "exec": [
-                          "pm.test('Status code is 200', function () {",
-                          "  pm.response.to.have.status(200);",
-                          "});",
-                          "const body = pm.response.json();",
-                          "const rows = Array.isArray(body) ? body : (body.results || []);",
-                          "if (rows.length && rows[0].sector) {",
-                          "  pm.collectionVariables.set('sector_id', String(rows[0].sector));",
-                          "}",
-                          "if (rows.length && rows[0].id) {",
-                          "  pm.collectionVariables.set('titulo_id', String(rows[0].id));",
-                          "}"
-                        ]
-                      }
-                    }
-                  ],
-                  "response": []
-                },
-                {
-                  "name": "Listar titulos por sector_id",
-                  "request": {
-                    "method": "GET",
-                    "header": [
-                      {
-                        "key": "Authorization",
-                        "value": "{{authHeader}}",
-                        "type": "text"
-                      }
-                    ],
-                    "url": {
-                      "raw": "{{baseUrl}}{{apiPrefix}}/vat/web/titulos/?activo=true&sector_id={{sector_id}}",
-                      "host": [
-                        "{{baseUrl}}{{apiPrefix}}"
-                      ],
-                      "path": [
-                        "vat",
-                        "web",
-                        "titulos",
-                        ""
-                      ],
-                      "query": [
-                        {
-                          "key": "activo",
-                          "value": "true"
-                        },
-                        {
-                          "key": "sector_id",
-                          "value": "{{sector_id}}"
-                        }
-                      ]
-                    }
-                  },
-                  "event": [
-                    {
-                      "listen": "test",
-                      "script": {
-                        "type": "text/javascript",
-                        "exec": [
-                          "pm.test('Status code is 200', function () {",
-                          "  pm.response.to.have.status(200);",
-                          "});",
-                          "const body = pm.response.json();",
-                          "const rows = Array.isArray(body) ? body : (body.results || []);",
-                          "if (rows.length && rows[0].subsector) {",
-                          "  pm.collectionVariables.set('subsector_id', String(rows[0].subsector));",
-                          "}",
-                          "if (rows.length && rows[0].id) {",
-                          "  pm.collectionVariables.set('titulo_id', String(rows[0].id));",
-                          "}"
-                        ]
-                      }
-                    }
-                  ],
-                  "response": []
-                }
-              ]
-            },
-            {
-              "name": "2 - Subsectores",
-              "item": [
-                {
-                  "name": "Listar titulos por sector_id + subsector_id",
-                  "request": {
-                    "method": "GET",
-                    "header": [
-                      {
-                        "key": "Authorization",
-                        "value": "{{authHeader}}",
-                        "type": "text"
-                      }
-                    ],
-                    "url": {
-                      "raw": "{{baseUrl}}{{apiPrefix}}/vat/web/titulos/?activo=true&sector_id={{sector_id}}&subsector_id={{subsector_id}}",
-                      "host": [
-                        "{{baseUrl}}{{apiPrefix}}"
-                      ],
-                      "path": [
-                        "vat",
-                        "web",
-                        "titulos",
-                        ""
-                      ],
-                      "query": [
-                        {
-                          "key": "activo",
-                          "value": "true"
-                        },
-                        {
-                          "key": "sector_id",
-                          "value": "{{sector_id}}"
-                        },
-                        {
-                          "key": "subsector_id",
-                          "value": "{{subsector_id}}"
-                        }
-                      ]
-                    }
-                  },
-                  "event": [
-                    {
-                      "listen": "test",
-                      "script": {
-                        "type": "text/javascript",
-                        "exec": [
-                          "pm.test('Status code is 200', function () {",
-                          "  pm.response.to.have.status(200);",
-                          "});",
-                          "const body = pm.response.json();",
-                          "const rows = Array.isArray(body) ? body : (body.results || []);",
-                          "if (rows.length && rows[0].id) {",
-                          "  pm.collectionVariables.set('titulo_id', String(rows[0].id));",
-                          "}"
-                        ]
-                      }
-                    }
-                  ],
-                  "response": []
-                }
-              ]
-            },
-            {
-              "name": "3 - Cursos y Comisiones de Curso",
-              "item": [
-                {
-                  "name": "Listar cursos web por titulo_id",
-                  "request": {
-                    "method": "GET",
-                    "header": [
-                      {
-                        "key": "Authorization",
-                        "value": "{{authHeader}}",
-                        "type": "text"
-                      }
-                    ],
-                    "url": {
-                      "raw": "{{baseUrl}}{{apiPrefix}}/vat/web/cursos/?titulo_id={{titulo_id}}",
-                      "host": [
-                        "{{baseUrl}}{{apiPrefix}}"
-                      ],
-                      "path": [
-                        "vat",
-                        "web",
-                        "cursos",
-                        ""
-                      ],
-                      "query": [
-                        {
-                          "key": "titulo_id",
-                          "value": "{{titulo_id}}"
-                        }
-                      ]
-                    }
-                  },
-                  "event": [
-                    {
-                      "listen": "test",
-                      "script": {
-                        "type": "text/javascript",
-                        "exec": [
-                          "pm.test('Status code is 200', function () {",
-                          "  pm.response.to.have.status(200);",
-                          "});",
-                          "const body = pm.response.json();",
-                          "const rows = Array.isArray(body) ? body : (body.results || []);",
-                          "if (rows.length && rows[0].id) {",
-                          "  pm.collectionVariables.set('comision_curso_id', String(rows[0].id));",
-                          "}",
-                          "if (rows.length && rows[0].centro_id) {",
-                          "  pm.collectionVariables.set('centro_id', String(rows[0].centro_id));",
-                          "}",
-                          "if (rows.length && rows[0].titulo_id) {",
-                          "  pm.collectionVariables.set('titulo_id', String(rows[0].titulo_id));",
-                          "}",
-                          "if (rows.length && rows[0].programa_id) {",
-                          "  pm.collectionVariables.set('programa_id', String(rows[0].programa_id));",
-                          "}",
-                          ""
-                        ]
-                      }
-                    }
-                  ],
-                  "response": []
-                },
-                {
-                  "name": "Listar cursos web por titulo_id + estado",
-                  "request": {
-                    "method": "GET",
-                    "header": [
-                      {
-                        "key": "Authorization",
-                        "value": "{{authHeader}}",
-                        "type": "text"
-                      }
-                    ],
-                    "url": {
-                      "raw": "{{baseUrl}}{{apiPrefix}}/vat/web/cursos/?titulo_id={{titulo_id}}&estado=activa",
-                      "host": [
-                        "{{baseUrl}}{{apiPrefix}}"
-                      ],
-                      "path": [
-                        "vat",
-                        "web",
-                        "cursos",
-                        ""
-                      ],
-                      "query": [
-                        {
-                          "key": "titulo_id",
-                          "value": "{{titulo_id}}"
-                        },
-                        {
-                          "key": "estado",
-                          "value": "activa"
-                        }
-                      ]
-                    }
-                  },
-                  "response": []
-                },
-                {
-                  "name": "Listar cursos web por titulo_id + usa_voucher=false",
-                  "request": {
-                    "method": "GET",
-                    "header": [
-                      {
-                        "key": "Authorization",
-                        "value": "{{authHeader}}",
-                        "type": "text"
-                      }
-                    ],
-                    "url": {
-                      "raw": "{{baseUrl}}{{apiPrefix}}/vat/web/cursos/?titulo_id={{titulo_id}}&usa_voucher=false",
-                      "host": [
-                        "{{baseUrl}}{{apiPrefix}}"
-                      ],
-                      "path": [
-                        "vat",
-                        "web",
-                        "cursos",
-                        ""
-                      ],
-                      "query": [
-                        {
-                          "key": "titulo_id",
-                          "value": "{{titulo_id}}"
-                        },
-                        {
-                          "key": "usa_voucher",
-                          "value": "false"
-                        }
-                      ]
-                    }
-                  },
-                  "response": []
-                },
-                {
-                  "name": "Listar cursos web por centro_id + q",
-                  "request": {
-                    "method": "GET",
-                    "header": [
-                      {
-                        "key": "Authorization",
-                        "value": "{{authHeader}}",
-                        "type": "text"
-                      }
-                    ],
-                    "url": {
-                      "raw": "{{baseUrl}}{{apiPrefix}}/vat/web/cursos/?centro_id={{centro_id}}&q=curso",
-                      "host": [
-                        "{{baseUrl}}{{apiPrefix}}"
-                      ],
-                      "path": [
-                        "vat",
-                        "web",
-                        "cursos",
-                        ""
-                      ],
-                      "query": [
-                        {
-                          "key": "centro_id",
-                          "value": "{{centro_id}}"
-                        },
-                        {
-                          "key": "q",
-                          "value": "curso"
-                        }
-                      ]
-                    }
-                  },
-                  "response": []
-                },
-                {
-                  "name": "Listar cursos web por programa_id + usa_voucher=true",
-                  "request": {
-                    "method": "GET",
-                    "header": [
-                      {
-                        "key": "Authorization",
-                        "value": "{{authHeader}}",
-                        "type": "text"
-                      }
-                    ],
-                    "url": {
-                      "raw": "{{baseUrl}}{{apiPrefix}}/vat/web/cursos/?programa_id={{programa_id}}&usa_voucher=true",
-                      "host": [
-                        "{{baseUrl}}{{apiPrefix}}"
-                      ],
-                      "path": [
-                        "vat",
-                        "web",
-                        "cursos",
-                        ""
-                      ],
-                      "query": [
-                        {
-                          "key": "programa_id",
-                          "value": "{{programa_id}}"
-                        },
-                        {
-                          "key": "usa_voucher",
-                          "value": "true"
-                        }
-                      ]
-                    }
-                  },
-                  "response": []
-                },
-                {
-                  "name": "Listar comisiones de curso operativas por curso_id",
-                  "request": {
-                    "method": "GET",
-                    "header": [
-                      {
-                        "key": "Authorization",
-                        "value": "{{authHeader}}",
-                        "type": "text"
-                      }
-                    ],
-                    "url": {
-                      "raw": "{{baseUrl}}{{apiPrefix}}/vat/comisiones-curso/?curso_id={{curso_id}}&estado=activa",
-                      "host": [
-                        "{{baseUrl}}{{apiPrefix}}"
-                      ],
-                      "path": [
-                        "vat",
-                        "comisiones-curso",
-                        ""
-                      ],
-                      "query": [
-                        {
-                          "key": "curso_id",
-                          "value": "{{curso_id}}"
-                        },
-                        {
-                          "key": "estado",
-                          "value": "activa"
-                        }
-                      ]
-                    }
-                  },
-                  "event": [
-                    {
-                      "listen": "test",
-                      "script": {
-                        "type": "text/javascript",
-                        "exec": [
-                          "pm.test('Status code is 200', function () {",
-                          "  pm.response.to.have.status(200);",
-                          "});",
-                          "const body = pm.response.json();",
-                          "const rows = Array.isArray(body) ? body : (body.results || []);",
-                          "if (rows.length && rows[0].id) {",
-                          "  pm.collectionVariables.set('comision_curso_id', String(rows[0].id));",
-                          "}"
-                        ]
-                      }
-                    }
-                  ],
-                  "response": []
-                }
-              ]
-            },
-            {
-              "name": "4 - Inscripciones",
-              "item": [
-                {
-                  "name": "Consultar vouchers por ciudadano_id",
-                  "request": {
-                    "method": "GET",
-                    "header": [
-                      {
-                        "key": "Authorization",
-                        "value": "{{authHeader}}",
-                        "type": "text"
-                      }
-                    ],
-                    "url": {
-                      "raw": "{{baseUrl}}{{apiPrefix}}/vat/vouchers/por_ciudadano/?ciudadano_id={{ciudadano_id}}",
-                      "host": [
-                        "{{baseUrl}}{{apiPrefix}}"
-                      ],
-                      "path": [
-                        "vat",
-                        "vouchers",
-                        "por_ciudadano",
-                        ""
-                      ],
-                      "query": [
-                        {
-                          "key": "ciudadano_id",
-                          "value": "{{ciudadano_id}}"
-                        }
-                      ]
-                    }
-                  },
-                  "event": [
-                    {
-                      "listen": "test",
-                      "script": {
-                        "type": "text/javascript",
-                        "exec": [
-                          "pm.test('Status code is 200', function () {",
-                          "  pm.response.to.have.status(200);",
-                          "});",
-                          "const body = pm.response.json();",
-                          "const rows = Array.isArray(body) ? body : (body.results || []);",
-                          "if (rows.length && rows[0].id) {",
-                          "  pm.collectionVariables.set('voucher_id', String(rows[0].id));",
-                          "}",
-                          "if (rows.length && rows[0].programa) {",
-                          "  pm.collectionVariables.set('programa_id', String(rows[0].programa));",
-                          "}"
-                        ]
-                      }
-                    }
-                  ],
-                  "response": []
-                },
-                {
-                  "name": "Consultar estado de voucher por documento",
-                  "request": {
-                    "method": "GET",
-                    "header": [
-                      {
-                        "key": "Authorization",
-                        "value": "{{authHeader}}",
-                        "type": "text"
-                      }
-                    ],
-                    "url": {
-                      "raw": "{{baseUrl}}{{apiPrefix}}/vat/web/ciudadanos/voucher-estado/?documento={{documento}}",
-                      "host": [
-                        "{{baseUrl}}{{apiPrefix}}"
-                      ],
-                      "path": [
-                        "vat",
-                        "web",
-                        "ciudadanos",
-                        "voucher-estado",
-                        ""
-                      ],
-                      "query": [
-                        {
-                          "key": "documento",
-                          "value": "{{documento}}"
-                        }
-                      ]
-                    }
-                  },
-                  "event": [
-                    {
-                      "listen": "test",
-                      "script": {
-                        "type": "text/javascript",
-                        "exec": [
-                          "pm.test('Status code is 200', function () {",
-                          "  pm.response.to.have.status(200);",
-                          "});",
-                          "const body = pm.response.json();",
-                          "pm.test('Devuelve un estado funcional de voucher', function () {",
-                          "  pm.expect(['Disponible', 'En uso', 'No disponible']).to.include(body.estado);",
-                          "});",
-                          "pm.test('Devuelve flags booleanos', function () {",
-                          "  pm.expect(body.tiene_voucher).to.be.a('boolean');",
-                          "  pm.expect(body.esta_inscripto).to.be.a('boolean');",
-                          "});"
-                        ]
-                      }
-                    }
-                  ],
-                  "response": []
-                },
-                {
-                  "name": "Listar inscripciones por documento",
-                  "request": {
-                    "method": "GET",
-                    "header": [
-                      {
-                        "key": "Authorization",
-                        "value": "{{authHeader}}",
-                        "type": "text"
-                      }
-                    ],
-                    "url": {
-                      "raw": "{{baseUrl}}{{apiPrefix}}/vat/web/inscripciones/?documento={{documento}}",
-                      "host": [
-                        "{{baseUrl}}{{apiPrefix}}"
-                      ],
-                      "path": [
-                        "vat",
-                        "web",
-                        "inscripciones",
-                        ""
-                      ],
-                      "query": [
-                        {
-                          "key": "documento",
-                          "value": "{{documento}}"
-                        }
-                      ]
-                    }
-                  },
-                  "response": []
-                },
-                {
-                  "name": "Listar inscripciones por ciudadano_id",
-                  "request": {
-                    "method": "GET",
-                    "header": [
-                      {
-                        "key": "Authorization",
-                        "value": "{{authHeader}}",
-                        "type": "text"
-                      }
-                    ],
-                    "url": {
-                      "raw": "{{baseUrl}}{{apiPrefix}}/vat/web/inscripciones/?ciudadano_id={{ciudadano_id}}",
-                      "host": [
-                        "{{baseUrl}}{{apiPrefix}}"
-                      ],
-                      "path": [
-                        "vat",
-                        "web",
-                        "inscripciones",
-                        ""
-                      ],
-                      "query": [
-                        {
-                          "key": "ciudadano_id",
-                          "value": "{{ciudadano_id}}"
-                        }
-                      ]
-                    }
-                  },
-                  "response": []
-                },
-                {
-                  "name": "Crear inscripcion web por documento",
-                  "request": {
-                    "method": "POST",
-                    "header": [
-                      {
-                        "key": "Authorization",
-                        "value": "{{authHeader}}",
-                        "type": "text"
-                      },
-                      {
-                        "key": "Content-Type",
-                        "value": "application/json",
-                        "type": "text"
-                      }
-                    ],
-                    "body": {
-                      "mode": "raw",
-                      "raw": "{\n  \"documento\": \"{{documento}}\",\n  \"comision_curso_id\": {{comision_curso_id}},\n  \"estado\": \"pre_inscripta\",\n  \"observaciones\": \"Alta desde Postman\"\n}"
-                    },
-                    "url": {
-                      "raw": "{{baseUrl}}{{apiPrefix}}/vat/web/inscripciones/",
-                      "host": [
-                        "{{baseUrl}}{{apiPrefix}}"
-                      ],
-                      "path": [
-                        "vat",
-                        "web",
-                        "inscripciones",
-                        ""
-                      ]
-                    }
-                  },
-                  "response": []
-                },
-                {
-                  "name": "Crear inscripcion web por ciudadano_id",
-                  "request": {
-                    "method": "POST",
-                    "header": [
-                      {
-                        "key": "Authorization",
-                        "value": "{{authHeader}}",
-                        "type": "text"
-                      },
-                      {
-                        "key": "Content-Type",
-                        "value": "application/json",
-                        "type": "text"
-                      }
-                    ],
-                    "body": {
-                      "mode": "raw",
-                      "raw": "{\n  \"ciudadano_id\": {{ciudadano_id}},\n  \"comision_curso_id\": {{comision_curso_id}},\n  \"estado\": \"inscripta\",\n  \"observaciones\": \"Alta desde Postman por ciudadano_id\"\n}"
-                    },
-                    "url": {
-                      "raw": "{{baseUrl}}{{apiPrefix}}/vat/web/inscripciones/",
-                      "host": [
-                        "{{baseUrl}}{{apiPrefix}}"
-                      ],
-                      "path": [
-                        "vat",
-                        "web",
-                        "inscripciones",
-                        ""
-                      ]
-                    }
-                  },
-                  "response": []
-                },
-                {
-                  "name": "Crear inscripcion API explicita en /vat/inscripciones-curso/",
-                  "request": {
-                    "method": "POST",
-                    "header": [
-                      {
-                        "key": "Authorization",
-                        "value": "{{authHeader}}",
-                        "type": "text"
-                      },
-                      {
-                        "key": "Content-Type",
-                        "value": "application/json",
-                        "type": "text"
-                      }
-                    ],
-                    "body": {
-                      "mode": "raw",
-                      "raw": "{\n  \"ciudadano\": {{ciudadano_id}},\n  \"comision_curso\": {{comision_curso_id}},\n  \"estado\": \"inscripta\",\n  \"origen_canal\": \"api\",\n  \"observaciones\": \"Alta API explicita sobre ComisionCurso\"\n}"
-                    },
-                    "url": {
-                      "raw": "{{baseUrl}}{{apiPrefix}}/vat/inscripciones-curso/",
-                      "host": [
-                        "{{baseUrl}}{{apiPrefix}}"
-                      ],
-                      "path": [
-                        "vat",
-                        "inscripciones-curso",
-                        ""
-                      ]
-                    }
-                  },
-                  "response": []
-                },
-                {
-                  "name": "Listar inscripciones API por comision_curso_id",
-                  "request": {
-                    "method": "GET",
-                    "header": [
-                      {
-                        "key": "Authorization",
-                        "value": "{{authHeader}}",
-                        "type": "text"
-                      }
-                    ],
-                    "url": {
-                      "raw": "{{baseUrl}}{{apiPrefix}}/vat/inscripciones-curso/?comision_curso_id={{comision_curso_id}}",
-                      "host": [
-                        "{{baseUrl}}{{apiPrefix}}"
-                      ],
-                      "path": [
-                        "vat",
-                        "inscripciones-curso",
-                        ""
-                      ],
-                      "query": [
-                        {
-                          "key": "comision_curso_id",
-                          "value": "{{comision_curso_id}}"
-                        }
-                      ]
-                    }
-                  },
                   "response": []
                 }
               ]

--- a/postman/api_inventory.md
+++ b/postman/api_inventory.md
@@ -1,7 +1,7 @@
 # API Inventory — SISOC
 
 Todas las APIs (internas y externas) están documentadas en la colección única:
-**`SISOC APIs.postman_collection.json`** · 170 requests · 11 carpetas · entorno: `Local.postman_environment.json`
+**`SISOC APIs.postman_collection.json`** · 243 requests · 11 carpetas · entorno: `Local.postman_environment.json`
 
 ---
 
@@ -17,20 +17,30 @@ Todas las APIs (internas y externas) están documentadas en la colección única
 | Relevamientos | 2 | PATCH relevamiento + primer seguimiento (`/api/relevamiento`) |
 | PWA | 33 | Health, push, colaboradores, actividades, formación, mensajes, nómina (`/api/espacios/`) |
 | Ticketera | 3 | Alta usuario, verificar auth, cambiar password (`/api/ticketera/`) |
-| VAT | 74 | Ver detalle abajo |
+| VAT | 147 | Cobertura completa del router público VAT; ver detalle abajo |
 | Integraciones Externas | 12 | GESTIONAR (AppSheet) + RENAPER API externa |
 | Docs | 2 | OpenAPI schema SISOC + VAT (`/api/schema/`) |
 
 ---
 
-## VAT (74 requests)
+## VAT (147 requests)
 
 | Subcarpeta | Requests | Endpoints principales |
 |-----------|----------|----------------------|
-| Operativo - Planes, Centros, Cursos, Comisiones | 38 | provincias, municipios, planes-curriculares, centros, cursos, comisiones-curso, sectores, subsectores, localidades, modalidades, titulos-referencia, institucion-contactos/identificadores/ubicaciones, ofertas-institucionales, comisiones, comision-horarios, inscripciones, inscripciones-oferta, inscripciones-curso, evaluaciones, resultado-evaluaciones, vouchers, web/ciudadanos |
-| Operativo - Cursos Busqueda y Prioritarios | 11 | `vat/cursos/buscar/`, `vat/cursos/prioritarios/` con casos de error |
-| Web - Mi Argentina Inscripcion | 6 | `vat/web/cursos/`, `vat/web/ciudadanos/voucher-estado/`, `vat/web/inscripciones/prevalidar/`, `vat/web/inscripciones/` |
-| Web - Sectores Subsectores Cursos | 19 | `vat/web/centros/`, `vat/web/titulos/`, `vat/web/cursos/`, `vat/inscripciones-curso/`, `vat/vouchers/por_ciudadano/` |
+| 0 - Guía de uso y autenticación | 0 | configuración, autenticación, encadenamiento de IDs y advertencias para escrituras |
+| 1 - API operativa - Geografía | 6 | provincias, municipios y localidades; list y retrieve |
+| 2 - API operativa - Centros e institución | 25 | centros, acción `activos`, contactos, identificadores y ubicaciones institucionales; CRUD completo |
+| 3 - API operativa - Catálogos y planes | 36 | modalidades institucionales/de cursada, sectores, subsectores, títulos y planes curriculares; CRUD completo |
+| 4 - API operativa - Cursos y comisiones | 14 | cursos, `buscar`, `prioritarios` y comisiones de curso; CRUD completo |
+| 5 - API operativa - Oferta institucional | 18 | ofertas institucionales, comisiones legacy y horarios; CRUD completo |
+| 6 - API operativa - Inscripciones y vouchers | 26 | inscripciones de oferta, vouchers, acciones `disponible`/`por_ciudadano`, inscripciones generales y de curso; CRUD completo |
+| 7 - API operativa - Evaluaciones | 12 | evaluaciones y resultados; CRUD completo |
+| 8 - API web | 10 | centros, títulos y cursos (list/retrieve), `voucher-estado`, listado/alta/prevalidación de inscripciones |
+
+La cobertura corresponde a los métodos de negocio registrados en
+`VAT/api_urls.py`: GET, POST, PUT, PATCH y DELETE según cada ViewSet, más sus
+acciones custom. No se duplican HEAD/OPTIONS generados automáticamente por DRF y
+no se incluyen vistas HTML ni AJAX internas de `VAT/urls.py`.
 
 ---
 
@@ -60,6 +70,7 @@ Todas las APIs (internas y externas) están documentadas en la colección única
 | `apiPrefix` | Prefijo REST (default: `/api`) |
 | `authToken` | Token sesión Django — formato: `Token <valor>` |
 | `apiKey` | Api-Key DRF — formato header: `Api-Key <valor>` |
+| `allowVatMutations` | Guard del ambiente activo; `false` omite POST/PUT/PATCH/DELETE VAT |
 
 ### IDs de entidades SISOC
 
@@ -81,16 +92,33 @@ Todas las APIs (internas y externas) están documentadas en la colección única
 |----------|---------|
 | `provincia_id` | Provincia |
 | `municipio_id` | Municipio |
+| `localidad_id` | Localidad |
 | `plan_id` | PlanCurricular |
 | `curso_id` | Curso |
 | `comision_curso_id` | ComisionCurso |
 | `sector_id` | Sector |
 | `subsector_id` | Subsector |
 | `titulo_id` | TituloReferencia |
-| `modalidad_id` | Modalidad |
+| `modalidad_id` | Modalidad (variable legacy) |
+| `modalidad_institucional_id` | ModalidadInstitucional |
+| `modalidad_cursada_id` | ModalidadCursada |
 | `programa_id` | Programa |
 | `ciudadano_id` | Ciudadano |
 | `voucher_id` | Voucher |
+| `institucion_contacto_id` | InstitucionContacto |
+| `institucion_identificador_id` | InstitucionIdentificadorHist |
+| `institucion_ubicacion_id` | InstitucionUbicacion |
+| `oferta_institucional_id` | OfertaInstitucional |
+| `comision_id` | Comisión de oferta institucional |
+| `comision_horario_id` | ComisionHorario |
+| `inscripcion_oferta_id` | InscripcionOferta |
+| `inscripcion_id` | Inscripcion general |
+| `inscripcion_curso_id` | Inscripción expuesta por `/inscripciones-curso/` |
+| `solicitud_inscripcion_id` | SolicitudInscripcionPublica devuelta por el alta web |
+| `evaluacion_id` | Evaluacion |
+| `resultado_evaluacion_id` | ResultadoEvaluacion |
+| `usuario_id` | Usuario que registra un resultado |
+| `dia_semana_id` | Día usado en un horario de comisión |
 | `documento` | DNI ciudadano (VAT Web) |
 | `cuil` | CUIL ciudadano (VAT Web) |
 


### PR DESCRIPTION
## Resumen

- actualiza la colección Postman para cubrir la API pública completa de VAT/INET
- incluye las superficies operativa y web bajo /api/vat/ y /api/vat/web/
- excluye las rutas AJAX y vistas HTML internas
- incorpora variables, ejemplos y encadenamiento de identificadores
- bloquea por defecto las 85 operaciones con efectos mediante allowVatMutations=false

## Cobertura

- 147 requests VAT
- 29 recursos registrados por router
- 7 acciones personalizadas
- métodos GET, POST, PUT, PATCH y DELETE según el contrato DRF
- guía de autenticación y ejecución segura dentro de la colección

## Validación

- comparación estática ruta/método contra VAT/api_urls.py y sus ViewSets
- JSON, cuerpos y variables validados
- sin rutas AJAX/HTML en la colección
- sin variables de Postman sin definir
- git diff --check sin errores

## Riesgo conocido

POST /vouchers/ se conserva por fidelidad al router, pero se documenta como riesgo conocido: actualmente existe una inconsistencia entre un campo obligatorio del modelo y el serializer de creación. Este PR no modifica el backend ni afirma que ese POST responda 201.

## No validado

- no se enviaron requests contra datos reales
- no se realizó una importación física en la aplicación Postman
- la validación del esquema Django local quedó bloqueada por la dependencia crispy_forms ausente