### PR TITLE
Celiaquia tk2320 y 2319

### DIFF
--- a/celiaquia/services/expediente_filter_config/__init__.py
+++ b/celiaquia/services/expediente_filter_config/__init__.py
@@ -1,0 +1,23 @@
+"""Configuración de filtros combinables del listado de expedientes."""
+
+from .impl import (
+    CHOICE_OPS,
+    DATE_OPS,
+    FIELD_MAP,
+    FIELD_TYPES,
+    FILTER_FIELDS,
+    NUM_OPS,
+    TEXT_OPS,
+    get_filters_ui_config,
+)
+
+__all__ = [
+    "CHOICE_OPS",
+    "DATE_OPS",
+    "FIELD_MAP",
+    "FIELD_TYPES",
+    "FILTER_FIELDS",
+    "NUM_OPS",
+    "TEXT_OPS",
+    "get_filters_ui_config",
+]

--- a/celiaquia/services/expediente_filter_config/impl.py
+++ b/celiaquia/services/expediente_filter_config/impl.py
@@ -1,0 +1,131 @@
+"""Configuración de filtros combinables para el listado de expedientes.
+
+Los campos expuestos siguen las columnas de la grilla para que el usuario filtre
+por lo mismo que ve. ``provincia`` apunta a la anotación ``provincia_derivada``
+del queryset (y no a un join con los legajos) porque el expediente no tiene
+provincia propia: se deriva de sus ciudadanos, con respaldo en el perfil legacy
+del usuario creador.
+"""
+
+from typing import Any, Dict
+
+# Mapea el identificador expuesto en la UI -> lookup real del ORM.
+FIELD_MAP: Dict[str, str] = {
+    "id": "id",
+    "numero_expediente": "numero_expediente",
+    "fecha_creacion": "fecha_creacion__date",
+    "provincia": "provincia_derivada",
+    "estado": "estado__nombre",
+    "tecnico": "asignaciones_tecnicos__tecnico__username",
+}
+
+FIELD_TYPES: Dict[str, str] = {
+    "id": "number",
+    "numero_expediente": "text",
+    "fecha_creacion": "date",
+    "provincia": "choice",
+    "estado": "choice",
+    "tecnico": "choice",
+}
+
+TEXT_OPS = ["contains", "ncontains", "eq", "ne", "empty"]
+NUM_OPS = ["eq", "ne", "gt", "lt", "empty"]
+DATE_OPS = ["eq", "ne", "gt", "lt", "empty"]
+CHOICE_OPS = ["eq", "ne", "empty"]
+
+FILTER_FIELDS = [
+    {"name": "id", "label": "ID", "type": "number"},
+    {"name": "numero_expediente", "label": "Número de expediente", "type": "text"},
+    {"name": "fecha_creacion", "label": "Fecha de creación", "type": "date"},
+    {"name": "provincia", "label": "Provincia", "type": "choice"},
+    {"name": "estado", "label": "Estado", "type": "choice"},
+    {"name": "tecnico", "label": "Técnico asignado", "type": "choice"},
+]
+
+
+def _estado_choices():
+    from celiaquia.models import (  # pylint: disable=import-outside-toplevel
+        EstadoExpediente,
+    )
+
+    return [
+        {"value": estado.nombre, "label": estado.display_name()}
+        for estado in EstadoExpediente.objects.order_by("nombre")
+    ]
+
+
+def _provincia_choices():
+    from core.models import Provincia  # pylint: disable=import-outside-toplevel
+
+    return [
+        {"value": nombre, "label": nombre}
+        for nombre in Provincia.objects.order_by("nombre").values_list(
+            "nombre", flat=True
+        )
+        if nombre
+    ]
+
+
+def _tecnico_choices(tecnicos):
+    return [
+        {
+            "value": tecnico.username,
+            "label": tecnico.get_full_name() or tecnico.username,
+        }
+        for tecnico in tecnicos
+    ]
+
+
+def get_filters_ui_config(*, tecnicos=None) -> Dict[str, Any]:
+    """Configuración serializable para la UI de filtros combinables.
+
+    ``tecnicos`` es el listado de técnicos seleccionables. Si viene vacío o en
+    ``None`` el campo "Técnico asignado" no se ofrece, de modo que quien no ve la
+    columna de técnico tampoco pueda filtrar por ella.
+    """
+
+    choices_by_field = {
+        "estado": _estado_choices(),
+        "provincia": _provincia_choices(),
+        "tecnico": _tecnico_choices(tecnicos or []),
+    }
+
+    fields = []
+    for field in FILTER_FIELDS:
+        name = field["name"]
+        choices = choices_by_field.get(name)
+        if field["type"] == "choice":
+            if not choices:
+                continue
+            field = {**field, "choices": choices}
+        else:
+            field = dict(field)
+        fields.append(field)
+
+    return {
+        "fields": fields,
+        "operators": {
+            "text": list(TEXT_OPS),
+            "number": list(NUM_OPS),
+            "date": list(DATE_OPS),
+            "choice": list(CHOICE_OPS),
+        },
+        "defaultOperators": {
+            "text": "contains",
+            "number": "eq",
+            "date": "eq",
+            "choice": "eq",
+        },
+    }
+
+
+__all__ = [
+    "CHOICE_OPS",
+    "DATE_OPS",
+    "FIELD_MAP",
+    "FIELD_TYPES",
+    "FILTER_FIELDS",
+    "NUM_OPS",
+    "TEXT_OPS",
+    "get_filters_ui_config",
+]

--- a/celiaquia/templates/celiaquia/expediente_list.html
+++ b/celiaquia/templates/celiaquia/expediente_list.html
@@ -12,7 +12,7 @@
 {% block content %}
     <!-- Estilos modernos reutilizables para listados -->
     <link rel="stylesheet" href="{% static 'custom/css/listModerno.css' %}" />
-    {% include 'components/search_bar.html' with titulo=titulo_listado placeholder="Buscar por ID, número, estado, provincia o técnico…" help_text="Buscar por ID, número, estado, provincia o técnico." reset_url='expediente_list' back_url='' search_name='q' query=request.GET.q show_add_button=is_provincial_celiaquia add_url='expediente_create' add_text='Nuevo Expediente' request=request only %}
+    {% include 'components/search_bar.html' with titulo=titulo_listado reset_url='expediente_list' back_url='' filters_mode=filters_mode filters_config=filters_config filters_action=filters_action show_add_button=is_provincial_celiaquia add_url='expediente_create' add_text='Nuevo Expediente' request=request only %}
     <div id="list-alerts"></div>
     <div class="card shadow-sm">
         <div class="table-responsive">
@@ -64,7 +64,7 @@
                                 {% endif %}
                                 {% if exp.legajos_subsanado_count > 0 %}
                                     <div class="mt-1">
-                                        <span class="badge bg-success">
+                                        <span class="badge badge-subsanado">
                                             <i class="fa fa-check-circle"></i> {{ exp.legajos_subsanado_count }} subsanados
                                         </span>
                                     </div>

