### PR TITLE
feat(vat): buscar centros por CUE

### DIFF
--- a/AGENT_REPO_MAP.md
+++ b/AGENT_REPO_MAP.md
@@ -567,6 +567,19 @@ La siguiente tabla mezcla hechos observados con inferencias explicitas cuando no
   `VAT/services/tipo_alumno_service.py`, tests VAT y
   `docs/vat/VOUCHER_SETUP.md`.
 
+### Si necesitas cambiar la búsqueda de Centros VAT por CUE
+
+- API pública: `VAT/api_views.py:CentroViewSet` y
+  `VAT/serializers.py:CentroCueDetalleSerializer`.
+- El parámetro `cue` busca el valor vigente e histórico en
+  `InstitucionIdentificadorHist` y usa `Centro.codigo` como compatibilidad
+  legacy; la respuesta detallada sólo se activa cuando el parámetro está
+  presente.
+- Tests de contrato: `VAT/tests.py` con prefijo
+  `test_api_vat_centros_cue_`.
+- Request manual: `postman/SISOC APIs.postman_collection.json`, carpeta VAT /
+  Centros e institución.
+
 ### Si necesitas cambiar CI o reglas de calidad
 
 - `.github/workflows/tests.yml`

--- a/VAT/api_views.py
+++ b/VAT/api_views.py
@@ -2,7 +2,7 @@
 import logging
 
 from django.db.models import Count, Prefetch, Q
-from drf_spectacular.utils import extend_schema
+from drf_spectacular.utils import PolymorphicProxySerializer, extend_schema
 from drf_spectacular.utils import OpenApiParameter, inline_serializer
 from drf_spectacular.types import OpenApiTypes
 from rest_framework import serializers as drf_serializers
