### PR TITLE
fix(comedores): revertir dropdown Territorial asignado a AppSheet (GESTIONAR)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+<!-- AUTO-GENERATED RELEASE START: 2026-09-02 -->
+# Versión SISOC 02.09.2026
+
+## Actualizaciones
+
+- [sin-area] fix(comedores): revertir dropdown Territorial asignado a AppSheet (GESTIONAR). (PR #2361)
+<!-- AUTO-GENERATED RELEASE END: 2026-09-02 -->
+
 <!-- AUTO-GENERATED RELEASE START: 2026-08-26 -->
 # Versión SISOC 26.08.2026
 

--- a/comedores/views_territorial.py
+++ b/comedores/views_territorial.py
@@ -10,53 +10,46 @@ from django.views.decorators.http import require_http_methods
 
 from comedores.services.comedor_service import ComedorService
 from comedores.services.territorial_service import TerritorialService
-from users.services_pwa import get_territorial_comedor_users_for_provincia
 
 logger = logging.getLogger("django")
-
-
-def _territoriales_sisoc_para_comedor(comedor):
-    """Lista de territoriales (usuarios SISOC) con alcance en la provincia del comedor.
-
-    Reemplaza el pull viejo desde GESTIONAR/AppSheet: ahora los territoriales son
-    usuarios de SISOC (`Profile.es_territorial_comedor`) filtrados por provincia.
-    Se mantiene la forma `{gestionar_uid, nombre, desactualizado}` para no romper
-    el front del modal de relevamiento; `gestionar_uid` viaja con el id del user.
-    """
-    provincia_id = getattr(comedor, "provincia_id", None)
-    territoriales = []
-    for user in get_territorial_comedor_users_for_provincia(provincia_id):
-        nombre = (user.get_full_name() or "").strip() or user.username
-        territoriales.append(
-            {
-                "gestionar_uid": str(user.id),
-                "nombre": nombre,
-                "desactualizado": False,
-            }
-        )
-    return territoriales
 
 
 @login_required
 @require_http_methods(["GET"])
 def obtener_territoriales_api(request, comedor_id):
-    """Territoriales asignables al comedor (usuarios SISOC por provincia)."""
+    """
+    API endpoint para obtener territoriales con cache híbrido.
+
+    Query params opcionales:
+    - force_sync: 'true' para forzar sincronización con GESTIONAR
+    """
     try:
         comedor = ComedorService.get_scoped_comedor_or_404(comedor_id, request.user)
-        territoriales = _territoriales_sisoc_para_comedor(comedor)
+        forzar_sync = request.GET.get("force_sync", "false").lower() == "true"
 
-        response = JsonResponse(
-            {
-                "success": True,
-                "territoriales": territoriales,
-                "meta": {
-                    "desactualizados": False,
-                    "fuente": "db_provincia",
-                    "total": len(territoriales),
-                },
-            }
+        resultado = TerritorialService.obtener_territoriales_para_comedor(
+            comedor_id=comedor.id, forzar_sync=forzar_sync
         )
-        response["Cache-Control"] = "no-cache"
+
+        response_data = {
+            "success": True,
+            "territoriales": resultado["territoriales"],
+            "meta": {
+                "desactualizados": resultado["desactualizados"],
+                "fuente": resultado["fuente"],
+                "total": len(resultado["territoriales"]),
+            },
+        }
+
+        response = JsonResponse(response_data)
+
+        if not resultado["desactualizados"]:
+            # Cache en navegador por 10 minutos si los datos están actualizados
+            response["Cache-Control"] = "public, max-age=600"
+        else:
+            # No cachear en navegador si los datos están desactualizados
+            response["Cache-Control"] = "no-cache"
+
         return response
 
     except Exception as e:
@@ -79,20 +72,24 @@ def obtener_territoriales_api(request, comedor_id):
 @login_required
 @require_http_methods(["POST"])
 def sincronizar_territoriales_api(request, comedor_id):
-    """Refresca la lista de territoriales (usuarios SISOC por provincia)."""
+    """
+    Endpoint para forzar sincronización con GESTIONAR.
+    """
     try:
         comedor = ComedorService.get_scoped_comedor_or_404(comedor_id, request.user)
-        territoriales = _territoriales_sisoc_para_comedor(comedor)
+        resultado = TerritorialService.obtener_territoriales_para_comedor(
+            comedor_id=comedor.id, forzar_sync=True
+        )
 
         return JsonResponse(
             {
                 "success": True,
-                "mensaje": "Lista actualizada",
-                "territoriales": territoriales,
+                "mensaje": "Sincronización completada",
+                "territoriales": resultado["territoriales"],
                 "meta": {
-                    "desactualizados": False,
-                    "fuente": "db_provincia",
-                    "total": len(territoriales),
+                    "desactualizados": resultado["desactualizados"],
+                    "fuente": resultado["fuente"],
+                    "total": len(resultado["territoriales"]),
                 },
             }
         )

--- a/docs/contexto/features/pr-2361-fix-comedores-revertir-dropdown-territorial-asignado-a-appsheet-gestionar.md
+++ b/docs/contexto/features/pr-2361-fix-comedores-revertir-dropdown-territorial-asignado-a-appsheet-gestionar.md
@@ -1,0 +1,43 @@
+# Contexto de feature PR #2361 - fix(comedores): revertir dropdown Territorial asignado a AppSheet (GESTIONAR)
+
+## Resumen
+
+- PR: https://github.com/dsocial118/SISOC/pull/2361
+- Base: `main`
+- Rama origen: `hotfix/territorial-dropdown-appsheet`
+- Autor: `Mkdir-arg`
+
+## Contexto funcional
+
+- No informado explícitamente; inferir desde el título del PR y el diff.
+
+## Arquitectura tocada
+
+- No se detectó un patrón arquitectónico dominante más allá del diff observado.
+
+## Decisiones y supuestos detectados
+
+- Tipo de cambio declarado: No informado
+- Área principal declarada: No informada
+- Impacto usuario declarado: No informado
+- Riesgos / rollback: No informado
+
+## Design system y UI
+
+- Sin cambios visibles de UI o design system detectados en el diff.
+
+## Memoria operativa para agentes
+
+- Empezar por `docs/registro/prs/PR-2361.md` para contexto resumido del PR.
+- Revisar primero estos archivos del diff:
+- `comedores/views_territorial.py`
+- Documentación sugerida para ampliar contexto:
+- `docs/indice.md`
+- `docs/ia/CONTEXT_HYGIENE.md`
+- `docs/ia/ARCHITECTURE.md`
+- `docs/ia/TESTING.md`
+
+## Trazabilidad
+
+- Documento generado automáticamente desde el evento de `pull_request`.
+- Si este PR cambia de título, el archivo se renombrará para mantener el slug alineado.

--- a/docs/registro/prs/PR-2361.md
+++ b/docs/registro/prs/PR-2361.md
@@ -1,0 +1,45 @@
+# PR #2361 - fix(comedores): revertir dropdown Territorial asignado a AppSheet (GESTIONAR)
+
+## Metadata
+
+- PR: https://github.com/dsocial118/SISOC/pull/2361
+- Base: `main`
+- Rama origen: `hotfix/territorial-dropdown-appsheet`
+- Autor: `Mkdir-arg`
+
+## Resumen operativo
+
+- Tipo de cambio: No informado
+- Área principal: No informada
+- Contexto funcional: No informado explícitamente; revisar título, diff y documentación relacionada.
+- Resumen para changelog: No informado
+- Impacto usuario: No informado
+
+## Áreas afectadas
+
+- `comedores`
+
+## Archivos relevantes del diff
+
+- `comedores/views_territorial.py`
+
+## Validación declarada
+
+- Pruebas automáticas: No informado en el PR.
+- Pruebas manuales: No informado en el PR.
+
+## Riesgos y rollback
+
+- No informado explícitamente en el PR.
+
+## Documentación sugerida para lectura
+
+- `docs/indice.md`
+- `docs/ia/CONTEXT_HYGIENE.md`
+- `docs/ia/ARCHITECTURE.md`
+- `docs/ia/TESTING.md`
+
+## Notas para continuidad
+
+- Este documento es generado automáticamente desde el contexto del PR y sirve como índice rápido para revisión y futuras sesiones de agentes.
+- Si la metadata del body del PR está incompleta, varias secciones usarán fallbacks derivados del título o del diff.

--- a/docs/registro/releases/pending/2026-09-02-pr-2361.md
+++ b/docs/registro/releases/pending/2026-09-02-pr-2361.md
@@ -1,0 +1,19 @@
+---
+pr: 2361
+release_date: 2026-09-02
+category: Actualizaciones
+area: sin-area
+title: fix(comedores): revertir dropdown Territorial asignado a AppSheet (GESTIONAR)
+summary: fix(comedores): revertir dropdown Territorial asignado a AppSheet (GESTIONAR)
+impact: No informado
+source_url: https://github.com/dsocial118/SISOC/pull/2361
+---
+# Release note preliminar PR #2361
+
+- Fecha objetivo de release: 2026-09-02
+- Categoría: Actualizaciones
+- Área: sin-area
+- Título del PR: fix(comedores): revertir dropdown Territorial asignado a AppSheet (GESTIONAR)
+- Resumen: fix(comedores): revertir dropdown Territorial asignado a AppSheet (GESTIONAR)
+- Impacto usuario: No informado
+- Fuente: https://github.com/dsocial118/SISOC/pull/2361


### PR DESCRIPTION
Revierte el dropdown "Territorial asignado" del modal Nuevo relevamiento (backoffice) a la fuente AppSheet/GESTIONAR (`TerritorialService.obtener_territoriales_para_comedor`), deshaciendo la opción-A no probada de `393660f60`.

Revert quirúrgico de un solo archivo (`comedores/views_territorial.py`). NO toca el resto de la feature territorial (modelos, migraciones, API `/api/territorial/…`, precarga campo/valor, login territorial): todo se conserva.

Sin cambios de test (ningún test cubre ese dropdown).

🤖 Generated with [Claude Code](https://claude.com/claude-code)