--- a/celiaquia/tests/test_expediente_list_badges.py
+++ b/celiaquia/tests/test_expediente_list_badges.py
@@ -1,0 +1,84 @@
+"""Colores de los badges de estado en el listado de expedientes (tk #2319)."""
+
+from datetime import date
+
+import pytest
+from django.contrib.auth.models import Permission, User
+from django.urls import reverse
+
+from ciudadanos.models import Ciudadano
+from core.models import Provincia
+from celiaquia.models import (
+    EstadoExpediente,
+    EstadoLegajo,
+    Expediente,
+    ExpedienteCiudadano,
+    RevisionTecnico,
+)
+from users.models import Profile
+
+
+def _usuario_provincial(provincia):
+    user = User.objects.create_user(username="prov", password="pass")
+    user.user_permissions.add(
+        Permission.objects.get(
+            content_type__app_label="celiaquia",
+            codename="view_expediente",
+        )
+    )
+    profile, _ = Profile.objects.get_or_create(user=user)
+    profile.es_usuario_provincial = True
+    profile.provincia = provincia
+    profile.save()
+    return user
+
+
+def _legajo(expediente, provincia, documento, revision):
+    ciudadano = Ciudadano.objects.create(
+        apellido="Perez",
+        nombre=f"Ciudadano {documento}",
+        fecha_nacimiento=date(2010, 1, 1),
+        documento=documento,
+        provincia=provincia,
+    )
+    estado_legajo, _ = EstadoLegajo.objects.get_or_create(nombre="DOCUMENTO_PENDIENTE")
+    return ExpedienteCiudadano.objects.create(
+        expediente=expediente,
+        ciudadano=ciudadano,
+        estado=estado_legajo,
+        revision_tecnico=revision,
+    )
+
+
+@pytest.mark.django_db
+def test_subsanados_no_usa_el_verde_de_cruce_finalizado(client):
+    """Subsanado y Cruce finalizado se muestran en la misma celda del listado:
+    si ambos fueran verdes no se distinguirían."""
+    provincia = Provincia.objects.create(nombre="Buenos Aires")
+    estado = EstadoExpediente.objects.create(nombre="CRUCE_FINALIZADO")
+    user = _usuario_provincial(provincia)
+    expediente = Expediente.objects.create(usuario_provincia=user, estado=estado)
+    _legajo(expediente, provincia, "60000001", RevisionTecnico.SUBSANADO)
+
+    client.force_login(user)
+    html = client.get(reverse("expediente_list")).content.decode()
+
+    assert "badge badge-subsanado" in html
+    assert "1 subsanados" in html
+    # El verde queda reservado al estado del expediente.
+    assert 'class="badge bg-success"' not in html
+
+
+@pytest.mark.django_db
+def test_a_subsanar_conserva_el_amarillo(client):
+    provincia = Provincia.objects.create(nombre="Buenos Aires")
+    estado = EstadoExpediente.objects.create(nombre="EN_ESPERA")
+    user = _usuario_provincial(provincia)
+    expediente = Expediente.objects.create(usuario_provincia=user, estado=estado)
+    _legajo(expediente, provincia, "60000002", RevisionTecnico.SUBSANAR)
+
+    client.force_login(user)
+    html = client.get(reverse("expediente_list")).content.decode()
+
+    assert "badge bg-warning text-dark" in html
+    assert "1 a subsanar" in html