@@ -30,6 +30,7 @@ from VAT.models import (
     OfertaInstitucional,
     Comision,
     ComisionHorario,
+    SesionComision,
     Inscripcion,
     Evaluacion,
     ResultadoEvaluacion,
@@ -42,6 +43,7 @@ from VAT.pagination import VATPageNumberPagination
 from VAT.services.inscripcion_service import ESTADOS_INSCRIPCION_OCUPAN_CUPO
 from VAT.serializers import (
     CentroSerializer,
+    CentroCueDetalleSerializer,
     ProvinciaSerializer,
     MunicipioSerializer,
     LocalidadSerializer,
@@ -84,6 +86,35 @@ CURSO_BUSQUEDA_PAGINATED_RESPONSE = inline_serializer(
 )
 
 
+CENTRO_LIST_PAGINATED_RESPONSE = inline_serializer(
+    name="CentroListPaginatedResponse",
+    fields={
+        "count": drf_serializers.IntegerField(),
+        "next": drf_serializers.URLField(allow_null=True),
+        "previous": drf_serializers.URLField(allow_null=True),
+        "results": PolymorphicProxySerializer(
+            component_name="CentroListResult",
+            serializers=[CentroSerializer, CentroCueDetalleSerializer],
+            resource_type_field_name=None,
+            many=True,
+        ),
+    },
+)
+
+
+def normalizar_cue_consulta(cue: str | None) -> str:
+    """Normaliza el CUE recibido sin asumir una jurisdicción de origen."""
+
+    cue_normalizado = (cue or "").strip()
+    if not cue_normalizado:
+        raise ValidationError({"cue": ["Este parámetro es requerido."]})
+    if not cue_normalizado.isdigit() or len(cue_normalizado) > 9:
+        raise ValidationError(
+            {"cue": ["Debe contener solo números y hasta 9 dígitos."]}
+        )
+    return cue_normalizado.zfill(9)
+
+
 class SoftDeleteDestroyMixin:
     def perform_destroy(self, instance):
         if is_soft_deletable_instance(instance):
@@ -117,8 +148,112 @@ class CentroViewSet(SoftDeleteDestroyMixin, VATModelViewSet):
     serializer_class = CentroSerializer
     permission_classes = [HasAPIKey]
 
+    def _cue_consultado(self):
+        if self.action != "list" or "cue" not in self.request.query_params:
+            return None
+        if not hasattr(self, "_cue_consultado_cache"):
+            self._cue_consultado_cache = normalizar_cue_consulta(
+                self.request.query_params.get("cue")
+            )
+        return self._cue_consultado_cache
+
+    def _queryset_detalle_cue(self):
+        horarios = ComisionHorario.objects.select_related("dia_semana").order_by(
+            "dia_semana", "hora_desde"
+        )
+        sesiones = SesionComision.objects.select_related(
+            "horario", "horario__dia_semana"
+        ).order_by("fecha", "horario__hora_desde")
+        comisiones_curso = ComisionCurso.objects.select_related(
+            "ubicacion",
+            "ubicacion__localidad",
+            "ubicacion__localidad__municipio",
+            "ubicacion__localidad__municipio__provincia",
+        ).prefetch_related(
+            Prefetch("horarios", queryset=horarios),
+            Prefetch("sesiones", queryset=sesiones),
+        )
+        comisiones_oferta = Comision.objects.select_related(
+            "ubicacion",
+            "ubicacion__localidad",
+            "ubicacion__localidad__municipio",
+            "ubicacion__localidad__municipio__provincia",
+        ).prefetch_related(
+            Prefetch("horarios", queryset=horarios),
+            Prefetch("sesiones", queryset=sesiones),
+        )
+        parametria_voucher = VoucherParametria.objects.select_related("programa").order_by(
+            "programa_id", "id"
+        )
+        cursos = Curso.objects.select_related(
+            "plan_estudio",
+            "plan_estudio__provincia",
+            "plan_estudio__sector",
+            "plan_estudio__subsector",
+            "plan_estudio__modalidad_cursada",
+            "modalidad",
+        ).prefetch_related(
+            "plan_estudio__titulos",
+            Prefetch("voucher_parametrias", queryset=parametria_voucher),
+            Prefetch("comisiones", queryset=comisiones_curso),
+        )
+        ofertas = OfertaInstitucional.objects.select_related(
+            "plan_curricular",
+            "plan_curricular__provincia",
+            "plan_curricular__sector",
+            "plan_curricular__subsector",
+            "plan_curricular__modalidad_cursada",
+            "programa",
+        ).prefetch_related(
+            "plan_curricular__titulos",
+            Prefetch("voucher_parametrias", queryset=parametria_voucher),
+            Prefetch("comisiones", queryset=comisiones_oferta),
+        )
+        ubicaciones = InstitucionUbicacion.objects.select_related(
+            "localidad",
+            "localidad__municipio",
+            "localidad__municipio__provincia",
+        ).order_by("rol_ubicacion", "id")
+
+        return Centro.objects.select_related(
+            "provincia", "municipio", "localidad"
+        ).prefetch_related(
+            Prefetch(
+                "identificadores_hist",
+                queryset=InstitucionIdentificadorHist.objects.select_related(
+                    "ubicacion"
+                ).order_by("-es_actual", "-vigencia_desde", "-id"),
+            ),
+            Prefetch(
+                "contactos_adicionales",
+                queryset=InstitucionContacto.objects.order_by(
+                    "-es_principal", "nombre_contacto", "rol_area"
+                ),
+            ),
+            Prefetch("ubicaciones", queryset=ubicaciones),
+            Prefetch("cursos", queryset=cursos),
+            Prefetch("ofertas_institucionales", queryset=ofertas),
+        ).order_by("id")
+
+    def get_serializer_class(self):
+        if self._cue_consultado() is not None:
+            return CentroCueDetalleSerializer
+        return super().get_serializer_class()
+
+    def get_serializer_context(self):
+        context = super().get_serializer_context()
+        cue = self._cue_consultado()
+        if cue is not None:
+            context["cue"] = cue
+        return context
+
     def get_queryset(self):
-        queryset = super().get_queryset()
+        cue = self._cue_consultado()
+        queryset = (
+            self._queryset_detalle_cue()
+            if cue is not None
+            else super().get_queryset()
+        )
         activo = self.request.query_params.get("activo")
         if activo is not None:
             queryset = queryset.filter(activo=activo.lower() == "true")
@@ -131,7 +266,38 @@ class CentroViewSet(SoftDeleteDestroyMixin, VATModelViewSet):
             queryset = queryset.filter(municipio_id=municipio_id)
         if localidad_id:
             queryset = queryset.filter(localidad_id=localidad_id)
+        if cue is not None:
+            queryset = queryset.filter(
+                Q(codigo=cue)
+                | Q(
+                    identificadores_hist__tipo_identificador="cue",
+                    identificadores_hist__valor_identificador=cue,
+                )
+            ).distinct()
         return queryset
+
+    @extend_schema(
+        summary="Listar centros VAT o buscar por CUE",
+        description=(
+            "Sin `cue` conserva el listado habitual. Con `cue` realiza una "
+            "búsqueda exacta, incluye CUEs históricos y devuelve la ficha "
+            "institucional y formativa ampliada, sin alumnos ni inscripciones."
+        ),
+        parameters=[
+            OpenApiParameter(
+                "cue",
+                OpenApiTypes.STR,
+                OpenApiParameter.QUERY,
+                description=(
+                    "CUE numérico de hasta 9 dígitos. Se completa con ceros a la "
+                    "izquierda para buscar el CUE vigente, histórico o código legacy."
+                ),
+            ),
+        ],
+        responses={200: CENTRO_LIST_PAGINATED_RESPONSE},
+    )
+    def list(self, request, *args, **kwargs):
+        return super().list(request, *args, **kwargs)
 
     @action(detail=False, methods=["get"])
     def activos(self, request):

--- a/VAT/api_views.py
+++ b/VAT/api_views.py
@@ -182,9 +182,9 @@ class CentroViewSet(SoftDeleteDestroyMixin, VATModelViewSet):
             Prefetch("horarios", queryset=horarios),
             Prefetch("sesiones", queryset=sesiones),
         )
-        parametria_voucher = VoucherParametria.objects.select_related("programa").order_by(
-            "programa_id", "id"
-        )
+        parametria_voucher = VoucherParametria.objects.select_related(
+            "programa"
+        ).order_by("programa_id", "id")
         cursos = Curso.objects.select_related(
             "plan_estudio",
             "plan_estudio__provincia",
@@ -215,25 +215,27 @@ class CentroViewSet(SoftDeleteDestroyMixin, VATModelViewSet):
             "localidad__municipio__provincia",
         ).order_by("rol_ubicacion", "id")
 
-        return Centro.objects.select_related(
-            "provincia", "municipio", "localidad"
-        ).prefetch_related(
-            Prefetch(
-                "identificadores_hist",
-                queryset=InstitucionIdentificadorHist.objects.select_related(
-                    "ubicacion"
-                ).order_by("-es_actual", "-vigencia_desde", "-id"),
-            ),
-            Prefetch(
-                "contactos_adicionales",
-                queryset=InstitucionContacto.objects.order_by(
-                    "-es_principal", "nombre_contacto", "rol_area"
+        return (
+            Centro.objects.select_related("provincia", "municipio", "localidad")
+            .prefetch_related(
+                Prefetch(
+                    "identificadores_hist",
+                    queryset=InstitucionIdentificadorHist.objects.select_related(
+                        "ubicacion"
+                    ).order_by("-es_actual", "-vigencia_desde", "-id"),
                 ),
-            ),
-            Prefetch("ubicaciones", queryset=ubicaciones),
-            Prefetch("cursos", queryset=cursos),
-            Prefetch("ofertas_institucionales", queryset=ofertas),
-        ).order_by("id")
+                Prefetch(
+                    "contactos_adicionales",
+                    queryset=InstitucionContacto.objects.order_by(
+                        "-es_principal", "nombre_contacto", "rol_area"
+                    ),
+                ),
+                Prefetch("ubicaciones", queryset=ubicaciones),
+                Prefetch("cursos", queryset=cursos),
+                Prefetch("ofertas_institucionales", queryset=ofertas),
+            )
+            .order_by("id")
+        )
 
     def get_serializer_class(self):
         if self._cue_consultado() is not None:
@@ -250,9 +252,7 @@ class CentroViewSet(SoftDeleteDestroyMixin, VATModelViewSet):
     def get_queryset(self):
         cue = self._cue_consultado()
         queryset = (
-            self._queryset_detalle_cue()
-            if cue is not None
-            else super().get_queryset()
+            self._queryset_detalle_cue() if cue is not None else super().get_queryset()
         )
         activo = self.request.query_params.get("activo")
         if activo is not None:

--- a/VAT/serializers.py
+++ b/VAT/serializers.py
@@ -486,7 +486,9 @@ class CentroCueHorarioSerializer(serializers.ModelSerializer):
 
 
 class CentroCueSesionSerializer(serializers.ModelSerializer):
-    dia_semana = serializers.IntegerField(source="horario.dia_semana_id", read_only=True)
+    dia_semana = serializers.IntegerField(
+        source="horario.dia_semana_id", read_only=True
+    )
     dia_nombre = serializers.CharField(
         source="horario.dia_semana.nombre", read_only=True
     )
@@ -546,7 +548,9 @@ class CentroCueCursoSerializer(serializers.ModelSerializer):
     modalidad_nombre = serializers.CharField(source="modalidad.nombre", read_only=True)
     programa = serializers.IntegerField(source="programa_id", read_only=True)
     programa_nombre = serializers.CharField(source="programa.nombre", read_only=True)
-    voucher_parametrias = CentroCueVoucherParametriaSerializer(many=True, read_only=True)
+    voucher_parametrias = CentroCueVoucherParametriaSerializer(
+        many=True, read_only=True
+    )
     comisiones = CentroCueComisionCursoSerializer(many=True, read_only=True)
 
     class Meta:
@@ -604,7 +608,9 @@ class CentroCueComisionSerializer(serializers.ModelSerializer):
 class CentroCueOfertaInstitucionalSerializer(serializers.ModelSerializer):
     plan_curricular = CentroCuePlanSerializer(read_only=True)
     programa_nombre = serializers.CharField(source="programa.nombre", read_only=True)
-    voucher_parametrias = CentroCueVoucherParametriaSerializer(many=True, read_only=True)
+    voucher_parametrias = CentroCueVoucherParametriaSerializer(
+        many=True, read_only=True
+    )
     comisiones = CentroCueComisionSerializer(many=True, read_only=True)
 
     class Meta:
@@ -653,7 +659,9 @@ class CentroCueContactoSerializer(serializers.ModelSerializer):
 
 class CentroCueUbicacionSerializer(serializers.ModelSerializer):
     localidad_nombre = serializers.CharField(source="localidad.nombre", read_only=True)
-    municipio = serializers.IntegerField(source="localidad.municipio_id", read_only=True)
+    municipio = serializers.IntegerField(
+        source="localidad.municipio_id", read_only=True
+    )
     municipio_nombre = serializers.CharField(
         source="localidad.municipio.nombre", read_only=True
     )
@@ -776,10 +784,7 @@ class CentroCueDetalleSerializer(serializers.ModelSerializer):
 
     def get_cue_actual(self, obj):
         for identificador in obj.identificadores_hist.all():
-            if (
-                identificador.tipo_identificador == "cue"
-                and identificador.es_actual
-            ):
+            if identificador.tipo_identificador == "cue" and identificador.es_actual:
                 return identificador.valor_identificador
         return obj.codigo
 

--- a/VAT/serializers.py
+++ b/VAT/serializers.py
@@ -408,6 +408,419 @@ class InstitucionUbicacionSerializer(serializers.ModelSerializer):
         ]
 
 
+class CentroCueTituloSerializer(serializers.ModelSerializer):
+    class Meta:
+        model = TituloReferencia
+        fields = ["id", "codigo_referencia", "nombre", "descripcion", "activo"]
+
+
+class CentroCuePlanSerializer(serializers.ModelSerializer):
+    provincia_nombre = serializers.CharField(source="provincia.nombre", read_only=True)
+    sector_nombre = serializers.CharField(source="sector.nombre", read_only=True)
+    subsector_nombre = serializers.CharField(source="subsector.nombre", read_only=True)
+    modalidad_cursada_nombre = serializers.CharField(
+        source="modalidad_cursada.nombre", read_only=True
+    )
+    titulos = CentroCueTituloSerializer(many=True, read_only=True)
+
+    class Meta:
+        model = PlanVersionCurricular
+        fields = [
+            "id",
+            "nombre",
+            "provincia",
+            "provincia_nombre",
+            "sector",
+            "sector_nombre",
+            "subsector",
+            "subsector_nombre",
+            "modalidad_cursada",
+            "modalidad_cursada_nombre",
+            "normativa",
+            "horas_reloj",
+            "nivel_requerido",
+            "nivel_certifica",
+            "activo",
+            "titulos",
+        ]
+
+
+class CentroCueVoucherParametriaSerializer(serializers.ModelSerializer):
+    programa_nombre = serializers.CharField(source="programa.nombre", read_only=True)
+
+    class Meta:
+        model = VoucherParametria
+        fields = [
+            "id",
+            "nombre",
+            "descripcion",
+            "programa",
+            "programa_nombre",
+            "cantidad_inicial",
+            "fecha_vencimiento",
+            "renovacion_mensual",
+            "cantidad_renovacion",
+            "renovacion_tipo",
+            "inscripcion_unica_activa",
+            "activa",
+            "fecha_creacion",
+        ]
+
+
+class CentroCueHorarioSerializer(serializers.ModelSerializer):
+    dia_nombre = serializers.CharField(source="dia_semana.nombre", read_only=True)
+
+    class Meta:
+        model = ComisionHorario
+        fields = [
+            "id",
+            "dia_semana",
+            "dia_nombre",
+            "hora_desde",
+            "hora_hasta",
+            "aula_espacio",
+            "vigente",
+            "fecha_creacion",
+            "fecha_modificacion",
+        ]
+
+
+class CentroCueSesionSerializer(serializers.ModelSerializer):
+    dia_semana = serializers.IntegerField(source="horario.dia_semana_id", read_only=True)
+    dia_nombre = serializers.CharField(
+        source="horario.dia_semana.nombre", read_only=True
+    )
+    hora_desde = serializers.TimeField(source="horario.hora_desde", read_only=True)
+    hora_hasta = serializers.TimeField(source="horario.hora_hasta", read_only=True)
+    aula_espacio = serializers.CharField(source="horario.aula_espacio", read_only=True)
+
+    class Meta:
+        model = SesionComision
+        fields = [
+            "id",
+            "horario",
+            "numero_sesion",
+            "fecha",
+            "estado",
+            "observaciones",
+            "dia_semana",
+            "dia_nombre",
+            "hora_desde",
+            "hora_hasta",
+            "aula_espacio",
+            "fecha_creacion",
+        ]
+
+
+class CentroCueComisionCursoSerializer(serializers.ModelSerializer):
+    ubicacion_nombre = serializers.CharField(
+        source="ubicacion.nombre_ubicacion", read_only=True
+    )
+    horarios = CentroCueHorarioSerializer(many=True, read_only=True)
+    sesiones = CentroCueSesionSerializer(many=True, read_only=True)
+
+    class Meta:
+        model = ComisionCurso
+        fields = [
+            "id",
+            "ubicacion",
+            "ubicacion_nombre",
+            "codigo_comision",
+            "nombre",
+            "cupo_total",
+            "acepta_lista_espera",
+            "cupo_lista_espera",
+            "fecha_inicio",
+            "fecha_fin",
+            "estado",
+            "horarios",
+            "sesiones",
+            "observaciones",
+            "fecha_creacion",
+            "fecha_modificacion",
+        ]
+
+
+class CentroCueCursoSerializer(serializers.ModelSerializer):
+    plan_estudio = CentroCuePlanSerializer(read_only=True)
+    modalidad_nombre = serializers.CharField(source="modalidad.nombre", read_only=True)
+    programa = serializers.IntegerField(source="programa_id", read_only=True)
+    programa_nombre = serializers.CharField(source="programa.nombre", read_only=True)
+    voucher_parametrias = CentroCueVoucherParametriaSerializer(many=True, read_only=True)
+    comisiones = CentroCueComisionCursoSerializer(many=True, read_only=True)
+
+    class Meta:
+        model = Curso
+        fields = [
+            "id",
+            "plan_estudio",
+            "nombre",
+            "tipo",
+            "prioritario",
+            "modalidad",
+            "modalidad_nombre",
+            "programa",
+            "programa_nombre",
+            "estado",
+            "usa_voucher",
+            "inscripcion_libre",
+            "voucher_parametrias",
+            "costo_creditos",
+            "comisiones",
+            "observaciones",
+            "fecha_creacion",
+            "fecha_modificacion",
+        ]
+
+
+class CentroCueComisionSerializer(serializers.ModelSerializer):
+    ubicacion_nombre = serializers.CharField(
+        source="ubicacion.nombre_ubicacion", read_only=True
+    )
+    horarios = CentroCueHorarioSerializer(many=True, read_only=True)
+    sesiones = CentroCueSesionSerializer(many=True, read_only=True)
+
+    class Meta:
+        model = Comision
+        fields = [
+            "id",
+            "ubicacion",
+            "ubicacion_nombre",
+            "codigo_comision",
+            "nombre",
+            "fecha_inicio",
+            "fecha_fin",
+            "cupo",
+            "acepta_lista_espera",
+            "estado",
+            "horarios",
+            "sesiones",
+            "observaciones",
+            "fecha_creacion",
+            "fecha_modificacion",
+        ]
+
+
+class CentroCueOfertaInstitucionalSerializer(serializers.ModelSerializer):
+    plan_curricular = CentroCuePlanSerializer(read_only=True)
+    programa_nombre = serializers.CharField(source="programa.nombre", read_only=True)
+    voucher_parametrias = CentroCueVoucherParametriaSerializer(many=True, read_only=True)
+    comisiones = CentroCueComisionSerializer(many=True, read_only=True)
+
+    class Meta:
+        model = OfertaInstitucional
+        fields = [
+            "id",
+            "plan_curricular",
+            "programa",
+            "programa_nombre",
+            "nombre_local",
+            "ciclo_lectivo",
+            "plan_externo_id",
+            "estado",
+            "costo",
+            "usa_voucher",
+            "voucher_parametrias",
+            "fecha_publicacion",
+            "comisiones",
+            "observaciones",
+            "fecha_creacion",
+            "fecha_modificacion",
+        ]
+
+
+class CentroCueContactoSerializer(serializers.ModelSerializer):
+    """Contacto institucional sin el documento personal del referente."""
+
+    class Meta:
+        model = InstitucionContacto
+        fields = [
+            "id",
+            "nombre_contacto",
+            "rol_area",
+            "telefono_contacto",
+            "email_contacto",
+            "tipo",
+            "valor",
+            "es_principal",
+            "observaciones",
+            "vigencia_desde",
+            "vigencia_hasta",
+            "fecha_creacion",
+            "fecha_modificacion",
+        ]
+
+
+class CentroCueUbicacionSerializer(serializers.ModelSerializer):
+    localidad_nombre = serializers.CharField(source="localidad.nombre", read_only=True)
+    municipio = serializers.IntegerField(source="localidad.municipio_id", read_only=True)
+    municipio_nombre = serializers.CharField(
+        source="localidad.municipio.nombre", read_only=True
+    )
+    provincia = serializers.IntegerField(
+        source="localidad.municipio.provincia_id", read_only=True
+    )
+    provincia_nombre = serializers.CharField(
+        source="localidad.municipio.provincia.nombre", read_only=True
+    )
+
+    class Meta:
+        model = InstitucionUbicacion
+        fields = [
+            "id",
+            "localidad",
+            "localidad_nombre",
+            "municipio",
+            "municipio_nombre",
+            "provincia",
+            "provincia_nombre",
+            "rol_ubicacion",
+            "nombre_ubicacion",
+            "domicilio",
+            "es_principal",
+            "latitud",
+            "longitud",
+            "observaciones",
+            "vigencia_desde",
+            "vigencia_hasta",
+            "fecha_creacion",
+            "fecha_modificacion",
+        ]
+
+
+class CentroCueIdentificadorSerializer(serializers.ModelSerializer):
+    ubicacion_nombre = serializers.CharField(
+        source="ubicacion.nombre_ubicacion", read_only=True, allow_null=True
+    )
+
+    class Meta:
+        model = InstitucionIdentificadorHist
+        fields = [
+            "id",
+            "tipo_identificador",
+            "valor_identificador",
+            "rol_institucional",
+            "ubicacion",
+            "ubicacion_nombre",
+            "es_actual",
+            "vigencia_desde",
+            "vigencia_hasta",
+            "motivo",
+            "fecha_creacion",
+            "fecha_modificacion",
+        ]
+
+
+class CentroCueDetalleSerializer(serializers.ModelSerializer):
+    """Ficha institucional/formativa expuesta únicamente en búsquedas por CUE."""
+
+    cue_consultado = serializers.SerializerMethodField()
+    cue_actual = serializers.SerializerMethodField()
+    coincidencias_cue = serializers.SerializerMethodField()
+    provincia_nombre = serializers.CharField(source="provincia.nombre", read_only=True)
+    municipio_nombre = serializers.CharField(source="municipio.nombre", read_only=True)
+    localidad_nombre = serializers.CharField(source="localidad.nombre", read_only=True)
+    responsable = serializers.SerializerMethodField()
+    identificadores = CentroCueIdentificadorSerializer(
+        source="identificadores_hist", many=True, read_only=True
+    )
+    contactos_institucionales = CentroCueContactoSerializer(
+        source="contactos_adicionales", many=True, read_only=True
+    )
+    ubicaciones = CentroCueUbicacionSerializer(many=True, read_only=True)
+    cursos = CentroCueCursoSerializer(many=True, read_only=True)
+    ofertas_institucionales = CentroCueOfertaInstitucionalSerializer(
+        many=True, read_only=True
+    )
+
+    class Meta:
+        model = Centro
+        fields = [
+            "id",
+            "cue_consultado",
+            "cue_actual",
+            "coincidencias_cue",
+            "nombre",
+            "codigo",
+            "activo",
+            "provincia",
+            "provincia_nombre",
+            "municipio",
+            "municipio_nombre",
+            "localidad",
+            "localidad_nombre",
+            "calle",
+            "numero",
+            "domicilio_actividad",
+            "codigo_postal",
+            "lote",
+            "manzana",
+            "entre_calles",
+            "telefono",
+            "celular",
+            "correo",
+            "sitio_web",
+            "responsable",
+            "tipo_gestion",
+            "clase_institucion",
+            "situacion",
+            "identificadores",
+            "contactos_institucionales",
+            "ubicaciones",
+            "cursos",
+            "ofertas_institucionales",
+        ]
+
+    def get_cue_consultado(self, _obj):
+        return self.context.get("cue")
+
+    def get_cue_actual(self, obj):
+        for identificador in obj.identificadores_hist.all():
+            if (
+                identificador.tipo_identificador == "cue"
+                and identificador.es_actual
+            ):
+                return identificador.valor_identificador
+        return obj.codigo
+
+    def get_coincidencias_cue(self, obj):
+        cue = self.context.get("cue")
+        coincidencias = []
+        for identificador in obj.identificadores_hist.all():
+            if (
+                identificador.tipo_identificador == "cue"
+                and identificador.valor_identificador == cue
+            ):
+                coincidencias.append(
+                    {
+                        "origen": "identificador_institucional",
+                        "identificador_id": identificador.id,
+                        "es_actual": identificador.es_actual,
+                        "vigencia_desde": identificador.vigencia_desde,
+                        "vigencia_hasta": identificador.vigencia_hasta,
+                    }
+                )
+        if obj.codigo == cue:
+            coincidencias.append(
+                {
+                    "origen": "codigo_legacy",
+                    "identificador_id": None,
+                    "es_actual": obj.codigo == self.get_cue_actual(obj),
+                    "vigencia_desde": None,
+                    "vigencia_hasta": None,
+                }
+            )
+        return coincidencias
+
+    def get_responsable(self, obj):
+        return {
+            "nombre": obj.nombre_referente,
+            "apellido": obj.apellido_referente,
+            "telefono": obj.telefono_referente,
+            "correo": obj.correo_referente,
+        }
+
+
 # ============================================================================
 # CURSOS (CAPA OPERATIVA)
 # ============================================================================

--- a/VAT/tests.py
+++ b/VAT/tests.py
@@ -4678,7 +4678,10 @@ def test_api_vat_centros_busca_por_cue_historico_y_devuelve_ficha_ampliada(
     assert detalle["cursos"][0]["comisiones"][0]["id"] == comision_curso.id
     assert detalle["cursos"][0]["comisiones"][0]["sesiones"][0]["id"]
     assert detalle["ofertas_institucionales"][0]["id"] == oferta.id
-    assert detalle["ofertas_institucionales"][0]["comisiones"][0]["id"] == comision_oferta.id
+    assert (
+        detalle["ofertas_institucionales"][0]["comisiones"][0]["id"]
+        == comision_oferta.id
+    )
 
 
 @pytest.mark.django_db
@@ -4806,7 +4809,17 @@ def test_api_vat_centros_cue_sin_coincidencias_mantiene_paginacion(vat_api_clien
 def test_api_vat_centros_cue_requiere_api_key(vat_curso_base):
     response = APIClient().get("/api/vat/centros/?cue=060144900")
 
-    assert response.status_code == 403
+    assert response.status_code == 401
+
+
+@pytest.mark.django_db
+def test_api_vat_centros_cue_rechaza_api_key_invalida(vat_curso_base):
+    client = APIClient()
+    client.credentials(HTTP_AUTHORIZATION="Api-Key clave-invalida")
+
+    response = client.get("/api/vat/centros/?cue=060144900")
+
+    assert response.status_code == 401
 
 
 @pytest.mark.django_db

--- a/VAT/tests.py
+++ b/VAT/tests.py
@@ -4520,6 +4520,296 @@ def test_api_vat_centros_lista_con_api_key(vat_api_client, vat_curso_base):
 
 
 @pytest.mark.django_db
+def test_api_vat_centros_busca_por_cue_historico_y_devuelve_ficha_ampliada(
+    vat_api_client, vat_curso_base
+):
+    centro, ubicacion, modalidad = vat_curso_base
+    sector = Sector.objects.create(nombre="Tecnología")
+    plan = PlanVersionCurricular.objects.create(
+        provincia=centro.provincia,
+        nombre="Plan de prueba CUE",
+        sector=sector,
+        modalidad_cursada=modalidad,
+        normativa="Resolución 10/2026",
+        horas_reloj=120,
+        nivel_requerido="Primario completo",
+        nivel_certifica="Formación profesional",
+        activo=True,
+    )
+    titulo = TituloReferencia.objects.create(
+        codigo_referencia="T-001",
+        nombre="Título de prueba CUE",
+        plan_estudio=plan,
+        activo=True,
+    )
+    contacto = InstitucionContacto.objects.create(
+        centro=centro,
+        tipo="email",
+        valor="contacto-institucional@vat.test",
+        nombre_contacto="Contacto Institucional",
+        rol_area="Secretaría",
+        documento="30111222",
+        email_contacto="contacto-institucional@vat.test",
+        es_principal=True,
+    )
+    cue_actual = InstitucionIdentificadorHist.objects.create(
+        centro=centro,
+        tipo_identificador="cue",
+        valor_identificador="060144900",
+        rol_institucional="sede",
+        ubicacion=ubicacion,
+        es_actual=True,
+    )
+    cue_historico = InstitucionIdentificadorHist.objects.create(
+        centro=centro,
+        tipo_identificador="cue",
+        valor_identificador="060144899",
+        rol_institucional="sede",
+        ubicacion=ubicacion,
+        es_actual=False,
+        vigencia_hasta=date.today(),
+        motivo="Reasignación administrativa",
+    )
+    programa = Programa.objects.create(nombre="Programa CUE API")
+    usuario = User.objects.create_user(username="creador-parametria-cue")
+    parametria = VoucherParametria.objects.create(
+        nombre="Parametría CUE API",
+        programa=programa,
+        cantidad_inicial=3,
+        fecha_vencimiento=date.today() + timedelta(days=30),
+        creado_por=usuario,
+    )
+    curso = Curso.objects.create(
+        centro=centro,
+        plan_estudio=plan,
+        nombre="Curso asociado al CUE",
+        modalidad=modalidad,
+        usa_voucher=True,
+        costo_creditos=1,
+        estado="activo",
+    )
+    curso.voucher_parametrias.add(parametria)
+    comision_curso = ComisionCurso.objects.create(
+        curso=curso,
+        ubicacion=ubicacion,
+        codigo_comision="CUR-CUE-01",
+        nombre="Comisión de curso CUE",
+        cupo_total=20,
+        fecha_inicio=date.today(),
+        fecha_fin=date.today() + timedelta(days=30),
+        estado="activa",
+    )
+    horario_curso = ComisionHorario.objects.create(
+        comision_curso=comision_curso,
+        dia_semana=Dia.objects.create(nombre="Lunes"),
+        hora_desde=time(9, 0),
+        hora_hasta=time(11, 0),
+        aula_espacio="Aula 1",
+    )
+    SesionComision.objects.create(
+        comision_curso=comision_curso,
+        horario=horario_curso,
+        numero_sesion=1,
+        fecha=date.today(),
+        estado="programada",
+    )
+    oferta = OfertaInstitucional.objects.create(
+        centro=centro,
+        plan_curricular=plan,
+        programa=programa,
+        ciclo_lectivo=2026,
+        estado="publicada",
+    )
+    oferta.voucher_parametrias.add(parametria)
+    comision_oferta = Comision.objects.create(
+        oferta=oferta,
+        ubicacion=ubicacion,
+        codigo_comision="OFE-CUE-01",
+        nombre="Comisión de oferta CUE",
+        fecha_inicio=date.today(),
+        fecha_fin=date.today() + timedelta(days=30),
+        cupo=25,
+        estado="activa",
+    )
+    horario_oferta = ComisionHorario.objects.create(
+        comision=comision_oferta,
+        dia_semana=Dia.objects.create(nombre="Martes"),
+        hora_desde=time(14, 0),
+        hora_hasta=time(16, 0),
+        aula_espacio="Aula 2",
+    )
+    SesionComision.objects.create(
+        comision=comision_oferta,
+        horario=horario_oferta,
+        numero_sesion=1,
+        fecha=date.today(),
+        estado="programada",
+    )
+
+    response = vat_api_client.get("/api/vat/centros/?cue=60144899")
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["count"] == 1
+    detalle = payload["results"][0]
+    assert detalle["id"] == centro.id
+    assert detalle["cue_consultado"] == cue_historico.valor_identificador
+    assert detalle["cue_actual"] == cue_actual.valor_identificador
+    assert detalle["coincidencias_cue"] == [
+        {
+            "origen": "identificador_institucional",
+            "identificador_id": cue_historico.id,
+            "es_actual": False,
+            "vigencia_desde": cue_historico.vigencia_desde.isoformat(),
+            "vigencia_hasta": cue_historico.vigencia_hasta.isoformat(),
+        }
+    ]
+    assert detalle["identificadores"][0]["id"] == cue_actual.id
+    assert detalle["contactos_institucionales"][0]["id"] == contacto.id
+    assert "documento" not in detalle["contactos_institucionales"][0]
+    assert "documento" not in json.dumps(detalle)
+    assert "autoridad_dni" not in detalle
+    assert "referente" not in detalle
+    assert "referentes" not in detalle
+    assert detalle["ubicaciones"][0]["id"] == ubicacion.id
+    assert detalle["cursos"][0]["id"] == curso.id
+    assert detalle["cursos"][0]["plan_estudio"]["titulos"][0]["id"] == titulo.id
+    assert detalle["cursos"][0]["voucher_parametrias"][0]["id"] == parametria.id
+    assert detalle["cursos"][0]["comisiones"][0]["id"] == comision_curso.id
+    assert detalle["cursos"][0]["comisiones"][0]["sesiones"][0]["id"]
+    assert detalle["ofertas_institucionales"][0]["id"] == oferta.id
+    assert detalle["ofertas_institucionales"][0]["comisiones"][0]["id"] == comision_oferta.id
+
+
+@pytest.mark.django_db
+def test_api_vat_centros_busca_por_cue_vigente(vat_api_client, vat_curso_base):
+    centro, ubicacion, _ = vat_curso_base
+    cue_actual = InstitucionIdentificadorHist.objects.create(
+        centro=centro,
+        tipo_identificador="cue",
+        valor_identificador="060144900",
+        rol_institucional="sede",
+        ubicacion=ubicacion,
+        es_actual=True,
+    )
+
+    response = vat_api_client.get("/api/vat/centros/?cue=60144900")
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["count"] == 1
+    detalle = payload["results"][0]
+    assert detalle["cue_actual"] == cue_actual.valor_identificador
+    assert detalle["coincidencias_cue"] == [
+        {
+            "origen": "identificador_institucional",
+            "identificador_id": cue_actual.id,
+            "es_actual": True,
+            "vigencia_desde": cue_actual.vigencia_desde.isoformat(),
+            "vigencia_hasta": None,
+        }
+    ]
+
+
+@pytest.mark.django_db
+def test_api_vat_centros_busca_por_codigo_legacy(vat_api_client, vat_curso_base):
+    centro, _, _ = vat_curso_base
+    centro.codigo = "060144901"
+    centro.save(update_fields=["codigo"])
+
+    response = vat_api_client.get("/api/vat/centros/?cue=60144901")
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["count"] == 1
+    detalle = payload["results"][0]
+    assert detalle["cue_actual"] == centro.codigo
+    assert detalle["coincidencias_cue"] == [
+        {
+            "origen": "codigo_legacy",
+            "identificador_id": None,
+            "es_actual": True,
+            "vigencia_desde": None,
+            "vigencia_hasta": None,
+        }
+    ]
+
+
+@pytest.mark.django_db
+def test_api_vat_centros_cue_duplicado_mantiene_paginacion(
+    vat_api_client, vat_curso_base
+):
+    centro, ubicacion, _ = vat_curso_base
+    otro_centro = Centro.objects.create(
+        nombre="CFP 502",
+        codigo="CFP-502",
+        provincia=centro.provincia,
+        municipio=centro.municipio,
+        localidad=centro.localidad,
+        domicilio_actividad="Calle 9 N° 222",
+        telefono="221-2222222",
+        celular="221-2222223",
+        correo="cfp502@vat.test",
+        nombre_referente="Juan",
+        apellido_referente="Pérez",
+        telefono_referente="221-2222224",
+        correo_referente="juan@vat.test",
+    )
+    otra_ubicacion = InstitucionUbicacion.objects.create(
+        centro=otro_centro,
+        localidad=centro.localidad,
+        rol_ubicacion="sede_principal",
+        domicilio="Calle 9 N° 222",
+        es_principal=True,
+    )
+    for centro_cue, centro_ubicacion in [
+        (centro, ubicacion),
+        (otro_centro, otra_ubicacion),
+    ]:
+        InstitucionIdentificadorHist.objects.create(
+            centro=centro_cue,
+            tipo_identificador="cue",
+            valor_identificador="060144902",
+            rol_institucional="sede",
+            ubicacion=centro_ubicacion,
+            es_actual=True,
+        )
+
+    response = vat_api_client.get("/api/vat/centros/?cue=60144902&page_size=1")
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["count"] == 2
+    assert len(payload["results"]) == 1
+    assert payload["next"]
+
+
+@pytest.mark.django_db
+@pytest.mark.parametrize("cue", ["", "CUE-INVALIDO", "0601449000"])
+def test_api_vat_centros_cue_invalido_retorna_400(vat_api_client, cue):
+    response = vat_api_client.get(f"/api/vat/centros/?cue={cue}")
+
+    assert response.status_code == 400
+    assert "cue" in response.json()
+
+
+@pytest.mark.django_db
+def test_api_vat_centros_cue_sin_coincidencias_mantiene_paginacion(vat_api_client):
+    response = vat_api_client.get("/api/vat/centros/?cue=060199999")
+
+    assert response.status_code == 200
+    assert response.json()["count"] == 0
+    assert response.json()["results"] == []
+
+
+@pytest.mark.django_db
+def test_api_vat_centros_cue_requiere_api_key(vat_curso_base):
+    response = APIClient().get("/api/vat/centros/?cue=060144900")
+
+    assert response.status_code == 403
+
+
+@pytest.mark.django_db
 def test_api_vat_cursos_lista_por_centro(vat_api_client, vat_curso_base):
     centro, _, modalidad = vat_curso_base
     curso = Curso.objects.create(

--- a/docs/contexto/features/pr-2352-feat-vat-buscar-centros-por-cue.md
+++ b/docs/contexto/features/pr-2352-feat-vat-buscar-centros-por-cue.md
@@ -1,0 +1,54 @@
+# Contexto de feature PR #2352 - feat(vat): buscar centros por CUE
+
+## Resumen
+
+- PR: https://github.com/dsocial118/SISOC/pull/2352
+- Base: `development`
+- Rama origen: `codex/vat-cue-lookup`
+- Autor: `juanikitro`
+
+## Contexto funcional
+
+- No informado explícitamente; inferir desde el título del PR y el diff.
+
+## Arquitectura tocada
+
+- Hay cambios en capa API/DRF y conviene revisar contratos de request/response.
+- Hay cambios en vistas web y puede existir impacto en permisos o renderizado.
+
+## Decisiones y supuestos detectados
+
+- Tipo de cambio declarado: No informado
+- Área principal declarada: No informada
+- Impacto usuario declarado: No informado
+- Riesgos / rollback: No informado
+
+## Design system y UI
+
+- Sin cambios visibles de UI o design system detectados en el diff.
+
+## Memoria operativa para agentes
+
+- Empezar por `docs/registro/prs/PR-2352.md` para contexto resumido del PR.
+- Revisar primero estos archivos del diff:
+- `AGENT_REPO_MAP.md`
+- `VAT/api_views.py`
+- `VAT/serializers.py`
+- `VAT/tests.py`
+- `docs/plans/2026-08-26-vat-busqueda-centro-por-cue-design.md`
+- `docs/registro/cambios/2026-08-26-vat-busqueda-centro-por-cue.md`
+- `postman/Local.postman_environment.json`
+- `postman/SISOC APIs.postman_collection.json`
+- `postman/api_inventory.md`
+- Documentación sugerida para ampliar contexto:
+- `docs/indice.md`
+- `docs/ia/CONTEXT_HYGIENE.md`
+- `docs/ia/ARCHITECTURE.md`
+- `docs/ia/TESTING.md`
+- `docs/plans/2026-08-26-vat-busqueda-centro-por-cue-design.md`
+- `docs/registro/cambios/2026-08-26-vat-busqueda-centro-por-cue.md`
+
+## Trazabilidad
+
+- Documento generado automáticamente desde el evento de `pull_request`.
+- Si este PR cambia de título, el archivo se renombrará para mantener el slug alineado.

--- a/docs/contexto/features/pr-2352-feat-vat-buscar-centros-por-cue.md
+++ b/docs/contexto/features/pr-2352-feat-vat-buscar-centros-por-cue.md
@@ -35,8 +35,10 @@
 - `VAT/api_views.py`
 - `VAT/serializers.py`
 - `VAT/tests.py`
+- `docs/contexto/features/pr-2352-feat-vat-buscar-centros-por-cue.md`
 - `docs/plans/2026-08-26-vat-busqueda-centro-por-cue-design.md`
 - `docs/registro/cambios/2026-08-26-vat-busqueda-centro-por-cue.md`
+- `docs/registro/prs/PR-2352.md`
 - `postman/Local.postman_environment.json`
 - `postman/SISOC APIs.postman_collection.json`
 - `postman/api_inventory.md`
@@ -45,8 +47,10 @@
 - `docs/ia/CONTEXT_HYGIENE.md`
 - `docs/ia/ARCHITECTURE.md`
 - `docs/ia/TESTING.md`
+- `docs/contexto/features/pr-2352-feat-vat-buscar-centros-por-cue.md`
 - `docs/plans/2026-08-26-vat-busqueda-centro-por-cue-design.md`
 - `docs/registro/cambios/2026-08-26-vat-busqueda-centro-por-cue.md`
+- `docs/registro/prs/PR-2352.md`
 
 ## Trazabilidad
 

--- a/docs/plans/2026-08-26-vat-busqueda-centro-por-cue-design.md
+++ b/docs/plans/2026-08-26-vat-busqueda-centro-por-cue-design.md
@@ -1,0 +1,50 @@
+# Búsqueda integral de Centros VAT por CUE
+
+Fecha: 2026-08-26
+
+## Objetivo
+
+Permitir que una integración o una persona consulte un Centro VAT mediante su
+CUE sin introducir una ruta nueva: `GET /api/vat/centros/?cue=<CUE>`.
+
+## Contrato aprobado
+
+- Conserva la paginación actual de `/api/vat/centros/` (`count`, `next`,
+  `previous`, `results`).
+- Sin `cue`, mantiene el serializer y comportamiento previos.
+- Con `cue`, normaliza un valor numérico de hasta nueve dígitos completando
+  ceros a la izquierda y realiza coincidencia exacta.
+- Busca el CUE en `InstitucionIdentificadorHist` tanto vigente como histórico,
+  y también en `Centro.codigo` como compatibilidad para datos legacy.
+- Devuelve cada Centro coincidente con una ficha institucional/formativa
+  ampliada. Si existiera un dato anómalo que relacione un CUE con más de un
+  Centro, la semántica de listado devuelve todos los resultados.
+
+## Información incluida
+
+- Identidad, ubicación, contacto institucional y responsable del Centro.
+- CUE consultado, CUE actual, identificadores vigentes/históricos y origen de
+  la coincidencia.
+- Sedes, anexos, dependencias y puntos de atención.
+- Cursos, planes, títulos, modalidades, parametrías de voucher institucionales
+  y sus comisiones, horarios y sesiones.
+- Oferta institucional legacy y sus comisiones, horarios y sesiones.
+
+## Privacidad y autorización
+
+El endpoint conserva `HasAPIKey`. No expone alumnos, ciudadanos, inscripciones,
+evaluaciones, resultados, vouchers individuales, usuarios internos ni el
+documento de los contactos institucionales.
+
+## Errores y compatibilidad
+
+- `400` para `cue` vacío, no numérico o de más de nueve dígitos.
+- `200` con `count: 0` cuando no hay coincidencias.
+- No se cambian modelos, migraciones, permisos ni los recursos CRUD existentes.
+
+## Validación prevista
+
+- CUE vigente e histórico, incluido normalizado sin ceros iniciales.
+- Sin coincidencias, valor inválido y ausencia de API key.
+- Paginación habitual y presencia de las relaciones institucionales/formativas.
+- Ausencia del documento de contacto y de recursos personales.

--- a/docs/plans/2026-08-26-vat-busqueda-centro-por-cue-design.md
+++ b/docs/plans/2026-08-26-vat-busqueda-centro-por-cue-design.md
@@ -40,6 +40,7 @@ documento de los contactos institucionales.
 
 - `400` para `cue` vacío, no numérico o de más de nueve dígitos.
 - `200` con `count: 0` cuando no hay coincidencias.
+- `401` cuando falta la API key o es inválida.
 - No se cambian modelos, migraciones, permisos ni los recursos CRUD existentes.
 
 ## Validación prevista

--- a/docs/registro/cambios/2026-08-26-vat-busqueda-centro-por-cue.md
+++ b/docs/registro/cambios/2026-08-26-vat-busqueda-centro-por-cue.md
@@ -1,0 +1,46 @@
+# Consulta integral de Centros VAT por CUE
+
+Fecha: 2026-08-26
+
+## Cambio funcional
+
+`GET /api/vat/centros/?cue=<CUE>` permite resolver un Centro por su CUE vigente
+o histórico sin cambiar la ruta ni la paginación del listado. Con el parámetro
+presente, la respuesta amplía la ficha con las relaciones institucionales y
+formativas del Centro.
+
+La colección Postman incluye un request de consulta y la variable `cue` en el
+ambiente Local.
+
+## Seguridad y datos excluidos
+
+La autorización continúa siendo mediante API Key. La respuesta no incorpora
+alumnos, ciudadanos, inscripciones, evaluaciones, resultados, vouchers
+individuales, usuarios internos ni el documento de contactos institucionales.
+
+## Compatibilidad
+
+Las consultas sin `cue` conservan el serializer y el resultado anteriores. La
+consulta por CUE devuelve la misma envoltura paginada y un resultado vacío para
+un CUE inexistente.
+
+## Validación
+
+- JSON de la colección y ambiente Postman válido.
+- Compilación sintáctica de los módulos Python modificados válida.
+- Se añadieron tests focalizados de CUE vigente e histórico normalizado,
+  compatibilidad por `Centro.codigo`, resultados duplicados paginados, error de
+  formato, resultado vacío, autenticación y exclusión del documento de contacto.
+
+La ejecución de pytest local quedó bloqueada antes de descubrir los tests:
+el Python global no tiene `django-crispy-forms`, dependencia declarada por el
+proyecto. No se instaló ni se levantó Docker para no modificar el entorno sin
+autorización; CI ejecutará la suite en la imagen del proyecto.
+
+## Riesgo operativo pendiente
+
+El alcance aprobado no incorpora una migración. Antes de una carga de datos
+grande conviene medir este filtro con `EXPLAIN` en la base real: la búsqueda por
+`InstitucionIdentificadorHist.tipo_identificador` y
+`valor_identificador` podría requerir un índice compuesto específico si el
+volumen de identificadores crece.

--- a/docs/registro/cambios/2026-08-26-vat-busqueda-centro-por-cue.md
+++ b/docs/registro/cambios/2026-08-26-vat-busqueda-centro-por-cue.md
@@ -30,7 +30,8 @@ un CUE inexistente.
 - Compilación sintáctica de los módulos Python modificados válida.
 - Se añadieron tests focalizados de CUE vigente e histórico normalizado,
   compatibilidad por `Centro.codigo`, resultados duplicados paginados, error de
-  formato, resultado vacío, autenticación y exclusión del documento de contacto.
+  formato, resultado vacío, autenticación por API key ausente o inválida y
+  exclusión del documento de contacto.
 
 La ejecución de pytest local quedó bloqueada antes de descubrir los tests:
 el Python global no tiene `django-crispy-forms`, dependencia declarada por el

--- a/docs/registro/prs/PR-2352.md
+++ b/docs/registro/prs/PR-2352.md
@@ -19,6 +19,7 @@
 
 - `AGENT_REPO_MAP.md`
 - `VAT`
+- `docs/contexto`
 - `docs/plans`
 - `docs/registro`
 - `postman`
@@ -29,8 +30,10 @@
 - `VAT/api_views.py`
 - `VAT/serializers.py`
 - `VAT/tests.py`
+- `docs/contexto/features/pr-2352-feat-vat-buscar-centros-por-cue.md`
 - `docs/plans/2026-08-26-vat-busqueda-centro-por-cue-design.md`
 - `docs/registro/cambios/2026-08-26-vat-busqueda-centro-por-cue.md`
+- `docs/registro/prs/PR-2352.md`
 - `postman/Local.postman_environment.json`
 - `postman/SISOC APIs.postman_collection.json`
 - `postman/api_inventory.md`
@@ -50,8 +53,10 @@
 - `docs/ia/CONTEXT_HYGIENE.md`
 - `docs/ia/ARCHITECTURE.md`
 - `docs/ia/TESTING.md`
+- `docs/contexto/features/pr-2352-feat-vat-buscar-centros-por-cue.md`
 - `docs/plans/2026-08-26-vat-busqueda-centro-por-cue-design.md`
 - `docs/registro/cambios/2026-08-26-vat-busqueda-centro-por-cue.md`
+- `docs/registro/prs/PR-2352.md`
 
 ## Notas para continuidad
 

--- a/docs/registro/prs/PR-2352.md
+++ b/docs/registro/prs/PR-2352.md
@@ -1,0 +1,59 @@
+# PR #2352 - feat(vat): buscar centros por CUE
+
+## Metadata
+
+- PR: https://github.com/dsocial118/SISOC/pull/2352
+- Base: `development`
+- Rama origen: `codex/vat-cue-lookup`
+- Autor: `juanikitro`
+
+## Resumen operativo
+
+- Tipo de cambio: No informado
+- Área principal: No informada
+- Contexto funcional: No informado explícitamente; revisar título, diff y documentación relacionada.
+- Resumen para changelog: No informado
+- Impacto usuario: No informado
+
+## Áreas afectadas
+
+- `AGENT_REPO_MAP.md`
+- `VAT`
+- `docs/plans`
+- `docs/registro`
+- `postman`
+
+## Archivos relevantes del diff
+
+- `AGENT_REPO_MAP.md`
+- `VAT/api_views.py`
+- `VAT/serializers.py`
+- `VAT/tests.py`
+- `docs/plans/2026-08-26-vat-busqueda-centro-por-cue-design.md`
+- `docs/registro/cambios/2026-08-26-vat-busqueda-centro-por-cue.md`
+- `postman/Local.postman_environment.json`
+- `postman/SISOC APIs.postman_collection.json`
+- `postman/api_inventory.md`
+
+## Validación declarada
+
+- Pruebas automáticas: No informado en el PR.
+- Pruebas manuales: No informado en el PR.
+
+## Riesgos y rollback
+
+- No informado explícitamente en el PR.
+
+## Documentación sugerida para lectura
+
+- `docs/indice.md`
+- `docs/ia/CONTEXT_HYGIENE.md`
+- `docs/ia/ARCHITECTURE.md`
+- `docs/ia/TESTING.md`
+- `docs/plans/2026-08-26-vat-busqueda-centro-por-cue-design.md`
+- `docs/registro/cambios/2026-08-26-vat-busqueda-centro-por-cue.md`
+
+## Notas para continuidad
+
+- Este documento es generado automáticamente desde el contexto del PR y sirve como índice rápido para revisión y futuras sesiones de agentes.
+- Si la metadata del body del PR está incompleta, varias secciones usarán fallbacks derivados del título o del diff.

--- a/postman/Local.postman_environment.json
+++ b/postman/Local.postman_environment.json
@@ -33,6 +33,12 @@
 			"enabled": true
 		},
 		{
+			"key": "cue",
+			"value": "",
+			"description": "CUE para buscar un Centro VAT, vigente o histórico. Admite hasta nueve dígitos y completa ceros a la izquierda.",
+			"enabled": true
+		},
+		{
 			"key": "centro_id",
 			"value": "1",
 			"description": "ID de un Centro VAT/INET (también puede usarse en otras carpetas SISOC según el request).",

--- a/postman/SISOC APIs.postman_collection.json
+++ b/postman/SISOC APIs.postman_collection.json
@@ -3998,6 +3998,66 @@
                   "response": []
                 },
                 {
+                  "name": "Buscar centro por CUE (ficha completa)",
+                  "request": {
+                    "method": "GET",
+                    "header": [
+                      {
+                        "key": "Authorization",
+                        "value": "Api-Key {{apiKey}}",
+                        "type": "text",
+                        "description": "API key VAT."
+                      }
+                    ],
+                    "url": {
+                      "raw": "{{vatBaseUrl}}{{apiPrefix}}/vat/centros/?cue={{cue}}",
+                      "host": [
+                        "{{vatBaseUrl}}{{apiPrefix}}"
+                      ],
+                      "path": [
+                        "vat",
+                        "centros",
+                        ""
+                      ],
+                      "query": [
+                        {
+                          "key": "cue",
+                          "value": "{{cue}}",
+                          "description": "CUE numérico de hasta nueve dígitos. Busca coincidencia exacta tanto en el CUE vigente como en el histórico; puede enviarse sin ceros iniciales.",
+                          "disabled": false
+                        },
+                        {
+                          "key": "activo",
+                          "value": "true",
+                          "description": "Filtro adicional opcional por estado del Centro.",
+                          "disabled": true
+                        }
+                      ]
+                    },
+                    "description": "Devuelve la ficha completa del Centro relacionado con el CUE, sin cambiar la paginación habitual. Incluye institución, identificadores, ubicaciones, contactos institucionales, cursos, comisiones, planes, títulos y oferta institucional. No expone alumnos, inscripciones, evaluaciones, vouchers individuales ni documentos de contactos.\n\nSi el CUE encontrado es histórico, `cue_actual` indica el vigente y `coincidencias_cue` explica la coincidencia."
+                  },
+                  "event": [
+                    {
+                      "listen": "test",
+                      "script": {
+                        "type": "text/javascript",
+                        "exec": [
+                          "pm.test('Status code 200', function () { pm.response.to.have.status(200); });",
+                          "const body = pm.response.json();",
+                          "const rows = body.results || [];",
+                          "pm.test('La respuesta mantiene la paginación', function () { pm.expect(Array.isArray(rows)).to.eql(true); });",
+                          "if (rows.length && rows[0].id !== undefined) {",
+                          "  const value = String(rows[0].id);",
+                          "  pm.collectionVariables.set('centro_id', value);",
+                          "  if (pm.environment && pm.environment.name) { pm.environment.set('centro_id', value); }",
+                          "}"
+                        ]
+                      }
+                    }
+                  ],
+                  "response": []
+                },
+                {
                   "name": "Crear centro",
                   "request": {
                     "method": "POST",

--- a/postman/api_inventory.md
+++ b/postman/api_inventory.md
@@ -1,7 +1,7 @@
 # API Inventory — SISOC
 
 Todas las APIs (internas y externas) están documentadas en la colección única:
-**`SISOC APIs.postman_collection.json`** · 243 requests · 11 carpetas · entorno: `Local.postman_environment.json`
+**`SISOC APIs.postman_collection.json`** · 244 requests · 11 carpetas · entorno: `Local.postman_environment.json`
 
 ---
 
@@ -17,19 +17,19 @@ Todas las APIs (internas y externas) están documentadas en la colección única
 | Relevamientos | 2 | PATCH relevamiento + primer seguimiento (`/api/relevamiento`) |
 | PWA | 33 | Health, push, colaboradores, actividades, formación, mensajes, nómina (`/api/espacios/`) |
 | Ticketera | 3 | Alta usuario, verificar auth, cambiar password (`/api/ticketera/`) |
-| VAT | 147 | Cobertura completa del router público VAT; ver detalle abajo |
+| VAT | 148 | Cobertura completa del router público VAT; ver detalle abajo |
 | Integraciones Externas | 12 | GESTIONAR (AppSheet) + RENAPER API externa |
 | Docs | 2 | OpenAPI schema SISOC + VAT (`/api/schema/`) |
 
 ---
 
-## VAT (147 requests)
+## VAT (148 requests)
 
 | Subcarpeta | Requests | Endpoints principales |
 |-----------|----------|----------------------|
 | 0 - Guía de uso y autenticación | 0 | configuración, autenticación, encadenamiento de IDs y advertencias para escrituras |
 | 1 - API operativa - Geografía | 6 | provincias, municipios y localidades; list y retrieve |
-| 2 - API operativa - Centros e institución | 25 | centros, acción `activos`, contactos, identificadores y ubicaciones institucionales; CRUD completo |
+| 2 - API operativa - Centros e institución | 26 | centros, búsqueda por CUE vigente/histórico, acción `activos`, contactos, identificadores y ubicaciones institucionales; CRUD completo |
 | 3 - API operativa - Catálogos y planes | 36 | modalidades institucionales/de cursada, sectores, subsectores, títulos y planes curriculares; CRUD completo |
 | 4 - API operativa - Cursos y comisiones | 14 | cursos, `buscar`, `prioritarios` y comisiones de curso; CRUD completo |
 | 5 - API operativa - Oferta institucional | 18 | ofertas institucionales, comisiones legacy y horarios; CRUD completo |
@@ -41,6 +41,11 @@ La cobertura corresponde a los métodos de negocio registrados en
 `VAT/api_urls.py`: GET, POST, PUT, PATCH y DELETE según cada ViewSet, más sus
 acciones custom. No se duplican HEAD/OPTIONS generados automáticamente por DRF y
 no se incluyen vistas HTML ni AJAX internas de `VAT/urls.py`.
+
+La consulta `GET /api/vat/centros/?cue=<CUE>` mantiene la paginación habitual y
+devuelve la ficha institucional/formativa ampliada del Centro. Busca CUE vigente,
+histórico o código legacy, y excluye alumnos, inscripciones, evaluaciones,
+vouchers individuales y documentos de contactos.
 
 ---
 
@@ -71,6 +76,7 @@ no se incluyen vistas HTML ni AJAX internas de `VAT/urls.py`.
 | `authToken` | Token sesión Django — formato: `Token <valor>` |
 | `apiKey` | Api-Key DRF — formato header: `Api-Key <valor>` |
 | `allowVatMutations` | Guard del ambiente activo; `false` omite POST/PUT/PATCH/DELETE VAT |
+| `cue` | CUE para buscar un Centro VAT, vigente o histórico |
 
 ### IDs de entidades SISOC
 


### PR DESCRIPTION
## Objetivo

Incorpora la búsqueda integral de centros VAT mediante `GET /api/vat/centros/?cue=<CUE>` sin agregar una ruta nueva.

## Comportamiento

- Conserva el envoltorio paginado habitual (`count`, `next`, `previous`, `results`).
- Normaliza CUE numérico de hasta 9 dígitos con ceros a la izquierda.
- Resuelve CUE vigente, histórico y `Centro.codigo` como compatibilidad legacy.
- Devuelve identidad institucional, responsable y contacto institucional, identificadores, ubicaciones, cursos, planes, títulos, parametrías institucionales, comisiones, horarios, sesiones y oferta legacy.
- Excluye alumnos, ciudadanos, inscripciones, evaluaciones, resultados, vouchers individuales, usuarios internos y documento de contactos.
- Actualiza la colección Postman e inventario para el request de consulta.

## Cobertura

- CUE vigente e histórico normalizado.
- Fallback legacy.
- Caso anómalo con más de un Centro y paginación.
- CUE vacío, alfanumérico o demasiado largo; sin resultados; ausencia de API key.

## Validación local

- `py -3 -m compileall -q VAT/api_views.py VAT/serializers.py VAT/tests.py` ✅
- JSON de colección y ambiente Postman validado ✅
- `git diff --check` ✅
- `py -3 -m pytest VAT/tests.py -k "centros_cue or busca_por_cue" -q` no llegó a descubrir tests: el Python global no tiene `django-crispy-forms`. No se instaló dependencia ni se levantó Docker sin autorización.

## Riesgo a seguir

El alcance aprobado no suma migraciones. Antes de una carga grande, medir con `EXPLAIN` la búsqueda histórica; podría requerir un índice compuesto sobre tipo/valor del identificador.