--- a/celiaquia/tests/test_expediente_list_filtros.py
+++ b/celiaquia/tests/test_expediente_list_filtros.py
@@ -1,0 +1,319 @@
+"""Filtros combinables del listado de expedientes de Celiaquía (tk #2320)."""
+
+import json
+from datetime import date
+
+import pytest
+from django.contrib.auth.models import Permission, User
+from django.contrib.contenttypes.models import ContentType
+from django.urls import reverse
+
+from ciudadanos.models import Ciudadano
+from core.models import Localidad, Municipio, Provincia
+from celiaquia.models import (
+    AsignacionTecnico,
+    EstadoExpediente,
+    EstadoLegajo,
+    Expediente,
+    ExpedienteCiudadano,
+)
+from celiaquia.services.expediente_filter_config import (  # pylint: disable=no-name-in-module
+    FIELD_MAP,
+    FIELD_TYPES,
+    get_filters_ui_config,
+)
+from users.models import Profile
+
+
+def _permiso(app_label, codename):
+    """Los permisos de rol (``auth.role_*``) los crea una data migration que no
+    corre en la base de tests, así que se siembran acá."""
+    try:
+        return Permission.objects.get(
+            content_type__app_label=app_label,
+            codename=codename,
+        )
+    except Permission.DoesNotExist:
+        content_type = ContentType.objects.get(app_label="auth", model="user")
+        return Permission.objects.create(
+            content_type=content_type,
+            codename=codename,
+            name=codename,
+        )
+
+
+def _crear_coordinador():
+    user = User.objects.create_user(username="coord", password="pass")
+    user.user_permissions.add(_permiso("celiaquia", "view_expediente"))
+    user.user_permissions.add(_permiso("auth", "role_coordinadorceliaquia"))
+    Profile.objects.get_or_create(user=user)
+    return user
+
+
+def _crear_expediente(*, owner, estado, provincia, documento, numero=None):
+    """Crea un expediente con un legajo, para que derive provincia."""
+    expediente = Expediente.objects.create(
+        usuario_provincia=owner,
+        estado=estado,
+        numero_expediente=numero,
+    )
+    municipio = Municipio.objects.create(
+        nombre=f"Municipio {documento}", provincia=provincia
+    )
+    localidad = Localidad.objects.create(
+        nombre=f"Localidad {documento}", municipio=municipio
+    )
+    ciudadano = Ciudadano.objects.create(
+        apellido="Perez",
+        nombre=f"Ciudadano {documento}",
+        fecha_nacimiento=date(2010, 1, 1),
+        documento=documento,
+        provincia=provincia,
+        municipio=municipio,
+        localidad=localidad,
+    )
+    estado_legajo, _ = EstadoLegajo.objects.get_or_create(nombre="DOCUMENTO_PENDIENTE")
+    ExpedienteCiudadano.objects.create(
+        expediente=expediente,
+        ciudadano=ciudadano,
+        estado=estado_legajo,
+    )
+    return expediente
+
+
+def _filtros(*items, logic="AND"):
+    return {"filters": json.dumps({"logic": logic, "items": list(items)})}
+
+
+def _ids_listados(response):
+    return {exp.pk for exp in response.context["expedientes"]}
+
+
+@pytest.mark.django_db
+def test_filtros_combinados_aplican_en_conjunto(client):
+    """Dos filtros distintos se combinan con AND, no se pisan entre sí."""
+    buenos_aires = Provincia.objects.create(nombre="Buenos Aires")
+    cordoba = Provincia.objects.create(nombre="Cordoba")
+    creado = EstadoExpediente.objects.create(nombre="CREADO")
+    en_espera = EstadoExpediente.objects.create(nombre="EN_ESPERA")
+    user = _crear_coordinador()
+
+    esperado = _crear_expediente(
+        owner=user, estado=creado, provincia=buenos_aires, documento="10000001"
+    )
+    # Coincide con la provincia pero no con el estado.
+    _crear_expediente(
+        owner=user, estado=en_espera, provincia=buenos_aires, documento="10000002"
+    )
+    # Coincide con el estado pero no con la provincia.
+    _crear_expediente(
+        owner=user, estado=creado, provincia=cordoba, documento="10000003"
+    )
+
+    client.force_login(user)
+    response = client.get(
+        reverse("expediente_list"),
+        _filtros(
+            {"field": "provincia", "op": "eq", "value": "Buenos Aires"},
+            {"field": "estado", "op": "eq", "value": "CREADO"},
+        ),
+    )
+
+    assert response.status_code == 200
+    assert _ids_listados(response) == {esperado.pk}
+
+
+@pytest.mark.django_db
+def test_filtro_por_numero_de_expediente(client):
+    provincia = Provincia.objects.create(nombre="Buenos Aires")
+    estado = EstadoExpediente.objects.create(nombre="CREADO")
+    user = _crear_coordinador()
+
+    esperado = _crear_expediente(
+        owner=user,
+        estado=estado,
+        provincia=provincia,
+        documento="20000001",
+        numero="EX-2026-777",
+    )
+    _crear_expediente(
+        owner=user,
+        estado=estado,
+        provincia=provincia,
+        documento="20000002",
+        numero="EX-2026-888",
+    )
+
+    client.force_login(user)
+    response = client.get(
+        reverse("expediente_list"),
+        _filtros({"field": "numero_expediente", "op": "contains", "value": "777"}),
+    )
+
+    assert _ids_listados(response) == {esperado.pk}
+
+
+@pytest.mark.django_db
+def test_filtro_por_tecnico_no_duplica_expedientes(client):
+    """Dos filtros sobre el mismo campo se combinan con OR sobre un único join.
+    Como ``asignaciones_tecnicos`` es multivalor, un expediente asignado a ambos
+    técnicos se repetiría una vez por asignación si faltara el ``distinct()``."""
+    provincia = Provincia.objects.create(nombre="Buenos Aires")
+    estado = EstadoExpediente.objects.create(nombre="ASIGNADO")
+    user = _crear_coordinador()
+
+    tecnico = User.objects.create_user(username="tecnico1", password="pass")
+    tecnico.user_permissions.add(_permiso("auth", "role_tecnicoceliaquia"))
+    otro_tecnico = User.objects.create_user(username="tecnico2", password="pass")
+    otro_tecnico.user_permissions.add(_permiso("auth", "role_tecnicoceliaquia"))
+
+    expediente = _crear_expediente(
+        owner=user, estado=estado, provincia=provincia, documento="30000001"
+    )
+    AsignacionTecnico.objects.create(expediente=expediente, tecnico=tecnico)
+    AsignacionTecnico.objects.create(expediente=expediente, tecnico=otro_tecnico)
+
+    sin_tecnico = _crear_expediente(
+        owner=user, estado=estado, provincia=provincia, documento="30000002"
+    )
+
+    client.force_login(user)
+    response = client.get(
+        reverse("expediente_list"),
+        _filtros(
+            {"field": "tecnico", "op": "eq", "value": "tecnico1"},
+            {"field": "tecnico", "op": "eq", "value": "tecnico2"},
+        ),
+    )
+
+    listados = list(response.context["expedientes"])
+    assert [exp.pk for exp in listados] == [expediente.pk]
+    assert sin_tecnico.pk not in {exp.pk for exp in listados}
+
+
+@pytest.mark.django_db
+def test_filtros_no_amplian_el_alcance_territorial(client):
+    """Un usuario provincial no puede alcanzar expedientes de otra provincia
+    filtrando por ella: los filtros se aplican sobre el queryset ya acotado."""
+    propia = Provincia.objects.create(nombre="Buenos Aires")
+    ajena = Provincia.objects.create(nombre="Cordoba")
+    estado = EstadoExpediente.objects.create(nombre="CREADO")
+
+    provincial = User.objects.create_user(username="prov", password="pass")
+    provincial.user_permissions.add(_permiso("celiaquia", "view_expediente"))
+    profile, _ = Profile.objects.get_or_create(user=provincial)
+    profile.es_usuario_provincial = True
+    profile.provincia = propia
+    profile.save()
+
+    otro = User.objects.create_user(username="otro", password="pass")
+    Profile.objects.get_or_create(user=otro)
+    ajeno = _crear_expediente(
+        owner=otro, estado=estado, provincia=ajena, documento="40000001"
+    )
+
+    client.force_login(provincial)
+    response = client.get(
+        reverse("expediente_list"),
+        _filtros({"field": "provincia", "op": "eq", "value": "Cordoba"}),
+    )
+
+    assert response.status_code == 200
+    assert ajeno.pk not in _ids_listados(response)
+
+
+@pytest.mark.django_db
+def test_filtro_invalido_no_rompe_el_listado(client):
+    """Un campo desconocido se ignora y el listado responde normalmente."""
+    provincia = Provincia.objects.create(nombre="Buenos Aires")
+    estado = EstadoExpediente.objects.create(nombre="CREADO")
+    user = _crear_coordinador()
+    expediente = _crear_expediente(
+        owner=user, estado=estado, provincia=provincia, documento="50000001"
+    )
+
+    client.force_login(user)
+    response = client.get(
+        reverse("expediente_list"),
+        _filtros({"field": "campo_inexistente", "op": "eq", "value": "x"}),
+    )
+
+    assert response.status_code == 200
+    assert expediente.pk in _ids_listados(response)
+
+
+@pytest.mark.django_db
+def test_config_oculta_el_campo_tecnico_para_usuarios_provinciales(client):
+    provincia = Provincia.objects.create(nombre="Buenos Aires")
+    EstadoExpediente.objects.create(nombre="CREADO")
+
+    provincial = User.objects.create_user(username="prov", password="pass")
+    provincial.user_permissions.add(_permiso("celiaquia", "view_expediente"))
+    profile, _ = Profile.objects.get_or_create(user=provincial)
+    profile.es_usuario_provincial = True
+    profile.provincia = provincia
+    profile.save()
+
+    client.force_login(provincial)
+    response = client.get(reverse("expediente_list"))
+
+    campos = {campo["name"] for campo in response.context["filters_config"]["fields"]}
+    assert "tecnico" not in campos
+    assert {"id", "numero_expediente", "estado", "provincia"} <= campos
+
+
+@pytest.mark.django_db
+def test_config_expone_el_campo_tecnico_al_coordinador(client):
+    Provincia.objects.create(nombre="Buenos Aires")
+    EstadoExpediente.objects.create(nombre="CREADO")
+    user = _crear_coordinador()
+    tecnico = User.objects.create_user(
+        username="tecnico1", password="pass", first_name="Ana", last_name="Diaz"
+    )
+    tecnico.user_permissions.add(_permiso("auth", "role_tecnicoceliaquia"))
+
+    client.force_login(user)
+    response = client.get(reverse("expediente_list"))
+
+    campos = {
+        campo["name"]: campo for campo in response.context["filters_config"]["fields"]
+    }
+    assert "tecnico" in campos
+    assert {"value": "tecnico1", "label": "Ana Diaz"} in campos["tecnico"]["choices"]
+
+
+@pytest.mark.django_db
+def test_config_usa_los_estados_reales_como_opciones():
+    EstadoExpediente.objects.create(nombre="CRUCE_FINALIZADO")
+    config = get_filters_ui_config()
+
+    estado = next(c for c in config["fields"] if c["name"] == "estado")
+    assert {"value": "CRUCE_FINALIZADO", "label": "Cruce finalizado"} in estado[
+        "choices"
+    ]
+
+
+@pytest.mark.django_db
+def test_listado_renderiza_la_barra_de_filtros_combinables(client):
+    provincia = Provincia.objects.create(nombre="Buenos Aires")
+    EstadoExpediente.objects.create(nombre="CREADO")
+    user = User.objects.create_user(username="prov", password="pass")
+    user.user_permissions.add(_permiso("celiaquia", "view_expediente"))
+    profile, _ = Profile.objects.get_or_create(user=user)
+    profile.es_usuario_provincial = True
+    profile.provincia = provincia
+    profile.save()
+
+    client.force_login(user)
+    html = client.get(reverse("expediente_list")).content.decode()
+
+    assert 'id="filters-form"' in html
+    assert 'id="filters-config-json"' in html
+    assert 'id="poncho-filters-rows"' in html
+    assert "advanced_filters.js" in html
+
+
+def test_todos_los_campos_tipados_tienen_lookup():
+    """Contrato del AdvancedFilterEngine: field_types no puede tener claves que
+    falten en field_map."""
+    assert set(FIELD_TYPES) <= set(FIELD_MAP)

--- a/celiaquia/tests/test_expediente_list_filtros.py
+++ b/celiaquia/tests/test_expediente_list_filtros.py
@@ -263,6 +263,38 @@ def test_config_oculta_el_campo_tecnico_para_usuarios_provinciales(client):
 
 
 @pytest.mark.django_db
+def test_usuario_provincial_no_puede_filtrar_por_tecnico_mediante_la_url(client):
+    """El campo oculto en la UI tampoco debe aceptarse en el backend."""
+    provincia = Provincia.objects.create(nombre="Buenos Aires")
+    estado = EstadoExpediente.objects.create(nombre="CREADO")
+
+    provincial = User.objects.create_user(username="prov", password="pass")
+    provincial.user_permissions.add(_permiso("celiaquia", "view_expediente"))
+    profile, _ = Profile.objects.get_or_create(user=provincial)
+    profile.es_usuario_provincial = True
+    profile.provincia = provincia
+    profile.save()
+
+    tecnico = User.objects.create_user(username="tecnico1", password="pass")
+    tecnico.user_permissions.add(_permiso("auth", "role_tecnicoceliaquia"))
+    asignado = _crear_expediente(
+        owner=provincial, estado=estado, provincia=provincia, documento="51000001"
+    )
+    sin_asignar = _crear_expediente(
+        owner=provincial, estado=estado, provincia=provincia, documento="51000002"
+    )
+    AsignacionTecnico.objects.create(expediente=asignado, tecnico=tecnico)
+
+    client.force_login(provincial)
+    response = client.get(
+        reverse("expediente_list"),
+        _filtros({"field": "tecnico", "op": "eq", "value": "tecnico1"}),
+    )
+
+    assert _ids_listados(response) == {asignado.pk, sin_asignar.pk}
+
+
+@pytest.mark.django_db
 def test_config_expone_el_campo_tecnico_al_coordinador(client):
     Provincia.objects.create(nombre="Buenos Aires")
     EstadoExpediente.objects.create(nombre="CREADO")

--- a/celiaquia/views/expediente.py
+++ b/celiaquia/views/expediente.py
@@ -103,6 +103,24 @@ EXPEDIENTE_ADVANCED_FILTER = AdvancedFilterEngine(
         "choice": CHOICE_OPS,
     },
 )
+EXPEDIENTE_ADVANCED_FILTER_SIN_TECNICO = AdvancedFilterEngine(
+    field_map={
+        field: lookup
+        for field, lookup in EXPEDIENTE_FILTER_MAP.items()
+        if field != "tecnico"
+    },
+    field_types={
+        field: field_type
+        for field, field_type in EXPEDIENTE_FILTER_TYPES.items()
+        if field != "tecnico"
+    },
+    allowed_ops={
+        "text": TEXT_OPS,
+        "number": NUM_OPS,
+        "date": DATE_OPS,
+        "choice": CHOICE_OPS,
+    },
+)
 
 
 def _user_has_permission(user, permission_code: str) -> bool:
@@ -113,6 +131,14 @@ def _is_admin(user) -> bool:
     return bool(
         getattr(user, "is_authenticated", False)
         and getattr(user, "is_superuser", False)
+    )
+
+
+def _can_view_tecnico_column(user) -> bool:
+    return bool(
+        _is_admin(user)
+        or _user_has_permission(user, ROLE_COORDINADOR_CELIAQUIA_PERMISSION)
+        or _user_has_permission(user, ROLE_TECNICO_CELIAQUIA_PERMISSION)
     )
 
 
@@ -811,7 +837,12 @@ class ExpedienteListView(ListView):
         # acotado por rol/territorio, así ningún filtro puede ampliar el alcance.
         # El distinct() cubre el filtro por técnico, que atraviesa una relación
         # multivalor y de otro modo repetiría el expediente por cada asignación.
-        filtros_q = EXPEDIENTE_ADVANCED_FILTER.build_q(self.request)
+        advanced_filter = (
+            EXPEDIENTE_ADVANCED_FILTER
+            if _can_view_tecnico_column(user)
+            else EXPEDIENTE_ADVANCED_FILTER_SIN_TECNICO
+        )
+        filtros_q = advanced_filter.build_q(self.request)
         if filtros_q is not None:
             qs = qs.filter(filtros_q).distinct()
 
@@ -831,7 +862,7 @@ class ExpedienteListView(ListView):
         ctx["is_provincial_celiaquia"] = _is_provincial(user)
         ctx["can_manage_tecnicos_celiaquia"] = is_admin or is_coord
         ctx["can_manage_excel_masivo_audit"] = is_admin or is_coord
-        ctx["show_tecnico_column_celiaquia"] = is_admin or is_coord or is_tecnico
+        ctx["show_tecnico_column_celiaquia"] = _can_view_tecnico_column(user)
 
         # El titulo depende del rol y lo consume el componente de busqueda, que
         # lo recibe como parametro; armarlo aca evita repetir el include.

--- a/celiaquia/views/expediente.py
+++ b/celiaquia/views/expediente.py
@@ -5,7 +5,7 @@ import traceback
 
 from django.views import View
 from django.views.generic import ListView, CreateView, DetailView, UpdateView
-from django.urls import reverse_lazy
+from django.urls import reverse, reverse_lazy
 from django.shortcuts import get_object_or_404, redirect
 from django.http import (
     FileResponse,
@@ -61,12 +61,22 @@ from celiaquia.services.importacion_service import (
 from celiaquia.permissions import can_delete_legajo
 from celiaquia.services.cruce_service import CruceService
 from celiaquia.services.cupo_service import CupoService, CupoNoConfigurado
+from celiaquia.services.expediente_filter_config import (  # pylint: disable=no-name-in-module
+    CHOICE_OPS,
+    DATE_OPS,
+    FIELD_MAP as EXPEDIENTE_FILTER_MAP,
+    FIELD_TYPES as EXPEDIENTE_FILTER_TYPES,
+    NUM_OPS,
+    TEXT_OPS,
+    get_filters_ui_config,
+)
 from celiaquia.services.padron_final_service import (  # pylint: disable=no-name-in-module
     PadronFinalService,
 )
 from django.utils import timezone
 from django.db import transaction
 from core.models import Nacionalidad, Provincia, Localidad
+from core.services.advanced_filters import AdvancedFilterEngine
 from core.soft_delete.preview import build_delete_preview
 from core.soft_delete.view_helpers import is_soft_deletable_instance
 from users.territorial_scope import (
@@ -82,6 +92,17 @@ logger = logging.getLogger("django")
 ROLE_COORDINADOR_CELIAQUIA_PERMISSION = "auth.role_coordinadorceliaquia"
 ROLE_TECNICO_CELIAQUIA_PERMISSION = "auth.role_tecnicoceliaquia"
 ROLE_PROVINCIA_CELIAQUIA_PERMISSION = "auth.role_provinciaceliaquia"
+
+EXPEDIENTE_ADVANCED_FILTER = AdvancedFilterEngine(
+    field_map=EXPEDIENTE_FILTER_MAP,
+    field_types=EXPEDIENTE_FILTER_TYPES,
+    allowed_ops={
+        "text": TEXT_OPS,
+        "number": NUM_OPS,
+        "date": DATE_OPS,
+        "choice": CHOICE_OPS,
+    },
+)
 
 
 def _user_has_permission(user, permission_code: str) -> bool:
@@ -786,6 +807,14 @@ class ExpedienteListView(ListView):
                 | Q(asignaciones_tecnicos__tecnico__username__icontains=search_query)
             ).distinct()
 
+        # Filtros combinables (?filters=...). Se aplican sobre el queryset ya
+        # acotado por rol/territorio, así ningún filtro puede ampliar el alcance.
+        # El distinct() cubre el filtro por técnico, que atraviesa una relación
+        # multivalor y de otro modo repetiría el expediente por cada asignación.
+        filtros_q = EXPEDIENTE_ADVANCED_FILTER.build_q(self.request)
+        if filtros_q is not None:
+            qs = qs.filter(filtros_q).distinct()
+
         return qs
 
     def get_context_data(self, **kwargs):
@@ -813,8 +842,20 @@ class ExpedienteListView(ListView):
         else:
             ctx["titulo_listado"] = "Mis Expedientes"
 
+        # Filtros combinables. El campo "Técnico asignado" solo se ofrece a quien
+        # ve la columna de técnico; para el resto get_filters_ui_config lo omite
+        # al no recibir técnicos seleccionables.
+        tecnicos_filtrables = (
+            _tecnicos_queryset().order_by("last_name", "first_name")
+            if ctx["show_tecnico_column_celiaquia"]
+            else None
+        )
         if is_admin or is_coord:
-            ctx["tecnicos"] = _tecnicos_queryset().order_by("last_name", "first_name")
+            ctx["tecnicos"] = tecnicos_filtrables
+
+        ctx["filters_mode"] = True
+        ctx["filters_config"] = get_filters_ui_config(tecnicos=tecnicos_filtrables)
+        ctx["filters_action"] = reverse("expediente_list")
         return ctx
 
 

--- a/docs/contexto/features/pr-2360-celiaquia-tk2320-y-2319.md
+++ b/docs/contexto/features/pr-2360-celiaquia-tk2320-y-2319.md
@@ -1,0 +1,53 @@
+# Contexto de feature PR #2360 - Celiaquia tk2320 y 2319
+
+## Resumen
+
+- PR: https://github.com/dsocial118/SISOC/pull/2360
+- Base: `development`
+- Rama origen: `Celiaquia_Tk2320`
+- Autor: `MariaNavarro90`
+
+## Contexto funcional
+
+- Celiaquía — listado de expedientes. Mejora de búsqueda y de legibilidad de estados para usuarios de Nación (coordinadores y técnicos) y de provincias.
+
+## Arquitectura tocada
+
+- El PR toca lógica en `services/`, por lo que impacta reglas de negocio u orquestación.
+- Se modifican templates, con posible impacto visual o de composición UI.
+
+## Decisiones y supuestos detectados
+
+- Tipo de cambio declarado: Mejora / evolutivo de UI. Sin cambios de modelo ni migraciones.
+- Área principal declarada: celiaquia (vista y template del listado). Toca además static/custom/css/listModerno.css, compartido por listados, con una clase nueva que no altera las existentes.
+- Impacto usuario declarado: Positivo — menos consultas sucesivas para encontrar un expediente y lectura más rápida del estado. Cambio de hábito a comunicar: la caja de búsqueda genérica se reemplaza por filtros por campo; quien buscaba "cualquier cosa" ahora debe elegir el campo. Los enlaces guardados con ?q= siguen funcionando.
+- Riesgos / rollback: Riesgo bajo. No hay migraciones ni datos que deshacer; el rollback es revertir el commit. El riesgo principal es de adopción (desaparición del buscador de texto libre), no técnico. El filtro por técnico atraviesa una relación multivalor y el distinct() del queryset evita filas repetidas.
+
+## Design system y UI
+
+- El PR toca piezas de UI y conviene revisar consistencia visual con el patrón existente.
+- Archivos visuales relevantes: celiaquia/templates/celiaquia/expediente_list.html, static/custom/css/listModerno.css
+
+## Memoria operativa para agentes
+
+- Empezar por `docs/registro/prs/PR-2360.md` para contexto resumido del PR.
+- Revisar primero estos archivos del diff:
+- `celiaquia/services/expediente_filter_config/__init__.py`
+- `celiaquia/services/expediente_filter_config/impl.py`
+- `celiaquia/templates/celiaquia/expediente_list.html`
+- `celiaquia/tests/test_expediente_list_badges.py`
+- `celiaquia/tests/test_expediente_list_filtros.py`
+- `celiaquia/views/expediente.py`
+- `docs/registro/cambios/2026-08-26-issues-2320-2319-listado-celiaquia.md`
+- `static/custom/css/listModerno.css`
+- Documentación sugerida para ampliar contexto:
+- `docs/indice.md`
+- `docs/ia/CONTEXT_HYGIENE.md`
+- `docs/ia/ARCHITECTURE.md`
+- `docs/ia/TESTING.md`
+- `docs/registro/cambios/2026-08-26-issues-2320-2319-listado-celiaquia.md`
+
+## Trazabilidad
+
+- Documento generado automáticamente desde el evento de `pull_request`.
+- Si este PR cambia de título, el archivo se renombrará para mantener el slug alineado.

--- a/docs/contexto/features/pr-2360-celiaquia-tk2320-y-2319.md
+++ b/docs/contexto/features/pr-2360-celiaquia-tk2320-y-2319.md
@@ -38,14 +38,18 @@
 - `celiaquia/tests/test_expediente_list_badges.py`
 - `celiaquia/tests/test_expediente_list_filtros.py`
 - `celiaquia/views/expediente.py`
+- `docs/contexto/features/pr-2360-celiaquia-tk2320-y-2319.md`
 - `docs/registro/cambios/2026-08-26-issues-2320-2319-listado-celiaquia.md`
+- `docs/registro/prs/PR-2360.md`
 - `static/custom/css/listModerno.css`
 - Documentación sugerida para ampliar contexto:
 - `docs/indice.md`
 - `docs/ia/CONTEXT_HYGIENE.md`
 - `docs/ia/ARCHITECTURE.md`
 - `docs/ia/TESTING.md`
+- `docs/contexto/features/pr-2360-celiaquia-tk2320-y-2319.md`
 - `docs/registro/cambios/2026-08-26-issues-2320-2319-listado-celiaquia.md`
+- `docs/registro/prs/PR-2360.md`
 
 ## Trazabilidad
 

--- a/docs/registro/cambios/2026-08-26-issues-2320-2319-listado-celiaquia.md
+++ b/docs/registro/cambios/2026-08-26-issues-2320-2319-listado-celiaquia.md
@@ -31,7 +31,9 @@
 - `estado` y `provincia` se ofrecen como desplegables poblados desde
   `EstadoExpediente` y `Provincia`; `tecnico` desde los usuarios con
   `role_tecnicoceliaquia`, y sólo para quienes ven la columna de técnico
-  (admin, coordinador y técnico).
+  (admin, coordinador y técnico). El backend también ignora el filtro
+  `tecnico` para el resto de los roles, incluso si se envía manualmente por
+  querystring.
 - El listado deja de renderizar el input de texto libre, que el componente reemplaza
   por las filas de filtros. El soporte de `?q=` se conserva en el backend para no
   romper enlaces existentes.

--- a/docs/registro/cambios/2026-08-26-issues-2320-2319-listado-celiaquia.md
+++ b/docs/registro/cambios/2026-08-26-issues-2320-2319-listado-celiaquia.md
@@ -1,0 +1,83 @@
+# 2026-08-26 - Issues 2320 y 2319: filtros y badges del listado de Celiaquía
+
+## Contexto
+
+- El listado de expedientes (`/celiaquia/expedientes/`) sólo ofrecía un buscador de
+  texto libre (`?q=`) que aplicaba un único criterio por vez sobre varios campos a
+  la vez, obligando a consultas sucesivas para acotar resultados.
+- El requerimiento pedía replicar el filtrado múltiple que ya existe en
+  `/comedores/listar`.
+- En la misma celda del listado, el badge de legajos "subsanados" usaba el mismo
+  verde (`bg-success`) que el estado "Cruce finalizado" del expediente, lo que
+  impedía distinguirlos de un vistazo (issue 2319).
+- Ese filtrado no es específico de Comedores: `core.services.advanced_filters` y el
+  componente `components/search_bar.html` en modo `filters_mode` ya lo proveen y son
+  usados por 12 secciones del sistema. Celiaquía era una de las que faltaba.
+
+## Cambios aplicados
+
+- Nuevo `celiaquia/services/expediente_filter_config/` con el mapeo de campos, tipos,
+  operadores y la configuración serializable para la UI, siguiendo la convención de
+  services de la app (`__init__.py` + `impl.py`).
+- Campos expuestos, alineados con las columnas de la grilla: ID, Número de
+  expediente, Fecha de creación, Provincia, Estado y Técnico asignado.
+- `ExpedienteListView` aplica `AdvancedFilterEngine` sobre el queryset **después**
+  del acotamiento por rol y alcance territorial, y pasa el modo filtros al
+  componente de búsqueda.
+- `provincia` filtra sobre la anotación `provincia_derivada` y no sobre un join con
+  los legajos: el expediente no tiene provincia propia (se deriva de sus ciudadanos,
+  con respaldo en el perfil legacy del creador), así que filtrar por el join daría
+  un resultado distinto del valor que muestra la grilla.
+- `estado` y `provincia` se ofrecen como desplegables poblados desde
+  `EstadoExpediente` y `Provincia`; `tecnico` desde los usuarios con
+  `role_tecnicoceliaquia`, y sólo para quienes ven la columna de técnico
+  (admin, coordinador y técnico).
+- El listado deja de renderizar el input de texto libre, que el componente reemplaza
+  por las filas de filtros. El soporte de `?q=` se conserva en el backend para no
+  romper enlaces existentes.
+- No se registró la sección en `favorite_filters`: el modal de filtros favoritos se
+  retiró de la UI por definición de UX/UI (2026-08-04) y registrarla sería código
+  muerto.
+- Issue 2319: el badge de "subsanados" pasa de `bg-success` a una clase propia
+  `badge-subsanado` (violeta `#6f42c1`), definida en `listModerno.css` junto al
+  resto de badges de listado. "A subsanar" conserva el amarillo y "Cruce
+  finalizado" conserva el verde.
+
+## Impacto esperado
+
+- Se pueden combinar varios filtros simultáneos; el engine aplica `OR` entre filtros
+  del mismo campo y `AND` entre campos distintos.
+- Los filtros no pueden ampliar el alcance de un usuario: se aplican sobre el
+  queryset ya restringido por rol y territorio.
+- Un filtro con un campo desconocido se ignora y el listado responde normalmente.
+- Los tres estados visibles en la celda de estado quedan diferenciados por color:
+  amarillo "a subsanar", violeta "subsanados", verde "Cruce finalizado".
+- No cambia el modelo de datos ni hay migraciones.
+
+## Validación
+
+- `pytest celiaquia/tests` en Docker: 179 tests aprobados (167 previos + 10 nuevos
+  en `test_expediente_list_filtros.py` y 2 en `test_expediente_list_badges.py`).
+- Dos tests se verificaron como regresiones reales, comprobando que fallan al
+  revertir el cambio: el de duplicados (si se quita el `distinct()`) y el del
+  badge violeta (si vuelve a `bg-success`).
+- `black --check`, `djlint --check` sobre el template modificado y `pylint` 10.00/10
+  sobre los archivos nuevos.
+- `pylint` sobre `views/expediente.py` comparado contra la baseline de `development`:
+  sin hallazgos nuevos más allá de los `E0401` de resolución de imports que la
+  configuración ya produce para todo import de primer nivel del repo.
+- `lint-imports` (15 contratos) y `lint-imports --config .importlinter_celiaquia_config`,
+  ambos KEPT.
+- `git diff --check` sin observaciones.
+
+## Riesgos y rollback
+
+- Riesgo principal: el buscador de texto libre deja de estar visible. Quien lo usara
+  para buscar "cualquier campo" ahora debe elegir el campo. Los enlaces con `?q=`
+  siguen funcionando.
+- Pendiente de definición de producto: en el detalle del expediente el estado
+  "Subsanado" del legajo se muestra en celeste (`bg-info`), no en violeta. El
+  issue 2319 pedía el cambio sólo en el listado, así que el detalle no se tocó.
+- El filtro por técnico atraviesa una relación multivalor; el `distinct()` del
+  queryset evita filas repetidas cuando se combinan dos técnicos.
+- Rollback: revertir el commit. No hay migraciones ni datos que deshacer.

--- a/docs/registro/prs/PR-2360.md
+++ b/docs/registro/prs/PR-2360.md
@@ -18,6 +18,7 @@
 ## Áreas afectadas
 
 - `celiaquia`
+- `docs/contexto`
 - `docs/registro`
 - `static`
 
@@ -29,7 +30,9 @@
 - `celiaquia/tests/test_expediente_list_badges.py`
 - `celiaquia/tests/test_expediente_list_filtros.py`
 - `celiaquia/views/expediente.py`
+- `docs/contexto/features/pr-2360-celiaquia-tk2320-y-2319.md`
 - `docs/registro/cambios/2026-08-26-issues-2320-2319-listado-celiaquia.md`
+- `docs/registro/prs/PR-2360.md`
 - `static/custom/css/listModerno.css`
 
 ## Validación declarada
@@ -47,7 +50,9 @@
 - `docs/ia/CONTEXT_HYGIENE.md`
 - `docs/ia/ARCHITECTURE.md`
 - `docs/ia/TESTING.md`
+- `docs/contexto/features/pr-2360-celiaquia-tk2320-y-2319.md`
 - `docs/registro/cambios/2026-08-26-issues-2320-2319-listado-celiaquia.md`
+- `docs/registro/prs/PR-2360.md`
 
 ## Notas para continuidad
 

--- a/docs/registro/prs/PR-2360.md
+++ b/docs/registro/prs/PR-2360.md
@@ -1,0 +1,55 @@
+# PR #2360 - Celiaquia tk2320 y 2319
+
+## Metadata
+
+- PR: https://github.com/dsocial118/SISOC/pull/2360
+- Base: `development`
+- Rama origen: `Celiaquia_Tk2320`
+- Autor: `MariaNavarro90`
+
+## Resumen operativo
+
+- Tipo de cambio: Mejora / evolutivo de UI. Sin cambios de modelo ni migraciones.
+- Área principal: celiaquia (vista y template del listado). Toca además static/custom/css/listModerno.css, compartido por listados, con una clase nueva que no altera las existentes.
+- Contexto funcional: Celiaquía — listado de expedientes. Mejora de búsqueda y de legibilidad de estados para usuarios de Nación (coordinadores y técnicos) y de provincias.
+- Resumen para changelog: El listado de expedientes de Celiaquía permite combinar varios filtros simultáneos (ID, número, fecha, provincia, estado y técnico) en lugar de un único criterio por vez, y diferencia por color los legajos subsanados de los expedientes con cruce finalizado.
+- Impacto usuario: Positivo — menos consultas sucesivas para encontrar un expediente y lectura más rápida del estado. Cambio de hábito a comunicar: la caja de búsqueda genérica se reemplaza por filtros por campo; quien buscaba "cualquier cosa" ahora debe elegir el campo. Los enlaces guardados con ?q= siguen funcionando.
+
+## Áreas afectadas
+
+- `celiaquia`
+- `docs/registro`
+- `static`
+
+## Archivos relevantes del diff
+
+- `celiaquia/services/expediente_filter_config/__init__.py`
+- `celiaquia/services/expediente_filter_config/impl.py`
+- `celiaquia/templates/celiaquia/expediente_list.html`
+- `celiaquia/tests/test_expediente_list_badges.py`
+- `celiaquia/tests/test_expediente_list_filtros.py`
+- `celiaquia/views/expediente.py`
+- `docs/registro/cambios/2026-08-26-issues-2320-2319-listado-celiaquia.md`
+- `static/custom/css/listModerno.css`
+
+## Validación declarada
+
+- Pruebas automáticas: bash docker exec sisoc_2-django-1 pytest celiaquia/tests -q --reuse-db 179 tests aprobados (167 previos + 12 nuevos). Baseline previa: 167. celiaquia/tests/test_expediente_list_filtros.py (10 tests): combinación de filtros con AND, filtro por número, filtro por técnico sin duplicados, que los filtros no amplíen el alcance territorial, que un campo desconocido no rompa el listado, visibilidad del campo "Técnico" según rol, opciones de estado, render de la barra y contrato del engine. celiaquia/tests/test_expediente_list_badges.py (2 tests): que "subsanados" no use el verde y que "a subsanar" conserve el amarillo. Ambos tests críticos se verificaron como regresiones reales, comprobando que fallan al revertir el cambio: el de duplicados falla si se quita el distinct(), y el del badge falla si vuelve a bg-success.
+- Pruebas manuales: Ir a /celiaquia/expedientes/.
+
+## Riesgos y rollback
+
+- Riesgo bajo. No hay migraciones ni datos que deshacer; el rollback es revertir el commit. El riesgo principal es de adopción (desaparición del buscador de texto libre), no técnico. El filtro por técnico atraviesa una relación multivalor y el distinct() del queryset evita filas repetidas.
+
+## Documentación sugerida para lectura
+
+- `docs/indice.md`
+- `docs/ia/CONTEXT_HYGIENE.md`
+- `docs/ia/ARCHITECTURE.md`
+- `docs/ia/TESTING.md`
+- `docs/registro/cambios/2026-08-26-issues-2320-2319-listado-celiaquia.md`
+
+## Notas para continuidad
+
+- Este documento es generado automáticamente desde el contexto del PR y sirve como índice rápido para revisión y futuras sesiones de agentes.
+- Si la metadata del body del PR está incompleta, varias secciones usarán fallbacks derivados del título o del diff.

--- a/static/custom/css/listModerno.css
+++ b/static/custom/css/listModerno.css
@@ -344,6 +344,15 @@
   font-size: 10px;
 }
 
+/* Celiaquía: los legajos subsanados usaban el mismo verde que el estado
+   "Cruce finalizado" del expediente, que se muestra en la misma celda del
+   listado. El violeta los separa sin invadir el amarillo de "a subsanar". */
+.badge-subsanado {
+  background-color: #6f42c1;
+  color: #fff;
+  border: 1px solid #59359a;
+}
+
 /* Etapas de rendición: paleta pastel independiente del estado semántico. */
 .etapa-badge {
     border: 1px solid transparent;


### PR DESCRIPTION
# Información de la Tarea
Vincular el #2320 #2319 

### **Resumen de la Solución:**
- Se incorpora el filtrado múltiple al listado de expedientes de Celiaquía reutilizando la infraestructura de filtros combinables que ya existe en el sistema (`core.services.advanced_filters` + el modo `filters_mode` del componente `components/search_bar.html`), el mismo que usan Comedores y otras 11 secciones. No se construyó un mecanismo nuevo: Celiaquía era una de las secciones que faltaba enganchar.
- Se diferencia por color el badge de legajos "subsanados", que compartía el verde con el estado "Cruce finalizado" del expediente en la misma celda.

### **Información Adicional:**
- **El buscador de texto libre deja de estar visible.** El componente compartido trata "modo filtros" y "modo texto" como excluyentes (`{% if %}/{% elif %}`), igual que en `/comedores/listar`. Se conservó el soporte de `?q=` en el backend para no romper enlaces ya guardados, pero la caja de búsqueda genérica ya no se renderiza. Si producto la quiere conservar junto a los filtros, habría que modificar el componente compartido y afectaría a las 12 secciones que lo usan.
- **`provincia` filtra sobre la anotación `provincia_derivada`, no sobre un join con los legajos.** El expediente no tiene provincia propia: se deriva de sus ciudadanos, con respaldo en el perfil legacy del usuario creador. Filtrar por el join daría un resultado distinto del valor que muestra la grilla.
- **No se registró la sección en `favorite_filters`.** Otras apps lo hacen, pero el modal de filtros favoritos se retiró de la UI por definición de UX/UI (2026-08-04, documentado en el propio `search_bar.html`). Registrarla sería código muerto.
- **Pendiente de definición de producto:** en el detalle del expediente el estado "Subsanado" del legajo ya se mostraba en celeste (`bg-info`), no en verde. La inconsistencia que reporta el #2319 existía sólo en el listado. Como el ticket pedía explícitamente el cambio "en el listado de expedientes", el detalle no se tocó. Si se quiere unificar en violeta, son 4 líneas en `expediente_detail.html`.

# Descripción de los Cambios

### **Cambios:**

**#2320 — Filtros combinables**
- **`celiaquia/services/expediente_filter_config/`** (nuevo): configuración de filtros siguiendo la convención de services de la app (`__init__.py` + `impl.py`). Define `FIELD_MAP` (identificador expuesto → lookup del ORM), `FIELD_TYPES`, los operadores permitidos por tipo y `get_filters_ui_config()`, que arma el JSON que consume el JS poblando los desplegables desde la base.
- **`celiaquia/views/expediente.py`**: se instancia `AdvancedFilterEngine` a nivel módulo; `ExpedienteListView.get_queryset()` aplica los filtros **después** del acotamiento por rol y alcance territorial (con `distinct()`); `get_context_data()` pasa `filters_mode`, `filters_config` y `filters_action` al template.
- **`celiaquia/templates/celiaquia/expediente_list.html`**: el include de `search_bar` pasa a modo filtros.
- Campos filtrables, alineados con las columnas de la grilla: ID, Número de expediente, Fecha de creación, Provincia, Estado y Técnico asignado. Estado, Provincia y Técnico son desplegables poblados desde la base.
- El campo "Técnico asignado" sólo se ofrece a quien ve la columna de técnico (admin, coordinador y técnico); para el resto `get_filters_ui_config` lo omite.

**#2319 — Color del badge "subsanados"**
- **`static/custom/css/listModerno.css`**: nueva clase `.badge-subsanado` (violeta `#6f42c1`), ubicada junto al resto de badges de listado que ya viven en ese archivo.
- **`celiaquia/templates/celiaquia/expediente_list.html`**: el badge pasa de `bg-success` a `badge-subsanado`. "A subsanar" conserva el amarillo y "Cruce finalizado" conserva el verde.

**Documentación**
- **`docs/registro/cambios/2026-08-26-issues-2320-2319-listado-celiaquia.md`** (nuevo): cubre ambos tickets.

**Sin migraciones. Sin cambios en el modelo de datos.**

# Cómo Testear los Cambios

### **Pruebas Automáticas:**
```bash
docker exec sisoc_2-django-1 pytest celiaquia/tests -q --reuse-db
```
- **179 tests aprobados** (167 previos + 12 nuevos). Baseline previa: 167.
- `celiaquia/tests/test_expediente_list_filtros.py` (10 tests): combinación de filtros con AND, filtro por número, filtro por técnico sin duplicados, que los filtros **no amplíen el alcance territorial**, que un campo desconocido no rompa el listado, visibilidad del campo "Técnico" según rol, opciones de estado, render de la barra y contrato del engine.
- `celiaquia/tests/test_expediente_list_badges.py` (2 tests): que "subsanados" no use el verde y que "a subsanar" conserve el amarillo.
- **Ambos tests críticos se verificaron como regresiones reales**, comprobando que fallan al revertir el cambio: el de duplicados falla si se quita el `distinct()`, y el del badge falla si vuelve a `bg-success`.

Linters y contratos:
```bash
docker exec sisoc_2-django-1 black --check celiaquia/
docker exec sisoc_2-django-1 djlint celiaquia/templates/celiaquia/expediente_list.html --check
docker exec sisoc_2-django-1 pylint celiaquia/services/expediente_filter_config/ celiaquia/tests/test_expediente_list_filtros.py
docker exec sisoc_2-django-1 lint-imports
docker exec sisoc_2-django-1 lint-imports --config .importlinter_celiaquia_config
```
- `black` y `djlint` sin cambios pendientes; `pylint` 10.00/10 en los archivos nuevos.
- `pylint` sobre `views/expediente.py` comparado contra la baseline de `development`: sin hallazgos nuevos.
- **`lint-imports`: 15 contratos KEPT** y el contrato específico de Celiaquía KEPT (relevante porque Celiaquía es el piloto de frontera modular del repo).

### **Pruebas Manuales:**
Ir a `/celiaquia/expedientes/`.

1. **Filtro simple**: elegir "Estado" en el desplegable, seleccionar un valor y buscar. Verificar que el listado se acota.
2. **Filtros combinados (AND)**: presionar "+ Filtro", agregar "Provincia" con otro valor y buscar. Deben aplicarse los dos criterios en conjunto, no pisarse.
3. **Mismo campo dos veces (OR)**: agregar dos filas de "Técnico asignado" con técnicos distintos. Deben listarse los expedientes de cualquiera de los dos, **sin filas repetidas**.
4. **Resetear**: el botón limpia los filtros y vuelve al listado completo.
5. **Permisos**: entrar como usuario provincial y verificar que el desplegable **no** ofrece "Técnico asignado". Entrar como coordinador/admin y verificar que **sí** aparece, con los nombres de los técnicos.
6. **Alcance territorial**: como usuario provincial, filtrar por una provincia ajena. No debe devolver expedientes de otra jurisdicción.
7. **Colores (#2319)**: buscar un expediente en estado "Cruce finalizado" que tenga legajos subsanados. En la columna Estado deben verse claramente diferenciados el verde del estado y el violeta de "N subsanados". Si además tiene legajos a subsanar, el amarillo debe seguir igual.

# Metadata para documentación automática

- **Contexto funcional:** Celiaquía — listado de expedientes. Mejora de búsqueda y de legibilidad de estados para usuarios de Nación (coordinadores y técnicos) y de provincias.
- **Tipo de cambio:** Mejora / evolutivo de UI. Sin cambios de modelo ni migraciones.
- **Área principal:** `celiaquia` (vista y template del listado). Toca además `static/custom/css/listModerno.css`, compartido por listados, con una clase nueva que no altera las existentes.
- **Resumen para changelog:** El listado de expedientes de Celiaquía permite combinar varios filtros simultáneos (ID, número, fecha, provincia, estado y técnico) en lugar de un único criterio por vez, y diferencia por color los legajos subsanados de los expedientes con cruce finalizado.
- **Impacto usuario:** Positivo — menos consultas sucesivas para encontrar un expediente y lectura más rápida del estado. **Cambio de hábito a comunicar:** la caja de búsqueda genérica se reemplaza por filtros por campo; quien buscaba "cualquier cosa" ahora debe elegir el campo. Los enlaces guardados con `?q=` siguen funcionando.
- **Riesgos / rollback:** Riesgo bajo. No hay migraciones ni datos que deshacer; el rollback es revertir el commit. El riesgo principal es de adopción (desaparición del buscador de texto libre), no técnico. El filtro por técnico atraviesa una relación multivalor y el `distinct()` del queryset evita filas repetidas.
- **Fecha objetivo de release:** *(a completar)*

# Capturas de Pantalla

<img width="2224" height="1030" alt="image" src="https://github.com/user-attachments/assets/614ac2d5-8443-46af-bceb-d227bbe45b87" />


